### PR TITLE
Maven: Do not override getPathForLocalArtifact()

### DIFF
--- a/analyzer/src/main/kotlin/managers/Maven.kt
+++ b/analyzer/src/main/kotlin/managers/Maven.kt
@@ -285,16 +285,8 @@ class Maven : PackageManager() {
         override fun find(session: RepositorySystemSession, request: LocalMetadataRequest): LocalMetadataResult =
                 localRepositoryManager.find(session, request)
 
-        override fun getPathForLocalArtifact(artifact: Artifact): String {
-            log.debug { "Request path for local artifact: $artifact" }
-
-            projectsByIdentifier[artifact.identifier()]?.let {
-                log.debug { "Found cached artifact: ${it.pomFile}" }
-                return it.pomFile.absolutePath
-            }
-
-            return localRepositoryManager.getPathForLocalArtifact(artifact)
-        }
+        override fun getPathForLocalArtifact(artifact: Artifact): String =
+                localRepositoryManager.getPathForLocalArtifact(artifact)
 
         override fun getPathForLocalMetadata(metadata: Metadata)
                 : String = localRepositoryManager.getPathForLocalMetadata(metadata)


### PR DESCRIPTION
Do not override the function from LocalRepositoryManager. It is not
required for the implementation to work, because it is only used when
adding new artifacts to the repository.

Also the implementation of the function was wrong, it is supposed to return
the path to the artifact relative to the root of the local repository, not
an absolute path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/43)
<!-- Reviewable:end -->
