### PR TITLE
Scanner: Do not shadow the downloadDirectory variable

### DIFF
--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -81,8 +81,7 @@ abstract class Scanner {
         }
 
         val sourceDirectory = try {
-            val downloadDirectory = (downloadDirectory ?: File(outputDirectory, "downloads")).apply { safeMkdirs() }
-            Main.download(pkg, downloadDirectory)
+            Main.download(pkg, downloadDirectory ?: File(outputDirectory, "downloads"))
         } catch (e: DownloadException) {
             if (Main.stacktrace) {
                 e.printStackTrace()


### PR DESCRIPTION
While at it, remove a superfluous call to safeMkdirs() as that is done
inside download() anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/38)
<!-- Reviewable:end -->
