### PR TITLE
analyzer: Move logic to process VcsInfo from NPM to PackageManager

### DIFF
--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -22,10 +22,13 @@ package com.here.ort.analyzer
 import ch.frankel.slf4k.*
 
 import com.here.ort.analyzer.managers.*
+import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.AnalyzerResult
 import com.here.ort.model.Project
+import com.here.ort.model.VcsInfo
 import com.here.ort.utils.collectMessages
 import com.here.ort.utils.log
+import com.here.ort.utils.normalizeVcsUrl
 
 import java.io.File
 import java.nio.file.FileVisitResult
@@ -108,6 +111,25 @@ abstract class PackageManager {
             })
 
             return result
+        }
+
+        /**
+         * Merge the [VcsInfo] read from the package with [VcsInfo] deduced from the VCS URL.
+         */
+        fun processPackageVcs(vcsFromPackage: VcsInfo): VcsInfo {
+            val vcsFromUrl = VersionControlSystem.splitUrl(normalizeVcsUrl(vcsFromPackage.url))
+            return vcsFromUrl.merge(vcsFromPackage)
+        }
+
+        /**
+         * Merge the [VcsInfo] read from the project with [VcsInfo] deduced from the VCS URL and from the working
+         * directory.
+         */
+        fun processProjectVcs(projectDir: File, vcsFromProject: VcsInfo = VcsInfo.EMPTY): VcsInfo {
+            val vcsFromWorkingTree = VersionControlSystem.forDirectory(projectDir)
+                    ?.getInfo(projectDir) ?: VcsInfo.EMPTY
+
+            return processPackageVcs(vcsFromProject).merge(vcsFromWorkingTree)
         }
     }
 


### PR DESCRIPTION
This makes the logic reusable by other package managers. The logic
itself it still the same, only a redundant let() call was removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/228)
<!-- Reviewable:end -->
