### PR TITLE
Enable running ORT in a Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM openjdk:8
+
+# Install dependencies for NPM scanning
+RUN ["/bin/bash", "-c", "set -o pipefail && curl -sL https://deb.nodesource.com/setup_8.x | bash - && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && echo \"deb https://dl.yarnpkg.com/debian/ stable main\" | tee /etc/apt/sources.list.d/yarn.list"]
+RUN apt update \
+  && apt install -y \
+    apt-utils \
+    build-essential \
+    python-pip \
+    nodejs \
+    yarn \
+    cvs \
+    git \
+    mercurial \
+    subversion \
+  && pip install virtualenv \
+  && rm -rf /var/lib/apt/lists
+
+# Install the OSS Review Toolkit
+ENV APPDIR=/opt/oss-review-toolkit
+COPY . "${APPDIR}"
+WORKDIR "${APPDIR}"
+RUN ./gradlew installDist
+
+# Add the tools to the path
+ENV PATH="${APPDIR}/analyzer/build/install/analyzer/bin:${APPDIR}/graph/build/install/graph/bin:${APPDIR}/downloader/build/install/downloader/bin:${APPDIR}/scanner/build/install/scanner/bin:${PATH}"
+
+# Change to non-root
+RUN groupadd -r toolkit && useradd --no-log-init -r -g toolkit toolkit
+USER toolkit


### PR DESCRIPTION
This adds a Dockerfile that allows the ORT scripts to be run inside a container (to avoid having to install dependencies such as a JDK) on the host.

Ideally, the oss-review-toolkit team would build the image and publish it to DockerHub so consumers don't need to clone the repository and build the image themselves. Let me know if you'd like me to help this out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/141)
<!-- Reviewable:end -->
