### PR TITLE
PackageManager: Do not pass resolution result to resolveDependencies

### DIFF
--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -101,7 +101,9 @@ abstract class PackageManager(
             println("Resolving ${javaClass.simpleName} dependencies in '$workingDir'...")
 
             val elapsed = measureTimeMillis {
-                resolveDependencies(projectDir, workingDir, definitionFile, result)
+                resolveDependencies(projectDir, workingDir, definitionFile)?.let {
+                    result[definitionFile] = it
+                }
             }
 
             log.info {
@@ -120,10 +122,9 @@ abstract class PackageManager(
     }
 
     /**
-     * Resolve dependencies for single [definitionFile], amending the [result].
+     * Resolve dependencies for a single [definitionFile], returning the [AnalyzerResult].
      */
-    protected open fun resolveDependencies(projectDir: File, workingDir: File, definitionFile: File,
-                                         result: ResolutionResult) {
+    protected open fun resolveDependencies(projectDir: File, workingDir: File, definitionFile: File): AnalyzerResult? {
         TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
     }
 }

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -26,7 +26,6 @@ import ch.frankel.slf4k.*
 
 import com.here.ort.analyzer.Main
 import com.here.ort.analyzer.PackageManager
-import com.here.ort.analyzer.ResolutionResult
 import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.AnalyzerResult
 import com.here.ort.model.Package
@@ -63,8 +62,7 @@ object Gradle : PackageManager(
         return if (File(workingDir, wrapper).isFile) wrapper else gradle
     }
 
-    override fun resolveDependencies(projectDir: File, workingDir: File, definitionFile: File,
-                                     result: ResolutionResult) {
+    override fun resolveDependencies(projectDir: File, workingDir: File, definitionFile: File): AnalyzerResult? {
         val connection = GradleConnector
                 .newConnector()
                 .forProjectDirectory(workingDir)
@@ -108,13 +106,14 @@ object Gradle : PackageManager(
                     scopes = scopes
             )
 
-            result.put(definitionFile, AnalyzerResult(true, project, packages.values.toSortedSet()))
+            return AnalyzerResult(true, project, packages.values.toSortedSet())
         } catch (e: BuildException) {
             if (Main.stacktrace) {
                 e.printStackTrace()
             }
 
             log.error { "Could not analyze '${definitionFile.absolutePath}': ${e.message}" }
+            return null
         } finally {
             connection.close()
         }

--- a/analyzer/src/main/kotlin/managers/NPM.kt
+++ b/analyzer/src/main/kotlin/managers/NPM.kt
@@ -26,7 +26,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode
 
 import com.here.ort.analyzer.Main
 import com.here.ort.analyzer.PackageManager
-import com.here.ort.analyzer.ResolutionResult
 import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.AnalyzerResult
 import com.here.ort.model.Package
@@ -82,8 +81,7 @@ object NPM : PackageManager(
         checkCommandVersion(yarn, Semver("1.1.0", SemverType.NPM), ignoreActualVersion = Main.ignoreVersions)
     }
 
-    override fun resolveDependencies(projectDir: File, workingDir: File, definitionFile: File,
-                                     result: ResolutionResult) {
+    override fun resolveDependencies(projectDir: File, workingDir: File, definitionFile: File): AnalyzerResult? {
         val modulesDir = File(workingDir, "node_modules")
 
         var tempModulesDir: File? = null
@@ -111,9 +109,7 @@ object NPM : PackageManager(
 
             // TODO: add support for peerDependencies, bundledDependencies, and optionalDependencies.
 
-            val project = parseProject(definitionFile, listOf(dependencies, devDependencies),
-                    packages.values.toSortedSet())
-            result[definitionFile] = project
+            return parseProject(definitionFile, listOf(dependencies, devDependencies), packages.values.toSortedSet())
         } finally {
             // Delete node_modules folder to not pollute the scan.
             if (!modulesDir.deleteRecursively()) {

--- a/analyzer/src/main/kotlin/managers/PIP.kt
+++ b/analyzer/src/main/kotlin/managers/PIP.kt
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.databind.JsonNode
 
 import com.here.ort.analyzer.Main
 import com.here.ort.analyzer.PackageManager
-import com.here.ort.analyzer.ResolutionResult
 import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.Package
 import com.here.ort.model.PackageReference
@@ -96,8 +95,7 @@ object PIP : PackageManager(
         checkCommandVersion("virtualenv", Semver("15.1.0"), ignoreActualVersion = Main.ignoreVersions)
     }
 
-    override fun resolveDependencies(projectDir: File, workingDir: File, definitionFile: File,
-                                     result: ResolutionResult) {
+    override fun resolveDependencies(projectDir: File, workingDir: File, definitionFile: File): AnalyzerResult? {
         val virtualEnvDir = setupVirtualEnv(workingDir, definitionFile)
 
         // List all packages installed locally in the virtualenv in JSON format.
@@ -220,10 +218,10 @@ object PIP : PackageManager(
                 scopes = scopes
         )
 
-        result[definitionFile] = AnalyzerResult(true, project, packages)
-
         // Remove the virtualenv by simply deleting the directory.
         virtualEnvDir.deleteRecursively()
+
+        return AnalyzerResult(true, project, packages)
     }
 
     private fun setupVirtualEnv(workingDir: File, definitionFile: File): File {


### PR DESCRIPTION
Instead let the method return AnalyzerResult? and let the PackageManager
class take care of adding it to the result map. This provides better
encapsulation of the result map.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/7)
<!-- Reviewable:end -->
