### PR TITLE
PIP: Ensure the temporary virtualenv directory name prefix length

### DIFF
--- a/analyzer/src/main/kotlin/managers/PIP.kt
+++ b/analyzer/src/main/kotlin/managers/PIP.kt
@@ -307,7 +307,7 @@ class PIP : PackageManager() {
     private fun setupVirtualEnv(workingDir: File, definitionFile: File): File {
         // Create an out-of-tree virtualenv.
         println("Creating a virtualenv for the '${workingDir.name}' project directory...")
-        val virtualEnvDir = createTempDir(workingDir.name, "virtualenv")
+        val virtualEnvDir = createTempDir(workingDir.name.padEnd(3, '_'), "virtualenv")
         ProcessCapture(workingDir, "virtualenv", virtualEnvDir.path).requireSuccess()
 
         var pip: ProcessCapture


### PR DESCRIPTION
The underlying createTempFile() requires at least 3 chars. Otherwise the
call would fail e.g. for a directory called "ci".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/201)
<!-- Reviewable:end -->
