### PR TITLE
Gradle: Upgrade to Kotlin 1.1.60

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     // We need to hard-code the version here because of
     // https://github.com/gradle/gradle/issues/1697
-    id 'org.jetbrains.kotlin.jvm' version '1.1.51' apply false
+    id 'org.jetbrains.kotlin.jvm' version '1.1.60' apply false
 
     // Note that the detekt Gradle plugin version does not necessarily
     // match the detekt tool version.
@@ -44,7 +44,7 @@ subprojects {
     }
 
     dependencies {
-        compile 'org.jetbrains.kotlin:kotlin-stdlib-jre8:1.1.51'
+        compile 'org.jetbrains.kotlin:kotlin-stdlib-jre8:1.1.60'
     }
 
     compileKotlin {


### PR DESCRIPTION
See https://blog.jetbrains.com/kotlin/2017/11/kotlin-1-1-60-is-out/.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/22)
<!-- Reviewable:end -->
