### PR TITLE
Git: Fix the isApplicableDirectory() check

### DIFF
--- a/downloader/src/main/kotlin/vcs/Git.kt
+++ b/downloader/src/main/kotlin/vcs/Git.kt
@@ -145,7 +145,9 @@ object Git : GitBase() {
 
     override fun isApplicableUrl(vcsUrl: String) = vcsUrl.endsWith(".git")
 
-    override fun isApplicableDirectory(vcsDirectory: File)
-            = runGitCommand(vcsDirectory, "rev-parse", "--is-inside-work-tree").stdout().trimEnd().toBoolean()
+    override fun isApplicableDirectory(vcsDirectory: File): Boolean {
+        val isInsideWorkTree = ProcessCapture(vcsDirectory, "git", "rev-parse", "--is-inside-work-tree")
+        return isInsideWorkTree.exitValue() == 0 && isInsideWorkTree.stdout().trimEnd().toBoolean()
+    }
 
 }


### PR DESCRIPTION
rev-parse actually returns exit code 128 when run outside of a working
tree. It only returns "false" when run from below the ".git" directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/9)
<!-- Reviewable:end -->
