### PR TITLE
scanner: Add parameter --download-directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,7 @@ The `scanner` command line tool takes the following arguments:
 Usage: scanner [options]
   Options:
   * --output-dir, -o
-      The output directory to store the scan results and source code of
-      packages.
+      The output directory to store the scan results in.
     --summary-format, -f
       The list of file formats for the summary files.
       Default: [YAML]
@@ -178,6 +177,9 @@ Usage: scanner [options]
     --input-path, -i
       The input directory or file to scan. This parameter and
       --dependencies-file are mutually exclusive.
+    --download-dir
+      The output directory for downloaded source code. Defaults to 
+      <output-dir>/downloads.
     --stacktrace
       Print out the stacktrace for all exceptions.
       Default: false

--- a/scanner/src/main/kotlin/Main.kt
+++ b/scanner/src/main/kotlin/Main.kt
@@ -91,12 +91,17 @@ object Main {
             order = 0)
     private var inputPath: File? = null
 
-    @Parameter(description = "The output directory to store the scan results and source code of packages.",
+    @Parameter(description = "The output directory to store the scan results in.",
             names = arrayOf("--output-dir", "-o"),
             required = true,
             order = 0)
     @Suppress("LateinitUsage")
     private lateinit var outputDir: File
+
+    @Parameter(description = "The output directory for downloaded source code. Defaults to <output-dir>/downloads.",
+            names = arrayOf("--download-dir"),
+            order = 0)
+    private var downloadDir: File? = null
 
     @Parameter(description = "The scanner to use.",
             names = arrayOf("--scanner", "-s"),
@@ -169,6 +174,12 @@ object Main {
             "The output directory '${outputDir.absolutePath}' must not exist yet."
         }
 
+        downloadDir?.let {
+            require(!it.exists()) {
+                "The download directory '${it.absolutePath}' must not exist yet."
+            }
+        }
+
         if (configFile != null) {
             ScanResultsCache.configure(yamlMapper.readTree(configFile))
         }
@@ -223,7 +234,7 @@ object Main {
             val result = when (input) {
                 is Package -> {
                     entry.licenses.addAll(input.declaredLicenses)
-                    scanner.scan(input, outputDir)
+                    scanner.scan(input, outputDir, downloadDir)
                 }
                 is File -> scanner.scan(input, outputDir)
                 else -> throw IllegalArgumentException("Unsupported scan input.")

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -58,12 +58,14 @@ abstract class Scanner {
      *
      * @param pkg The package to scan.
      * @param outputDirectory The base directory to store scan results in.
+     * @param downloadDirectory The directory to download source code to. Defaults to [outputDirectory]/downloads if
+     *                          null.
      *
      * @return The set of found licenses.
      *
      * @throws ScanException In case the package could not be scanned.
      */
-    fun scan(pkg: Package, outputDirectory: File): ScannerResult {
+    fun scan(pkg: Package, outputDirectory: File, downloadDirectory: File? = null): ScannerResult {
         val scanResultsDirectory = File(outputDirectory, "scanResults").apply { safeMkdirs() }
         val scannerName = toString().toLowerCase()
 
@@ -79,7 +81,7 @@ abstract class Scanner {
         }
 
         val sourceDirectory = try {
-            val downloadDirectory = File(outputDirectory, "download").apply { safeMkdirs() }
+            val downloadDirectory = (downloadDirectory ?: File(outputDirectory, "downloads")).apply { safeMkdirs() }
             Main.download(pkg, downloadDirectory)
         } catch (e: DownloadException) {
             if (Main.stacktrace) {


### PR DESCRIPTION
Add a parameter to set a download-directory to separate downloaded source
code from scan results.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/33)
<!-- Reviewable:end -->
