### PR TITLE
Alignments about creating / deleting temporary files / directories

### DIFF
--- a/analyzer/src/funTest/kotlin/MainTest.kt
+++ b/analyzer/src/funTest/kotlin/MainTest.kt
@@ -19,7 +19,7 @@
 
 package com.here.ort.analyzer
 
-import io.kotlintest.Spec
+import io.kotlintest.TestCaseContext
 import io.kotlintest.matchers.shouldBe
 import io.kotlintest.specs.StringSpec
 
@@ -32,11 +32,19 @@ import java.io.PrintStream
  */
 class MainTest : StringSpec() {
     private val syntheticProjectDir = File("src/funTest/assets/projects/synthetic")
-    private val outputDir = createTempDir()
 
-    override fun interceptSpec(context: Spec, spec: () -> Unit) {
-        spec()
-        outputDir.deleteRecursively()
+    private lateinit var outputDir: File
+
+    // Required to make lateinit of outputDir work.
+    override val oneInstancePerTest = false
+
+    override fun interceptTestCase(context: TestCaseContext, test: () -> Unit) {
+        outputDir = createTempDir()
+        try {
+            super.interceptTestCase(context, test)
+        } finally {
+            outputDir.deleteRecursively()
+        }
     }
 
     init {

--- a/analyzer/src/funTest/kotlin/NpmTest.kt
+++ b/analyzer/src/funTest/kotlin/NpmTest.kt
@@ -39,7 +39,7 @@ class NpmTest : FreeSpec() {
     @Suppress("CatchException")
     override fun interceptTestCase(context: TestCaseContext, test: () -> Unit) {
         try {
-            test()
+            super.interceptTestCase(context, test)
         } catch (exception: Exception) {
             // Make sure the node_modules directory is always deleted from each subdirectory to prevent side-effects
             // from failing tests.

--- a/analyzer/src/funTest/kotlin/integration/AbstractIntegrationSpec.kt
+++ b/analyzer/src/funTest/kotlin/integration/AbstractIntegrationSpec.kt
@@ -26,7 +26,7 @@ import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.Package
 import com.here.ort.utils.Expensive
 
-import io.kotlintest.Spec
+import io.kotlintest.TestCaseContext
 import io.kotlintest.matchers.beEmpty
 import io.kotlintest.matchers.shouldBe
 import io.kotlintest.matchers.shouldNot
@@ -61,7 +61,7 @@ abstract class AbstractIntegrationSpec : StringSpec() {
     /**
      * A temporary directory used as working directory for the test suite.
      */
-    private val outputDir = createTempDir()
+    private lateinit var outputDir: File
 
     /**
      * The instance needs to be shared between tests because otherwise the source code of [pkg] would have to be
@@ -69,9 +69,13 @@ abstract class AbstractIntegrationSpec : StringSpec() {
      */
     override val oneInstancePerTest = false
 
-    override fun interceptSpec(context: Spec, spec: () -> Unit) {
-        spec()
-        outputDir.deleteRecursively()
+    override fun interceptTestCase(context: TestCaseContext, test: () -> Unit) {
+        outputDir = createTempDir()
+        try {
+            super.interceptTestCase(context, test)
+        } finally {
+            outputDir.deleteRecursively()
+        }
     }
 
     init {

--- a/analyzer/src/main/kotlin/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/MavenSupport.kt
@@ -194,15 +194,15 @@ class MavenSupport(localRepositoryManagerConverter: (LocalRepositoryManager) -> 
                 log.debug { "Checksums: $checksums" }
 
                 val checksum = checksums.first()
-                val tmpFile = File.createTempFile("checksum", checksum.algorithm)
+                val tempFile = File.createTempFile("checksum", checksum.algorithm)
 
                 val transporter = transporterProvider.newTransporter(repositorySystemSession, repository)
                 val actualChecksum = try {
-                    transporter.get(GetTask(checksum.location).setDataFile(tmpFile))
+                    transporter.get(GetTask(checksum.location).setDataFile(tempFile))
 
                     // Sometimes the checksum file contains a path after the actual checksum, so strip everything after
                     // the first space.
-                    tmpFile.readText().substringBefore(" ")
+                    tempFile.readText().substringBefore(" ")
                 } catch (e: Exception) {
                     if (Main.stacktrace) {
                         e.printStackTrace()
@@ -214,8 +214,8 @@ class MavenSupport(localRepositoryManagerConverter: (LocalRepositoryManager) -> 
                     ""
                 }
 
-                if (!tmpFile.delete()) {
-                    log.warn { "Unable to delete temporary file '$tmpFile'." }
+                if (!tempFile.delete()) {
+                    log.warn { "Unable to delete temporary file '$tempFile'." }
                 }
 
                 val downloadUrl = "${repository.url}/$remoteLocation"

--- a/analyzer/src/main/kotlin/managers/PIP.kt
+++ b/analyzer/src/main/kotlin/managers/PIP.kt
@@ -282,7 +282,9 @@ class PIP : PackageManager() {
         )
 
         // Remove the virtualenv by simply deleting the directory.
-        virtualEnvDir.deleteRecursively()
+        if (!virtualEnvDir.deleteRecursively()) {
+            log.warn { "Unable to delete temporary directory '$virtualEnvDir'." }
+        }
 
         return AnalyzerResult(true, project, packages)
     }

--- a/downloader/src/funTest/kotlin/DirectoryTest.kt
+++ b/downloader/src/funTest/kotlin/DirectoryTest.kt
@@ -22,19 +22,27 @@ package com.here.ort.downloader
 import com.here.ort.model.Package
 import com.here.ort.model.RemoteArtifact
 import com.here.ort.model.VcsInfo
-import io.kotlintest.Spec
+
+import io.kotlintest.TestCaseContext
 import io.kotlintest.matchers.shouldBe
 import io.kotlintest.matchers.shouldThrow
-
 import io.kotlintest.specs.StringSpec
 
+import java.io.File
+
 class DirectoryTest : StringSpec() {
+    private lateinit var outputDir: File
 
-    private val outputDir = createTempDir()
+    // Required to make lateinit of outputDir work.
+    override val oneInstancePerTest = false
 
-    override fun interceptSpec(context: Spec, spec: () -> Unit) {
-        spec()
-        outputDir.deleteRecursively()
+    override fun interceptTestCase(context: TestCaseContext, test: () -> Unit) {
+        outputDir = createTempDir()
+        try {
+            super.interceptTestCase(context, test)
+        } finally {
+            outputDir.deleteRecursively()
+        }
     }
 
     init {

--- a/downloader/src/funTest/kotlin/DownloaderTest.kt
+++ b/downloader/src/funTest/kotlin/DownloaderTest.kt
@@ -26,7 +26,7 @@ import com.here.ort.model.RemoteArtifact
 import com.here.ort.model.VcsInfo
 import com.here.ort.utils.Expensive
 
-import io.kotlintest.Spec
+import io.kotlintest.TestCaseContext
 import io.kotlintest.matchers.beGreaterThan
 import io.kotlintest.matchers.should
 import io.kotlintest.matchers.shouldBe
@@ -36,12 +36,18 @@ import io.kotlintest.specs.StringSpec
 import java.io.File
 
 class DownloaderTest : StringSpec() {
+    private lateinit var outputDir: File
 
-    private val outputDir = createTempDir()
+    // Required to make lateinit of outputDir work.
+    override val oneInstancePerTest = false
 
-    override fun interceptSpec(context: Spec, spec: () -> Unit) {
-        spec()
-        outputDir.deleteRecursively()
+    override fun interceptTestCase(context: TestCaseContext, test: () -> Unit) {
+        outputDir = createTempDir()
+        try {
+            super.interceptTestCase(context, test)
+        } finally {
+            outputDir.deleteRecursively()
+        }
     }
 
     init {

--- a/downloader/src/funTest/kotlin/MercurialTest.kt
+++ b/downloader/src/funTest/kotlin/MercurialTest.kt
@@ -44,8 +44,11 @@ class MercurialTest : StringSpec() {
 
     override fun interceptTestCase(context: TestCaseContext, test: () -> Unit) {
         outputDir = createTempDir()
-        super.interceptTestCase(context, test)
-        outputDir.deleteRecursively()
+        try {
+            super.interceptTestCase(context, test)
+        } finally {
+            outputDir.deleteRecursively()
+        }
     }
 
     init {

--- a/downloader/src/funTest/kotlin/SubversionTest.kt
+++ b/downloader/src/funTest/kotlin/SubversionTest.kt
@@ -44,8 +44,11 @@ class SubversionTest : StringSpec() {
 
     override fun interceptTestCase(context: TestCaseContext, test: () -> Unit) {
         outputDir = createTempDir()
-        super.interceptTestCase(context, test)
-        outputDir.deleteRecursively()
+        try {
+            super.interceptTestCase(context, test)
+        } finally {
+            outputDir.deleteRecursively()
+        }
     }
 
     init {

--- a/downloader/src/main/kotlin/Main.kt
+++ b/downloader/src/main/kotlin/Main.kt
@@ -275,6 +275,10 @@ object Main {
         } catch (e: IOException) {
             log.error { "Could not unpack source artifact '${tempFile.absolutePath}': ${e.message}" }
             throw DownloadException(e)
+        } finally {
+            if (!tempFile.delete()) {
+                log.warn { "Unable to delete temporary file '$tempFile'." }
+            }
         }
 
         return outputDirectory

--- a/downloader/src/test/kotlin/ArchiveUtilsTest.kt
+++ b/downloader/src/test/kotlin/ArchiveUtilsTest.kt
@@ -19,49 +19,54 @@
 
 package com.here.ort.downloader
 
+import io.kotlintest.TestCaseContext
 import io.kotlintest.matchers.shouldBe
 import io.kotlintest.specs.StringSpec
 
 import java.io.File
 
 class ArchiveUtilsTest : StringSpec() {
+    private lateinit var outputDir: File
+
+    // Required to make lateinit of outputDir work.
+    override val oneInstancePerTest = false
+
+    override fun interceptTestCase(context: TestCaseContext, test: () -> Unit) {
+        outputDir = createTempDir()
+        try {
+            super.interceptTestCase(context, test)
+        } finally {
+            outputDir.deleteRecursively()
+        }
+    }
+
     init {
         "Tar GZ archive can be unpacked" {
             val archive = File("src/test/assets/test.tar.gz")
-            val outputDirectory = createTempDir()
 
-            try {
-                archive.unpack(outputDirectory)
+            archive.unpack(outputDir)
 
-                val fileA = File(outputDirectory, "a")
-                val fileB = File(outputDirectory, "dir/b")
+            val fileA = File(outputDir, "a")
+            val fileB = File(outputDir, "dir/b")
 
-                fileA.exists() shouldBe true
-                fileA.readText() shouldBe "a\n"
-                fileB.exists() shouldBe true
-                fileB.readText() shouldBe "b\n"
-            } finally {
-                outputDirectory.deleteRecursively()
-            }
+            fileA.exists() shouldBe true
+            fileA.readText() shouldBe "a\n"
+            fileB.exists() shouldBe true
+            fileB.readText() shouldBe "b\n"
         }
 
         "Zip archive can be unpacked" {
             val archive = File("src/test/assets/test.zip")
-            val outputDirectory = createTempDir()
 
-            try {
-                archive.unpack(outputDirectory)
+            archive.unpack(outputDir)
 
-                val fileA = File(outputDirectory, "a")
-                val fileB = File(outputDirectory, "dir/b")
+            val fileA = File(outputDir, "a")
+            val fileB = File(outputDir, "dir/b")
 
-                fileA.exists() shouldBe true
-                fileA.readText() shouldBe "a\n"
-                fileB.exists() shouldBe true
-                fileB.readText() shouldBe "b\n"
-            } finally {
-                outputDirectory.deleteRecursively()
-            }
+            fileA.exists() shouldBe true
+            fileA.readText() shouldBe "a\n"
+            fileB.exists() shouldBe true
+            fileB.readText() shouldBe "b\n"
         }
     }
 }

--- a/downloader/src/test/kotlin/GitTest.kt
+++ b/downloader/src/test/kotlin/GitTest.kt
@@ -31,6 +31,7 @@ import java.io.File
 class GitTest : StringSpec() {
     private lateinit var zipContentDir: File
 
+    // Required to make lateinit of outputDir work.
     override val oneInstancePerTest = false
 
     override fun interceptSpec(context: Spec, spec: () -> Unit) {
@@ -42,7 +43,7 @@ class GitTest : StringSpec() {
         zipFile.unpack(zipContentDir)
 
         try {
-            spec()
+            super.interceptSpec(context, spec)
         } finally {
             zipContentDir.deleteRecursively()
         }

--- a/downloader/src/test/kotlin/MercurialTest.kt
+++ b/downloader/src/test/kotlin/MercurialTest.kt
@@ -31,6 +31,7 @@ import java.io.File
 class MercurialTest : StringSpec() {
     private lateinit var zipContentDir: File
 
+    // Required to make lateinit of outputDir work.
     override val oneInstancePerTest = false
 
     override fun interceptSpec(context: Spec, spec: () -> Unit) {
@@ -42,7 +43,7 @@ class MercurialTest : StringSpec() {
         zipFile.unpack(zipContentDir)
 
         try {
-            spec()
+            super.interceptSpec(context, spec)
         } finally {
             zipContentDir.deleteRecursively()
         }

--- a/downloader/src/test/kotlin/SubversionTest.kt
+++ b/downloader/src/test/kotlin/SubversionTest.kt
@@ -31,6 +31,7 @@ import java.io.File
 class SubversionTest : StringSpec() {
     private lateinit var zipContentDir: File
 
+    // Required to make lateinit of outputDir work.
     override val oneInstancePerTest = false
 
     override fun interceptSpec(context: Spec, spec: () -> Unit) {
@@ -42,7 +43,7 @@ class SubversionTest : StringSpec() {
         zipFile.unpack(zipContentDir)
 
         try {
-            spec()
+            super.interceptSpec(context, spec)
         } finally {
             zipContentDir.deleteRecursively()
         }

--- a/scanner/src/funTest/kotlin/HttpCacheTest.kt
+++ b/scanner/src/funTest/kotlin/HttpCacheTest.kt
@@ -65,7 +65,7 @@ class HttpCacheTest : StringSpec() {
             server.createContext("/", MyHttpHandler())
             server.start()
 
-            test()
+            super.interceptTestCase(context, test)
         } finally {
             // Ensure the server is properly stopped even in case of exceptions.
             server.stop(0)

--- a/scanner/src/funTest/kotlin/ScanPathTest.kt
+++ b/scanner/src/funTest/kotlin/ScanPathTest.kt
@@ -23,12 +23,25 @@ import com.here.ort.scanner.scanners.ScanCode
 import com.here.ort.utils.Expensive
 
 import io.kotlintest.matchers.shouldBe
+import io.kotlintest.TestCaseContext
 import io.kotlintest.specs.StringSpec
 
 import java.io.File
 
 class ScanPathTest : StringSpec() {
-    private val outputDir = createTempDir()
+    private lateinit var outputDir: File
+
+    // Required to make lateinit of outputDir work.
+    override val oneInstancePerTest = false
+
+    override fun interceptTestCase(context: TestCaseContext, test: () -> Unit) {
+        outputDir = createTempDir()
+        try {
+            super.interceptTestCase(context, test)
+        } finally {
+            outputDir.deleteRecursively()
+        }
+    }
 
     init {
         "ScanCode recognizes our own LICENSE" {

--- a/utils/src/test/kotlin/UtilsTest.kt
+++ b/utils/src/test/kotlin/UtilsTest.kt
@@ -42,9 +42,10 @@ class UtilsTest : WordSpec({
         }
 
         "create a valid file name" {
-            val fileFromStr = File(createTempDir(), str.fileSystemEncode()).apply { writeText("dummy") }
+            val tempDir = createTempDir()
+            val fileFromStr = File(tempDir, str.fileSystemEncode()).apply { writeText("dummy") }
             fileFromStr.isFile shouldBe true
-            fileFromStr.delete() shouldBe true
+            tempDir.deleteRecursively() shouldBe true
         }
 
         "be reversible by String.urldecode" {


### PR DESCRIPTION
Warn if files could not be deleted, except for NPM where an IOException
is thrown if our node_modules directory could not be deleted, and except
test which do not depend on the logger.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/182)
<!-- Reviewable:end -->
