### PR TITLE
AbstractIntegrationSpec: Use processed VCS information as the actual data

### DIFF
--- a/analyzer/src/funTest/kotlin/integration/AbstractIntegrationSpec.kt
+++ b/analyzer/src/funTest/kotlin/integration/AbstractIntegrationSpec.kt
@@ -106,9 +106,9 @@ abstract class AbstractIntegrationSpec : StringSpec() {
 
                 results.size shouldBe files.size
                 results.values.forEach { result ->
-                    VersionControlSystem.forProvider(result.project.vcs.provider) shouldBe
+                    VersionControlSystem.forProvider(result.project.vcsProcessed.provider) shouldBe
                             VersionControlSystem.forProvider(pkg.vcs.provider)
-                    result.project.vcs.url shouldBe pkg.vcs.url
+                    result.project.vcsProcessed.url shouldBe pkg.vcs.url
                     result.project.scopes shouldNot beEmpty()
                     result.packages shouldNot beEmpty()
                     result.hasErrors() shouldBe false


### PR DESCRIPTION
To benefit from URL normalization. This fixes a breakage in expensive
tests run by Travis CRON.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/167)
<!-- Reviewable:end -->
