### PR TITLE
Develop/downloader fun tests

### DIFF
--- a/downloader/src/funTest/kotlin/DirectoryTest.kt
+++ b/downloader/src/funTest/kotlin/DirectoryTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2017 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.downloader
+
+import com.here.ort.model.Package
+import io.kotlintest.Spec
+import io.kotlintest.matchers.shouldBe
+import io.kotlintest.matchers.shouldThrow
+
+import io.kotlintest.specs.StringSpec
+
+class DirectoryTest : StringSpec() {
+
+    private val outputDir = createTempDir()
+
+    override fun interceptSpec(context: Spec, spec: () -> Unit) {
+        spec()
+        outputDir.deleteRecursively()
+    }
+
+    init {
+        "Creates directories for gradle submodules" {
+            val pkg = Package(
+                    packageManager = "Gradle",
+                    namespace = "",
+                    name = "project :model",
+                    version = "",
+                    declaredLicenses = sortedSetOf(),
+                    description = "",
+                    homepageUrl = "",
+                    downloadUrl = "",
+                    hash = "",
+                    hashAlgorithm = "",
+                    vcsProvider = "",
+                    vcsUrl = "",
+                    vcsRevision = "",
+                    vcsPath = ""
+                    )
+
+            // No download source specified, we expect exception in this case.
+            shouldThrow<DownloadException> {
+                Main.download(pkg, outputDir)
+            }
+
+            outputDir.list().size shouldBe 1
+            outputDir.list().first() shouldBe pkg.normalizedName
+        }
+
+    }
+}

--- a/downloader/src/funTest/kotlin/DownloaderTest.kt
+++ b/downloader/src/funTest/kotlin/DownloaderTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2017 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.downloader
+
+import com.here.ort.model.Package
+
+import io.kotlintest.Spec
+import io.kotlintest.matchers.beGreaterThan
+import io.kotlintest.matchers.contain
+import io.kotlintest.matchers.should
+import io.kotlintest.matchers.shouldBe
+import io.kotlintest.specs.StringSpec
+
+import java.io.File
+
+class DownloaderTest : StringSpec() {
+
+    private val outputDir = createTempDir()
+
+    override fun interceptSpec(context: Spec, spec: () -> Unit) {
+        spec()
+        outputDir.deleteRecursively()
+    }
+
+    init {
+        "Downloads gradle module by vcs path" {
+            val submoduleName = "model"
+            val pkg = Package(
+                    packageManager = "Gradle",
+                    namespace = "",
+                    name = "project :model",
+                    version = "",
+                    declaredLicenses = sortedSetOf(),
+                    description = "",
+                    homepageUrl = "",
+                    downloadUrl = "",
+                    hash = "",
+                    hashAlgorithm = "",
+                    vcsProvider = "Git",
+                    vcsUrl = "git@github.com:heremaps/oss-review-toolkit.git",
+                    vcsRevision = "",
+                    vcsPath = submoduleName
+                    )
+            Main.download(pkg, outputDir)
+            val downloadedProjectDir = File(outputDir, pkg.normalizedName)
+            val downloadedModuleDir = File(downloadedProjectDir, submoduleName)
+
+            outputDir.list().size shouldBe 1
+            outputDir.list().first() shouldBe pkg.normalizedName
+
+            downloadedProjectDir.isDirectory shouldBe true
+            downloadedModuleDir.isDirectory shouldBe true
+
+            downloadedModuleDir.list().size shouldBe beGreaterThan(1)
+
+            val moduleDirList = downloadedModuleDir.list().asList()
+            moduleDirList should contain("build.gradle")
+            moduleDirList should contain("src")
+        }.config(tags = setOf(Expensive))
+
+        "Downloads github oss-review-toolkit repo " {
+            val pkg = Package(
+                    packageManager = "Gradle",
+                    namespace = "",
+                    name = "oss-review-toolkit",
+                    version = "",
+                    declaredLicenses = sortedSetOf(),
+                    description = "",
+                    homepageUrl = "",
+                    downloadUrl = "",
+                    hash = "",
+                    hashAlgorithm = "",
+                    vcsProvider = "Git",
+                    vcsUrl = "git@github.com:heremaps/oss-review-toolkit.git",
+                    vcsRevision = "",
+                    vcsPath = ""
+                    )
+            try {
+                Main.download(pkg, outputDir)
+            } catch (exception: DownloadException) {
+
+            }
+
+            val downloadDir = File(outputDir, pkg.normalizedName)
+            val downloadedPkgDirList = downloadDir.list().asList()
+            print("dir listing: $downloadedPkgDirList")
+            outputDir.list().size shouldBe 1
+            outputDir.list().first() shouldBe pkg.normalizedName
+            downloadedPkgDirList should contain("build.gradle")
+            downloadedPkgDirList should contain("downloader")
+            downloadedPkgDirList should contain("scanner")
+            downloadedPkgDirList should contain("model")
+            downloadedPkgDirList should contain("analyzer")
+            downloadedPkgDirList should contain("util")
+            downloadedPkgDirList should contain("graph")
+            downloadedPkgDirList should contain("docs")
+        }.config(tags = setOf(Expensive))
+    }
+}

--- a/downloader/src/main/kotlin/Main.kt
+++ b/downloader/src/main/kotlin/Main.kt
@@ -184,7 +184,7 @@ object Main {
         val p = fun(string: String) = println("${target.identifier}: $string")
 
         // TODO: add namespace to path
-        val targetDir = File(outputDirectory, "${target.name}/${target.version}").apply { safeMkdirs() }
+        val targetDir = File(outputDirectory, "${target.normalizedName}/${target.version}").apply { safeMkdirs() }
         p("Downloading source code to '${targetDir.absolutePath}'...")
 
         if (target.normalizedVcsUrl.isNotBlank()) {

--- a/model/src/main/kotlin/Package.kt
+++ b/model/src/main/kotlin/Package.kt
@@ -22,6 +22,7 @@ package com.here.ort.model
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 
+import com.here.ort.util.normalizePackageName
 import com.here.ort.util.normalizeVcsUrl
 
 import com.vdurmont.semver4j.Semver
@@ -37,7 +38,7 @@ import java.util.SortedSet
  * dependency resolution process. For example, if multiple versions of the same package are used in a project, the build
  * system might decide to align on a single version of that package.
  */
-@JsonIgnoreProperties("identifier", "normalizedVcsUrl", "semverType")
+@JsonIgnoreProperties("identifier", "normalizedVcsUrl", "semverType", "normalizedName")
 data class Package(
         /**
          * The name of the package manager that was used to discover this package, for example Maven or NPM.
@@ -140,6 +141,13 @@ data class Package(
      * @see normalizeVcsUrl
      */
     val normalizedVcsUrl = normalizeVcsUrl(vcsUrl, semverType)
+
+    /**
+     * The normalized package name, so it can be used as downloaded package directory.
+     *
+     * @see normalizePackageName
+     */
+    val normalizedName = normalizePackageName(name)
 
     /**
      * Return a template [PackageReference] to refer to this [Package]. It is only a template because e.g. the

--- a/util/src/main/kotlin/Utils.kt
+++ b/util/src/main/kotlin/Utils.kt
@@ -143,6 +143,15 @@ fun normalizeVcsUrl(vcsUrl: String, semverType: Semver.SemverType = Semver.Semve
 }
 
 /**
+ * Normalize the given package [name] by replacing characters that are usually not supported by file systems of
+ * different operating systems, or that make the path hard to read (like spaces).
+ * @param name package name
+ */
+fun normalizePackageName(name: String) : String =  name.replace("[^\\w\\-_\\s]".toRegex(), "").trim()
+        .replace("\\s".toRegex(), "_")
+
+
+/**
  * Split a [vcsUrl] into a pair of strings denoting the base repository URL and the path within the repository.
  */
 fun splitVcsPathFromUrl(vcsUrl: String): Pair<String, String> {


### PR DESCRIPTION
1. normalize package names (for output directory name) before downloading (ex. gradle modules are named: "project :module")

2.  functional tests task added:
    - one test implemented: check if for packages which are gradle modules, directories are created
 

3.   integration tests tasks added with this test implemented:
     - test if oss-review-toolkit can be cloned from git repo
     - test if oss-review-toolkit single module can be cloned from git repo
     - test if oss-review-toolkit can be downloaded as ZIP file (using downloadUrl property) - failing test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/23)
<!-- Reviewable:end -->
