### PR TITLE
Add ScanCode and dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,19 @@
 FROM openjdk:8
 
-# Install dependencies for NPM scanning
-RUN ["/bin/bash", "-c", "set -o pipefail && curl -sL https://deb.nodesource.com/setup_8.x | bash - && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && echo \"deb https://dl.yarnpkg.com/debian/ stable main\" | tee /etc/apt/sources.list.d/yarn.list"]
-RUN apt update \
+# Environment
+ENV APPDIR=/opt/oss-review-toolkit \
+    SCANCODE_VERSION=2.2.1
+
+# Install dependencies
+RUN ["/bin/bash", "-c", "set -o pipefail \
+  && groupadd -r toolkit \
+  && useradd --no-log-init -r -g toolkit toolkit \
+  && curl -sL https://github.com/nexB/scancode-toolkit/releases/download/v${SCANCODE_VERSION}/scancode-toolkit-${SCANCODE_VERSION}.tar.bz2 > /tmp/scancode.tar.bz2 \
+  && tar xvjf /tmp/scancode.tar.bz2 -C /opt/ \
+  && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
+  && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+  && echo \"deb https://dl.yarnpkg.com/debian/ stable main\" | tee /etc/apt/sources.list.d/yarn.list \
+  && apt update \
   && apt install -y \
     apt-utils \
     build-essential \
@@ -13,18 +24,25 @@ RUN apt update \
     git \
     mercurial \
     subversion \
+    python-dev \
+    libbz2-1.0 \
+    xz-utils \
+    zlib1g \
+    libxml2-dev \
+    libxslt1-dev \
   && pip install virtualenv \
-  && rm -rf /var/lib/apt/lists
+  && rm -rf /var/lib/apt/lists \
+  && rm /tmp/scancode.tar.bz2 \
+  && /opt/scancode-toolkit-${SCANCODE_VERSION}/scancode --version \
+  && chown -R toolkit:toolkit /opt/scancode-toolkit-${SCANCODE_VERSION}/"]
 
 # Install the OSS Review Toolkit
-ENV APPDIR=/opt/oss-review-toolkit
 COPY . "${APPDIR}"
 WORKDIR "${APPDIR}"
 RUN ./gradlew installDist
 
 # Add the tools to the path
-ENV PATH="${APPDIR}/analyzer/build/install/analyzer/bin:${APPDIR}/graph/build/install/graph/bin:${APPDIR}/downloader/build/install/downloader/bin:${APPDIR}/scanner/build/install/scanner/bin:${PATH}"
+ENV PATH="${APPDIR}/analyzer/build/install/analyzer/bin:${APPDIR}/graph/build/install/graph/bin:${APPDIR}/downloader/build/install/downloader/bin:${APPDIR}/scanner/build/install/scanner/bin:/opt/scancode-toolkit-${SCANCODE_VERSION}:${PATH}"
 
 # Change to non-root
-RUN groupadd -r toolkit && useradd --no-log-init -r -g toolkit toolkit
 USER toolkit


### PR DESCRIPTION
One minor issue, since I did all my testing with the analyzer and downloader I neglected to put ScanCode in the image! This adds ScanCode and its dependencies and also runs `scancode --version` to pre-download its first-launch dependencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/146)
<!-- Reviewable:end -->
