### PR TITLE
Gradle: Also show exception causes in error messages

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/project-gradle-expected-output-lib-without-repo.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/project-gradle-expected-output-lib-without-repo.yml
@@ -25,8 +25,8 @@ project:
       version: ""
       dependencies: []
       errors:
-      - "Unresolved: Cannot resolve external dependency org.apache.commons:commons-text:1.1\
-        \ because no repositories are defined."
+      - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
+        \ org.apache.commons:commons-text:1.1 because no repositories are defined."
   - name: "compileClasspath"
     delivered: true
     dependencies:
@@ -35,8 +35,8 @@ project:
       version: ""
       dependencies: []
       errors:
-      - "Unresolved: Cannot resolve external dependency org.apache.commons:commons-text:1.1\
-        \ because no repositories are defined."
+      - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
+        \ org.apache.commons:commons-text:1.1 because no repositories are defined."
   - name: "compileOnly"
     delivered: true
     dependencies: []
@@ -48,8 +48,8 @@ project:
       version: ""
       dependencies: []
       errors:
-      - "Unresolved: Cannot resolve external dependency org.apache.commons:commons-text:1.1\
-        \ because no repositories are defined."
+      - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
+        \ org.apache.commons:commons-text:1.1 because no repositories are defined."
   - name: "runtime"
     delivered: true
     dependencies:
@@ -58,8 +58,8 @@ project:
       version: ""
       dependencies: []
       errors:
-      - "Unresolved: Cannot resolve external dependency org.apache.commons:commons-text:1.1\
-        \ because no repositories are defined."
+      - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
+        \ org.apache.commons:commons-text:1.1 because no repositories are defined."
   - name: "runtimeClasspath"
     delivered: true
     dependencies:
@@ -68,8 +68,8 @@ project:
       version: ""
       dependencies: []
       errors:
-      - "Unresolved: Cannot resolve external dependency org.apache.commons:commons-text:1.1\
-        \ because no repositories are defined."
+      - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
+        \ org.apache.commons:commons-text:1.1 because no repositories are defined."
   - name: "testCompile"
     delivered: true
     dependencies:
@@ -78,15 +78,15 @@ project:
       version: ""
       dependencies: []
       errors:
-      - "Unresolved: Cannot resolve external dependency junit:junit:4.12 because no\
-        \ repositories are defined."
+      - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
+        \ junit:junit:4.12 because no repositories are defined."
     - namespace: ""
       name: "org.apache.commons:commons-text:1.1"
       version: ""
       dependencies: []
       errors:
-      - "Unresolved: Cannot resolve external dependency org.apache.commons:commons-text:1.1\
-        \ because no repositories are defined."
+      - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
+        \ org.apache.commons:commons-text:1.1 because no repositories are defined."
   - name: "testCompileClasspath"
     delivered: true
     dependencies:
@@ -95,15 +95,15 @@ project:
       version: ""
       dependencies: []
       errors:
-      - "Unresolved: Cannot resolve external dependency junit:junit:4.12 because no\
-        \ repositories are defined."
+      - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
+        \ junit:junit:4.12 because no repositories are defined."
     - namespace: ""
       name: "org.apache.commons:commons-text:1.1"
       version: ""
       dependencies: []
       errors:
-      - "Unresolved: Cannot resolve external dependency org.apache.commons:commons-text:1.1\
-        \ because no repositories are defined."
+      - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
+        \ org.apache.commons:commons-text:1.1 because no repositories are defined."
   - name: "testCompileOnly"
     delivered: true
     dependencies: []
@@ -115,15 +115,15 @@ project:
       version: ""
       dependencies: []
       errors:
-      - "Unresolved: Cannot resolve external dependency junit:junit:4.12 because no\
-        \ repositories are defined."
+      - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
+        \ junit:junit:4.12 because no repositories are defined."
     - namespace: ""
       name: "org.apache.commons:commons-text:1.1"
       version: ""
       dependencies: []
       errors:
-      - "Unresolved: Cannot resolve external dependency org.apache.commons:commons-text:1.1\
-        \ because no repositories are defined."
+      - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
+        \ org.apache.commons:commons-text:1.1 because no repositories are defined."
   - name: "testRuntimeClasspath"
     delivered: true
     dependencies:
@@ -132,15 +132,15 @@ project:
       version: ""
       dependencies: []
       errors:
-      - "Unresolved: Cannot resolve external dependency junit:junit:4.12 because no\
-        \ repositories are defined."
+      - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
+        \ junit:junit:4.12 because no repositories are defined."
     - namespace: ""
       name: "org.apache.commons:commons-text:1.1"
       version: ""
       dependencies: []
       errors:
-      - "Unresolved: Cannot resolve external dependency org.apache.commons:commons-text:1.1\
-        \ because no repositories are defined."
+      - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
+        \ org.apache.commons:commons-text:1.1 because no repositories are defined."
 packages: []
 errors:
 - "Configuration 'apiElements' cannot be resolved."

--- a/analyzer/src/main/resources/init.gradle
+++ b/analyzer/src/main/resources/init.gradle
@@ -143,7 +143,7 @@ class DependencyTreePlugin implements Plugin<Gradle> {
                     if (result instanceof ResolvedArtifactResult) {
                         pomFile = result.file.absolutePath
                     } else if (result instanceof UnresolvedArtifactResult) {
-                        error = result.failure.message
+                        error = collectCauses(result.failure).toString()
                     } else {
                         error = "Unknown ArtifactResult type: ${result.getClass().name}".toString()
                     }
@@ -157,11 +157,21 @@ class DependencyTreePlugin implements Plugin<Gradle> {
                 }
             } else if (dependencyResult instanceof UnresolvedDependencyResult) {
                 return new DependencyImpl("", dependencyResult.attempted.displayName, "", [],
-                        "Unresolved: ${dependencyResult.failure.message}".toString(), "")
+                        "Unresolved: ${collectCauses(dependencyResult.failure)}".toString(), "")
             } else {
                 return new DependencyImpl("", dependencyResult.requested.displayName, "", [],
                         "Unknown result type: ${dependencyResult.getClass().simpleName}".toString(), "")
             }
+        }
+
+        private String collectCauses(Throwable throwable) {
+            def result = "${throwable.getClass().simpleName}: ${throwable.message}"
+            def cause = throwable.cause
+            while (cause != null) {
+                result += "\nCaused by: ${cause.getClass().simpleName}: ${cause.message}"
+                cause = cause.cause
+            }
+            return result
         }
     }
 


### PR DESCRIPTION
Collect the messages from all exception causes for resolution errors. This
simplifies debugging as usually the most helpful message is in the root
cause.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/108)
<!-- Reviewable:end -->
