### PR TITLE
util: Correctly handle GitHub SSH URLs

### DIFF
--- a/util/src/main/kotlin/Utils.kt
+++ b/util/src/main/kotlin/Utils.kt
@@ -93,8 +93,8 @@ fun getUserConfigDirectory() = File(System.getProperty("user.home"), ".ort")
 fun normalizeVcsUrl(vcsUrl: String, semverType: Semver.SemverType = Semver.SemverType.STRICT): String {
     var url = vcsUrl.trimEnd('/')
 
-    if (url.startsWith("git@github.com:")) {
-        url = url.replace("git@github.com:", "https://github.com/")
+    url = url.replace(Regex("(.+://)?git@github\\.com[:/](.+)")) {
+        "ssh://git@github.com/${it.groupValues[2]}"
     }
 
     // A hierarchical URI looks like
@@ -129,7 +129,7 @@ fun normalizeVcsUrl(vcsUrl: String, semverType: Semver.SemverType = Semver.Semve
         return File(url).toSafeURI().toString()
     }
 
-    if (uri.host != null && uri.host.endsWith("github.com")) {
+    if (uri.scheme != "ssh" && uri.host != null && uri.host.endsWith("github.com")) {
         // Ensure the path ends in ".git".
         val path = if (uri.path.endsWith(".git")) uri.path else uri.path + ".git"
 
@@ -139,8 +139,7 @@ fun normalizeVcsUrl(vcsUrl: String, semverType: Semver.SemverType = Semver.Semve
         return "https://" + host + path
     }
 
-    // Return the URL unmodified.
-    return uri.toString()
+    return url
 }
 
 /**

--- a/util/src/test/kotlin/UtilsTest.kt
+++ b/util/src/test/kotlin/UtilsTest.kt
@@ -49,16 +49,27 @@ class UtilsTest : WordSpec({
             }
         }
 
-        "convert non-https to anonymous https for GitHub URLs" {
+        "properly handle anonymous Git / HTTPS URL schemes" {
             val packages = mapOf(
                     "git://github.com/cheeriojs/cheerio.git"
                             to "https://github.com/cheeriojs/cheerio.git",
                     "git+https://github.com/fb55/boolbase.git"
                             to "https://github.com/fb55/boolbase.git",
-                    "git+ssh://git@github.com/logicalparadox/idris.git"
-                            to "https://github.com/logicalparadox/idris.git",
                     "https://www.github.com/DefinitelyTyped/DefinitelyTyped.git"
                             to "https://github.com/DefinitelyTyped/DefinitelyTyped.git"
+            )
+
+            packages.forEach { actualUrl, expectedUrl ->
+                normalizeVcsUrl(actualUrl) shouldBe expectedUrl
+            }
+        }
+
+        "properly handle authenticated SSH URL schemes" {
+            val packages = mapOf(
+                    "git+ssh://git@github.com/logicalparadox/idris.git"
+                            to "ssh://git@github.com/logicalparadox/idris.git",
+                    "git@github.com:heremaps/oss-review-toolkit.git"
+                            to "ssh://git@github.com/heremaps/oss-review-toolkit.git"
             )
 
             packages.forEach { actualUrl, expectedUrl ->


### PR DESCRIPTION
SSH URLs, which are always authenticated, must not be turned into HTTPS
URLs as that avoids private GitHub repositories to be scanned.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/68)
<!-- Reviewable:end -->
