### PR TITLE
analyzer: Clean up "node_modules" in tests in "finally"

### DIFF
--- a/analyzer/src/funTest/kotlin/BabelTest.kt
+++ b/analyzer/src/funTest/kotlin/BabelTest.kt
@@ -38,7 +38,7 @@ class BabelTest : WordSpec() {
     override fun interceptTestCase(context: TestCaseContext, test: () -> Unit) {
         try {
             super.interceptTestCase(context, test)
-        } catch (exception: Exception) {
+        } finally {
             // Make sure the node_modules directory is always deleted from each subdirectory to prevent side-effects
             // from failing tests.
             projectDir.listFiles().forEach {
@@ -50,8 +50,6 @@ class BabelTest : WordSpec() {
                     }
                 }
             }
-
-            throw exception
         }
     }
 

--- a/analyzer/src/funTest/kotlin/NpmTest.kt
+++ b/analyzer/src/funTest/kotlin/NpmTest.kt
@@ -43,7 +43,7 @@ class NpmTest : FreeSpec() {
     override fun interceptTestCase(context: TestCaseContext, test: () -> Unit) {
         try {
             super.interceptTestCase(context, test)
-        } catch (exception: Exception) {
+        } finally {
             // Make sure the node_modules directory is always deleted from each subdirectory to prevent side-effects
             // from failing tests.
             projectDir.listFiles().forEach {
@@ -55,8 +55,6 @@ class NpmTest : FreeSpec() {
                     }
                 }
             }
-
-            throw exception
         }
     }
 


### PR DESCRIPTION
Instead of catching and re-throwing the exception.