### PR TITLE
Git: Relax the version pattern

### DIFF
--- a/downloader/src/main/kotlin/vcs/Git.kt
+++ b/downloader/src/main/kotlin/vcs/Git.kt
@@ -34,7 +34,7 @@ import java.io.IOException
 
 abstract class GitBase : VersionControlSystem() {
     override fun getVersion(): String {
-        val gitVersionRegex = Regex("git version (?<version>[\\d.a-z]+)")
+        val gitVersionRegex = Regex("git version (?<version>[\\d.a-z-]+)(\\s.+)?")
 
         return getCommandVersion("git") {
             gitVersionRegex.matchEntire(it.lineSequence().first())?.groups?.get("version")?.value ?: ""


### PR DESCRIPTION
To also match e.g.

    git version 2.15.1-271-g1a4e40aa5dc

or

    git version 2.4.9 (Apple Git-60)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/164)
<!-- Reviewable:end -->
