### PR TITLE
AppVeyor: Upload test results also in case of test failures

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ build_script:
 test_script:
   - gradlew check
 
-after_test:
+on_finish:
   - gradlew --stop # Fix "fileHashes.bin" being used by another process.
   - ps: |
       $url = "https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)"


### PR DESCRIPTION
Esp. in case of test failures we are interested in the results, but
after_test is only called on success, so use on_finish instead. Also see

http://help.appveyor.com/discussions/questions/1479-after_test-not-invoked-when-test-fails

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/39)
<!-- Reviewable:end -->
