### PR TITLE
MercurialTest: Disable sparse checkout tests on versions below 4.3

### DIFF
--- a/downloader/src/funTest/kotlin/MercurialTest.kt
+++ b/downloader/src/funTest/kotlin/MercurialTest.kt
@@ -98,7 +98,7 @@ class MercurialTest : StringSpec() {
             workingTree.isValid() shouldBe true
             workingTree.getRevision() shouldBe REPO_REV
             actualFiles.joinToString("\n") shouldBe expectedFiles.joinToString("\n")
-        }.config(tags = setOf(Expensive))
+        }.config(enabled = Mercurial.isAtLeastVersion("4.3"), tags = setOf(Expensive))
 
         "Mercurial can download based on a version" {
             val vcs = VcsInfo("Mercurial", REPO_URL, "", "")
@@ -135,6 +135,6 @@ class MercurialTest : StringSpec() {
             workingTree.isValid() shouldBe true
             workingTree.getRevision() shouldBe REPO_REV_FOR_VERSION
             actualFiles.joinToString("\n") shouldBe expectedFiles.joinToString("\n")
-        }.config(tags = setOf(Expensive))
+        }.config(enabled = Mercurial.isAtLeastVersion("4.3"), tags = setOf(Expensive))
     }
 }

--- a/downloader/src/main/kotlin/vcs/Mercurial.kt
+++ b/downloader/src/main/kotlin/vcs/Mercurial.kt
@@ -140,7 +140,7 @@ object Mercurial : VersionControlSystem() {
         }
     }
 
-    private fun isAtLeastVersion(version: String): Boolean {
+    fun isAtLeastVersion(version: String): Boolean {
         val mercurialVersion = Semver(getVersion(), Semver.SemverType.LOOSE)
         return mercurialVersion.isGreaterThanOrEqualTo(Semver(version, Semver.SemverType.LOOSE))
     }


### PR DESCRIPTION
The extension for sparse checkouts is only available starting with
Mercurial 4.3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/197)
<!-- Reviewable:end -->
