### PR TITLE
ProcessCapture: use min 3 chars length prefix when creating tmp files

### DIFF
--- a/util/src/main/kotlin/ProcessCapture.kt
+++ b/util/src/main/kotlin/ProcessCapture.kt
@@ -38,11 +38,13 @@ class ProcessCapture(workingDir: File?, vararg command: String) {
 
     val commandLine = command.joinToString(" ")
 
-    @Suppress("UnsafeCallOnNullableType")
-    val stdoutFile = File.createTempFile(command.first(), ".stdout")!!
+    private val tempPrefix = command.first().padEnd(3, '_')
 
     @Suppress("UnsafeCallOnNullableType")
-    val stderrFile = File.createTempFile(command.first(), ".stderr")!!
+    val stdoutFile = File.createTempFile(tempPrefix, ".stdout")!!
+
+    @Suppress("UnsafeCallOnNullableType")
+    val stderrFile = File.createTempFile(tempPrefix, ".stderr")!!
 
     private val builder = ProcessBuilder(*command)
             .directory(workingDir)


### PR DESCRIPTION
`File.createTempFile` fun requires prefix with minimum length of 3. 
Current implementation fails for shorter commands (ex. Mercurial's `hg`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/77)
<!-- Reviewable:end -->
