### PR TITLE
Fix issue #129

### DIFF
--- a/utils/src/main/kotlin/ProcessCapture.kt
+++ b/utils/src/main/kotlin/ProcessCapture.kt
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
 
 import com.vdurmont.semver4j.Requirement
+import com.vdurmont.semver4j.Semver
 
 import java.io.File
 import java.io.IOException
@@ -113,7 +114,8 @@ fun checkCommandVersion(
         ignoreActualVersion: Boolean = false,
         transform: (String) -> String = { it }
 ) {
-    val actualVersion = getCommandVersion(command, versionArguments, workingDir, transform)
+    val toolVersionOutput = getCommandVersion(command, versionArguments, workingDir, transform)
+    val actualVersion = Semver(toolVersionOutput, Semver.SemverType.LOOSE)
     if (!requirement.isSatisfiedBy(actualVersion)) {
         val message = "Unsupported $command version $actualVersion does not fulfill $requirement."
         if (ignoreActualVersion) {


### PR DESCRIPTION
Resolves an issue where if a tool's version doesn't include a patch then then OSS Review Toolkit is unable to determine if there tool version requirement has been met.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/130)
<!-- Reviewable:end -->
