### PR TITLE
Ensure sbt does not produce ANSI output so matching works corrently

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
@@ -61,3 +61,4 @@ packages:
   vcs_url: "git@github.com:hamcrest/JavaHamcrest.git/hamcrest-core"
   vcs_revision: "HEAD"
   vcs_path: ""
+errors: []

--- a/analyzer/src/main/kotlin/managers/SBT.kt
+++ b/analyzer/src/main/kotlin/managers/SBT.kt
@@ -72,7 +72,7 @@ class SBT : PackageManager() {
              checkCommandVersion(
                      command(workingDir),
                      Requirement.buildIvy("[0.13.0,)"),
-                     versionArgument = "sbtVersion",
+                     versionArguments = "\"-Dsbt.log.noformat=true\" sbtVersion",
                      workingDir = workingDir,
                      ignoreActualVersion = Main.ignoreVersions,
                      transform = this::extractLowestSbtVersion

--- a/util/src/main/kotlin/ProcessCapture.kt
+++ b/util/src/main/kotlin/ProcessCapture.kt
@@ -106,12 +106,12 @@ class ProcessCapture(workingDir: File?, vararg command: String) {
 fun checkCommandVersion(
         command: String,
         requirement: Requirement,
-        versionArgument: String = "--version",
+        versionArguments: String = "--version",
         workingDir: File? = null,
         ignoreActualVersion: Boolean = false,
         transform: (String) -> String = { it }
 ) {
-    val actualVersion = getCommandVersion(command, versionArgument, workingDir, transform)
+    val actualVersion = getCommandVersion(command, versionArguments, workingDir, transform)
     if (!requirement.isSatisfiedBy(actualVersion)) {
         val message = "Unsupported $command version $actualVersion does not fulfill $requirement."
         if (ignoreActualVersion) {
@@ -127,11 +127,12 @@ fun checkCommandVersion(
  */
 fun getCommandVersion(
         command: String,
-        versionArgument: String = "--version",
+        versionArguments: String = "--version",
         workingDir: File? = null,
         transform: (String) -> String = { it }
 ): String {
-    val version = ProcessCapture(workingDir, command, versionArgument).requireSuccess()
+    val commandLine = arrayOf(command).plus(versionArguments.split(' '))
+    val version = ProcessCapture(workingDir, *commandLine).requireSuccess()
 
     var versionString = transform(version.stdout().trim())
     if (versionString.isEmpty()) {


### PR DESCRIPTION
Extend getCommandVersion() to be able to receive multiple
space-separated arguments to we can additionally pass
"-Dsbt.log.noformat=true" to sbt. At least for Windows, this argument
needs to be quoted currently because of

https://github.com/sbt/sbt/issues/2695

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/57)
<!-- Reviewable:end -->
