### PR TITLE
logback: Remove the thread and logger names from the pattern

### DIFF
--- a/utils/src/main/resources/logback.xml
+++ b/utils/src/main/resources/logback.xml
@@ -3,7 +3,7 @@
         <!-- encoders are assigned the type
              ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} %-5level - %msg%n</pattern>
         </encoder>
     </appender>
     <root level="WARN">


### PR DESCRIPTION
We currently only use a single "main" thread and a single logger, so
this information is all the same. Remove it to get shorter logs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/153)
<!-- Reviewable:end -->
