### PR TITLE
Gradle: Sync the tooling API version with the main version again

### DIFF
--- a/analyzer/build.gradle
+++ b/analyzer/build.gradle
@@ -4,6 +4,12 @@ apply plugin: 'application'
 applicationName = 'analyzer'
 mainClassName = 'com.here.ort.analyzer.Main'
 
+repositories {
+    maven {
+        url 'https://repo.gradle.org/gradle/libs-releases-local/'
+    }
+}
+
 dependencies {
     compile project(':downloader')
     compile project(':model')
@@ -21,6 +27,5 @@ dependencies {
     compile "org.apache.maven.resolver:maven-resolver-transport-file:$mavenResolverVersion"
     compile "org.apache.maven.resolver:maven-resolver-transport-http:$mavenResolverVersion"
 
-    // The tooling API does not necessarily get upgraded with new versions of Gradle.
-    compile "org.gradle:gradle-tooling-api:${gradleToolingApiVersion}"
+    compile "org.gradle:gradle-tooling-api:${gradle.gradleVersion}"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 disklrucacheVersion = 2.0.2
-gradleToolingApiVersion = 4.3
 jacksonVersion = 2.9.2
 jcommanderVersion = 1.72
 kotlintestVersion = 2.0.7


### PR DESCRIPTION
Turns out they do come in pairs (unlike assumed in 5c0744d), but the
tooling API artifact is (now) published at repo.gradle.org, not at
JCenter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/151)
<!-- Reviewable:end -->
