### PR TITLE
Move the scancode submodule to the scanner project

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,11 +2,11 @@
 	path = analyzer/src/funTest/assets/projects/external/jgnash
 	url = https://github.com/ccavanaugh/jgnash.git
 	ignore = untracked
-[submodule "scancode-toolkit"]
-	path = analyzer/src/funTest/assets/projects/external/scancode-toolkit
-	url = https://github.com/nexb/scancode-toolkit.git
-	ignore = untracked
 [submodule "spdx-tools-python"]
 	path = analyzer/src/funTest/assets/projects/external/spdx-tools-python
 	url = https://github.com/spdx/tools-python.git
+	ignore = untracked
+[submodule "scancode-toolkit"]
+	path = scanner/src/funTest/assets/scanners/scancode-toolkit
+	url = https://github.com/nexb/scancode-toolkit.git
 	ignore = untracked

--- a/scanner/build.gradle
+++ b/scanner/build.gradle
@@ -34,7 +34,7 @@ task funTest(type: Test) {
     testClassesDirs = sourceSets.funTest.output.classesDirs
 
     // Add the Git submodule for ScanCode to PATH so functional tests can find the scanner.
-    def scanCodePath = rootDir.path + '/analyzer/src/funTest/assets/projects/external/scancode-toolkit'
+    def scanCodePath = "$projectDir/src/funTest/assets/scanners/scancode-toolkit"
     environment('PATH', scanCodePath + File.pathSeparator + System.env['PATH'])
 
     testLogging {


### PR DESCRIPTION
We really only use this in scanner funcional tests, and do not plan to
use it for analyzer tests anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/14)
<!-- Reviewable:end -->
