### PR TITLE
Improve ordering of command line parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,23 +70,16 @@ The `analyzer` command line tool takes the following arguments:
 ```
 Usage: analyzer [options]
   Options:
+  * --input-dir, -i
+      The project directory to scan.
+  * --output-dir, -o
+      The directory to write dependency information to.
+    --package-curations-file
+      A YAML file that contains package curation data.
     --ignore-versions
       Ignore versions of required tools. NOTE: This may lead to erroneous
       results.
       Default: false
-    --debug
-      Enable debug logging and keep any temporary files.
-      Default: false
-    --stacktrace
-      Print out the stacktrace for all exceptions.
-      Default: false
-  * --input-dir, -i
-      The project directory to scan.
-    --info
-      Enable info logging.
-      Default: false
-  * --output-dir, -o
-      The directory to write dependency information to.
     --allow-dynamic-versions
       Allow dynamic versions of dependencies. This can result in unstable
       results when dependencies use version ranges. This option only affects
@@ -99,6 +92,15 @@ Usage: analyzer [options]
       The data format used for dependency information.
       Default: YAML
       Possible Values: [JSON, YAML]
+    --debug
+      Enable debug logging and keep any temporary files.
+      Default: false
+    --stacktrace
+      Print out the stacktrace for all exceptions.
+      Default: false
+    --info
+      Enable info logging.
+      Default: false
     --help, -h
       Display the command line help.
 ```
@@ -114,6 +116,8 @@ The `graph` command line tool takes the following arguments:
 ```
 Usage: graph [options]
   Options:
+  * --dependencies-file, -d
+      The dependencies analysis file to use.
     --info
       Enable info logging.
       Default: false
@@ -123,8 +127,6 @@ Usage: graph [options]
     --stacktrace
       Print out the stacktrace for all exceptions.
       Default: false
-  * --dependencies-file, -d
-      The dependencies analysis file to use.
     --help, -h
       Display the command line help.
 ```
@@ -142,25 +144,25 @@ Usage: downloader [options]
   Options:
   * --dependencies-file, -d
       The dependencies analysis file to use.
-    --debug
-      Enable debug logging and keep any temporary files.
-      Default: false
+  * --output-dir, -o
+      The output directory to download the source code to.
     --allow-moving-revisions
       Allow the download of moving revisions (like e.g. HEAD or master in
       Git). By default these revision are forbidden because they are not
       pointing to a stable revision of the source code.
       Default: false
-  * --output-dir, -o
-      The output directory to download the source code to.
+    --entities, -e
+      The data entities from the dependencies analysis file to download.
+      Default: [PACKAGES, PROJECT]
+    --debug
+      Enable debug logging and keep any temporary files.
+      Default: false
     --info
       Enable info logging.
       Default: false
     --stacktrace
       Print out the stacktrace for all exceptions.
       Default: false
-    --entities, -e
-      The data entities from the dependencies analysis file to download.
-      Default: [PACKAGES, PROJECT]
     --help, -h
       Display the command line help.
 ```
@@ -192,30 +194,30 @@ Usage: scanner [options]
     --summary-format, -f
       The list of file formats for the summary files.
       Default: [YAML]
-    --info
-      Enable info logging.
-      Default: false
     --dependencies-file, -d
       The dependencies analysis file to use. Source code will be downloaded
       automatically if needed. This parameter and --input-path are mutually
       exclusive.
-    --debug
-      Enable debug logging and keep any temporary files.
-      Default: false
     --input-path, -i
       The input directory or file to scan. This parameter and
       --dependencies-file are mutually exclusive.
     --download-dir
-      The output directory for downloaded source code. Defaults to 
+      The output directory for downloaded source code. Defaults to
       <output-dir>/downloads.
-    --stacktrace
-      Print out the stacktrace for all exceptions.
-      Default: false
     --scanner, -s
       The scanner to use.
       Default: ScanCode
     --config, -c
       The path to the configuration file.
+    --info
+      Enable info logging.
+      Default: false
+    --debug
+      Enable debug logging and keep any temporary files.
+      Default: false
+    --stacktrace
+      Print out the stacktrace for all exceptions.
+      Default: false
     --help, -h
       Display the command line help.
 ```

--- a/analyzer/src/main/kotlin/Main.kt
+++ b/analyzer/src/main/kotlin/Main.kt
@@ -34,6 +34,10 @@ import com.here.ort.model.Identifier
 import com.here.ort.model.OutputFormat
 import com.here.ort.model.Project
 import com.here.ort.model.VcsInfo
+import com.here.ort.utils.PARAMETER_ORDER_HELP
+import com.here.ort.utils.PARAMETER_ORDER_LOGGING
+import com.here.ort.utils.PARAMETER_ORDER_MANDATORY
+import com.here.ort.utils.PARAMETER_ORDER_OPTIONAL
 import com.here.ort.utils.jsonMapper
 import com.here.ort.utils.log
 import com.here.ort.utils.safeMkdirs
@@ -64,26 +68,26 @@ object Main {
     @Parameter(description = "A list of package managers to activate.",
             names = ["--package-managers", "-m"],
             converter = PackageManagerConverter::class,
-            order = 0)
+            order = PARAMETER_ORDER_OPTIONAL)
     private var packageManagers = PackageManager.ALL
 
     @Parameter(description = "The project directory to scan.",
             names = ["--input-dir", "-i"],
             required = true,
-            order = 0)
+            order = PARAMETER_ORDER_MANDATORY)
     @Suppress("LateinitUsage")
     private lateinit var inputDir: File
 
     @Parameter(description = "The directory to write dependency information to.",
             names = ["--output-dir", "-o"],
             required = true,
-            order = 0)
+            order = PARAMETER_ORDER_MANDATORY)
     @Suppress("LateinitUsage")
     private lateinit var outputDir: File
 
     @Parameter(description = "The data format used for dependency information.",
             names = ["--output-format", "-f"],
-            order = 0)
+            order = PARAMETER_ORDER_OPTIONAL)
     private var outputFormat = OutputFormat.YAML
 
     @Suppress("LateinitUsage")
@@ -91,40 +95,40 @@ object Main {
 
     @Parameter(description = "Ignore versions of required tools. NOTE: This may lead to erroneous results.",
             names = ["--ignore-versions"],
-            order = 0)
+            order = PARAMETER_ORDER_OPTIONAL)
     var ignoreVersions = false
 
     @Parameter(description = "Allow dynamic versions of dependencies. This can result in unstable results when " +
             "dependencies use version ranges. This option only affects package managers that support lock files, " +
             "like NPM.",
             names = ["--allow-dynamic-versions"],
-            order = 0)
+            order = PARAMETER_ORDER_OPTIONAL)
     var allowDynamicVersions = false
 
     @Parameter(description = "A YAML file that contains package curation data.",
             names = ["--package-curations-file"],
-            order = 0)
+            order = PARAMETER_ORDER_OPTIONAL)
     var packageCurationsFile: File? = null
 
     @Parameter(description = "Enable info logging.",
             names = ["--info"],
-            order = 0)
+            order = PARAMETER_ORDER_LOGGING)
     private var info = false
 
     @Parameter(description = "Enable debug logging and keep any temporary files.",
             names = ["--debug"],
-            order = 0)
+            order = PARAMETER_ORDER_LOGGING)
     private var debug = false
 
     @Parameter(description = "Print out the stacktrace for all exceptions.",
             names = ["--stacktrace"],
-            order = 0)
+            order = PARAMETER_ORDER_LOGGING)
     var stacktrace = false
 
     @Parameter(description = "Display the command line help.",
             names = ["--help", "-h"],
             help = true,
-            order = 100)
+            order = PARAMETER_ORDER_HELP)
     private var help = false
 
     private fun writeResultFile(projectRoot: File, currentPath: File, outputRoot: File, result: AnalyzerResult) {

--- a/downloader/src/main/kotlin/Main.kt
+++ b/downloader/src/main/kotlin/Main.kt
@@ -30,6 +30,10 @@ import com.here.ort.model.OutputFormat
 import com.here.ort.model.Package
 import com.here.ort.model.AnalyzerResult
 import com.here.ort.utils.OkHttpClientHelper
+import com.here.ort.utils.PARAMETER_ORDER_HELP
+import com.here.ort.utils.PARAMETER_ORDER_LOGGING
+import com.here.ort.utils.PARAMETER_ORDER_MANDATORY
+import com.here.ort.utils.PARAMETER_ORDER_OPTIONAL
 import com.here.ort.utils.jsonMapper
 import com.here.ort.utils.log
 import com.here.ort.utils.safeDeleteRecursively
@@ -82,48 +86,48 @@ object Main {
     @Parameter(description = "The dependencies analysis file to use.",
             names = ["--dependencies-file", "-d"],
             required = true,
-            order = 0)
+            order = PARAMETER_ORDER_MANDATORY)
     @Suppress("LateinitUsage")
     private lateinit var dependenciesFile: File
 
     @Parameter(description = "The output directory to download the source code to.",
             names = ["--output-dir", "-o"],
             required = true,
-            order = 0)
+            order = PARAMETER_ORDER_MANDATORY)
     @Suppress("LateinitUsage")
     private lateinit var outputDir: File
 
     @Parameter(description = "The data entities from the dependencies analysis file to download.",
             names = ["--entities", "-e"],
             converter = DataEntityConverter::class,
-            order = 0)
+            order = PARAMETER_ORDER_OPTIONAL)
     private var entities = DataEntity.ALL
 
     @Parameter(description = "Allow the download of moving revisions (like e.g. HEAD or master in Git). By default " +
             "these revision are forbidden because they are not pointing to a stable revision of the source code.",
             names = ["--allow-moving-revisions"],
-            order = 0)
+            order = PARAMETER_ORDER_OPTIONAL)
     private var allowMovingRevisions = false
 
     @Parameter(description = "Enable info logging.",
             names = ["--info"],
-            order = 0)
+            order = PARAMETER_ORDER_LOGGING)
     private var info = false
 
     @Parameter(description = "Enable debug logging and keep any temporary files.",
             names = ["--debug"],
-            order = 0)
+            order = PARAMETER_ORDER_LOGGING)
     private var debug = false
 
     @Parameter(description = "Print out the stacktrace for all exceptions.",
             names = ["--stacktrace"],
-            order = 0)
+            order = PARAMETER_ORDER_LOGGING)
     var stacktrace = false
 
     @Parameter(description = "Display the command line help.",
             names = ["--help", "-h"],
             help = true,
-            order = 100)
+            order = PARAMETER_ORDER_HELP)
     private var help = false
 
     /**

--- a/graph/src/main/kotlin/Main.kt
+++ b/graph/src/main/kotlin/Main.kt
@@ -25,6 +25,9 @@ import com.beust.jcommander.Parameter
 import com.here.ort.model.OutputFormat
 import com.here.ort.model.PackageReference
 import com.here.ort.model.AnalyzerResult
+import com.here.ort.utils.PARAMETER_ORDER_HELP
+import com.here.ort.utils.PARAMETER_ORDER_LOGGING
+import com.here.ort.utils.PARAMETER_ORDER_MANDATORY
 import com.here.ort.utils.jsonMapper
 import com.here.ort.utils.log
 import com.here.ort.utils.yamlMapper
@@ -48,29 +51,29 @@ object Main {
     @Parameter(description = "The dependencies analysis file to use.",
             names = ["--dependencies-file", "-d"],
             required = true,
-            order = 0)
+            order = PARAMETER_ORDER_MANDATORY)
     @Suppress("LateinitUsage")
     private lateinit var dependenciesFile: File
 
     @Parameter(description = "Enable info logging.",
             names = ["--info"],
-            order = 0)
+            order = PARAMETER_ORDER_LOGGING)
     private var info = false
 
     @Parameter(description = "Enable debug logging and keep any temporary files.",
             names = ["--debug"],
-            order = 0)
+            order = PARAMETER_ORDER_LOGGING)
     private var debug = false
 
     @Parameter(description = "Print out the stacktrace for all exceptions.",
             names = ["--stacktrace"],
-            order = 0)
+            order = PARAMETER_ORDER_LOGGING)
     var stacktrace = false
 
     @Parameter(description = "Display the command line help.",
             names = ["--help", "-h"],
             help = true,
-            order = 100)
+            order = PARAMETER_ORDER_HELP)
     private var help = false
 
     /**

--- a/scanner/src/main/kotlin/Main.kt
+++ b/scanner/src/main/kotlin/Main.kt
@@ -31,6 +31,10 @@ import com.here.ort.model.Package
 import com.here.ort.model.Project
 import com.here.ort.model.AnalyzerResult
 import com.here.ort.scanner.scanners.ScanCode
+import com.here.ort.utils.PARAMETER_ORDER_HELP
+import com.here.ort.utils.PARAMETER_ORDER_LOGGING
+import com.here.ort.utils.PARAMETER_ORDER_MANDATORY
+import com.here.ort.utils.PARAMETER_ORDER_OPTIONAL
 import com.here.ort.utils.collectMessages
 import com.here.ort.utils.jsonMapper
 import com.here.ort.utils.log
@@ -85,64 +89,64 @@ object Main {
     @Parameter(description = "The dependencies analysis file to use. Source code will be downloaded automatically if " +
             "needed. This parameter and --input-path are mutually exclusive.",
             names = ["--dependencies-file", "-d"],
-            order = 0)
+            order = PARAMETER_ORDER_OPTIONAL)
     private var dependenciesFile: File? = null
 
     @Parameter(description = "The input directory or file to scan. This parameter and --dependencies-file are " +
             "mutually exclusive.",
             names = ["--input-path", "-i"],
-            order = 0)
+            order = PARAMETER_ORDER_OPTIONAL)
     private var inputPath: File? = null
 
     @Parameter(description = "The output directory to store the scan results in.",
             names = ["--output-dir", "-o"],
             required = true,
-            order = 0)
+            order = PARAMETER_ORDER_MANDATORY)
     @Suppress("LateinitUsage")
     private lateinit var outputDir: File
 
     @Parameter(description = "The output directory for downloaded source code. Defaults to <output-dir>/downloads.",
             names = ["--download-dir"],
-            order = 0)
+            order = PARAMETER_ORDER_OPTIONAL)
     private var downloadDir: File? = null
 
     @Parameter(description = "The scanner to use.",
             names = ["--scanner", "-s"],
             converter = ScannerConverter::class,
-            order = 0)
+            order = PARAMETER_ORDER_OPTIONAL)
     private var scanner: Scanner = ScanCode
 
     @Parameter(description = "The path to the configuration file.",
             names = ["--config", "-c"],
-            order = 0)
+            order = PARAMETER_ORDER_OPTIONAL)
     @Suppress("LateinitUsage")
     private var configFile: File? = null
 
     @Parameter(description = "The list of file formats for the summary files.",
             names = ["--summary-format", "-f"],
             converter = OutputFormatConverter::class,
-            order = 0)
+            order = PARAMETER_ORDER_OPTIONAL)
     private var summaryFormats = listOf(OutputFormat.YAML)
 
     @Parameter(description = "Enable info logging.",
             names = ["--info"],
-            order = 0)
+            order = PARAMETER_ORDER_LOGGING)
     private var info = false
 
     @Parameter(description = "Enable debug logging and keep any temporary files.",
             names = ["--debug"],
-            order = 0)
+            order = PARAMETER_ORDER_LOGGING)
     private var debug = false
 
     @Parameter(description = "Print out the stacktrace for all exceptions.",
             names = ["--stacktrace"],
-            order = 0)
+            order = PARAMETER_ORDER_LOGGING)
     var stacktrace = false
 
     @Parameter(description = "Display the command line help.",
             names = ["--help", "-h"],
             help = true,
-            order = 100)
+            order = PARAMETER_ORDER_HELP)
     private var help = false
 
     /**

--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -52,6 +52,26 @@ val xmlMapper = ObjectMapper(XmlFactory()).registerKotlinModule()
 val yamlMapper = ObjectMapper(YAMLFactory()).registerKotlinModule()
 
 /**
+ * Ordinal for mandatory program parameters.
+ */
+const val PARAMETER_ORDER_MANDATORY = 0
+
+/**
+ * Ordinal for optional program parameters.
+ */
+const val PARAMETER_ORDER_OPTIONAL = 1
+
+/**
+ * Ordinal for logging related program parameters.
+ */
+const val PARAMETER_ORDER_LOGGING = 2
+
+/**
+ * Ordinal for the help program parameter.
+ */
+const val PARAMETER_ORDER_HELP = 100
+
+/**
  * A helper class to manage OkHttp instances backed by distinct cache directories.
  */
 object OkHttpClientHelper {


### PR DESCRIPTION
Sort the parameters in this order for all tools:

1) Mandatory parameters
2) Optional parameters
3) Logging related parameters
4) Help parameters

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/226)
<!-- Reviewable:end -->
