### PR TITLE
AppVeyor: Execute the "classes" task instead of "assemble"

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,8 +22,10 @@ install:
   - cinst sbt --version 1.0.2 -y
   - refreshenv
 
+# Even if "classes" is a task dependency of "check" below, use it here to
+# override the default MSBuild (which would fail otherwise).
 build_script:
-  - gradlew assemble
+  - gradlew classes
 
 test_script:
   - gradlew -DexcludeTags=Expensive --stacktrace check


### PR DESCRIPTION
"assemble" is doing too much, like building docs, which is cluttering
the CI log output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/212)
<!-- Reviewable:end -->
