### PR TITLE
Upgrade detekt to version 1.0.0.RC6-1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
     // Note that the detekt Gradle plugin version does not necessarily
     // match the detekt tool version.
-    id 'io.gitlab.arturbosch.detekt' version '1.0.0.RC5-6' apply false
+    id 'io.gitlab.arturbosch.detekt' version '1.0.0.RC6-1' apply false
 
     id 'com.github.ben-manes.versions' version '0.15.0' apply false
 }
@@ -87,7 +87,7 @@ subprojects {
     }
 
     detekt {
-        version = '1.0.0.RC5-6'
+        version = '1.0.0.RC6-1'
 
         profile('main') {
             config = '../detekt.yml'


### PR DESCRIPTION
This fixes an annoying warning on Windows:

https://github.com/arturbosch/detekt/issues/630

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/174)
<!-- Reviewable:end -->
