### PR TITLE
AppVeyor: To safe some time and storage, do not archive the build reports

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,3 @@ on_finish:
       foreach ($file in (Resolve-Path $pattern)) {
         (New-Object 'System.Net.WebClient').UploadFile($url, $file)
       }
-
-artifacts:
-  - path: '**\build\reports\**\*'
-    name: Build report


### PR DESCRIPTION
We are already uploading the XML files, which should be enough to track
down test failures.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/149)
<!-- Reviewable:end -->
