### PR TITLE
NPM: Fall back to package.json when no remote version info is available

### DIFF
--- a/analyzer/src/main/kotlin/managers/NPM.kt
+++ b/analyzer/src/main/kotlin/managers/NPM.kt
@@ -241,20 +241,26 @@ class NPM : PackageManager() {
                 // TODO: add detection of hash algorithm
 
                 parseVcsInfo(infoJson)
-            } catch (e: IOException) {
-                if (Main.stacktrace) {
-                    e.printStackTrace()
+            } catch (e: Exception) {
+                when (e) {
+                    is IOException, is NullPointerException -> {
+                        if (Main.stacktrace) {
+                            e.printStackTrace()
+                        }
+
+                        // Fallback to getting detailed info from the package.json file. Some info will likely be
+                        // missing.
+                        description = json["description"].asTextOrEmpty()
+                        homepageUrl = json["homepage"].asTextOrEmpty()
+                        downloadUrl = json["_resolved"].asTextOrEmpty()
+
+                        hash = json["_integrity"].asTextOrEmpty()
+                        // TODO: add detection of hash algorithm
+
+                        parseVcsInfo(json)
+                    }
+                    else -> throw e
                 }
-
-                // Fallback to getting detailed info from the package.json file. Some info will likely be missing.
-                description = json["description"].asTextOrEmpty()
-                homepageUrl = json["homepage"].asTextOrEmpty()
-                downloadUrl = json["_resolved"].asTextOrEmpty()
-
-                hash = json["_integrity"].asTextOrEmpty()
-                // TODO: add detection of hash algorithm
-
-                parseVcsInfo(json)
             }
 
             val module = Package(


### PR DESCRIPTION
When the remote package information does not contain an entry for the
specific version of the package, fall back to using the information from
the local package.json. Before this resulted in a NullPointerException.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/184)
<!-- Reviewable:end -->
