### PR TITLE
Introduce a class to represent a local VCS working directory

### DIFF
--- a/analyzer/src/funTest/kotlin/GradleTest.kt
+++ b/analyzer/src/funTest/kotlin/GradleTest.kt
@@ -30,9 +30,9 @@ import java.io.File
 
 class GradleTest : StringSpec() {
     private val projectDir = File("src/funTest/assets/projects/synthetic/gradle")
-    private val vcs = VersionControlSystem.fromDirectory(projectDir)!!
-    private val vcsRevision = vcs.getWorkingRevision(projectDir)
-    private val vcsUrl = vcs.getRemoteUrl(projectDir)
+    private val vcsDir = VersionControlSystem.fromDirectory(projectDir)!!
+    private val vcsRevision = vcsDir.getRevision()
+    private val vcsUrl = vcsDir.getRemoteUrl()
 
     private fun patchExpectedResult(filename: String) =
             File(projectDir.parentFile, filename)

--- a/analyzer/src/funTest/kotlin/GradleTest.kt
+++ b/analyzer/src/funTest/kotlin/GradleTest.kt
@@ -30,7 +30,7 @@ import java.io.File
 
 class GradleTest : StringSpec() {
     private val projectDir = File("src/funTest/assets/projects/synthetic/gradle")
-    private val vcsDir = VersionControlSystem.fromDirectory(projectDir)!!
+    private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     private val vcsRevision = vcsDir.getRevision()
     private val vcsUrl = vcsDir.getRemoteUrl()
 

--- a/analyzer/src/funTest/kotlin/MavenTest.kt
+++ b/analyzer/src/funTest/kotlin/MavenTest.kt
@@ -30,7 +30,7 @@ import java.io.File
 
 class MavenTest : StringSpec() {
     private val syntheticProjectDir = File("src/funTest/assets/projects/synthetic/maven")
-    private val vcsDir = VersionControlSystem.fromDirectory(syntheticProjectDir)!!
+    private val vcsDir = VersionControlSystem.forDirectory(syntheticProjectDir)!!
     private val vcsRevision = vcsDir.getRevision()
     private val vcsUrl = vcsDir.getRemoteUrl()
 

--- a/analyzer/src/funTest/kotlin/MavenTest.kt
+++ b/analyzer/src/funTest/kotlin/MavenTest.kt
@@ -30,9 +30,9 @@ import java.io.File
 
 class MavenTest : StringSpec() {
     private val syntheticProjectDir = File("src/funTest/assets/projects/synthetic/maven")
-    private val vcs = VersionControlSystem.fromDirectory(syntheticProjectDir)!!
-    private val vcsRevision = vcs.getWorkingRevision(syntheticProjectDir)
-    private val vcsUrl = vcs.getRemoteUrl(syntheticProjectDir)
+    private val vcsDir = VersionControlSystem.fromDirectory(syntheticProjectDir)!!
+    private val vcsRevision = vcsDir.getRevision()
+    private val vcsUrl = vcsDir.getRemoteUrl()
 
     private fun patchExpectedResult(filename: String) =
             File(syntheticProjectDir.parentFile, filename)

--- a/analyzer/src/funTest/kotlin/NpmTest.kt
+++ b/analyzer/src/funTest/kotlin/NpmTest.kt
@@ -35,7 +35,8 @@ import java.io.File
 
 class NpmTest : WordSpec() {
     private val projectDir = File("src/funTest/assets/projects/synthetic/project-npm")
-    private val vcsRevision = VersionControlSystem.fromDirectory(projectDir)!!.getWorkingRevision(projectDir)
+    private val vcsDir = VersionControlSystem.fromDirectory(projectDir)!!
+    private val vcsRevision = vcsDir.getRevision()
 
     @Suppress("CatchException")
     override fun interceptTestCase(context: TestCaseContext, test: () -> Unit) {

--- a/analyzer/src/funTest/kotlin/NpmTest.kt
+++ b/analyzer/src/funTest/kotlin/NpmTest.kt
@@ -35,7 +35,7 @@ import java.io.File
 
 class NpmTest : WordSpec() {
     private val projectDir = File("src/funTest/assets/projects/synthetic/project-npm")
-    private val vcsDir = VersionControlSystem.fromDirectory(projectDir)!!
+    private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     private val vcsRevision = vcsDir.getRevision()
 
     @Suppress("CatchException")

--- a/analyzer/src/main/kotlin/Main.kt
+++ b/analyzer/src/main/kotlin/Main.kt
@@ -211,7 +211,7 @@ object Main {
         if (managedProjectPaths.isEmpty()) {
             println("No package-managed projects found.")
 
-            val vcsDir = VersionControlSystem.fromDirectory(absoluteProjectPath)
+            val vcsDir = VersionControlSystem.forDirectory(absoluteProjectPath)
             val project = Project(
                     packageManager = "",
                     namespace = "",

--- a/analyzer/src/main/kotlin/Main.kt
+++ b/analyzer/src/main/kotlin/Main.kt
@@ -211,7 +211,7 @@ object Main {
         if (managedProjectPaths.isEmpty()) {
             println("No package-managed projects found.")
 
-            val vcs = VersionControlSystem.fromDirectory(absoluteProjectPath)
+            val vcsDir = VersionControlSystem.fromDirectory(absoluteProjectPath)
             val project = Project(
                     packageManager = "",
                     namespace = "",
@@ -219,10 +219,10 @@ object Main {
                     version = "",
                     declaredLicenses = sortedSetOf(),
                     aliases = emptyList(),
-                    vcsProvider = vcs?.toString() ?: "",
-                    vcsUrl = vcs?.getRemoteUrl(absoluteProjectPath) ?: "",
-                    vcsRevision = vcs?.getWorkingRevision(absoluteProjectPath) ?: "",
-                    vcsPath = vcs?.getPathToRoot(absoluteProjectPath) ?: "",
+                    vcsProvider = vcsDir?.getProvider() ?: "",
+                    vcsUrl = vcsDir?.getRemoteUrl() ?: "",
+                    vcsRevision = vcsDir?.getRevision() ?: "",
+                    vcsPath = vcsDir?.getPathToRoot(absoluteProjectPath) ?: "",
                     homepageUrl = "",
                     scopes = sortedSetOf()
             )

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -112,7 +112,7 @@ class Gradle : PackageManager() {
                 Scope(configuration.name, true, dependencies.toSortedSet())
             }
 
-            val vcsDir = VersionControlSystem.fromDirectory(projectDir)
+            val vcsDir = VersionControlSystem.forDirectory(projectDir)
             val project = Project(
                     packageManager = javaClass.simpleName,
                     namespace = "",

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -112,7 +112,7 @@ class Gradle : PackageManager() {
                 Scope(configuration.name, true, dependencies.toSortedSet())
             }
 
-            val vcs = VersionControlSystem.fromDirectory(projectDir)
+            val vcsDir = VersionControlSystem.fromDirectory(projectDir)
             val project = Project(
                     packageManager = javaClass.simpleName,
                     namespace = "",
@@ -120,10 +120,10 @@ class Gradle : PackageManager() {
                     version = "",
                     declaredLicenses = sortedSetOf(),
                     aliases = emptyList(),
-                    vcsProvider = vcs?.toString() ?: "",
-                    vcsUrl = vcs?.getRemoteUrl(projectDir) ?: "",
-                    vcsRevision = vcs?.getWorkingRevision(projectDir) ?: "",
-                    vcsPath = vcs?.getPathToRoot(projectDir) ?: "",
+                    vcsProvider = vcsDir?.getProvider() ?: "",
+                    vcsUrl = vcsDir?.getRemoteUrl() ?: "",
+                    vcsRevision = vcsDir?.getRevision() ?: "",
+                    vcsPath = vcsDir?.getPathToRoot(projectDir) ?: "",
                     homepageUrl = "",
                     scopes = scopes.toSortedSet()
             )

--- a/analyzer/src/main/kotlin/managers/Maven.kt
+++ b/analyzer/src/main/kotlin/managers/Maven.kt
@@ -107,7 +107,7 @@ class Maven : PackageManager() {
 
         val vcsInfo = maven.parseVcsInfo(mavenProject).let {
             if (it.isEmpty()) {
-                VersionControlSystem.fromDirectory(projectDir).let {
+                VersionControlSystem.forDirectory(projectDir).let {
                     MavenSupport.VcsInfo(
                             it?.getProvider() ?: "",
                             it?.getRemoteUrl() ?: "",

--- a/analyzer/src/main/kotlin/managers/Maven.kt
+++ b/analyzer/src/main/kotlin/managers/Maven.kt
@@ -107,11 +107,16 @@ class Maven : PackageManager() {
 
         val vcsInfo = maven.parseVcsInfo(mavenProject).let {
             if (it.isEmpty()) {
-                val vcs = VersionControlSystem.fromDirectory(projectDir)
-                MavenSupport.VcsInfo(vcs?.toString() ?: "", vcs?.getRemoteUrl(projectDir) ?: "",
-                        vcs?.getWorkingRevision(projectDir) ?: "")
+                VersionControlSystem.fromDirectory(projectDir).let {
+                    MavenSupport.VcsInfo(
+                            it?.getProvider() ?: "",
+                            it?.getRemoteUrl() ?: "",
+                            it?.getRevision() ?: ""
+                    )
+                }
             } else it
         }
+
         val project = Project(
                 packageManager = javaClass.simpleName,
                 namespace = mavenProject.groupId,

--- a/analyzer/src/main/kotlin/managers/NPM.kt
+++ b/analyzer/src/main/kotlin/managers/NPM.kt
@@ -381,7 +381,7 @@ class NPM : PackageManager() {
         val homepageUrl = json["homepage"].asTextOrEmpty()
 
         val projectDir = packageJson.parentFile
-        val vcsDir = VersionControlSystem.fromDirectory(projectDir)
+        val vcsDir = VersionControlSystem.forDirectory(projectDir)
 
         val vcsProviderFromDirectory = vcsDir?.getProvider() ?: ""
         if (vcsProviderFromDirectory != vcsProviderFromPackage) {

--- a/analyzer/src/main/kotlin/managers/NPM.kt
+++ b/analyzer/src/main/kotlin/managers/NPM.kt
@@ -381,9 +381,9 @@ class NPM : PackageManager() {
         val homepageUrl = json["homepage"].asTextOrEmpty()
 
         val projectDir = packageJson.parentFile
-        val vcs = VersionControlSystem.fromDirectory(projectDir)
+        val vcsDir = VersionControlSystem.fromDirectory(projectDir)
 
-        val vcsProviderFromDirectory = vcs?.toString() ?: ""
+        val vcsProviderFromDirectory = vcsDir?.getProvider() ?: ""
         if (vcsProviderFromDirectory != vcsProviderFromPackage) {
             log.warn {
                 "The VCS provider '$vcsProviderFromPackage' specified in 'package.json' does not match " +
@@ -392,7 +392,7 @@ class NPM : PackageManager() {
             }
         }
 
-        val vcsUrlFromDirectory = vcs?.getRemoteUrl(projectDir) ?: ""
+        val vcsUrlFromDirectory = vcsDir?.getRemoteUrl() ?: ""
         if (vcsUrlFromDirectory != vcsUrlFromPackage) {
             log.warn {
                 "The VCS URL '$vcsUrlFromPackage' specified in 'package.json' does not match " +
@@ -410,8 +410,8 @@ class NPM : PackageManager() {
                 aliases = emptyList(),
                 vcsProvider = vcsProviderFromPackage,
                 vcsUrl = vcsUrlFromPackage,
-                vcsRevision = vcs?.getWorkingRevision(projectDir) ?: "",
-                vcsPath = vcs?.getPathToRoot(projectDir) ?: "",
+                vcsRevision = vcsDir?.getRevision() ?: "",
+                vcsPath = vcsDir?.getPathToRoot(projectDir) ?: "",
                 homepageUrl = homepageUrl,
                 scopes = scopes
         )

--- a/analyzer/src/main/kotlin/managers/PIP.kt
+++ b/analyzer/src/main/kotlin/managers/PIP.kt
@@ -220,7 +220,7 @@ class PIP : PackageManager() {
                 Scope("install", true, installDependencies)
         )
 
-        val vcs = VersionControlSystem.fromDirectory(projectDir)
+        val vcsDir = VersionControlSystem.fromDirectory(projectDir)
         val project = Project(
                 packageManager = javaClass.simpleName,
                 namespace = "",
@@ -228,10 +228,10 @@ class PIP : PackageManager() {
                 version = projectVersion,
                 declaredLicenses = sortedSetOf(),  // TODO: Get the licenses for local projects.
                 aliases = emptyList(),
-                vcsProvider = vcs?.toString() ?: "",
-                vcsUrl = vcs?.getRemoteUrl(projectDir) ?: "",
-                vcsRevision = vcs?.getWorkingRevision(projectDir) ?: "",
-                vcsPath = vcs?.getPathToRoot(projectDir) ?: "",
+                vcsProvider = vcsDir?.getProvider() ?: "",
+                vcsUrl = vcsDir?.getRemoteUrl() ?: "",
+                vcsRevision = vcsDir?.getRevision() ?: "",
+                vcsPath = vcsDir?.getPathToRoot(projectDir) ?: "",
                 homepageUrl = projectHomepage,
                 scopes = scopes
         )

--- a/analyzer/src/main/kotlin/managers/PIP.kt
+++ b/analyzer/src/main/kotlin/managers/PIP.kt
@@ -220,7 +220,7 @@ class PIP : PackageManager() {
                 Scope("install", true, installDependencies)
         )
 
-        val vcsDir = VersionControlSystem.fromDirectory(projectDir)
+        val vcsDir = VersionControlSystem.forDirectory(projectDir)
         val project = Project(
                 packageManager = javaClass.simpleName,
                 namespace = "",

--- a/downloader/build.gradle
+++ b/downloader/build.gradle
@@ -9,4 +9,6 @@ dependencies {
     compile project(':util')
 
     compile "com.beust:jcommander:$jcommanderVersion"
+
+    testCompile "io.kotlintest:kotlintest:$kotlintestVersion"
 }

--- a/downloader/src/main/kotlin/Main.kt
+++ b/downloader/src/main/kotlin/Main.kt
@@ -207,12 +207,12 @@ object Main {
 
             if (applicableVcs == null && target.vcsProvider.isNotBlank()) {
                 p("from provider name '${target.vcsProvider}'...")
-                applicableVcs = VersionControlSystem.fromProvider(target.vcsProvider)
+                applicableVcs = VersionControlSystem.forProvider(target.vcsProvider)
             }
 
             if (applicableVcs == null && target.normalizedVcsUrl.isNotBlank()) {
                 p("from URL '${target.normalizedVcsUrl}'...")
-                applicableVcs = VersionControlSystem.fromUrl(target.normalizedVcsUrl)
+                applicableVcs = VersionControlSystem.forUrl(target.normalizedVcsUrl)
             }
 
             if (applicableVcs == null) {

--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -39,17 +39,17 @@ abstract class VersionControlSystem {
         /**
          * Return the applicable VCS for the given [vcsProvider], or null if none is applicable.
          */
-        fun fromProvider(vcsProvider: String) = ALL.find { it.isApplicableProvider(vcsProvider) }
+        fun forProvider(vcsProvider: String) = ALL.find { it.isApplicableProvider(vcsProvider) }
 
         /**
          * Return the applicable VCS for the given [vcsUrl], or null if none is applicable.
          */
-        fun fromUrl(vcsUrl: String) = ALL.find { it.isApplicableUrl(vcsUrl) }
+        fun forUrl(vcsUrl: String) = ALL.find { it.isApplicableUrl(vcsUrl) }
 
         /**
          * Return the applicable VCS for the given [vcsDirectory], or null if none is applicable.
          */
-        fun fromDirectory(vcsDirectory: File) =
+        fun forDirectory(vcsDirectory: File) =
             ALL.map {
                 it.getWorkingDirectory(vcsDirectory)
             }.find {

--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -49,7 +49,12 @@ abstract class VersionControlSystem {
         /**
          * Return the applicable VCS for the given [vcsDirectory], or null if none is applicable.
          */
-        fun fromDirectory(vcsDirectory: File) = ALL.find { it.isApplicableDirectory(vcsDirectory) }
+        fun fromDirectory(vcsDirectory: File) =
+            ALL.map {
+                it.getWorkingDirectory(vcsDirectory)
+            }.find {
+                it.isValid()
+            }
     }
 
     /**
@@ -58,14 +63,44 @@ abstract class VersionControlSystem {
     override fun toString(): String = javaClass.simpleName
 
     /**
-     * Use this VCS to download the source code from the specified URL.
-     *
-     * @return A String identifying the revision that was downloaded.
-     *
-     * @throws DownloadException In case the download failed.
+     * A class representing a local VCS working directory.
      */
-    abstract fun download(vcsUrl: String, vcsRevision: String?, vcsPath: String?, version: String, targetDir: File)
-            : String
+    abstract inner class WorkingDirectory(val workingDir: File) {
+        /**
+         * Return a simple string representation for the VCS this working directory belongs to.
+         */
+        fun getProvider() = this@VersionControlSystem.toString()
+
+        /**
+         * Return true if the [workingDir] is managed by this VCS, false otherwise.
+         */
+        abstract fun isValid(): Boolean
+
+        /**
+         * Return the clone URL of the associated remote repository.
+         */
+        abstract fun getRemoteUrl(): String
+
+        /**
+         * Return the VCS-specific working directory revision.
+         */
+        abstract fun getRevision(): String
+
+        /**
+         * Return the VCS root for the given [path].
+         */
+        abstract fun getRootPath(path: File): String
+
+        /**
+         * Return the relative path to [path] with respect to the VCS root.
+         */
+        abstract fun getPathToRoot(path: File): String
+    }
+
+    /**
+     * Return a working directory instance for this VCS.
+     */
+    abstract fun getWorkingDirectory(vcsDirectory: File): WorkingDirectory
 
     /**
      * Return true if the provider name matches this VCS. For example for SVN it should return true on "svn",
@@ -81,22 +116,12 @@ abstract class VersionControlSystem {
     abstract fun isApplicableUrl(vcsUrl: String): Boolean
 
     /**
-     * Return true if the specified local directory is managed by this VCS, false otherwise.
+     * Use this VCS to download the source code from the specified URL.
+     *
+     * @return A String identifying the revision that was downloaded.
+     *
+     * @throws DownloadException In case the download failed.
      */
-    abstract fun isApplicableDirectory(vcsDirectory: File): Boolean
-
-    /**
-     * Return the relative path of [workingDir] with respect to the VCS root directory.
-     */
-    abstract fun getPathToRoot(workingDir: File): String
-
-    /**
-     * Return the VCS-specific revision for the given [workingDir].
-     */
-    abstract fun getWorkingRevision(workingDir: File): String
-
-    /**
-     * Return the URL of the (remote) repository the [workingDir] was cloned from.
-     */
-    abstract fun getRemoteUrl(workingDir: File): String
+    abstract fun download(vcsUrl: String, vcsRevision: String?, vcsPath: String?, version: String, targetDir: File)
+            : String
 }

--- a/downloader/src/main/kotlin/vcs/Git.kt
+++ b/downloader/src/main/kotlin/vcs/Git.kt
@@ -32,26 +32,41 @@ import java.io.File
 import java.io.IOException
 
 abstract class GitBase : VersionControlSystem() {
+    override fun getWorkingDirectory(vcsDirectory: File) =
+            object : WorkingDirectory(vcsDirectory) {
+                override fun isValid(): Boolean {
+                    val isInsideWorkTree = ProcessCapture(workingDir, "git", "rev-parse", "--is-inside-work-tree")
+                    return isInsideWorkTree.exitValue() == 0 && isInsideWorkTree.stdout().trimEnd().toBoolean()
+                }
 
-    override fun getPathToRoot(workingDir: File): String {
-        return runGitCommand(workingDir, "rev-parse", "--show-prefix").stdout().trimEnd('\n', '/')
-    }
+                override fun getRemoteUrl() =
+                    runGitCommand(workingDir, "remote", "get-url", "origin").stdout().trimEnd()
 
-    override fun getWorkingRevision(workingDir: File): String {
-        return runGitCommand(workingDir, "rev-parse", "HEAD").stdout().trimEnd()
-    }
+                override fun getRevision() =
+                    runGitCommand(workingDir, "rev-parse", "HEAD").stdout().trimEnd()
 
-    override fun getRemoteUrl(workingDir: File): String {
-        return runGitCommand(workingDir, "remote", "get-url", "origin").stdout().trimEnd()
-    }
+                override fun getRootPath(path: File) =
+                    runGitCommand(workingDir, "rev-parse", "--show-toplevel").stdout().trimEnd('\n', '/')
 
-    protected fun runGitCommand(workingDir: File, vararg args: String): ProcessCapture {
-        return ProcessCapture(workingDir, "git", *args).requireSuccess()
-    }
+                override fun getPathToRoot(path: File): String {
+                    val absolutePath = if (path.isAbsolute || path == workingDir) {
+                        path
+                    } else {
+                        workingDir.resolve(path)
+                    }
 
+                    return runGitCommand(absolutePath, "rev-parse", "--show-prefix").stdout().trimEnd('\n', '/')
+                }
+            }
+
+    protected fun runGitCommand(workingDir: File, vararg args: String) =
+        ProcessCapture(workingDir, "git", *args).requireSuccess()
 }
 
 object Git : GitBase() {
+    override fun isApplicableProvider(vcsProvider: String) = vcsProvider.equals("git", true)
+
+    override fun isApplicableUrl(vcsUrl: String) = vcsUrl.endsWith(".git")
 
     /**
      * Clones the Git repository using the native Git command.
@@ -69,6 +84,8 @@ object Git : GitBase() {
             runGitCommand(targetDir, "init")
             runGitCommand(targetDir, "remote", "add", "origin", vcsUrl)
 
+            val workingDir = getWorkingDirectory(targetDir)
+
             if (vcsPath != null && vcsPath.isNotEmpty()) {
                 log.info { "Configuring Git to do sparse checkout of path '$vcsPath'." }
                 runGitCommand(targetDir, "config", "core.sparseCheckout", "true")
@@ -82,7 +99,7 @@ object Git : GitBase() {
             try {
                 runGitCommand(targetDir, "fetch", "origin", committish)
                 runGitCommand(targetDir, "checkout", "FETCH_HEAD")
-                return getWorkingRevision(targetDir)
+                return workingDir.getRevision()
             } catch (e: IOException) {
                 if (Main.stacktrace) {
                     e.printStackTrace()
@@ -100,7 +117,7 @@ object Git : GitBase() {
 
             try {
                 runGitCommand(targetDir, "checkout", committish)
-                return getWorkingRevision(targetDir)
+                return workingDir.getRevision()
             } catch (e: IOException) {
                 if (Main.stacktrace) {
                     e.printStackTrace()
@@ -124,7 +141,7 @@ object Git : GitBase() {
                     log.info { "Using '$tag'." }
                     runGitCommand(targetDir, "fetch", "origin", tag)
                     runGitCommand(targetDir, "checkout", "FETCH_HEAD")
-                    return getWorkingRevision(targetDir)
+                    return workingDir.getRevision()
                 }
 
                 log.warn { "No matching tag found for version '$version'." }
@@ -140,14 +157,4 @@ object Git : GitBase() {
             throw DownloadException("Could not clone $vcsUrl.", e)
         }
     }
-
-    override fun isApplicableProvider(vcsProvider: String) = vcsProvider.equals("git", true)
-
-    override fun isApplicableUrl(vcsUrl: String) = vcsUrl.endsWith(".git")
-
-    override fun isApplicableDirectory(vcsDirectory: File): Boolean {
-        val isInsideWorkTree = ProcessCapture(vcsDirectory, "git", "rev-parse", "--is-inside-work-tree")
-        return isInsideWorkTree.exitValue() == 0 && isInsideWorkTree.stdout().trimEnd().toBoolean()
-    }
-
 }

--- a/downloader/src/test/kotlin/VersionControlSystemTest.kt
+++ b/downloader/src/test/kotlin/VersionControlSystemTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2017 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.downloader
+
+import io.kotlintest.matchers.shouldBe
+import io.kotlintest.specs.WordSpec
+
+import java.io.File
+
+class VersionControlSystemTest : WordSpec({
+    val vcsRoot = File("..").canonicalFile
+    val relProjDir = File("src/test")
+    val absProjDir = relProjDir.absoluteFile
+
+    "For an absolute working directory, getPathToRoot()" should {
+        val absVcsDir = VersionControlSystem.forDirectory(absProjDir)!!
+
+        "work if given absolute paths" {
+            absVcsDir.getPathToRoot(vcsRoot) shouldBe ""
+            absVcsDir.getPathToRoot(vcsRoot.resolve("downloader/src")) shouldBe "downloader/src"
+            absVcsDir.getPathToRoot(absProjDir.resolve("kotlin")) shouldBe "downloader/src/test/kotlin"
+        }
+
+        "work if given relative paths" {
+            absVcsDir.getPathToRoot(File(".")) shouldBe "downloader/src/test"
+            absVcsDir.getPathToRoot(File("..")) shouldBe "downloader/src"
+            absVcsDir.getPathToRoot(File("kotlin")) shouldBe "downloader/src/test/kotlin"
+        }
+    }
+
+    "For a relative working directory, getPathToRoot()" should {
+        val relVcsDir = VersionControlSystem.forDirectory(relProjDir)!!
+
+        "work if given absolute paths" {
+            relVcsDir.getPathToRoot(vcsRoot) shouldBe ""
+            relVcsDir.getPathToRoot(vcsRoot.resolve("downloader/src")) shouldBe "downloader/src"
+            relVcsDir.getPathToRoot(absProjDir.resolve("kotlin")) shouldBe "downloader/src/test/kotlin"
+        }
+
+        "work if given relative paths" {
+            relVcsDir.getPathToRoot(relProjDir) shouldBe "downloader/src/test"
+            relVcsDir.getPathToRoot(File("..")) shouldBe "downloader/src"
+            relVcsDir.getPathToRoot(File("kotlin")) shouldBe "downloader/src/test/kotlin"
+        }
+    }
+})


### PR DESCRIPTION
Previously, the call to fromDirectory() and e.g. to a succeeding call to
getRemoteUrl() both needed to get the workingDir passed. With the
intermediate WorkingDirectory class this is not needed anymore as it
stores the workingDir internally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/44)
<!-- Reviewable:end -->
