### PR TITLE
MavenSupport: Do print the stack trace if an artifact failed to download

### DIFF
--- a/analyzer/src/main/kotlin/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/MavenSupport.kt
@@ -25,6 +25,7 @@ import com.here.ort.model.Package
 import com.here.ort.model.RemoteArtifact
 import com.here.ort.model.VcsInfo
 import com.here.ort.utils.DiskCache
+import com.here.ort.utils.collectMessages
 import com.here.ort.utils.getUserConfigDirectory
 import com.here.ort.utils.log
 import com.here.ort.utils.yamlMapper
@@ -222,15 +223,13 @@ class MavenSupport(localRepositoryManagerConverter: (LocalRepositoryManager) -> 
                     remoteArtifactCache.write(artifact.toString(), yamlMapper.writeValueAsString(it))
                 }
             } else {
-                if (Main.stacktrace) {
-                    artifactDownload.exception.printStackTrace()
+                log.debug {
+                    "Could not find '$artifact' in '$repository': ${artifactDownload.exception.collectMessages()}"
                 }
-
-                log.debug { "Could not find '$artifact' in $repository." }
             }
         }
 
-        log.info { "Could not receive data about remote artifact '$artifact'." }
+        log.warn { "Unable to find '$artifact' in any of $allRepositories." }
 
         return RemoteArtifact.EMPTY.also {
             log.debug { "Writing empty remote artifact for $artifact to disk cache." }


### PR DESCRIPTION
To not clutter stdout, do not print the stack trace (not even with
--stacktrace) if an artifact failed to download from a single
repository, because running into such exceptions is completely fine if
the artifacts succeeds to download from a repository further down the
list.

So only put any exception's message into the debug log, and only warn if
the artifact failed to download from all repositories.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/148)
<!-- Reviewable:end -->
