### PR TITLE
Store original and processed VcsInfo instead of only a normalizedVcsUrl

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
@@ -13,6 +13,11 @@ project:
     url: "git@github.com:soc/directories.git"
     revision: "HEAD"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "git@github.com:soc/directories.git"
+    revision: "HEAD"
+    path: ""
   homepage_url: "https://github.com/soc/directories"
   scopes:
   - name: "compile"
@@ -51,6 +56,11 @@ packages:
     url: "git://github.com/junit-team/junit.git"
     revision: "r4.12"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "git://github.com/junit-team/junit.git"
+    revision: "r4.12"
+    path: ""
 - package_manager: "Maven"
   namespace: "org.hamcrest"
   name: "hamcrest-core"
@@ -70,6 +80,11 @@ packages:
     hash: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
     hash_algorithm: "SHA-1"
   vcs:
+    provider: "git"
+    url: "git@github.com:hamcrest/JavaHamcrest.git/hamcrest-core"
+    revision: "HEAD"
+    path: ""
+  vcs_original:
     provider: "git"
     url: "git@github.com:hamcrest/JavaHamcrest.git/hamcrest-core"
     revision: "HEAD"

--- a/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
@@ -12,6 +12,11 @@ project:
     url: "https://github.com/deis/example-python-flask.git"
     revision: "0773991e36a4c69b121cdb05146d6140347d4065"
     path: ""
+  vcs_original:
+    provider: "Git"
+    url: "https://github.com/deis/example-python-flask.git"
+    revision: "0773991e36a4c69b121cdb05146d6140347d4065"
+    path: ""
   homepage_url: ""
   scopes:
   - name: "install"
@@ -74,6 +79,11 @@ packages:
     url: ""
     revision: ""
     path: ""
+  vcs_original:
+    provider: ""
+    url: ""
+    revision: ""
+    path: ""
 - package_manager: "PIP"
   namespace: ""
   name: "Jinja2"
@@ -92,6 +102,11 @@ packages:
     hash: ""
     hash_algorithm: ""
   vcs:
+    provider: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_original:
     provider: ""
     url: ""
     revision: ""
@@ -117,6 +132,11 @@ packages:
     url: ""
     revision: ""
     path: ""
+  vcs_original:
+    provider: ""
+    url: ""
+    revision: ""
+    path: ""
 - package_manager: "PIP"
   namespace: ""
   name: "Werkzeug"
@@ -134,6 +154,11 @@ packages:
     hash: ""
     hash_algorithm: ""
   vcs:
+    provider: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_original:
     provider: ""
     url: ""
     revision: ""
@@ -159,6 +184,11 @@ packages:
     url: ""
     revision: ""
     path: ""
+  vcs_original:
+    provider: ""
+    url: ""
+    revision: ""
+    path: ""
 - package_manager: "PIP"
   namespace: ""
   name: "gunicorn"
@@ -176,6 +206,11 @@ packages:
     hash: ""
     hash_algorithm: ""
   vcs:
+    provider: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_original:
     provider: ""
     url: ""
     revision: ""
@@ -198,6 +233,11 @@ packages:
     hash: ""
     hash_algorithm: ""
   vcs:
+    provider: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_original:
     provider: ""
     url: ""
     revision: ""

--- a/analyzer/src/funTest/assets/projects/external/gradle-submodules/logging/expected-logging-integration-test-build-src-dependencies.yml
+++ b/analyzer/src/funTest/assets/projects/external/gradle-submodules/logging/expected-logging-integration-test-build-src-dependencies.yml
@@ -12,6 +12,11 @@ project:
     url: "https://github.com/gradle/gradle.git"
     revision: "d7ae8915b50c21a4862ee981f19f41dc38e38020"
     path: ""
+  vcs_original:
+    provider: "Git"
+    url: "https://github.com/gradle/gradle.git"
+    revision: "d7ae8915b50c21a4862ee981f19f41dc38e38020"
+    path: ""
   homepage_url: ""
   scopes: []
 packages: []

--- a/analyzer/src/funTest/assets/projects/external/gradle-submodules/logging/expected-logging-integration-test-dependencies.yml
+++ b/analyzer/src/funTest/assets/projects/external/gradle-submodules/logging/expected-logging-integration-test-dependencies.yml
@@ -12,6 +12,11 @@ project:
     url: "https://github.com/gradle/gradle.git"
     revision: "d7ae8915b50c21a4862ee981f19f41dc38e38020"
     path: ""
+  vcs_original:
+    provider: "Git"
+    url: "https://github.com/gradle/gradle.git"
+    revision: "d7ae8915b50c21a4862ee981f19f41dc38e38020"
+    path: ""
   homepage_url: ""
   scopes: []
 packages: []

--- a/analyzer/src/funTest/assets/projects/external/gradle-submodules/logging/expected-logging-integration-test-multi-threaded-dependencies.yml
+++ b/analyzer/src/funTest/assets/projects/external/gradle-submodules/logging/expected-logging-integration-test-multi-threaded-dependencies.yml
@@ -12,6 +12,11 @@ project:
     url: "https://github.com/gradle/gradle.git"
     revision: "d7ae8915b50c21a4862ee981f19f41dc38e38020"
     path: ""
+  vcs_original:
+    provider: "Git"
+    url: "https://github.com/gradle/gradle.git"
+    revision: "d7ae8915b50c21a4862ee981f19f41dc38e38020"
+    path: ""
   homepage_url: ""
   scopes: []
 packages: []

--- a/analyzer/src/funTest/assets/projects/external/gradle-submodules/logging/expected-logging-integration-test-nested-build-build-src-dependencies.yml
+++ b/analyzer/src/funTest/assets/projects/external/gradle-submodules/logging/expected-logging-integration-test-nested-build-build-src-dependencies.yml
@@ -12,6 +12,11 @@ project:
     url: "https://github.com/gradle/gradle.git"
     revision: "d7ae8915b50c21a4862ee981f19f41dc38e38020"
     path: ""
+  vcs_original:
+    provider: "Git"
+    url: "https://github.com/gradle/gradle.git"
+    revision: "d7ae8915b50c21a4862ee981f19f41dc38e38020"
+    path: ""
   homepage_url: ""
   scopes: []
 packages: []

--- a/analyzer/src/funTest/assets/projects/external/gradle-submodules/logging/expected-logging-integration-test-nested-build-dependencies.yml
+++ b/analyzer/src/funTest/assets/projects/external/gradle-submodules/logging/expected-logging-integration-test-nested-build-dependencies.yml
@@ -12,6 +12,11 @@ project:
     url: "https://github.com/gradle/gradle.git"
     revision: "d7ae8915b50c21a4862ee981f19f41dc38e38020"
     path: ""
+  vcs_original:
+    provider: "Git"
+    url: "https://github.com/gradle/gradle.git"
+    revision: "d7ae8915b50c21a4862ee981f19f41dc38e38020"
+    path: ""
   homepage_url: ""
   scopes: []
 packages: []

--- a/analyzer/src/funTest/assets/projects/external/gradle-submodules/logging/expected-logging-integration-test-project1-dependencies.yml
+++ b/analyzer/src/funTest/assets/projects/external/gradle-submodules/logging/expected-logging-integration-test-project1-dependencies.yml
@@ -12,6 +12,11 @@ project:
     url: "https://github.com/gradle/gradle.git"
     revision: "d7ae8915b50c21a4862ee981f19f41dc38e38020"
     path: ""
+  vcs_original:
+    provider: "Git"
+    url: "https://github.com/gradle/gradle.git"
+    revision: "d7ae8915b50c21a4862ee981f19f41dc38e38020"
+    path: ""
   homepage_url: ""
   scopes: []
 packages: []

--- a/analyzer/src/funTest/assets/projects/external/gradle-submodules/logging/expected-logging-integration-test-project2-dependencies.yml
+++ b/analyzer/src/funTest/assets/projects/external/gradle-submodules/logging/expected-logging-integration-test-project2-dependencies.yml
@@ -12,6 +12,11 @@ project:
     url: "https://github.com/gradle/gradle.git"
     revision: "d7ae8915b50c21a4862ee981f19f41dc38e38020"
     path: ""
+  vcs_original:
+    provider: "Git"
+    url: "https://github.com/gradle/gradle.git"
+    revision: "d7ae8915b50c21a4862ee981f19f41dc38e38020"
+    path: ""
   homepage_url: ""
   scopes: []
 packages: []

--- a/analyzer/src/funTest/assets/projects/external/gradle-submodules/wrapper/expected-wrapper-gradle-dependencies.yml
+++ b/analyzer/src/funTest/assets/projects/external/gradle-submodules/wrapper/expected-wrapper-gradle-dependencies.yml
@@ -12,6 +12,11 @@ project:
     url: "https://github.com/gradle/gradle.git"
     revision: "fdafeac26dbb661805dc3cbb5d54411fe72c5e86"
     path: ""
+  vcs_original:
+    provider: "Git"
+    url: "https://github.com/gradle/gradle.git"
+    revision: "fdafeac26dbb661805dc3cbb5d54411fe72c5e86"
+    path: ""
   homepage_url: ""
   scopes: []
 packages: []

--- a/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
@@ -12,6 +12,11 @@ project:
     url: "git://github.com:ccavanaugh/jgnash.git/jgnash-core"
     revision: "HEAD"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "git://github.com:ccavanaugh/jgnash.git/jgnash-core"
+    revision: "HEAD"
+    path: ""
   homepage_url: "http://sourceforge.net/projects/jgnash/jgnash-core/"
   scopes:
   - name: "compile"
@@ -223,6 +228,11 @@ packages:
     url: ""
     revision: ""
     path: ""
+  vcs_original:
+    provider: ""
+    url: ""
+    revision: ""
+    path: ""
 - package_manager: "Maven"
   namespace: "com.fasterxml"
   name: "classmate"
@@ -241,6 +251,11 @@ packages:
     hash: "818530d5e3e8f862d0aeefb4c2df8e07a1d9ad83"
     hash_algorithm: "SHA-1"
   vcs:
+    provider: "git"
+    url: "git@github.com:cowtowncoder/java-classmate.git"
+    revision: "classmate-1.3.0"
+    path: ""
+  vcs_original:
     provider: "git"
     url: "git@github.com:cowtowncoder/java-classmate.git"
     revision: "classmate-1.3.0"
@@ -269,6 +284,11 @@ packages:
     url: "git://github.com/virtuald/curvesapi.git"
     revision: "HEAD"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "git://github.com/virtuald/curvesapi.git"
+    revision: "HEAD"
+    path: ""
 - package_manager: "Maven"
   namespace: "com.h2database"
   name: "h2"
@@ -286,6 +306,11 @@ packages:
     hash: "60aba689ca3459012da9115f68c4dcfcceee51b2"
     hash_algorithm: "SHA-1"
   vcs:
+    provider: "git"
+    url: "https://github.com/h2database/h2database"
+    revision: "HEAD"
+    path: ""
+  vcs_original:
     provider: "git"
     url: "https://github.com/h2database/h2database"
     revision: "HEAD"
@@ -312,6 +337,11 @@ packages:
     url: "git@github.com:swaldman/c3p0.git"
     revision: "HEAD"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "git@github.com:swaldman/c3p0.git"
+    revision: "HEAD"
+    path: ""
 - package_manager: "Maven"
   namespace: "com.mchange"
   name: "mchange-commons-java"
@@ -330,6 +360,11 @@ packages:
     hash: "33a53955501fa830ecfc98d6ae611c6dc451946c"
     hash_algorithm: "SHA-1"
   vcs:
+    provider: "git"
+    url: "git@github.com:swaldman/mchange-commons-java.git"
+    revision: "HEAD"
+    path: ""
+  vcs_original:
     provider: "git"
     url: "git@github.com:swaldman/mchange-commons-java.git"
     revision: "HEAD"
@@ -355,6 +390,11 @@ packages:
     url: "https://github.com/x-stream/xstream.git/xstream-hibernate"
     revision: "v-1.4.x"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "https://github.com/x-stream/xstream.git/xstream-hibernate"
+    revision: "v-1.4.x"
+    path: ""
 - package_manager: "Maven"
   namespace: "com.thoughtworks.xstream"
   name: "xstream"
@@ -372,6 +412,11 @@ packages:
     hash: "a9eb7942e1c58d99d53226b13cc21b4b88cb5cab"
     hash_algorithm: "SHA-1"
   vcs:
+    provider: "git"
+    url: "https://github.com/x-stream/xstream.git/xstream"
+    revision: "v-1.4.x"
+    path: ""
+  vcs_original:
     provider: "git"
     url: "https://github.com/x-stream/xstream.git/xstream"
     revision: "v-1.4.x"
@@ -400,6 +445,11 @@ packages:
     url: "http://svn.apache.org/repos/asf/commons/proper/codec/trunk"
     revision: "HEAD"
     path: ""
+  vcs_original:
+    provider: "svn"
+    url: "http://svn.apache.org/repos/asf/commons/proper/codec/trunk"
+    revision: "HEAD"
+    path: ""
 - package_manager: "Maven"
   namespace: "dom4j"
   name: "dom4j"
@@ -416,6 +466,11 @@ packages:
     hash: "a8e7149359255f43e0e5e3b1837948f9ed5861fb"
     hash_algorithm: "SHA-1"
   vcs:
+    provider: "cvs"
+    url: "pserver:anonymous@cvs.sourceforge.net:/cvsroot/dom4j:dom4j"
+    revision: "HEAD"
+    path: ""
+  vcs_original:
     provider: "cvs"
     url: "pserver:anonymous@cvs.sourceforge.net:/cvsroot/dom4j:dom4j"
     revision: "HEAD"
@@ -443,6 +498,11 @@ packages:
     url: "git://github.com/netty/netty.git/netty-buffer"
     revision: "netty-4.1.9.Final"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "git://github.com/netty/netty.git/netty-buffer"
+    revision: "netty-4.1.9.Final"
+    path: ""
 - package_manager: "Maven"
   namespace: "io.netty"
   name: "netty-codec"
@@ -462,6 +522,11 @@ packages:
     hash: "086dc41eab00c51f56d384b3ea4772f3d7704e4a"
     hash_algorithm: "SHA-1"
   vcs:
+    provider: "git"
+    url: "git://github.com/netty/netty.git/netty-codec"
+    revision: "netty-4.1.9.Final"
+    path: ""
+  vcs_original:
     provider: "git"
     url: "git://github.com/netty/netty.git/netty-codec"
     revision: "netty-4.1.9.Final"
@@ -489,6 +554,11 @@ packages:
     url: "git://github.com/netty/netty.git/netty-common"
     revision: "netty-4.1.9.Final"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "git://github.com/netty/netty.git/netty-common"
+    revision: "netty-4.1.9.Final"
+    path: ""
 - package_manager: "Maven"
   namespace: "io.netty"
   name: "netty-resolver"
@@ -508,6 +578,11 @@ packages:
     hash: "2618cb7663514bfb77d2dd9bc8df2ba93ce141e7"
     hash_algorithm: "SHA-1"
   vcs:
+    provider: "git"
+    url: "git://github.com/netty/netty.git/netty-resolver"
+    revision: "netty-4.1.9.Final"
+    path: ""
+  vcs_original:
     provider: "git"
     url: "git://github.com/netty/netty.git/netty-resolver"
     revision: "netty-4.1.9.Final"
@@ -535,6 +610,11 @@ packages:
     url: "git://github.com/netty/netty.git/netty-transport"
     revision: "netty-4.1.9.Final"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "git://github.com/netty/netty.git/netty-transport"
+    revision: "netty-4.1.9.Final"
+    path: ""
 - package_manager: "Maven"
   namespace: "jgnash"
   name: "jgnash-resources"
@@ -551,6 +631,11 @@ packages:
     hash: ""
     hash_algorithm: ""
   vcs:
+    provider: "git"
+    url: "git://github.com:ccavanaugh/jgnash.git/jgnash-resources"
+    revision: "HEAD"
+    path: ""
+  vcs_original:
     provider: "git"
     url: "git://github.com:ccavanaugh/jgnash.git/jgnash-resources"
     revision: "HEAD"
@@ -577,6 +662,11 @@ packages:
     url: "git://github.com/junit-team/junit.git"
     revision: "r4.12"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "git://github.com/junit-team/junit.git"
+    revision: "r4.12"
+    path: ""
 - package_manager: "Maven"
   namespace: "log4j"
   name: "log4j"
@@ -594,6 +684,11 @@ packages:
     hash: "677abe279b68c5e7490d6d50c6951376238d7d3e"
     hash_algorithm: "SHA-1"
   vcs:
+    provider: "svn"
+    url: "http://svn.apache.org/repos/asf/logging/log4j/tags/v1_2_17_rc3"
+    revision: "HEAD"
+    path: ""
+  vcs_original:
     provider: "svn"
     url: "http://svn.apache.org/repos/asf/logging/log4j/tags/v1_2_17_rc3"
     revision: "HEAD"
@@ -622,6 +717,11 @@ packages:
     url: ""
     revision: "HEAD"
     path: ""
+  vcs_original:
+    provider: ""
+    url: ""
+    revision: "HEAD"
+    path: ""
 - package_manager: "Maven"
   namespace: "org.apache.commons"
   name: "commons-lang3"
@@ -641,6 +741,11 @@ packages:
     hash: "d2a489573c0ed2c4942b3660decad5d65087b406"
     hash_algorithm: "SHA-1"
   vcs:
+    provider: "svn"
+    url: "http://svn.apache.org/repos/asf/commons/proper/lang/trunk"
+    revision: "HEAD"
+    path: ""
+  vcs_original:
     provider: "svn"
     url: "http://svn.apache.org/repos/asf/commons/proper/lang/trunk"
     revision: "HEAD"
@@ -666,6 +771,11 @@ packages:
     url: ""
     revision: ""
     path: ""
+  vcs_original:
+    provider: ""
+    url: ""
+    revision: ""
+    path: ""
 - package_manager: "Maven"
   namespace: "org.apache.poi"
   name: "poi-ooxml"
@@ -683,6 +793,11 @@ packages:
     hash: "736eeb639587c8efa620d5f10fd6fee53ad1996f"
     hash_algorithm: "SHA-1"
   vcs:
+    provider: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_original:
     provider: ""
     url: ""
     revision: ""
@@ -708,6 +823,11 @@ packages:
     url: ""
     revision: ""
     path: ""
+  vcs_original:
+    provider: ""
+    url: ""
+    revision: ""
+    path: ""
 - package_manager: "Maven"
   namespace: "org.apache.xmlbeans"
   name: "xmlbeans"
@@ -725,6 +845,11 @@ packages:
     hash: ""
     hash_algorithm: ""
   vcs:
+    provider: "svn"
+    url: "https://svn.apache.org/repos/asf/xmlbeans/"
+    revision: "HEAD"
+    path: ""
+  vcs_original:
     provider: "svn"
     url: "https://svn.apache.org/repos/asf/xmlbeans/"
     revision: "HEAD"
@@ -751,6 +876,11 @@ packages:
     url: "git@github.com:hamcrest/JavaHamcrest.git/hamcrest-all"
     revision: "HEAD"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "git@github.com:hamcrest/JavaHamcrest.git/hamcrest-all"
+    revision: "HEAD"
+    path: ""
 - package_manager: "Maven"
   namespace: "org.hibernate.common"
   name: "hibernate-commons-annotations"
@@ -768,6 +898,11 @@ packages:
     hash: "203038e420aaa3fa6df8bad4fda19ca1e2824005"
     hash_algorithm: "SHA-1"
   vcs:
+    provider: "git"
+    url: "http://github.com/hibernate/hibernate-commons-annotations.git"
+    revision: "HEAD"
+    path: ""
+  vcs_original:
     provider: "git"
     url: "http://github.com/hibernate/hibernate-commons-annotations.git"
     revision: "HEAD"
@@ -795,6 +930,11 @@ packages:
     url: "http://github.com/hibernate/hibernate-jpa-api.git"
     revision: "HEAD"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "http://github.com/hibernate/hibernate-jpa-api.git"
+    revision: "HEAD"
+    path: ""
 - package_manager: "Maven"
   namespace: "org.hibernate"
   name: "hibernate-c3p0"
@@ -812,6 +952,11 @@ packages:
     hash: "eec7c630bc036b28e082949d5f9463bd9abc57b7"
     hash_algorithm: "SHA-1"
   vcs:
+    provider: "git"
+    url: "http://github.com/hibernate/hibernate-orm.git"
+    revision: "HEAD"
+    path: ""
+  vcs_original:
     provider: "git"
     url: "http://github.com/hibernate/hibernate-orm.git"
     revision: "HEAD"
@@ -837,6 +982,11 @@ packages:
     url: "http://github.com/hibernate/hibernate-orm.git"
     revision: "HEAD"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "http://github.com/hibernate/hibernate-orm.git"
+    revision: "HEAD"
+    path: ""
 - package_manager: "Maven"
   namespace: "org.hsqldb"
   name: "hsqldb"
@@ -854,6 +1004,11 @@ packages:
     hash: "a9174917777d96078daaa3b519088fe9ebc7b40e"
     hash_algorithm: "SHA-1"
   vcs:
+    provider: "svn"
+    url: "http://svn.code.sf.net/p/hsqldb/svn/base/"
+    revision: "2.4.0"
+    path: ""
+  vcs_original:
     provider: "svn"
     url: "http://svn.code.sf.net/p/hsqldb/svn/base/"
     revision: "2.4.0"
@@ -882,6 +1037,11 @@ packages:
     url: "git@github.com:jboss-javassist/javassist.git"
     revision: "HEAD"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "git@github.com:jboss-javassist/javassist.git"
+    revision: "HEAD"
+    path: ""
 - package_manager: "Maven"
   namespace: "org.jboss.logging"
   name: "jboss-logging"
@@ -899,6 +1059,11 @@ packages:
     hash: "3625e6818158ddb4754fa2ec51299e5f57e596b4"
     hash_algorithm: "SHA-1"
   vcs:
+    provider: "git"
+    url: "git://github.com/jboss-logging/jboss-logging.git"
+    revision: "HEAD"
+    path: ""
+  vcs_original:
     provider: "git"
     url: "git://github.com/jboss-logging/jboss-logging.git"
     revision: "HEAD"
@@ -925,6 +1090,11 @@ packages:
     url: "git@github.com:jboss/jboss-transaction-api_spec.git"
     revision: "jboss-transaction-api_1.2_spec-1.0.1.Final"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "git@github.com:jboss/jboss-transaction-api_spec.git"
+    revision: "jboss-transaction-api_1.2_spec-1.0.1.Final"
+    path: ""
 - package_manager: "Maven"
   namespace: "org.jboss"
   name: "jandex"
@@ -942,6 +1112,11 @@ packages:
     hash: "edc4552ad816df11579a8e02e19f778c77a915b5"
     hash_algorithm: "SHA-1"
   vcs:
+    provider: "git"
+    url: "git@github.com:jboss/jboss-parent-pom.git/jandex"
+    revision: "HEAD"
+    path: ""
+  vcs_original:
     provider: "git"
     url: "git@github.com:jboss/jboss-parent-pom.git/jandex"
     revision: "HEAD"
@@ -967,6 +1142,11 @@ packages:
     url: ""
     revision: "HEAD"
     path: ""
+  vcs_original:
+    provider: ""
+    url: ""
+    revision: "HEAD"
+    path: ""
 - package_manager: "Maven"
   namespace: "org.slf4j"
   name: "slf4j-log4j12"
@@ -984,6 +1164,11 @@ packages:
     hash: "16b1333786ea93d16bff6fb0f5e3b82716d1b008"
     hash_algorithm: "SHA-1"
   vcs:
+    provider: ""
+    url: ""
+    revision: "HEAD"
+    path: ""
+  vcs_original:
     provider: ""
     url: ""
     revision: "HEAD"

--- a/analyzer/src/funTest/assets/projects/external/jgnash-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/jgnash-expected-output.yml
@@ -12,6 +12,11 @@ project:
     url: "git://github.com:ccavanaugh/jgnash.git"
     revision: "HEAD"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "git://github.com:ccavanaugh/jgnash.git"
+    revision: "HEAD"
+    path: ""
   homepage_url: "http://sourceforge.net/projects/jgnash/"
   scopes:
   - name: "test"
@@ -50,6 +55,11 @@ packages:
     url: "git://github.com/junit-team/junit.git"
     revision: "r4.12"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "git://github.com/junit-team/junit.git"
+    revision: "r4.12"
+    path: ""
 - package_manager: "Maven"
   namespace: "org.hamcrest"
   name: "hamcrest-all"
@@ -68,6 +78,11 @@ packages:
     hash: "47e033b7ab18c5dbd5fe29fc1bd5a40afe028818"
     hash_algorithm: "SHA-1"
   vcs:
+    provider: "git"
+    url: "git@github.com:hamcrest/JavaHamcrest.git/hamcrest-all"
+    revision: "HEAD"
+    path: ""
+  vcs_original:
     provider: "git"
     url: "git@github.com:hamcrest/JavaHamcrest.git/hamcrest-all"
     revision: "HEAD"

--- a/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
@@ -12,6 +12,11 @@ project:
     url: "https://github.com/spdx/tools-python.git"
     revision: "a48022e65a8897d0e4f2e93d8e53695d2c13ea23"
     path: ""
+  vcs_original:
+    provider: "Git"
+    url: "https://github.com/spdx/tools-python.git"
+    revision: "a48022e65a8897d0e4f2e93d8e53695d2c13ea23"
+    path: ""
   homepage_url: "https://github.com/spdx/tools-python"
   scopes:
   - name: "install"
@@ -69,6 +74,11 @@ packages:
     url: ""
     revision: ""
     path: ""
+  vcs_original:
+    provider: ""
+    url: ""
+    revision: ""
+    path: ""
 - package_manager: "PIP"
   namespace: ""
   name: "ply"
@@ -90,6 +100,11 @@ packages:
     url: ""
     revision: ""
     path: ""
+  vcs_original:
+    provider: ""
+    url: ""
+    revision: ""
+    path: ""
 - package_manager: "PIP"
   namespace: ""
   name: "pyparsing"
@@ -107,6 +122,11 @@ packages:
     hash: ""
     hash_algorithm: ""
   vcs:
+    provider: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_original:
     provider: ""
     url: ""
     revision: ""
@@ -134,6 +154,11 @@ packages:
     url: ""
     revision: ""
     path: ""
+  vcs_original:
+    provider: ""
+    url: ""
+    revision: ""
+    path: ""
 - package_manager: "PIP"
   namespace: ""
   name: "six"
@@ -151,6 +176,11 @@ packages:
     hash: ""
     hash_algorithm: ""
   vcs:
+    provider: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_original:
     provider: ""
     url: ""
     revision: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
@@ -12,6 +12,11 @@ project:
     url: ""
     revision: ""
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
+  vcs_original:
+    provider: "Git"
+    url: ""
+    revision: ""
+    path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
   homepage_url: ""
   scopes:
   - name: "archives"
@@ -206,6 +211,11 @@ packages:
     url: ""
     revision: ""
     path: ""
+  vcs_original:
+    provider: ""
+    url: ""
+    revision: ""
+    path: ""
 - package_manager: "Gradle"
   namespace: "org.apache.commons"
   name: "commons-lang3"
@@ -229,6 +239,11 @@ packages:
     url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
     revision: "LANG_3_5"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
+    revision: "LANG_3_5"
+    path: ""
 - package_manager: "Gradle"
   namespace: "org.apache.commons"
   name: "commons-text"
@@ -247,6 +262,11 @@ packages:
     hash: "f0770f7f0472bf120ada47beecadce4056fbd20a"
     hash_algorithm: "SHA-1"
   vcs:
+    provider: "git"
+    url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
+    revision: "HEAD"
+    path: ""
+  vcs_original:
     provider: "git"
     url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
     revision: "HEAD"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
@@ -12,6 +12,11 @@ project:
     url: ""
     revision: ""
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
+  vcs_original:
+    provider: "Git"
+    url: ""
+    revision: ""
+    path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
   homepage_url: ""
   scopes:
   - name: "archives"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
@@ -12,6 +12,11 @@ project:
     url: ""
     revision: ""
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
+  vcs_original:
+    provider: "Git"
+    url: ""
+    revision: ""
+    path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
   homepage_url: ""
   scopes:
   - name: "archives"
@@ -203,6 +208,11 @@ packages:
     url: "git://github.com/junit-team/junit.git"
     revision: "r4.12"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "git://github.com/junit-team/junit.git"
+    revision: "r4.12"
+    path: ""
 - package_manager: "Gradle"
   namespace: "org.apache.commons"
   name: "commons-lang3"
@@ -222,6 +232,11 @@ packages:
     hash: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
     hash_algorithm: "SHA-1"
   vcs:
+    provider: "git"
+    url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
+    revision: "LANG_3_5"
+    path: ""
+  vcs_original:
     provider: "git"
     url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
     revision: "LANG_3_5"
@@ -248,6 +263,11 @@ packages:
     url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
     revision: "HEAD"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
+    revision: "HEAD"
+    path: ""
 - package_manager: "Gradle"
   namespace: "org.hamcrest"
   name: "hamcrest-core"
@@ -267,6 +287,11 @@ packages:
     hash: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
     hash_algorithm: "SHA-1"
   vcs:
+    provider: "git"
+    url: "git@github.com:hamcrest/JavaHamcrest.git/hamcrest-core"
+    revision: "HEAD"
+    path: ""
+  vcs_original:
     provider: "git"
     url: "git@github.com:hamcrest/JavaHamcrest.git/hamcrest-core"
     revision: "HEAD"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-root.yml
@@ -12,6 +12,11 @@ project:
     url: ""
     revision: ""
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
+  vcs_original:
+    provider: "Git"
+    url: ""
+    revision: ""
+    path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
   homepage_url: ""
   scopes: []
 packages: []

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-app.yml
@@ -12,6 +12,11 @@ project:
     url: ""
     revision: ""
     path: "analyzer/src/funTest/assets/projects/synthetic/maven"
+  vcs_original:
+    provider: "Git"
+    url: ""
+    revision: ""
+    path: "analyzer/src/funTest/assets/projects/synthetic/maven"
   homepage_url: "http://maven.apache.org"
   scopes:
   - name: "compile"
@@ -53,6 +58,11 @@ packages:
     url: ""
     revision: ""
     path: ""
+  vcs_original:
+    provider: ""
+    url: ""
+    revision: ""
+    path: ""
 - package_manager: "Maven"
   namespace: "org.apache.commons"
   name: "commons-lang3"
@@ -76,6 +86,11 @@ packages:
     url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
     revision: "LANG_3_5"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
+    revision: "LANG_3_5"
+    path: ""
 - package_manager: "Maven"
   namespace: "org.apache.commons"
   name: "commons-text"
@@ -94,6 +109,11 @@ packages:
     hash: "f0770f7f0472bf120ada47beecadce4056fbd20a"
     hash_algorithm: "SHA-1"
   vcs:
+    provider: "git"
+    url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
+    revision: "HEAD"
+    path: ""
+  vcs_original:
     provider: "git"
     url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
     revision: "HEAD"

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-lib.yml
@@ -12,6 +12,11 @@ project:
     url: ""
     revision: ""
     path: "analyzer/src/funTest/assets/projects/synthetic/maven"
+  vcs_original:
+    provider: "Git"
+    url: ""
+    revision: ""
+    path: "analyzer/src/funTest/assets/projects/synthetic/maven"
   homepage_url: "http://maven.apache.org"
   scopes:
   - name: "compile"
@@ -58,6 +63,11 @@ packages:
     url: ""
     revision: "HEAD"
     path: ""
+  vcs_original:
+    provider: ""
+    url: ""
+    revision: "HEAD"
+    path: ""
 - package_manager: "Maven"
   namespace: "org.apache.commons"
   name: "commons-lang3"
@@ -81,6 +91,11 @@ packages:
     url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
     revision: "LANG_3_5"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
+    revision: "LANG_3_5"
+    path: ""
 - package_manager: "Maven"
   namespace: "org.apache.commons"
   name: "commons-text"
@@ -99,6 +114,11 @@ packages:
     hash: "f0770f7f0472bf120ada47beecadce4056fbd20a"
     hash_algorithm: "SHA-1"
   vcs:
+    provider: "git"
+    url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
+    revision: "HEAD"
+    path: ""
+  vcs_original:
     provider: "git"
     url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
     revision: "HEAD"

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-root.yml
@@ -12,6 +12,11 @@ project:
     url: ""
     revision: ""
     path: "analyzer/src/funTest/assets/projects/synthetic/maven"
+  vcs_original:
+    provider: "Git"
+    url: ""
+    revision: ""
+    path: "analyzer/src/funTest/assets/projects/synthetic/maven"
   homepage_url: "http://maven.apache.org"
   scopes: []
 packages: []

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output.yml
@@ -13,6 +13,11 @@ project:
     url: "https://github.com/heremaps/oss-review-toolkit.git"
     revision: ""
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "https://github.com/heremaps/oss-review-toolkit.git"
+    revision: ""
+    path: ""
   homepage_url: ""
   scopes:
   - name: "dependencies"
@@ -323,6 +328,11 @@ packages:
     url: "git+https://github.com/kriskowal/asap.git"
     revision: "e7f3d29eed4967ecfcaddbfc9542e2ee12b76227"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "git+https://github.com/kriskowal/asap.git"
+    revision: "e7f3d29eed4967ecfcaddbfc9542e2ee12b76227"
+    path: ""
 - package_manager: "NPM"
   namespace: ""
   name: "boolbase"
@@ -340,6 +350,11 @@ packages:
     hash: ""
     hash_algorithm: ""
   vcs:
+    provider: "git"
+    url: "https://github.com/fb55/boolbase"
+    revision: ""
+    path: ""
+  vcs_original:
     provider: "git"
     url: "https://github.com/fb55/boolbase"
     revision: ""
@@ -366,6 +381,11 @@ packages:
     url: "git://github.com/cheeriojs/cheerio.git"
     revision: "f21ffef971826d1ba64ccbdf96adbc44964d30c5"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "git://github.com/cheeriojs/cheerio.git"
+    revision: "f21ffef971826d1ba64ccbdf96adbc44964d30c5"
+    path: ""
 - package_manager: "NPM"
   namespace: ""
   name: "coffee-script"
@@ -383,6 +403,11 @@ packages:
     hash: ""
     hash_algorithm: ""
   vcs:
+    provider: "git"
+    url: "git://github.com/jashkenas/coffeescript.git"
+    revision: "f0e9837dca51244ef994ff535768d3a606912020"
+    path: ""
+  vcs_original:
     provider: "git"
     url: "git://github.com/jashkenas/coffeescript.git"
     revision: "f0e9837dca51244ef994ff535768d3a606912020"
@@ -408,6 +433,11 @@ packages:
     url: "git://github.com/isaacs/core-util-is.git"
     revision: "a177da234df5638b363ddc15fa324619a38577c8"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "git://github.com/isaacs/core-util-is.git"
+    revision: "a177da234df5638b363ddc15fa324619a38577c8"
+    path: ""
 - package_manager: "NPM"
   namespace: ""
   name: "cson-parser"
@@ -425,6 +455,11 @@ packages:
     hash: ""
     hash_algorithm: ""
   vcs:
+    provider: "git"
+    url: "git+ssh://git@github.com/groupon/cson-parser.git"
+    revision: "fa37e04bc6c516eb76ef01df2d105a413c0253a0"
+    path: ""
+  vcs_original:
     provider: "git"
     url: "git+ssh://git@github.com/groupon/cson-parser.git"
     revision: "fa37e04bc6c516eb76ef01df2d105a413c0253a0"
@@ -451,6 +486,11 @@ packages:
     url: "git+https://github.com/bevry/cson.git"
     revision: "0e913a90be66b2f29d2d75433b06ed52e83ba810"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "git+https://github.com/bevry/cson.git"
+    revision: "0e913a90be66b2f29d2d75433b06ed52e83ba810"
+    path: ""
 - package_manager: "NPM"
   namespace: ""
   name: "css-select"
@@ -468,6 +508,11 @@ packages:
     hash: ""
     hash_algorithm: ""
   vcs:
+    provider: "git"
+    url: "git://github.com/fb55/css-select.git"
+    revision: "09c405d8296bd97a660256604d8cdfb23fca47b6"
+    path: ""
+  vcs_original:
     provider: "git"
     url: "git://github.com/fb55/css-select.git"
     revision: "09c405d8296bd97a660256604d8cdfb23fca47b6"
@@ -493,6 +538,11 @@ packages:
     url: "git+https://github.com/fb55/css-what.git"
     revision: "fd6b9f62146efec8e17ee80ddaebdfb6ede21d7b"
     path: ""
+  vcs_original:
+    provider: ""
+    url: "git+https://github.com/fb55/css-what.git"
+    revision: "fd6b9f62146efec8e17ee80ddaebdfb6ede21d7b"
+    path: ""
 - package_manager: "NPM"
   namespace: ""
   name: "dom-serializer"
@@ -510,6 +560,11 @@ packages:
     hash: ""
     hash_algorithm: ""
   vcs:
+    provider: "git"
+    url: "git://github.com/cheeriojs/dom-renderer.git"
+    revision: "249b9a921e6ba318c52b87de21e8475bcb4050e5"
+    path: ""
+  vcs_original:
     provider: "git"
     url: "git://github.com/cheeriojs/dom-renderer.git"
     revision: "249b9a921e6ba318c52b87de21e8475bcb4050e5"
@@ -534,6 +589,11 @@ packages:
     url: "git://github.com/FB55/domelementtype.git"
     revision: "012a97a1d38737e096de2045b2b5f28768d8187e"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "git://github.com/FB55/domelementtype.git"
+    revision: "012a97a1d38737e096de2045b2b5f28768d8187e"
+    path: ""
 - package_manager: "NPM"
   namespace: ""
   name: "domelementtype"
@@ -550,6 +610,11 @@ packages:
     hash: ""
     hash_algorithm: ""
   vcs:
+    provider: "git"
+    url: "git://github.com/FB55/domelementtype.git"
+    revision: "2a95eed4c829ef479a88984d117cb5f4b379e6e8"
+    path: ""
+  vcs_original:
     provider: "git"
     url: "git://github.com/FB55/domelementtype.git"
     revision: "2a95eed4c829ef479a88984d117cb5f4b379e6e8"
@@ -575,6 +640,11 @@ packages:
     url: "git://github.com/fb55/DomHandler.git"
     revision: "9b17cc6cc9387a87dde6eb8ddbae11c753e7d23d"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "git://github.com/fb55/DomHandler.git"
+    revision: "9b17cc6cc9387a87dde6eb8ddbae11c753e7d23d"
+    path: ""
 - package_manager: "NPM"
   namespace: ""
   name: "domutils"
@@ -591,6 +661,11 @@ packages:
     hash: ""
     hash_algorithm: ""
   vcs:
+    provider: "git"
+    url: "git://github.com/FB55/domutils.git"
+    revision: "7d4bd16cd36ffce62362ef91616806ea27e30d95"
+    path: ""
+  vcs_original:
     provider: "git"
     url: "git://github.com/FB55/domutils.git"
     revision: "7d4bd16cd36ffce62362ef91616806ea27e30d95"
@@ -618,6 +693,11 @@ packages:
     url: "git+ssh://git@github.com/bevry/eachr.git"
     revision: "57ef794d001c16fd906b2558137e8ea51c1f6330"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "git+ssh://git@github.com/bevry/eachr.git"
+    revision: "57ef794d001c16fd906b2558137e8ea51c1f6330"
+    path: ""
 - package_manager: "NPM"
   namespace: ""
   name: "editions"
@@ -636,6 +716,11 @@ packages:
     hash: ""
     hash_algorithm: ""
   vcs:
+    provider: "git"
+    url: "git+https://github.com/bevry/editions.git"
+    revision: "272530079d941652a2679cf2152e83ed2f3f2129"
+    path: ""
+  vcs_original:
     provider: "git"
     url: "git+https://github.com/bevry/editions.git"
     revision: "272530079d941652a2679cf2152e83ed2f3f2129"
@@ -661,6 +746,11 @@ packages:
     url: "git://github.com/fb55/node-entities.git"
     revision: ""
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "git://github.com/fb55/node-entities.git"
+    revision: ""
+    path: ""
 - package_manager: "NPM"
   namespace: ""
   name: "extract-opts"
@@ -678,6 +768,11 @@ packages:
     hash: ""
     hash_algorithm: ""
   vcs:
+    provider: "git"
+    url: "git+ssh://git@github.com/bevry/extract-opts.git"
+    revision: "87e349bbf92a6f95d1ecc8b064a1631def105dc8"
+    path: ""
+  vcs_original:
     provider: "git"
     url: "git+ssh://git@github.com/bevry/extract-opts.git"
     revision: "87e349bbf92a6f95d1ecc8b064a1631def105dc8"
@@ -703,6 +798,11 @@ packages:
     url: "git+https://github.com/isaacs/node-graceful-fs.git"
     revision: "65cf80d1fd3413b823c16c626c1e7c326452bee5"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "git+https://github.com/isaacs/node-graceful-fs.git"
+    revision: "65cf80d1fd3413b823c16c626c1e7c326452bee5"
+    path: ""
 - package_manager: "NPM"
   namespace: ""
   name: "htmlparser2"
@@ -720,6 +820,11 @@ packages:
     hash: ""
     hash_algorithm: ""
   vcs:
+    provider: "git"
+    url: "git://github.com/fb55/htmlparser2.git"
+    revision: "e1f12f626f65cf4a082f89bdde89081b54187818"
+    path: ""
+  vcs_original:
     provider: "git"
     url: "git://github.com/fb55/htmlparser2.git"
     revision: "e1f12f626f65cf4a082f89bdde89081b54187818"
@@ -746,6 +851,11 @@ packages:
     url: "git://github.com/isaacs/inherits.git"
     revision: "e05d0fb27c61a3ec687214f0476386b765364d5f"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "git://github.com/isaacs/inherits.git"
+    revision: "e05d0fb27c61a3ec687214f0476386b765364d5f"
+    path: ""
 - package_manager: "NPM"
   namespace: ""
   name: "isarray"
@@ -763,6 +873,11 @@ packages:
     hash: ""
     hash_algorithm: ""
   vcs:
+    provider: "git"
+    url: "git://github.com/juliangruber/isarray.git"
+    revision: "2a23a281f369e9ae06394c0fb4d2381355a6ba33"
+    path: ""
+  vcs_original:
     provider: "git"
     url: "git://github.com/juliangruber/isarray.git"
     revision: "2a23a281f369e9ae06394c0fb4d2381355a6ba33"
@@ -788,6 +903,11 @@ packages:
     url: "git+https://github.com/lodash/lodash.git"
     revision: ""
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "git+https://github.com/lodash/lodash.git"
+    revision: ""
+    path: ""
 - package_manager: "NPM"
   namespace: ""
   name: "long"
@@ -809,6 +929,11 @@ packages:
     url: "git+https://github.com/dcodeIO/long.js.git"
     revision: "8cdc1f74ced4f771aa844f1cbc565b1d4c4451b8"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "git+https://github.com/dcodeIO/long.js.git"
+    revision: "8cdc1f74ced4f771aa844f1cbc565b1d4c4451b8"
+    path: ""
 - package_manager: "NPM"
   namespace: ""
   name: "nth-check"
@@ -826,6 +951,11 @@ packages:
     hash: ""
     hash_algorithm: ""
   vcs:
+    provider: "git"
+    url: "https://github.com/fb55/nth-check"
+    revision: "257338e5bbd53228236abd4cc09539b66b27dd11"
+    path: ""
+  vcs_original:
     provider: "git"
     url: "https://github.com/fb55/nth-check"
     revision: "257338e5bbd53228236abd4cc09539b66b27dd11"
@@ -852,6 +982,11 @@ packages:
     url: "git://github.com/inikulin/parse5.git"
     revision: "969ed22f53db38c101449e05a1b804ea456d4e04"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "git://github.com/inikulin/parse5.git"
+    revision: "969ed22f53db38c101449e05a1b804ea456d4e04"
+    path: ""
 - package_manager: "NPM"
   namespace: ""
   name: "process-nextick-args"
@@ -869,6 +1004,11 @@ packages:
     hash: ""
     hash_algorithm: ""
   vcs:
+    provider: "git"
+    url: "https://github.com/calvinmetcalf/process-nextick-args.git"
+    revision: "5c00899ab01dd32f93ad4b5743da33da91404f39"
+    path: ""
+  vcs_original:
     provider: "git"
     url: "https://github.com/calvinmetcalf/process-nextick-args.git"
     revision: "5c00899ab01dd32f93ad4b5743da33da91404f39"
@@ -894,6 +1034,11 @@ packages:
     url: "git+https://github.com/then/promise.git"
     revision: "cebfa6049cc08843f428c6fc92dde918f8687e6d"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "git+https://github.com/then/promise.git"
+    revision: "cebfa6049cc08843f428c6fc92dde918f8687e6d"
+    path: ""
 - package_manager: "NPM"
   namespace: ""
   name: "readable-stream"
@@ -911,6 +1056,11 @@ packages:
     hash: ""
     hash_algorithm: ""
   vcs:
+    provider: "git"
+    url: "git://github.com/nodejs/readable-stream.git"
+    revision: "cd59995050105b946884ee20e3bcadc252feda8c"
+    path: ""
+  vcs_original:
     provider: "git"
     url: "git://github.com/nodejs/readable-stream.git"
     revision: "cd59995050105b946884ee20e3bcadc252feda8c"
@@ -936,6 +1086,11 @@ packages:
     url: "git+ssh://git@github.com/bevry/requirefresh.git"
     revision: "f0c589db055ba21ebb30da442742cd19e64e3efa"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "git+ssh://git@github.com/bevry/requirefresh.git"
+    revision: "f0c589db055ba21ebb30da442742cd19e64e3efa"
+    path: ""
 - package_manager: "NPM"
   namespace: ""
   name: "safe-buffer"
@@ -953,6 +1108,11 @@ packages:
     hash: ""
     hash_algorithm: ""
   vcs:
+    provider: "git"
+    url: "git://github.com/feross/safe-buffer.git"
+    revision: "5261e0c19dd820c31dd21cb4116902b0ed0f9e57"
+    path: ""
+  vcs_original:
     provider: "git"
     url: "git://github.com/feross/safe-buffer.git"
     revision: "5261e0c19dd820c31dd21cb4116902b0ed0f9e57"
@@ -979,6 +1139,11 @@ packages:
     url: "git+ssh://git@github.com/bevry/safefs.git"
     revision: "51d15eaa03e53aaedd3002dc67814355073e8a55"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "git+ssh://git@github.com/bevry/safefs.git"
+    revision: "51d15eaa03e53aaedd3002dc67814355073e8a55"
+    path: ""
 - package_manager: "NPM"
   namespace: ""
   name: "string_decoder"
@@ -996,6 +1161,11 @@ packages:
     hash: ""
     hash_algorithm: ""
   vcs:
+    provider: "git"
+    url: "git://github.com/rvagg/string_decoder.git"
+    revision: "e97f24dd3d047b72b9836518e2a0788e2a6a2fdb"
+    path: ""
+  vcs_original:
     provider: "git"
     url: "git://github.com/rvagg/string_decoder.git"
     revision: "e97f24dd3d047b72b9836518e2a0788e2a6a2fdb"
@@ -1022,6 +1192,11 @@ packages:
     url: "git+ssh://git@github.com/bevry/typechecker.git"
     revision: "ab3925bc0270f8df65f5c05ae1ba09e648aaff8e"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "git+ssh://git@github.com/bevry/typechecker.git"
+    revision: "ab3925bc0270f8df65f5c05ae1ba09e648aaff8e"
+    path: ""
 - package_manager: "NPM"
   namespace: ""
   name: "util-deprecate"
@@ -1043,6 +1218,11 @@ packages:
     url: "git://github.com/TooTallNate/util-deprecate.git"
     revision: "475fb6857cd23fafff20c1be846c1350abf8e6d4"
     path: ""
+  vcs_original:
+    provider: "git"
+    url: "git://github.com/TooTallNate/util-deprecate.git"
+    revision: "475fb6857cd23fafff20c1be846c1350abf8e6d4"
+    path: ""
 - package_manager: "NPM"
   namespace: "@types"
   name: "node"
@@ -1060,6 +1240,11 @@ packages:
     hash: ""
     hash_algorithm: ""
   vcs:
+    provider: "git"
+    url: "https://www.github.com/DefinitelyTyped/DefinitelyTyped.git"
+    revision: ""
+    path: ""
+  vcs_original:
     provider: "git"
     url: "https://www.github.com/DefinitelyTyped/DefinitelyTyped.git"
     revision: ""

--- a/analyzer/src/funTest/kotlin/GradleTest.kt
+++ b/analyzer/src/funTest/kotlin/GradleTest.kt
@@ -49,6 +49,10 @@ class GradleTest : StringSpec() {
     private fun patchExpectedResult(filename: String) =
             File(projectDir.parentFile, filename)
                     .readText()
+                    // vcs:
+                    .replaceFirst("url: \"\"", "url: \"$vcsUrl\"")
+                    .replaceFirst("revision: \"\"", "revision: \"$vcsRevision\"")
+                    // vcs_original:
                     .replaceFirst("url: \"\"", "url: \"$vcsUrl\"")
                     .replaceFirst("revision: \"\"", "revision: \"$vcsRevision\"")
 

--- a/analyzer/src/funTest/kotlin/MavenTest.kt
+++ b/analyzer/src/funTest/kotlin/MavenTest.kt
@@ -37,6 +37,10 @@ class MavenTest : StringSpec() {
     private fun patchExpectedResult(filename: String) =
             File(syntheticProjectDir.parentFile, filename)
                     .readText()
+                    // vcs:
+                    .replaceFirst("url: \"\"", "url: \"$vcsUrl\"")
+                    .replaceFirst("revision: \"\"", "revision: \"$vcsRevision\"")
+                    // vcs_original:
                     .replaceFirst("url: \"\"", "url: \"$vcsUrl\"")
                     .replaceFirst("revision: \"\"", "revision: \"$vcsRevision\"")
 

--- a/downloader/src/main/kotlin/Main.kt
+++ b/downloader/src/main/kotlin/Main.kt
@@ -188,11 +188,11 @@ object Main {
         val targetDir = File(outputDirectory, "${target.normalizedName}/${target.version}").apply { safeMkdirs() }
         p("Downloading source code to '${targetDir.absolutePath}'...")
 
-        if (target.normalizedVcsUrl.isNotBlank()) {
-            p("Trying to download from URL '${target.normalizedVcsUrl}'...")
+        if (target.vcs.url.isNotBlank()) {
+            p("Trying to download from URL '${target.vcs.url}'...")
 
-            if (target.vcs.url != target.normalizedVcsUrl) {
-                p("URL was normalized, original URL was '${target.vcs.url}'.")
+            if (target.vcs.url != target.vcsOriginal.url) {
+                p("URL was normalized, original URL was '${target.vcsOriginal.url}'.")
             }
 
             if (target.vcs.revision.isBlank()) {
@@ -212,8 +212,8 @@ object Main {
             }
 
             if (applicableVcs == null) {
-                p("from URL '${target.normalizedVcsUrl}'...")
-                applicableVcs = VersionControlSystem.forUrl(target.normalizedVcsUrl)
+                p("from URL '${target.vcs.url}'...")
+                applicableVcs = VersionControlSystem.forUrl(target.vcs.url)
             }
 
             if (applicableVcs == null) {
@@ -223,7 +223,7 @@ object Main {
             p("Using VCS provider '$applicableVcs'.")
 
             try {
-                val revision = applicableVcs.download(target.normalizedVcsUrl, target.vcs.revision, target.vcs.path,
+                val revision = applicableVcs.download(target.vcs.url, target.vcs.revision, target.vcs.path,
                         target.version, targetDir)
                 p("Finished downloading source code revision '$revision' to '${targetDir.absolutePath}'.")
                 return targetDir

--- a/model/src/main/kotlin/Package.kt
+++ b/model/src/main/kotlin/Package.kt
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 
 import com.here.ort.util.fileSystemEncode
-import com.here.ort.util.normalizeVcsUrl
 
 import java.util.SortedSet
 
@@ -90,9 +89,15 @@ data class Package(
         val sourceArtifact: RemoteArtifact,
 
         /**
-         * VCS-related information about the [Package].
+         * Processed VCS-related information about the [Package] that has e.g. common mistakes corrected.
          */
-        val vcs: VcsInfo
+        val vcs: VcsInfo,
+
+        /**
+         * Original VCS-related information as defined in the [Package]'s meta-data.
+         */
+        @JsonProperty("vcs_original")
+        val vcsOriginal: VcsInfo = vcs
 ) : Comparable<Package> {
     /**
      * The normalized package name, can be used to create directories.
@@ -103,13 +108,6 @@ data class Package(
      * The unique identifier for this package, created from [packageManager], [namespace], [name], and [version].
      */
     val identifier = "$packageManager:$namespace:$normalizedName:$version"
-
-    /**
-     * The normalized VCS URL.
-     *
-     * @see normalizeVcsUrl
-     */
-    val normalizedVcsUrl = normalizeVcsUrl(vcs.url)
 
     /**
      * Return a template [PackageReference] to refer to this [Package]. It is only a template because e.g. the

--- a/model/src/main/kotlin/Project.kt
+++ b/model/src/main/kotlin/Project.kt
@@ -67,9 +67,15 @@ data class Project(
         val aliases: List<String>,
 
         /**
-         * VCS-related information about the [Project].
+         * Processed VCS-related information about the [Project] that has e.g. common mistakes corrected.
          */
         val vcs: VcsInfo,
+
+        /**
+         * Original VCS-related information as defined in the [Project]'s meta-data.
+         */
+        @JsonProperty("vcs_original")
+        val vcsOriginal: VcsInfo = vcs,
 
         /**
          * The URL to the project's homepage.
@@ -95,7 +101,8 @@ data class Project(
             homepageUrl = homepageUrl,
             binaryArtifact = RemoteArtifact.EMPTY,
             sourceArtifact = RemoteArtifact.EMPTY,
-            vcs = vcs
+            vcs = vcs,
+            vcsOriginal = vcsOriginal
     )
 
     companion object {
@@ -111,6 +118,7 @@ data class Project(
                 declaredLicenses = sortedSetOf(),
                 aliases = emptyList(),
                 vcs = VcsInfo.EMPTY,
+                vcsOriginal = VcsInfo.EMPTY,
                 homepageUrl = "",
                 scopes = sortedSetOf()
         )

--- a/scanner/src/funTest/kotlin/HttpCacheTest.kt
+++ b/scanner/src/funTest/kotlin/HttpCacheTest.kt
@@ -86,7 +86,8 @@ class HttpCacheTest : StringSpec() {
                     homepageUrl = "homepageUrl",
                     binaryArtifact = RemoteArtifact.EMPTY,
                     sourceArtifact = RemoteArtifact.EMPTY,
-                    vcs = VcsInfo.EMPTY
+                    vcs = VcsInfo.EMPTY,
+                    vcsOriginal = VcsInfo.EMPTY
             )
 
             val resultFile = createTempFile()


### PR DESCRIPTION
Extend Projects and Packages to contain all processed VcsInfo, not just
the normalizedVcsUrl. Also make the plain "vcs" variable contain the
processed / normalized info and keep the unmodified info as "vcsOriginal".
Since we usually want to work with the former, a shorter name for it is
desirable. Unless explicitly specified, "vcsOriginal" equals "vcs" for
simplicity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/127)
<!-- Reviewable:end -->
