### PR TITLE
Travis: Enable pipefail to avoid tee shadowing gradlew's exit code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ script:
       echo "Please add Copyright statements to the above files.";
       exit 1;
     fi
+  - set -o pipefail
   - if [ "$TRAVIS_EVENT_TYPE" != "cron" ]; then
       ./gradlew -DexcludeTags=Expensive check | tee log.txt;
     else


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/133)
<!-- Reviewable:end -->
