### PR TITLE
SBT: Only quote sbt.log.noformat on Windows

### DIFF
--- a/analyzer/src/main/kotlin/managers/SBT.kt
+++ b/analyzer/src/main/kotlin/managers/SBT.kt
@@ -69,10 +69,20 @@ class SBT : PackageManager() {
              // Note that "sbt sbtVersion" behaves differently when executed inside or outside an SBT project, see
              // https://stackoverflow.com/a/20337575/1127485.
              val workingDir = definitionFiles.first().parentFile
+
+             // See https://github.com/sbt/sbt/issues/2695.
+             val sbtLogNoformat = "-Dsbt.log.noformat=true".let {
+                 if (OS.isWindows) {
+                     "\"$it\""
+                 } else {
+                     it
+                 }
+             }
+
              checkCommandVersion(
                      command(workingDir),
                      Requirement.buildIvy("[0.13.0,)"),
-                     versionArguments = "\"-Dsbt.log.noformat=true\" sbtVersion",
+                     versionArguments = "$sbtLogNoformat sbtVersion",
                      workingDir = workingDir,
                      ignoreActualVersion = Main.ignoreVersions,
                      transform = this::extractLowestSbtVersion


### PR DESCRIPTION
This breaks on Linux otherwise, which went unnoticed by CI due to
another problem with calling System.exit() as part of MainTest.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/59)
<!-- Reviewable:end -->
