### PR TITLE
Add a utility function to split a VCS URL into the base repo and a path 

### DIFF
--- a/scanner/src/main/kotlin/Main.kt
+++ b/scanner/src/main/kotlin/Main.kt
@@ -230,7 +230,7 @@ object Main {
             }
             entry.licenses.addAll(result)
 
-            println("Found licenses for '$identifier: ${entry.licenses.joinToString()}")
+            println("Found licenses for '$identifier': ${entry.licenses.joinToString()}")
         } catch (e: ScanException) {
             if (stacktrace) {
                 e.printStackTrace()

--- a/util/src/main/kotlin/Utils.kt
+++ b/util/src/main/kotlin/Utils.kt
@@ -144,6 +144,28 @@ fun normalizeVcsUrl(vcsUrl: String, semverType: Semver.SemverType = Semver.Semve
 }
 
 /**
+ * Split a [vcsUrl] into a pair of strings denoting the base repository URL and the path within the repository.
+ */
+fun splitVcsPathFromUrl(vcsUrl: String): Pair<String, String> {
+    val uri = URI(vcsUrl)
+
+    if (uri.host.endsWith("github.com")) {
+        val split = vcsUrl.split("/blob/", "/tree/")
+        if (split.size == 2) {
+            val repo = split.first() + ".git"
+
+            // Remove the blob / tree committish (e.g. a branch name) and any ".git" suffix.
+            val path = split.last().substringAfter("/").substringBeforeLast(".git")
+
+            return Pair(repo, path)
+        }
+    }
+
+    // Fall back to returning just the original URL.
+    return Pair(vcsUrl, "")
+}
+
+/**
  * Create all missing intermediate directories without failing if any already exists.
  *
  * @throws IOException if any missing directory could not be created.

--- a/util/src/main/kotlin/Utils.kt
+++ b/util/src/main/kotlin/Utils.kt
@@ -87,11 +87,11 @@ fun getUserConfigDirectory() = File(System.getProperty("user.home"), ".ort")
 /**
  * Parse the standard output of a process as JSON.
  */
-fun parseJsonProcessOutput(workingDir: File, vararg command: String, multiJson: Boolean = false): JsonNode {
+fun parseJsonProcessOutput(workingDir: File, vararg command: String, jsonLines: Boolean = false): JsonNode {
     val process = ProcessCapture(workingDir, *command).requireSuccess()
 
     // Support parsing multiple lines with one JSON object per line by wrapping the whole output into a JSON array.
-    if (multiJson) {
+    if (jsonLines) {
         val array = JsonNodeFactory.instance.arrayNode()
         process.stdoutFile.readLines().forEach { array.add(jsonMapper.readTree(it)) }
         return array

--- a/util/src/main/kotlin/Utils.kt
+++ b/util/src/main/kotlin/Utils.kt
@@ -21,7 +21,6 @@ package com.here.ort.util
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 
@@ -83,56 +82,6 @@ object OkHttpClientHelper {
  * Return the directory to store user-specific configuration in.
  */
 fun getUserConfigDirectory() = File(System.getProperty("user.home"), ".ort")
-
-/**
- * Parse the standard output of a process as JSON.
- */
-fun parseJsonProcessOutput(workingDir: File, vararg command: String, jsonLines: Boolean = false): JsonNode {
-    val process = ProcessCapture(workingDir, *command).requireSuccess()
-
-    // Support parsing multiple lines with one JSON object per line by wrapping the whole output into a JSON array.
-    if (jsonLines) {
-        val array = JsonNodeFactory.instance.arrayNode()
-        process.stdoutFile.readLines().forEach { array.add(jsonMapper.readTree(it)) }
-        return array
-    }
-
-    return jsonMapper.readTree(process.stdout())
-}
-
-/**
- * Run a command to get its version.
- */
-fun getCommandVersion(command: String, versionArgument: String = "--version",
-                      semverType: Semver.SemverType = Semver.SemverType.LOOSE,
-                      transform: (String) -> String = { it }): Semver {
-    val version = ProcessCapture(command, versionArgument).requireSuccess()
-
-    var versionString = transform(version.stdout().trim())
-    if (versionString.isEmpty()) {
-        // Fall back to trying to read the version from stderr.
-        versionString = version.stderr().trim()
-    }
-
-    return Semver(versionString, semverType)
-}
-
-/**
- * Run a command to check it for specific version.
- */
-fun checkCommandVersion(command: String, expectedVersion: Semver, versionArgument: String = "--version",
-                        ignoreActualVersion: Boolean = false, transform: (String) -> String = { it }) {
-    val actualVersion = getCommandVersion(command, versionArgument, expectedVersion.type, transform)
-    if (actualVersion != expectedVersion) {
-        val messagePrefix = "Unsupported $command version $actualVersion, version $expectedVersion is "
-        if (ignoreActualVersion) {
-            println(messagePrefix + "expected.")
-            println("Still continuing because you chose to ignore the actual version.")
-        } else {
-            throw IOException(messagePrefix + "required.")
-        }
-    }
-}
 
 /**
  * Normalize a VCS URL by converting it to a common pattern. For example NPM defines some shortcuts for GitHub or GitLab

--- a/util/src/test/kotlin/UtilsTest.kt
+++ b/util/src/test/kotlin/UtilsTest.kt
@@ -116,4 +116,24 @@ class UtilsTest : WordSpec({
             }
         }
     }
+
+    "splitVcsPathFromUrl" should {
+        "not modify GitHub URLs without a path" {
+            val actual = splitVcsPathFromUrl("https://github.com/heremaps/oss-review-toolkit.git")
+            val expected = Pair("https://github.com/heremaps/oss-review-toolkit.git", "")
+            actual shouldBe expected
+        }
+
+        "properly split GitHub tree URLs" {
+            val actual = splitVcsPathFromUrl("https://github.com/babel/babel/tree/master/packages/babel-code-frame.git")
+            val expected = Pair("https://github.com/babel/babel.git", "packages/babel-code-frame")
+            actual shouldBe expected
+        }
+
+        "properly split GitHub blob URLs" {
+            val actual = splitVcsPathFromUrl("https://github.com/crypto-browserify/crypto-browserify/blob/6aebafa/test/create-hmac.js")
+            val expected = Pair("https://github.com/crypto-browserify/crypto-browserify.git", "test/create-hmac.js")
+            actual shouldBe expected
+        }
+    }
 })

--- a/util/src/test/kotlin/UtilsTest.kt
+++ b/util/src/test/kotlin/UtilsTest.kt
@@ -75,7 +75,7 @@ class UtilsTest : WordSpec({
             }
         }
 
-        "handle trailing slash correctly" {
+        "handle a trailing slash correctly" {
             val packages = mapOf(
                     "https://github.com/kilian/electron-to-chromium/"
                             to "https://github.com/kilian/electron-to-chromium.git",


### PR DESCRIPTION
Please have a look at the individual commit messages for the details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/18)
<!-- Reviewable:end -->
