### PR TITLE
analyzer: Only convert the package manager name to upper case for comparison

### DIFF
--- a/analyzer/src/funTest/kotlin/MainTest.kt
+++ b/analyzer/src/funTest/kotlin/MainTest.kt
@@ -31,7 +31,7 @@ import java.io.PrintStream
  * A test for the main entry point of the application.
  */
 class MainTest : StringSpec() {
-    private val inputDir = File("src/funTest/assets/projects/synthetic/project-npm/package-lock")
+    private val syntheticProjectDir = File("src/funTest/assets/projects/synthetic")
     private val outputDir = createTempDir()
 
     override fun interceptSpec(context: Spec, spec: () -> Unit) {
@@ -40,7 +40,34 @@ class MainTest : StringSpec() {
     }
 
     init {
+        "Activating only Gradle works" {
+            val inputDir = File(syntheticProjectDir, "gradle")
+
+            // Redirect standard output to a stream.
+            val standardOut = System.out
+            val streamOut = ByteArrayOutputStream()
+            System.setOut(PrintStream(streamOut))
+
+            Main.main(arrayOf(
+                    "-m", "Gradle",
+                    "-i", inputDir.path,
+                    "-o", File(outputDir, "gradle").path
+            ))
+
+            // Restore standard output.
+            System.setOut(standardOut)
+            val lines = streamOut.toString().lines()
+
+            lines.component1() shouldBe "The following package managers are activated:"
+            lines.component2() shouldBe "\tGradle"
+            lines.component3() shouldBe "Scanning project path:"
+            lines.component4() shouldBe "\t" + inputDir.absolutePath
+            lines.component5() shouldBe "Gradle projects found in:"
+        }
+
         "Activating only NPM works" {
+            val inputDir = File(syntheticProjectDir, "project-npm/package-lock")
+
             // Redirect standard output to a stream.
             val standardOut = System.out
             val streamOut = ByteArrayOutputStream()

--- a/analyzer/src/main/kotlin/Main.kt
+++ b/analyzer/src/main/kotlin/Main.kt
@@ -52,7 +52,7 @@ object Main {
     private class PackageManagerConverter : IStringConverter<PackageManagerFactory<PackageManager>> {
         companion object {
             // Map upper-cased package manager class names to their instances.
-            val PACKAGE_MANAGER_NAMES = PackageManager.ALL.associateBy { it.toString() }
+            val PACKAGE_MANAGER_NAMES = PackageManager.ALL.associateBy { it.toString().toUpperCase() }
         }
 
         override fun convert(name: String): PackageManagerFactory<PackageManager> {

--- a/analyzer/src/main/kotlin/PackageManagerFactory.kt
+++ b/analyzer/src/main/kotlin/PackageManagerFactory.kt
@@ -44,7 +44,7 @@ abstract class PackageManagerFactory<out T : PackageManager>(
      * Return the Java class name to make JCommander display a proper name in list parameters of this custom type.
      */
     override fun toString() =
-            javaClass.name.toUpperCase().substringBefore('$').substringAfterLast('.')
+            javaClass.name.substringBefore('$').substringAfterLast('.')
 
     /**
      * The glob matchers for all definition files.


### PR DESCRIPTION
Add a test to only enable "Gradle" to ensure it is not called "GRADLE"
in the console output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/60)
<!-- Reviewable:end -->
