### PR TITLE
Set a max-age of 0 to have Artifactory validate cached responses

### DIFF
--- a/scanner/src/main/kotlin/ArtifactoryCache.kt
+++ b/scanner/src/main/kotlin/ArtifactoryCache.kt
@@ -27,7 +27,9 @@ import com.here.ort.util.log
 
 import java.io.File
 import java.net.HttpURLConnection
+import java.util.concurrent.TimeUnit
 
+import okhttp3.CacheControl
 import okhttp3.Request
 
 class ArtifactoryCache(
@@ -42,6 +44,7 @@ class ArtifactoryCache(
 
         val request = Request.Builder()
                 .header("X-JFrog-Art-Api", apiToken)
+                .cacheControl(CacheControl.Builder().maxAge(0, TimeUnit.SECONDS).build())
                 .get()
                 .url("$url/$cachePath")
                 .build()


### PR DESCRIPTION
Otherwise we might continue using scan results from the local cache
although they have already been deleted from Artifactory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/47)
<!-- Reviewable:end -->
