### PR TITLE
Gradle: add settings.gradle to glob patterns of definition files

### DIFF
--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -60,7 +60,7 @@ class Gradle : PackageManager() {
     companion object : PackageManagerFactory<Gradle>(
             "https://gradle.org/",
             "Java",
-            listOf("build.gradle")
+            listOf("build.gradle", "settings.gradle")
     ) {
         override fun create() = Gradle()
     }


### PR DESCRIPTION
Change matcher for gradle projects, so it matches custom build files names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/53)
<!-- Reviewable:end -->
