### PR TITLE
VcsInfo: Support deserialization from incomplete data

### DIFF
--- a/model/src/main/kotlin/VcsInfo.kt
+++ b/model/src/main/kotlin/VcsInfo.kt
@@ -19,11 +19,19 @@
 
 package com.here.ort.model
 
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+
+import com.here.ort.utils.asTextOrEmpty
 import com.here.ort.utils.normalizeVcsUrl
 
 /**
  * Bundles general Version Control System information.
  */
+@JsonDeserialize(using = VcsInfoDeserializer::class)
 data class VcsInfo(
         /**
          * The name of the VCS provider, for example Git, Hg or SVN.
@@ -99,4 +107,15 @@ data class VcsInfo(
      * Returns this [VcsInfo] in normalized form. Currently, this only applies [normalizeVcsUrl] to the [url].
      */
     fun normalize() = copy(url = normalizeVcsUrl(url))
+}
+
+class VcsInfoDeserializer : StdDeserializer<VcsInfo>(VcsInfo::class.java) {
+    override fun deserialize(p: JsonParser, ctxt: DeserializationContext): VcsInfo {
+        val node = p.codec.readTree<JsonNode>(p)
+        val provider = node.get("provider").asTextOrEmpty()
+        val url = node.get("url").asTextOrEmpty()
+        val revision = node.get("revision").asTextOrEmpty()
+        val path = node.get("path").asTextOrEmpty()
+        return VcsInfo(provider, url, revision, path)
+    }
 }

--- a/model/src/test/kotlin/VcsInfoTest.kt
+++ b/model/src/test/kotlin/VcsInfoTest.kt
@@ -19,11 +19,62 @@
 
 package com.here.ort.model
 
+import com.here.ort.utils.yamlMapper
+
 import io.kotlintest.matchers.should
 import io.kotlintest.matchers.shouldBe
 import io.kotlintest.specs.StringSpec
 
 class VcsInfoTest : StringSpec({
+    "Deserializing VcsInfo" should {
+        "work when all fields are given" {
+            val yaml = """
+                ---
+                provider: "provider"
+                url: "url"
+                revision: "revision"
+                path: "path"
+                """.trimIndent()
+
+            println(yaml)
+
+            val vcsInfo = yamlMapper.readValue(yaml, VcsInfo::class.java)
+
+            vcsInfo.provider shouldBe "provider"
+            vcsInfo.url shouldBe "url"
+            vcsInfo.revision shouldBe "revision"
+            vcsInfo.path shouldBe "path"
+        }
+
+        "assign empty strings to missing fields when only provider is set" {
+            val yaml = """
+                ---
+                provider: "provider"
+                """.trimIndent()
+
+            val vcsInfo = yamlMapper.readValue(yaml, VcsInfo::class.java)
+
+            vcsInfo.provider shouldBe "provider"
+            vcsInfo.url shouldBe ""
+            vcsInfo.revision shouldBe ""
+            vcsInfo.path shouldBe ""
+        }
+
+        "assign empty strings to missing fields when only path is set" {
+            val yaml = """
+                ---
+                path: "path"
+                """.trimIndent()
+
+            val vcsInfo = yamlMapper.readValue(yaml, VcsInfo::class.java)
+
+            vcsInfo.provider shouldBe ""
+            vcsInfo.url shouldBe ""
+            vcsInfo.revision shouldBe ""
+            vcsInfo.path shouldBe "path"
+        }
+    }
+
     "Merging VcsInfo" should {
         "ignore empty information" {
             val inputA = VcsInfo(


### PR DESCRIPTION
Assign empty strings to fields of VcsInfo if they are missing in the
serialized form.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/221)
<!-- Reviewable:end -->
