### PR TITLE
Travis: Add a crude check for aborted tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,11 @@ script:
       exit 1;
     fi
   - if [ "$TRAVIS_EVENT_TYPE" != "cron" ]; then
-      ./gradlew -DexcludeTags=Expensive check;
+      ./gradlew -DexcludeTags=Expensive check | tee log.txt;
     else
-      ./gradlew check;
+      ./gradlew check | tee log.txt;
+    fi
+  - if grep -A1 ".+Test.+STARTED$" log.txt | grep -q "^:"; then
+      echo "Some tests seemingly have been aborted.";
+      exit 1;
     fi


### PR DESCRIPTION
If functional tests execute a code path which calls exitProcess() the
JVM running the tests is terminated, shadowing any upcoming failing
tests. Fail CI builds if such a case is detected by checking that the
line following

    [...] > GradleLoggingSubprojectTest.analyzer produces ABCD files
            for all .gradle files STARTED

does not start wirh ":" like in

    :analyzer:testPicked up _JAVA_OPTIONS: -Xmx2048m -Xms512m

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/131)
<!-- Reviewable:end -->
