### PR TITLE
Gradle: Guard against circular dependencies

### DIFF
--- a/analyzer/src/main/resources/init.gradle
+++ b/analyzer/src/main/resources/init.gradle
@@ -110,7 +110,7 @@ class DependencyTreePlugin implements Plugin<Gradle> {
             List<Configuration> configurations = project.configurations.collect { configuration ->
                 if (configuration.isCanBeResolved()) {
                     ResolutionResult result = configuration.getIncoming().getResolutionResult()
-                    List<Dependency> dependencies = result.getRoot().getDependencies().collect { parseDependency(it, project) }
+                    List<Dependency> dependencies = result.getRoot().getDependencies().collect { parseDependency(it, project, []) }
 
                     new ConfigurationImpl(configuration.name, dependencies)
                 } else {
@@ -124,10 +124,15 @@ class DependencyTreePlugin implements Plugin<Gradle> {
             return new DependencyTreeModelImpl(project.name, configurations, repositories, errors)
         }
 
-        Dependency parseDependency(DependencyResult dependencyResult, Project project) {
+        Dependency parseDependency(DependencyResult dependencyResult, Project project, List<String> parents) {
             if (dependencyResult instanceof ResolvedDependencyResult) {
-                List<Dependency> dependencies = dependencyResult.selected.dependencies.collect { dependency ->
-                    parseDependency(dependency, project)
+                List<Dependency> dependencies = dependencyResult.selected.dependencies.findResults { dependency ->
+                    // Do not follow circular dependencies, these can exist for project dependencies.
+                    if (!(dependencyResult.requested.displayName in parents)) {
+                        parseDependency(dependency, project, [*parents, dependencyResult.requested.displayName])
+                    } else {
+                        null
+                    }
                 }
 
                 ComponentIdentifier id = dependencyResult.selected.id


### PR DESCRIPTION
Project dependencies in Gradle can be circular which caused a stack overflow
in the recursive parseDependency method. To fix it do not continue building
the dependency tree when a dependency was already seen on the same branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/124)
<!-- Reviewable:end -->
