### PR TITLE
PIP: Do not hard-code "requirements.txt" in conditional

### DIFF
--- a/analyzer/src/main/kotlin/managers/PIP.kt
+++ b/analyzer/src/main/kotlin/managers/PIP.kt
@@ -161,7 +161,7 @@ class PIP : PackageManager() {
         if (pipdeptreeJson.exitValue() == 0) {
             val allDependencies = jsonMapper.readTree(pipdeptreeJson.stdout()) as ArrayNode
 
-            if (definitionFile.name == "requirements.txt" && pipdeptree.exitValue() == 0) {
+            if (definitionFile.name != "setup.py" && pipdeptree.exitValue() == 0) {
                 val topLevelDependencies = pipdeptree.stdout().lines().mapNotNull {
                     PIPDEPTREE_TOP_LEVEL_REGEX.matchEntire(it)?.groupValues?.get(1).takeUnless {
                         it in PIPDEPTREE_DEPENDENCIES


### PR DESCRIPTION
To check here for "requirements.txt"-like, simply check for not being
a "setup.py". That works as that is (currently) the only other supported
PIP definition file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/195)
<!-- Reviewable:end -->
