### PR TITLE
analyzer: Consistently take project VCS information only from the package

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
@@ -9,14 +9,14 @@ project:
   declared_licenses: []
   aliases: []
   vcs:
-    provider: "Git"
-    url: "https://github.com/deis/example-python-flask.git"
-    revision: "0773991e36a4c69b121cdb05146d6140347d4065"
+    provider: ""
+    url: ""
+    revision: ""
     path: ""
   vcs_processed:
-    provider: "Git"
-    url: "https://github.com/deis/example-python-flask.git"
-    revision: "0773991e36a4c69b121cdb05146d6140347d4065"
+    provider: ""
+    url: ""
+    revision: ""
     path: ""
   homepage_url: ""
   scopes:

--- a/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
@@ -9,14 +9,14 @@ project:
   declared_licenses: []
   aliases: []
   vcs:
-    provider: "Git"
-    url: "https://github.com/spdx/tools-python.git"
-    revision: "a48022e65a8897d0e4f2e93d8e53695d2c13ea23"
+    provider: ""
+    url: ""
+    revision: ""
     path: ""
   vcs_processed:
-    provider: "Git"
-    url: "https://github.com/spdx/tools-python.git"
-    revision: "a48022e65a8897d0e4f2e93d8e53695d2c13ea23"
+    provider: ""
+    url: ""
+    revision: ""
     path: ""
   homepage_url: "https://github.com/spdx/tools-python"
   scopes:

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
@@ -9,15 +9,15 @@ project:
   declared_licenses: []
   aliases: []
   vcs:
-    provider: "Git"
+    provider: ""
     url: ""
     revision: ""
-    path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
+    path: ""
   vcs_processed:
-    provider: "Git"
+    provider: ""
     url: ""
     revision: ""
-    path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
+    path: ""
   homepage_url: ""
   scopes:
   - name: "archives"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
@@ -9,15 +9,15 @@ project:
   declared_licenses: []
   aliases: []
   vcs:
-    provider: "Git"
+    provider: ""
     url: ""
     revision: ""
-    path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
+    path: ""
   vcs_processed:
-    provider: "Git"
+    provider: ""
     url: ""
     revision: ""
-    path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
+    path: ""
   homepage_url: ""
   scopes:
   - name: "archives"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
@@ -9,15 +9,15 @@ project:
   declared_licenses: []
   aliases: []
   vcs:
-    provider: "Git"
+    provider: ""
     url: ""
     revision: ""
-    path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
+    path: ""
   vcs_processed:
-    provider: "Git"
+    provider: ""
     url: ""
     revision: ""
-    path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
+    path: ""
   homepage_url: ""
   scopes:
   - name: "archives"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-root.yml
@@ -9,15 +9,15 @@ project:
   declared_licenses: []
   aliases: []
   vcs:
-    provider: "Git"
+    provider: ""
     url: ""
     revision: ""
-    path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
+    path: ""
   vcs_processed:
-    provider: "Git"
+    provider: ""
     url: ""
     revision: ""
-    path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
+    path: ""
   homepage_url: ""
   scopes: []
 packages: []

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-app.yml
@@ -9,15 +9,15 @@ project:
   declared_licenses: []
   aliases: []
   vcs:
-    provider: "Git"
+    provider: ""
     url: ""
     revision: ""
-    path: "analyzer/src/funTest/assets/projects/synthetic/maven"
+    path: ""
   vcs_processed:
-    provider: "Git"
+    provider: ""
     url: ""
     revision: ""
-    path: "analyzer/src/funTest/assets/projects/synthetic/maven"
+    path: ""
   homepage_url: "http://maven.apache.org"
   scopes:
   - name: "compile"

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-lib.yml
@@ -9,15 +9,15 @@ project:
   declared_licenses: []
   aliases: []
   vcs:
-    provider: "Git"
+    provider: ""
     url: ""
     revision: ""
-    path: "analyzer/src/funTest/assets/projects/synthetic/maven"
+    path: ""
   vcs_processed:
-    provider: "Git"
+    provider: ""
     url: ""
     revision: ""
-    path: "analyzer/src/funTest/assets/projects/synthetic/maven"
+    path: ""
   homepage_url: "http://maven.apache.org"
   scopes:
   - name: "compile"

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-root.yml
@@ -9,15 +9,15 @@ project:
   declared_licenses: []
   aliases: []
   vcs:
-    provider: "Git"
+    provider: ""
     url: ""
     revision: ""
-    path: "analyzer/src/funTest/assets/projects/synthetic/maven"
+    path: ""
   vcs_processed:
-    provider: "Git"
+    provider: ""
     url: ""
     revision: ""
-    path: "analyzer/src/funTest/assets/projects/synthetic/maven"
+    path: ""
   homepage_url: "http://maven.apache.org"
   scopes: []
 packages: []

--- a/analyzer/src/funTest/kotlin/GradleTest.kt
+++ b/analyzer/src/funTest/kotlin/GradleTest.kt
@@ -41,12 +41,9 @@ class GradleTest : StringSpec() {
     private fun patchExpectedResult(filename: String) =
             File(projectDir.parentFile, filename)
                     .readText()
-                    // vcs:
-                    .replaceFirst("url: \"\"", "url: \"$vcsUrl\"")
-                    .replaceFirst("revision: \"\"", "revision: \"$vcsRevision\"")
                     // vcs_processed:
-                    .replaceFirst("url: \"\"", "url: \"${normalizeVcsUrl(vcsUrl)}\"")
-                    .replaceFirst("revision: \"\"", "revision: \"$vcsRevision\"")
+                    .replaceFirst("url: \"<REPLACE>\"", "url: \"${normalizeVcsUrl(vcsUrl)}\"")
+                    .replaceFirst("revision: \"<REPLACE>\"", "revision: \"$vcsRevision\"")
 
     init {
         "Root project dependencies are detected correctly" {

--- a/analyzer/src/funTest/kotlin/MavenTest.kt
+++ b/analyzer/src/funTest/kotlin/MavenTest.kt
@@ -38,12 +38,9 @@ class MavenTest : StringSpec() {
     private fun patchExpectedResult(filename: String) =
             File(syntheticProjectDir.parentFile, filename)
                     .readText()
-                    // vcs:
-                    .replaceFirst("url: \"\"", "url: \"$vcsUrl\"")
-                    .replaceFirst("revision: \"\"", "revision: \"$vcsRevision\"")
                     // vcs_processed:
-                    .replaceFirst("url: \"\"", "url: \"${normalizeVcsUrl(vcsUrl)}\"")
-                    .replaceFirst("revision: \"\"", "revision: \"$vcsRevision\"")
+                    .replaceFirst("url: \"<REPLACE>\"", "url: \"${normalizeVcsUrl(vcsUrl)}\"")
+                    .replaceFirst("revision: \"<REPLACE>\"", "revision: \"$vcsRevision\"")
 
     init {
         "jgnash parent dependencies are detected correctly" {

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -29,7 +29,6 @@ import com.here.ort.analyzer.MavenSupport
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.analyzer.PackageManagerFactory
 import com.here.ort.analyzer.identifier
-import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.AnalyzerResult
 import com.here.ort.model.Identifier
 import com.here.ort.model.Package
@@ -125,7 +124,6 @@ class Gradle : PackageManager() {
                 Scope(configuration.name, true, dependencies.toSortedSet())
             }
 
-            val vcsDir = VersionControlSystem.forDirectory(projectDir)
             val project = Project(
                     id = Identifier(
                             packageManager = javaClass.simpleName,
@@ -135,7 +133,7 @@ class Gradle : PackageManager() {
                     ),
                     declaredLicenses = sortedSetOf(),
                     aliases = emptyList(),
-                    vcs = vcsDir?.getInfo(projectDir) ?: VcsInfo.EMPTY,
+                    vcs = VcsInfo.EMPTY,
                     homepageUrl = "",
                     scopes = scopes.toSortedSet()
             )

--- a/analyzer/src/main/kotlin/managers/Maven.kt
+++ b/analyzer/src/main/kotlin/managers/Maven.kt
@@ -26,14 +26,12 @@ import com.here.ort.analyzer.MavenSupport
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.analyzer.PackageManagerFactory
 import com.here.ort.analyzer.identifier
-import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.AnalyzerResult
 import com.here.ort.model.Identifier
 import com.here.ort.model.Package
 import com.here.ort.model.PackageReference
 import com.here.ort.model.Project
 import com.here.ort.model.Scope
-import com.here.ort.model.VcsInfo
 import com.here.ort.utils.collectMessages
 import com.here.ort.utils.log
 
@@ -129,12 +127,7 @@ class Maven : PackageManager() {
             scope.dependencies.add(parseDependency(node, packages))
         }
 
-        // Try to get VCS information from the POM's SCM tag, or otherwise from the VCS working tree.
-        val vcs = maven.parseVcsInfo(mavenProject).takeUnless {
-            it == VcsInfo.EMPTY
-        } ?: VersionControlSystem.forDirectory(projectDir)?.let {
-            it.getInfo(projectDir)
-        } ?: VcsInfo.EMPTY
+        val vcsFromPackage = maven.parseVcsInfo(mavenProject)
 
         val project = Project(
                 id = Identifier(
@@ -145,7 +138,7 @@ class Maven : PackageManager() {
                 ),
                 declaredLicenses = maven.parseLicenses(mavenProject),
                 aliases = emptyList(),
-                vcs = vcs,
+                vcs = vcsFromPackage,
                 homepageUrl = mavenProject.url ?: "",
                 scopes = scopes.values.toSortedSet()
         )

--- a/analyzer/src/main/kotlin/managers/PIP.kt
+++ b/analyzer/src/main/kotlin/managers/PIP.kt
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.databind.node.ArrayNode
 import com.here.ort.analyzer.Main
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.analyzer.PackageManagerFactory
-import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.Package
 import com.here.ort.model.PackageReference
 import com.here.ort.model.Project
@@ -281,7 +280,6 @@ class PIP : PackageManager() {
                 Scope("install", true, installDependencies)
         )
 
-        val vcsDir = VersionControlSystem.forDirectory(projectDir)
         val project = Project(
                 id = Identifier(
                         packageManager = javaClass.simpleName,
@@ -291,7 +289,7 @@ class PIP : PackageManager() {
                 ),
                 declaredLicenses = sortedSetOf(), // TODO: Get the licenses for local projects.
                 aliases = emptyList(),
-                vcs = vcsDir?.getInfo(projectDir) ?: VcsInfo.EMPTY,
+                vcs = VcsInfo.EMPTY,
                 homepageUrl = projectHomepage,
                 scopes = scopes
         )


### PR DESCRIPTION
Unprocessed VCS information should not fall back to using the working
tree as there might be local / unpublished changes, or the clone might
have happened from a fork.

Instead of removing the code to patch expected results completely, just
deactivate it by using a pattern that is not yet matched. This way we can
make use of the code again in a follow-up commit that aligns merging of
package VCS information to how it is already done for NPM also for the
remaining package managers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/229)
<!-- Reviewable:end -->
