### PR TITLE
Git: Exit early in isValid() if the working directory does not exist

### DIFF
--- a/downloader/src/main/kotlin/vcs/Git.kt
+++ b/downloader/src/main/kotlin/vcs/Git.kt
@@ -35,6 +35,10 @@ abstract class GitBase : VersionControlSystem() {
     override fun getWorkingDirectory(vcsDirectory: File) =
             object : WorkingDirectory(vcsDirectory) {
                 override fun isValid(): Boolean {
+                    if (!workingDir.isDirectory) {
+                        return false
+                    }
+
                     val isInsideWorkTree = ProcessCapture(workingDir, "git", "rev-parse", "--is-inside-work-tree")
                     return isInsideWorkTree.exitValue() == 0 && isInsideWorkTree.stdout().trimEnd().toBoolean()
                 }


### PR DESCRIPTION
This avoid an IOException during the real check in case the working
directory does not exist.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/66)
<!-- Reviewable:end -->
