### PR TITLE
downloader: Fix sorting of files in tests, again

### DIFF
--- a/downloader/src/funTest/kotlin/GitTest.kt
+++ b/downloader/src/funTest/kotlin/GitTest.kt
@@ -84,7 +84,7 @@ class GitTest : StringSpec() {
                     .onEnter { it.name != ".git" }
                     .filter { it.isFile }
                     .map { it.relativeTo(outputDir) }
-                    .sorted()
+                    .sortedBy { it.path }
 
             workingTree.isValid() shouldBe true
             workingTree.getRevision() shouldBe REPO_REV
@@ -111,7 +111,7 @@ class GitTest : StringSpec() {
                     .onEnter { it.name != ".git" }
                     .filter { it.isFile }
                     .map { it.relativeTo(outputDir) }
-                    .sorted()
+                    .sortedBy { it.path }
 
             workingTree.isValid() shouldBe true
             workingTree.getRevision() shouldBe REPO_REV_FOR_VERSION

--- a/downloader/src/funTest/kotlin/MercurialTest.kt
+++ b/downloader/src/funTest/kotlin/MercurialTest.kt
@@ -93,7 +93,7 @@ class MercurialTest : StringSpec() {
                     .onEnter { it.name != ".hg" }
                     .filter { it.isFile }
                     .map { it.relativeTo(outputDir) }
-                    .sorted()
+                    .sortedBy { it.path }
 
             workingTree.isValid() shouldBe true
             workingTree.getRevision() shouldBe REPO_REV
@@ -130,7 +130,7 @@ class MercurialTest : StringSpec() {
                     .onEnter { it.name != ".hg" }
                     .filter { it.isFile }
                     .map { it.relativeTo(outputDir) }
-                    .sorted()
+                    .sortedBy { it.path }
 
             workingTree.isValid() shouldBe true
             workingTree.getRevision() shouldBe REPO_REV_FOR_VERSION


### PR DESCRIPTION
This is a follow-up to aa01230. As the implementation of
File.compareTo() is OS-specific, ensure to always sort by the path
string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/196)
<!-- Reviewable:end -->
