### PR TITLE
OSS-344: Add a field for declared licenses to projects and packages

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
@@ -5,6 +5,7 @@ project:
   namespace: ""
   name: "spdx-tools"
   version: "0.5.4"
+  declared_licenses: []
   aliases: []
   vcs_path: ""
   vcs_provider: "Git"
@@ -50,6 +51,9 @@ packages:
   namespace: ""
   name: "isodate"
   version: "0.6.0"
+  declared_licenses:
+  - "BSD"
+  - "BSD License"
   description: "An ISO 8601 date/time/duration parser and formatter"
   homepage_url: "https://github.com/gweis/isodate/"
   download_url: "https://pypi.python.org/packages/9b/9f/b36f7774ff5ea8e428fdcfc4bb332c39ee5b9362ddd3d40d9516a55221b2/isodate-0.6.0-py2.py3-none-any.whl"
@@ -63,6 +67,8 @@ packages:
   namespace: ""
   name: "ply"
   version: "3.10"
+  declared_licenses:
+  - "BSD"
   description: "Python Lex & Yacc"
   homepage_url: "http://www.dabeaz.com/ply/"
   download_url: "https://pypi.python.org/packages/ce/3d/1f9ca69192025046f02a02ffc61bfbac2731aab06325a218370fd93e18df/ply-3.10.tar.gz"
@@ -76,6 +82,8 @@ packages:
   namespace: ""
   name: "pyparsing"
   version: "2.2.0"
+  declared_licenses:
+  - "MIT License"
   description: "Python parsing module"
   homepage_url: "http://pyparsing.wikispaces.com/"
   download_url: "https://pypi.python.org/packages/6a/8a/718fd7d3458f9fab8e67186b00abdd345b639976bc7fb3ae722e1b026a50/pyparsing-2.2.0-py2.py3-none-any.whl"
@@ -89,6 +97,9 @@ packages:
   namespace: ""
   name: "rdflib"
   version: "4.2.2"
+  declared_licenses:
+  - "https://raw.github.com/RDFLib/rdflib/master/LICENSE"
+  - "BSD License"
   description: "RDFLib is a Python library for working with RDF, a simple yet powerful\
     \ language for representing information."
   homepage_url: "https://github.com/RDFLib/rdflib"
@@ -103,6 +114,9 @@ packages:
   namespace: ""
   name: "six"
   version: "1.11.0"
+  declared_licenses:
+  - "MIT"
+  - "MIT License"
   description: "Python 2 and 3 compatibility utilities"
   homepage_url: "http://pypi.python.org/pypi/six/"
   download_url: "https://pypi.python.org/packages/67/4b/141a581104b1f6397bfa78ac9d43d8ad29a7ca43ea90a2d863fe3056e86a/six-1.11.0-py2.py3-none-any.whl"

--- a/analyzer/src/funTest/assets/projects/synthetic/project-gradle-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/project-gradle-expected-output-app.yml
@@ -5,6 +5,7 @@ project:
   namespace: ""
   name: "app"
   version: ""
+  declared_licenses: []
   aliases: []
   vcs_path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
   vcs_provider: "Git"
@@ -188,6 +189,7 @@ packages:
   namespace: ""
   name: "project :lib"
   version: ""
+  declared_licenses: []
   description: ""
   homepage_url: ""
   download_url: ""
@@ -201,6 +203,7 @@ packages:
   namespace: "org.apache.commons"
   name: "commons-lang3"
   version: "3.5"
+  declared_licenses: []
   description: ""
   homepage_url: ""
   download_url: ""
@@ -214,6 +217,7 @@ packages:
   namespace: "org.apache.commons"
   name: "commons-text"
   version: "1.1"
+  declared_licenses: []
   description: ""
   homepage_url: ""
   download_url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/project-gradle-expected-output-lib-without-repo.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/project-gradle-expected-output-lib-without-repo.yml
@@ -5,6 +5,7 @@ project:
   namespace: ""
   name: "lib-without-repo"
   version: ""
+  declared_licenses: []
   aliases: []
   vcs_path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
   vcs_provider: "Git"

--- a/analyzer/src/funTest/assets/projects/synthetic/project-gradle-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/project-gradle-expected-output-lib.yml
@@ -5,6 +5,7 @@ project:
   namespace: ""
   name: "lib"
   version: ""
+  declared_licenses: []
   aliases: []
   vcs_path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
   vcs_provider: "Git"
@@ -183,6 +184,7 @@ packages:
   namespace: "junit"
   name: "junit"
   version: "4.12"
+  declared_licenses: []
   description: ""
   homepage_url: ""
   download_url: ""
@@ -196,6 +198,7 @@ packages:
   namespace: "org.apache.commons"
   name: "commons-lang3"
   version: "3.5"
+  declared_licenses: []
   description: ""
   homepage_url: ""
   download_url: ""
@@ -209,6 +212,7 @@ packages:
   namespace: "org.apache.commons"
   name: "commons-text"
   version: "1.1"
+  declared_licenses: []
   description: ""
   homepage_url: ""
   download_url: ""
@@ -222,6 +226,7 @@ packages:
   namespace: "org.hamcrest"
   name: "hamcrest-core"
   version: "1.3"
+  declared_licenses: []
   description: ""
   homepage_url: ""
   download_url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/project-gradle-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/project-gradle-expected-output-root.yml
@@ -5,6 +5,7 @@ project:
   namespace: ""
   name: "Gradle sample"
   version: ""
+  declared_licenses: []
   aliases: []
   vcs_path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
   vcs_provider: "Git"

--- a/analyzer/src/funTest/assets/projects/synthetic/project-npm-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/project-npm-expected-output.yml
@@ -5,6 +5,8 @@ project:
   namespace: ""
   name: "project-npm"
   version: "2.0.0"
+  declared_licenses:
+  - "Apache-2.0"
   aliases: []
   vcs_path: ""
   vcs_provider: "git"
@@ -303,6 +305,8 @@ packages:
   namespace: ""
   name: "asap"
   version: "2.0.5"
+  declared_licenses:
+  - "MIT"
   description: "High-priority task queue for Node.js and browsers"
   homepage_url: "https://github.com/kriskowal/asap#readme"
   download_url: "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz"
@@ -316,6 +320,8 @@ packages:
   namespace: ""
   name: "boolbase"
   version: "1.0.0"
+  declared_licenses:
+  - "ISC"
   description: "two functions: One that returns true, one that returns false"
   homepage_url: "https://github.com/fb55/boolbase"
   download_url: "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
@@ -329,6 +335,8 @@ packages:
   namespace: ""
   name: "cheerio"
   version: "1.0.0-rc.1"
+  declared_licenses:
+  - "MIT"
   description: "Tiny, fast, and elegant implementation of core jQuery designed specifically\
     \ for the server"
   homepage_url: "https://github.com/cheeriojs/cheerio#readme"
@@ -343,6 +351,8 @@ packages:
   namespace: ""
   name: "coffee-script"
   version: "1.12.6"
+  declared_licenses:
+  - "MIT"
   description: "Unfancy JavaScript"
   homepage_url: "http://coffeescript.org"
   download_url: "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.6.tgz"
@@ -356,6 +366,8 @@ packages:
   namespace: ""
   name: "core-util-is"
   version: "1.0.2"
+  declared_licenses:
+  - "MIT"
   description: "The `util.is*` functions introduced in Node v0.12."
   homepage_url: "https://github.com/isaacs/core-util-is#readme"
   download_url: "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
@@ -369,6 +381,8 @@ packages:
   namespace: ""
   name: "cson-parser"
   version: "1.3.5"
+  declared_licenses:
+  - "BSD-3-Clause"
   description: "Safe parsing of CSON files"
   homepage_url: "https://github.com/groupon/cson-parser"
   download_url: "https://registry.npmjs.org/cson-parser/-/cson-parser-1.3.5.tgz"
@@ -382,6 +396,8 @@ packages:
   namespace: ""
   name: "cson"
   version: "4.1.0"
+  declared_licenses:
+  - "MIT"
   description: "CoffeeScript-Object-Notation Parser. Same as JSON but for CoffeeScript\
     \ objects."
   homepage_url: "https://github.com/bevry/cson"
@@ -396,6 +412,8 @@ packages:
   namespace: ""
   name: "css-select"
   version: "1.2.0"
+  declared_licenses:
+  - "BSD-like"
   description: "a CSS selector compiler/engine"
   homepage_url: "https://github.com/fb55/css-select#readme"
   download_url: "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz"
@@ -409,6 +427,8 @@ packages:
   namespace: ""
   name: "css-what"
   version: "2.1.0"
+  declared_licenses:
+  - "BSD-like"
   description: "a CSS selector parser"
   homepage_url: "https://github.com/fb55/css-what#readme"
   download_url: "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz"
@@ -422,6 +442,8 @@ packages:
   namespace: ""
   name: "dom-serializer"
   version: "0.1.0"
+  declared_licenses:
+  - "MIT"
   description: "render dom nodes to string"
   homepage_url: "https://github.com/cheeriojs/dom-renderer"
   download_url: "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz"
@@ -435,6 +457,7 @@ packages:
   namespace: ""
   name: "domelementtype"
   version: "1.1.3"
+  declared_licenses: []
   description: "all the types of nodes in htmlparser2's dom"
   homepage_url: "https://github.com/FB55/domelementtype"
   download_url: "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
@@ -448,6 +471,7 @@ packages:
   namespace: ""
   name: "domelementtype"
   version: "1.3.0"
+  declared_licenses: []
   description: "all the types of nodes in htmlparser2's dom"
   homepage_url: "https://github.com/FB55/domelementtype"
   download_url: "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
@@ -461,6 +485,8 @@ packages:
   namespace: ""
   name: "domhandler"
   version: "2.4.1"
+  declared_licenses:
+  - "BSD-2-Clause"
   description: "handler for htmlparser2 that turns pages into a dom"
   homepage_url: "https://github.com/fb55/DomHandler#readme"
   download_url: "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz"
@@ -474,6 +500,7 @@ packages:
   namespace: ""
   name: "domutils"
   version: "1.5.1"
+  declared_licenses: []
   description: "utilities for working with htmlparser2's dom"
   homepage_url: "https://github.com/FB55/domutils"
   download_url: "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz"
@@ -487,6 +514,8 @@ packages:
   namespace: ""
   name: "eachr"
   version: "3.2.0"
+  declared_licenses:
+  - "MIT"
   description: "Give eachr an item to iterate (array, object or map) and an iterator,\
     \ then in return eachr gives iterator the value and key of each item, and will\
     \ stop if the iterator returned false."
@@ -502,6 +531,8 @@ packages:
   namespace: ""
   name: "editions"
   version: "1.3.3"
+  declared_licenses:
+  - "MIT"
   description: "Publish multiple editions for your JavaScript packages consistently\
     \ and easily (e.g. source edition, esnext edition, es2015 edition)"
   homepage_url: "https://github.com/bevry/editions"
@@ -516,6 +547,8 @@ packages:
   namespace: ""
   name: "entities"
   version: "1.1.1"
+  declared_licenses:
+  - "BSD-like"
   description: "Encode & decode XML/HTML entities with ease"
   homepage_url: "https://github.com/fb55/node-entities"
   download_url: "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
@@ -529,6 +562,8 @@ packages:
   namespace: ""
   name: "extract-opts"
   version: "3.3.1"
+  declared_licenses:
+  - "MIT"
   description: "Extract the options and callback from a function's arguments easily"
   homepage_url: "https://github.com/bevry/extract-opts"
   download_url: "https://registry.npmjs.org/extract-opts/-/extract-opts-3.3.1.tgz"
@@ -542,6 +577,8 @@ packages:
   namespace: ""
   name: "graceful-fs"
   version: "4.1.11"
+  declared_licenses:
+  - "ISC"
   description: "A drop-in replacement for fs, making various improvements."
   homepage_url: "https://github.com/isaacs/node-graceful-fs#readme"
   download_url: "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
@@ -555,6 +592,8 @@ packages:
   namespace: ""
   name: "htmlparser2"
   version: "3.9.2"
+  declared_licenses:
+  - "MIT"
   description: "Fast & forgiving HTML/XML/RSS parser"
   homepage_url: "https://github.com/fb55/htmlparser2#readme"
   download_url: "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz"
@@ -568,6 +607,8 @@ packages:
   namespace: ""
   name: "inherits"
   version: "2.0.3"
+  declared_licenses:
+  - "ISC"
   description: "Browser-friendly inheritance fully compatible with standard node.js\
     \ inherits()"
   homepage_url: "https://github.com/isaacs/inherits#readme"
@@ -582,6 +623,8 @@ packages:
   namespace: ""
   name: "isarray"
   version: "1.0.0"
+  declared_licenses:
+  - "MIT"
   description: "Array#isArray for older browsers"
   homepage_url: "https://github.com/juliangruber/isarray"
   download_url: "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
@@ -595,6 +638,8 @@ packages:
   namespace: ""
   name: "lodash"
   version: "4.17.4"
+  declared_licenses:
+  - "MIT"
   description: "Lodash modular utilities."
   homepage_url: "https://lodash.com/"
   download_url: "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
@@ -608,6 +653,8 @@ packages:
   namespace: ""
   name: "long"
   version: "3.2.0"
+  declared_licenses:
+  - "Apache-2.0"
   description: "A Long class for representing a 64-bit two's-complement integer value."
   homepage_url: "https://github.com/dcodeIO/long.js#readme"
   download_url: "https://registry.npmjs.org/long/-/long-3.2.0.tgz"
@@ -621,6 +668,8 @@ packages:
   namespace: ""
   name: "nth-check"
   version: "1.0.1"
+  declared_licenses:
+  - "BSD"
   description: "performant nth-check parser & compiler"
   homepage_url: "https://github.com/fb55/nth-check"
   download_url: "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz"
@@ -634,6 +683,8 @@ packages:
   namespace: ""
   name: "parse5"
   version: "3.0.2"
+  declared_licenses:
+  - "MIT"
   description: "HTML parsing/serialization toolset for Node.js. WHATWG HTML Living\
     \ Standard (aka HTML5)-compliant."
   homepage_url: "https://github.com/inikulin/parse5"
@@ -648,6 +699,8 @@ packages:
   namespace: ""
   name: "process-nextick-args"
   version: "1.0.7"
+  declared_licenses:
+  - "MIT"
   description: "process.nextTick but always with args"
   homepage_url: "https://github.com/calvinmetcalf/process-nextick-args"
   download_url: "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
@@ -661,6 +714,8 @@ packages:
   namespace: ""
   name: "promise"
   version: "7.3.1"
+  declared_licenses:
+  - "MIT"
   description: "Bare bones Promises/A+ implementation"
   homepage_url: "https://github.com/then/promise#readme"
   download_url: "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz"
@@ -674,6 +729,8 @@ packages:
   namespace: ""
   name: "readable-stream"
   version: "2.3.3"
+  declared_licenses:
+  - "MIT"
   description: "Streams3, a user-land copy of the stream library from Node.js"
   homepage_url: "https://github.com/nodejs/readable-stream#readme"
   download_url: "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
@@ -687,6 +744,8 @@ packages:
   namespace: ""
   name: "requirefresh"
   version: "2.1.0"
+  declared_licenses:
+  - "MIT"
   description: "Require a file without adding it into the require cache"
   homepage_url: "https://github.com/bevry/requirefresh"
   download_url: "https://registry.npmjs.org/requirefresh/-/requirefresh-2.1.0.tgz"
@@ -700,6 +759,8 @@ packages:
   namespace: ""
   name: "safe-buffer"
   version: "5.1.1"
+  declared_licenses:
+  - "MIT"
   description: "Safer Node.js Buffer API"
   homepage_url: "https://github.com/feross/safe-buffer"
   download_url: "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
@@ -713,6 +774,8 @@ packages:
   namespace: ""
   name: "safefs"
   version: "4.1.0"
+  declared_licenses:
+  - "MIT"
   description: "Stop getting EMFILE errors! Open only as many files as the operating\
     \ system supports."
   homepage_url: "https://github.com/bevry/safefs"
@@ -727,6 +790,8 @@ packages:
   namespace: ""
   name: "string_decoder"
   version: "1.0.3"
+  declared_licenses:
+  - "MIT"
   description: "The string_decoder module from Node core"
   homepage_url: "https://github.com/rvagg/string_decoder"
   download_url: "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
@@ -740,6 +805,8 @@ packages:
   namespace: ""
   name: "typechecker"
   version: "4.4.1"
+  declared_licenses:
+  - "MIT"
   description: "Utilities to get and check variable types (isString, isPlainObject,\
     \ isRegExp, etc)"
   homepage_url: "https://github.com/bevry/typechecker"
@@ -754,6 +821,8 @@ packages:
   namespace: ""
   name: "util-deprecate"
   version: "1.0.2"
+  declared_licenses:
+  - "MIT"
   description: "The Node.js `util.deprecate()` function with browser support"
   homepage_url: "https://github.com/TooTallNate/util-deprecate"
   download_url: "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
@@ -767,6 +836,8 @@ packages:
   namespace: "@types"
   name: "node"
   version: "6.0.79"
+  declared_licenses:
+  - "MIT"
   description: "TypeScript definitions for Node.js"
   homepage_url: ""
   download_url: "https://registry.npmjs.org/@types/node/-/node-6.0.79.tgz"

--- a/analyzer/src/main/kotlin/Main.kt
+++ b/analyzer/src/main/kotlin/Main.kt
@@ -219,6 +219,7 @@ object Main {
                     namespace = "",
                     name = absoluteProjectPath.name,
                     version = "",
+                    declaredLicenses = emptySet(),
                     aliases = emptyList(),
                     vcsPath = vcs?.getPathToRoot(absoluteProjectPath),
                     vcsProvider = vcs?.javaClass?.simpleName ?: "",

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -98,6 +98,7 @@ object Gradle : PackageManager(
                     namespace = "",
                     name = dependencyTreeModel.name,
                     version = "",
+                    declaredLicenses = emptySet(),
                     aliases = emptyList(),
                     vcsPath = vcs?.getPathToRoot(projectDir),
                     vcsProvider = vcs?.javaClass?.simpleName ?: "",
@@ -124,8 +125,22 @@ object Gradle : PackageManager(
             // Only look for a package when there was no error resolving the dependency.
             packages.getOrPut("${dependency.groupId}:${dependency.artifactId}:${dependency.version}") {
                 // TODO: add metadata for package
-                Package(javaClass.simpleName, dependency.groupId, dependency.artifactId,
-                        dependency.version, "", "", "", "", "", "", "", "", "")
+                Package(
+                        packageManager = javaClass.simpleName,
+                        namespace = dependency.groupId,
+                        name = dependency.artifactId,
+                        version = dependency.version,
+                        declaredLicenses = emptySet(),
+                        description = "",
+                        homepageUrl = "",
+                        downloadUrl = "",
+                        hash = "",
+                        hashAlgorithm = "",
+                        vcsPath = "",
+                        vcsProvider = "",
+                        vcsUrl = "",
+                        vcsRevision = ""
+                )
             }
         }
         val transitiveDependencies = dependency.dependencies.map { parseDependency(it, packages) }

--- a/analyzer/src/main/kotlin/managers/NPM.kt
+++ b/analyzer/src/main/kotlin/managers/NPM.kt
@@ -148,6 +148,11 @@ object NPM : PackageManager(
             val (namespace, name) = splitNamespaceAndName(rawName)
             val version = json["version"].asText()
 
+            val declaredLicenses = mutableSetOf<String>()
+            setOf(json["license"]).mapNotNullTo(declaredLicenses) {
+                it?.asText()
+            }
+
             var description: String
             var homepageUrl: String
             var downloadUrl: String
@@ -205,8 +210,22 @@ object NPM : PackageManager(
                 }
             }
 
-            val module = Package(javaClass.simpleName, namespace, name, version, description, homepageUrl, downloadUrl,
-                    hash, hashAlgorithm, vcsPath, vcsProvider, vcsUrl, vcsRevision)
+            val module = Package(
+                    packageManager = javaClass.simpleName,
+                    namespace = namespace,
+                    name = name,
+                    version = version,
+                    declaredLicenses = declaredLicenses,
+                    description = description,
+                    homepageUrl = homepageUrl,
+                    downloadUrl = downloadUrl,
+                    hash = hash,
+                    hashAlgorithm = hashAlgorithm,
+                    vcsPath = vcsPath,
+                    vcsProvider = vcsProvider,
+                    vcsUrl = vcsUrl,
+                    vcsRevision = vcsRevision
+            )
 
             require(module.name.isNotEmpty()) {
                 "Generated package info for $identifier has no name."
@@ -351,6 +370,12 @@ object NPM : PackageManager(
         val rawName = json["name"].asText()
         val (namespace, name) = splitNamespaceAndName(rawName)
         val version = json["version"].asText()
+
+        val declaredLicenses = mutableSetOf<String>()
+        setOf(json["license"]).mapNotNullTo(declaredLicenses) {
+            it?.asText()
+        }
+
         val (vcsProviderFromPackage, vcsUrlFromPackage) = parseRepository(json)
         val homepageUrl = json["homepage"].asTextOrEmpty()
 
@@ -380,6 +405,7 @@ object NPM : PackageManager(
                 namespace = namespace,
                 name = name,
                 version = version,
+                declaredLicenses = declaredLicenses,
                 aliases = emptyList(),
                 vcsPath = vcs?.getPathToRoot(projectDir),
                 vcsProvider = vcsProviderFromPackage,

--- a/model/src/main/kotlin/Package.kt
+++ b/model/src/main/kotlin/Package.kt
@@ -61,6 +61,13 @@ data class Package(
         val version: String,
 
         /**
+         * The list of licenses the authors have declared for this package. This does not necessarily correspond to the
+         * licenses as detected by a scanner. Both need to be taken into account for any conclusions.
+         */
+        @JsonProperty("declared_licenses")
+        val declaredLicenses: Set<String>,
+
+        /**
          * The description of the package, as provided by the package manager.
          */
         val description: String,

--- a/model/src/main/kotlin/Project.kt
+++ b/model/src/main/kotlin/Project.kt
@@ -53,6 +53,13 @@ data class Project(
         val version: String,
 
         /**
+         * The list of licenses the authors have declared for this package. This does not necessarily correspond to the
+         * licenses as detected by a scanner. Both need to be taken into account for any conclusions.
+         */
+        @JsonProperty("declared_licenses")
+        val declaredLicenses: Set<String>,
+
+        /**
          * Alternate project names, like abbreviations or code names.
          */
         val aliases: List<String>,
@@ -106,7 +113,21 @@ data class Project(
     /**
      * Return a [Package] representation of this [Project].
      */
-    fun toPackage() = Package(packageManager, namespace, name, "", version, homepageUrl, "", "", "", vcsPath,
-            vcsProvider, vcsUrl, vcsRevision)
+    fun toPackage() = Package(
+            packageManager = packageManager,
+            namespace = namespace,
+            name = name,
+            version = version,
+            declaredLicenses = declaredLicenses,
+            description = "",
+            homepageUrl = homepageUrl,
+            downloadUrl = "",
+            hash = "",
+            hashAlgorithm = "",
+            vcsPath = vcsPath,
+            vcsProvider = vcsProvider,
+            vcsUrl = vcsUrl,
+            vcsRevision = vcsRevision
+    )
 
 }

--- a/model/src/test/kotlin/PackageTest.kt
+++ b/model/src/test/kotlin/PackageTest.kt
@@ -28,14 +28,44 @@ import io.kotlintest.specs.WordSpec
 class PackageTest : WordSpec({
     "normalizedVcsUrl" should {
         "actually be normalized" {
-            val pkg = Package("", "", "", "", "1.0.0", "", "", "", "", "", "", "https://github.com/fb55/nth-check", "")
+            val pkg = Package(
+                    packageManager = "",
+                    namespace = "",
+                    name = "",
+                    version = "1.0.0",
+                    declaredLicenses = emptySet(),
+                    description = "",
+                    homepageUrl = "",
+                    downloadUrl = "",
+                    hash = "",
+                    hashAlgorithm = "",
+                    vcsPath = "",
+                    vcsProvider = "",
+                    vcsUrl = "https://github.com/fb55/nth-check",
+                    vcsRevision = ""
+            )
             val expectedUrl = "https://github.com/fb55/nth-check.git"
 
             pkg.normalizedVcsUrl shouldBe expectedUrl
         }
 
         "should understand NPM shortcuts for NPM packages" {
-            val pkg = Package("NPM", "", "", "", "1.0.0", "", "", "", "", "", "", "npm/npm", "")
+            val pkg = Package(
+                    packageManager = "NPM",
+                    namespace = "",
+                    name = "",
+                    version = "1.0.0",
+                    declaredLicenses = emptySet(),
+                    description = "",
+                    homepageUrl = "",
+                    downloadUrl = "",
+                    hash = "",
+                    hashAlgorithm = "",
+                    vcsPath = "",
+                    vcsProvider = "",
+                    vcsUrl = "npm/npm",
+                    vcsRevision = ""
+            )
             val expectedUrl = "https://github.com/npm/npm.git"
 
             pkg.normalizedVcsUrl shouldBe expectedUrl

--- a/scanner/src/funTest/kotlin/HttpCacheTest.kt
+++ b/scanner/src/funTest/kotlin/HttpCacheTest.kt
@@ -75,19 +75,20 @@ class HttpCacheTest : StringSpec() {
             val cache = ArtifactoryCache("http://${loopback.hostAddress}:$port", "apiToken")
 
             val pkg = Package(
-                    "packageManager",
-                    "namespace",
-                    "name",
-                    "version",
-                    "description",
-                    "homepageUrl",
-                    "downloadUrl",
-                    "hash",
-                    "hashAlgorithm",
-                    "vcsPath",
-                    "vcsProvider",
-                    "vcsUrl",
-                    "vcsRevision"
+                    packageManager = "packageManager",
+                    namespace = "namespace",
+                    name = "name",
+                    version = "version",
+                    declaredLicenses = setOf("license"),
+                    description = "description",
+                    homepageUrl = "homepageUrl",
+                    downloadUrl = "downloadUrl",
+                    hash = "hash",
+                    hashAlgorithm = "hashAlgorithm",
+                    vcsPath = "vcsPath",
+                    vcsProvider = "vcsProvider",
+                    vcsUrl = "vcsUrl",
+                    vcsRevision = "vcsRevision"
             )
 
             val resultFile = createTempFile()


### PR DESCRIPTION
We need to track the declared licenses, too. While at it, always
construct projects and packages using named arguments to guards against
introduction / reordering of fields. This also actually fixes occurances
in PIP.kt, Project.kt and PackageTest.kt where the package description and
version fields were swapped.

Change-Id: I880c9df0bce51fac0568e05e256691e77697bd19

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/4)
<!-- Reviewable:end -->
