### PR TITLE
UtilsTest: Also test to encode ":" properly

### DIFF
--- a/util/src/test/kotlin/UtilsTest.kt
+++ b/util/src/test/kotlin/UtilsTest.kt
@@ -37,6 +37,10 @@ class UtilsTest : WordSpec({
             ".".fileSystemEncode() shouldBe "%2E"
         }
 
+        "encode ':'" {
+            ":".fileSystemEncode() shouldBe "%3A"
+        }
+
         "create a valid file name" {
             val fileFromStr = File(createTempDir(), str.fileSystemEncode()).apply { writeText("dummy") }
             fileFromStr.isFile shouldBe true


### PR DESCRIPTION
This is the drive letter separator on Windows and must not be used
literally in a file name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/123)
<!-- Reviewable:end -->
