### PR TITLE
PackageManager: Support multiple matches of a single glob in a directory

### DIFF
--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -83,14 +83,23 @@ abstract class PackageManager {
                     val filesInDir = dir.toFile().listFiles()
 
                     packageManagers.forEach { manager ->
-                        val matches = manager.matchersForDefinitionFiles.mapNotNull { glob ->
-                            filesInDir.find { file ->
-                                glob.matches(file.toPath())
+                        // Create a list of lists of matching files per glob.
+                        val matchesPerGlob = manager.matchersForDefinitionFiles.mapNotNull { glob ->
+                            // Create a list of files in the current directory that match the current glob.
+                            val filesMatchingGlob = filesInDir.filter { file ->
+                                file != null && glob.matches(file.toPath())
                             }
+                            filesMatchingGlob.takeIf { it.isNotEmpty() }
                         }
 
-                        if (matches.isNotEmpty()) {
-                            result.getOrPut(manager) { mutableListOf() }.add(matches.first())
+                        if (matchesPerGlob.isNotEmpty()) {
+                            // Only consider all matches for the first glob that has matches. This is because globs are
+                            // defined in order of priority, and multiple globs may just be alternative ways to detect
+                            // the exact same project.
+                            // That is, at the example of a PIP project, if a directory contains all three files
+                            // "requirements-py2.txt", "requirements-py3.txt" and "setup.py", only consider the
+                            // former two as they match the glob with the highest priority, but ignore "setup.py".
+                            result.getOrPut(manager) { mutableListOf() }.addAll(matchesPerGlob.first())
                         }
                     }
 

--- a/analyzer/src/main/kotlin/PackageManagerFactory.kt
+++ b/analyzer/src/main/kotlin/PackageManagerFactory.kt
@@ -28,7 +28,7 @@ import java.nio.file.FileSystems
  * @property homepageUrl The URL to the package manager's homepage.
  * @property primaryLanguage The name of the programming language this package manager is primarily used with.
  * @param globsForDefinitionFiles A prioritized list of glob patterns of definition files supported by this package
- *                                manager.
+ *                                manager. Only all matches of the first glob having any matches is considered.
  */
 abstract class PackageManagerFactory<out T : PackageManager>(
         val homepageUrl: String,


### PR DESCRIPTION
This handles cases like in https://github.com/wireservice/csvkit.

/cc @haikoschol 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/190)
<!-- Reviewable:end -->
