### PR TITLE
MavenSupport: Only print the repo URLs if an artifact could not be found

### DIFF
--- a/analyzer/src/main/kotlin/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/MavenSupport.kt
@@ -229,7 +229,7 @@ class MavenSupport(localRepositoryManagerConverter: (LocalRepositoryManager) -> 
             }
         }
 
-        log.warn { "Unable to find '$artifact' in any of $allRepositories." }
+        log.warn { "Unable to find '$artifact' in any of ${allRepositories.map { it.url }}." }
 
         return RemoteArtifact.EMPTY.also {
             log.debug { "Writing empty remote artifact for $artifact to disk cache." }


### PR DESCRIPTION
Otherwise the log gets too cluttered the the repo's id, content type,
policy etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/152)
<!-- Reviewable:end -->
