### PR TITLE
downloader: Only call safeMkdirs() on the output directory once

### DIFF
--- a/downloader/src/main/kotlin/Main.kt
+++ b/downloader/src/main/kotlin/Main.kt
@@ -144,8 +144,6 @@ object Main {
             else -> throw IllegalArgumentException("Provided input file is neither JSON nor YAML.")
         }
 
-        outputDir.safeMkdirs()
-
         val analyzerResult = mapper.readValue(dependenciesFile, AnalyzerResult::class.java)
         val packages = mutableListOf<Package>()
 


### PR DESCRIPTION
This is already done in download().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/8)
<!-- Reviewable:end -->
