### PR TITLE
scanner: Do not read the native result file format twice

### DIFF
--- a/scanner/src/funTest/kotlin/ScanPathTest.kt
+++ b/scanner/src/funTest/kotlin/ScanPathTest.kt
@@ -32,7 +32,7 @@ class ScanPathTest : StringSpec() {
     init {
         "ScanCode recognizes our own LICENSE" {
             val result = ScanCode.scan(File("../LICENSE"), outputDir)
-            result shouldBe setOf("Apache-2.0")
+            result.licenses shouldBe setOf("Apache-2.0")
         }
     }
 }

--- a/scanner/src/main/kotlin/Main.kt
+++ b/scanner/src/main/kotlin/Main.kt
@@ -239,7 +239,7 @@ object Main {
                 is File -> scanner.scan(input, outputDir)
                 else -> throw IllegalArgumentException("Unsupported scan input.")
             }
-            entry.licenses.addAll(result)
+            entry.licenses.addAll(result.licenses)
 
             println("Found licenses for '$identifier': ${entry.licenses.joinToString()}")
         } catch (e: ScanException) {

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -28,8 +28,6 @@ import com.here.ort.util.safeMkdirs
 import java.io.File
 import java.util.SortedSet
 
-typealias ScannerResult = SortedSet<String>
-
 abstract class Scanner {
 
     companion object {
@@ -43,6 +41,8 @@ abstract class Scanner {
             )
         }
     }
+
+    data class Result(val licenses: SortedSet<String>, val errors: SortedSet<String>)
 
     /**
      * Return the Java class name as a simply way to refer to the scanner.
@@ -65,7 +65,7 @@ abstract class Scanner {
      *
      * @throws ScanException In case the package could not be scanned.
      */
-    fun scan(pkg: Package, outputDirectory: File, downloadDirectory: File? = null): ScannerResult {
+    fun scan(pkg: Package, outputDirectory: File, downloadDirectory: File? = null): Result {
         val scanResultsDirectory = File(outputDirectory, "scanResults").apply { safeMkdirs() }
         val scannerName = toString().toLowerCase()
 
@@ -77,7 +77,7 @@ abstract class Scanner {
                 "${pkg.name}-${pkgRevision}_$scannerName.$resultFileExtension")
 
         if (ScanResultsCache.read(pkg, resultsFile)) {
-            return toScannerResult(resultsFile)
+            return getResult(resultsFile)
         }
 
         val sourceDirectory = try {
@@ -104,7 +104,7 @@ abstract class Scanner {
      *
      * @throws ScanException In case the package could not be scanned.
      */
-    fun scan(path: File, outputDirectory: File): ScannerResult {
+    fun scan(path: File, outputDirectory: File): Result {
         val scanResultsDirectory = File(outputDirectory, "scanResults").apply { safeMkdirs() }
         val scannerName = toString().toLowerCase()
         val resultsFile = File(scanResultsDirectory,
@@ -121,11 +121,11 @@ abstract class Scanner {
     /**
      * Scan the provided [path] for license information, writing results to [resultsFile].
      */
-    protected abstract fun scanPath(path: File, resultsFile: File): ScannerResult
+    protected abstract fun scanPath(path: File, resultsFile: File): Result
 
     /**
-     * Convert the scanner's native file format to a [ScannerResult].
+     * Convert the scanner's native file format to a [Result].
      */
-    protected abstract fun toScannerResult(resultsFile: File): ScannerResult
+    internal abstract fun getResult(resultsFile: File): Result
 
 }

--- a/scanner/src/test/kotlin/ScanCodeTest.kt
+++ b/scanner/src/test/kotlin/ScanCodeTest.kt
@@ -31,13 +31,15 @@ class ScanCodeTest : WordSpec({
         "return true for scan results with only timeout errors" {
             val resultFileName = "/esprima-2.7.3_scancode-2.2.1.post59.970c46191.json"
             val resultFile = File(Resources.javaClass.getResource(resultFileName).toURI())
-            ScanCode.hasOnlyTimeoutErrors(resultFile) shouldBe true
+            val result = ScanCode.getResult(resultFile)
+            ScanCode.hasOnlyTimeoutErrors(result) shouldBe true
         }
 
         "return false for scan results without errors" {
             val resultFileName = "/esprima-2.7.3_scancode-2.2.1.json"
             val resultFile = File(Resources.javaClass.getResource(resultFileName).toURI())
-            ScanCode.hasOnlyTimeoutErrors(resultFile) shouldBe false
+            val result = ScanCode.getResult(resultFile)
+            ScanCode.hasOnlyTimeoutErrors(result) shouldBe false
         }
     }
 })


### PR DESCRIPTION
Add errors to an extended scan result class so we can parse the errors
at the same time as the licenses to not call readTree() twice on the
native JSON result file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/50)
<!-- Reviewable:end -->
