### PR TITLE
analyzer: Align processing of VcsInfo for all package managers

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
@@ -15,7 +15,7 @@ project:
     revision: "HEAD"
     path: ""
   vcs_processed:
-    provider: "git"
+    provider: "Git"
     url: "ssh://git@github.com/soc/directories.git"
     revision: "HEAD"
     path: ""
@@ -59,7 +59,7 @@ packages:
     revision: "r4.12"
     path: ""
   vcs_processed:
-    provider: "git"
+    provider: "Git"
     url: "https://github.com/junit-team/junit.git"
     revision: "r4.12"
     path: ""
@@ -88,8 +88,8 @@ packages:
     revision: "HEAD"
     path: ""
   vcs_processed:
-    provider: "git"
-    url: "ssh://git@github.com/hamcrest/JavaHamcrest.git/hamcrest-core"
+    provider: "Git"
+    url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
     revision: "HEAD"
-    path: ""
+    path: "hamcrest-core"
 errors: []

--- a/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
@@ -14,9 +14,9 @@ project:
     revision: ""
     path: ""
   vcs_processed:
-    provider: ""
-    url: ""
-    revision: ""
+    provider: "Git"
+    url: "https://github.com/deis/example-python-flask.git"
+    revision: "0773991e36a4c69b121cdb05146d6140347d4065"
     path: ""
   homepage_url: ""
   scopes:

--- a/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
@@ -14,10 +14,10 @@ project:
     revision: "HEAD"
     path: ""
   vcs_processed:
-    provider: "git"
-    url: "https://github.com/ccavanaugh/jgnash.git/jgnash-core"
+    provider: "Git"
+    url: "https://github.com/ccavanaugh/jgnash.git"
     revision: "HEAD"
-    path: ""
+    path: "jgnash-core"
   homepage_url: "http://sourceforge.net/projects/jgnash/jgnash-core/"
   scopes:
   - name: "compile"
@@ -259,7 +259,7 @@ packages:
     revision: "classmate-1.3.0"
     path: ""
   vcs_processed:
-    provider: "git"
+    provider: "Git"
     url: "ssh://git@github.com/cowtowncoder/java-classmate.git"
     revision: "classmate-1.3.0"
     path: ""
@@ -289,7 +289,7 @@ packages:
     revision: "HEAD"
     path: ""
   vcs_processed:
-    provider: "git"
+    provider: "Git"
     url: "https://github.com/virtuald/curvesapi.git"
     revision: "HEAD"
     path: ""
@@ -316,7 +316,7 @@ packages:
     revision: "HEAD"
     path: ""
   vcs_processed:
-    provider: "git"
+    provider: "Git"
     url: "https://github.com/h2database/h2database.git"
     revision: "HEAD"
     path: ""
@@ -344,7 +344,7 @@ packages:
     revision: "HEAD"
     path: ""
   vcs_processed:
-    provider: "git"
+    provider: "Git"
     url: "ssh://git@github.com/swaldman/c3p0.git"
     revision: "HEAD"
     path: ""
@@ -372,7 +372,7 @@ packages:
     revision: "HEAD"
     path: ""
   vcs_processed:
-    provider: "git"
+    provider: "Git"
     url: "ssh://git@github.com/swaldman/mchange-commons-java.git"
     revision: "HEAD"
     path: ""
@@ -399,10 +399,10 @@ packages:
     revision: "v-1.4.x"
     path: ""
   vcs_processed:
-    provider: "git"
-    url: "https://github.com/x-stream/xstream.git/xstream-hibernate"
+    provider: "Git"
+    url: "https://github.com/x-stream/xstream.git"
     revision: "v-1.4.x"
-    path: ""
+    path: "xstream-hibernate"
 - id:
     package_manager: "Maven"
     namespace: "com.thoughtworks.xstream"
@@ -426,10 +426,10 @@ packages:
     revision: "v-1.4.x"
     path: ""
   vcs_processed:
-    provider: "git"
-    url: "https://github.com/x-stream/xstream.git/xstream"
+    provider: "Git"
+    url: "https://github.com/x-stream/xstream.git"
     revision: "v-1.4.x"
-    path: ""
+    path: "xstream"
 - id:
     package_manager: "Maven"
     namespace: "commons-codec"
@@ -511,10 +511,10 @@ packages:
     revision: "netty-4.1.9.Final"
     path: ""
   vcs_processed:
-    provider: "git"
-    url: "https://github.com/netty/netty.git/netty-buffer"
+    provider: "Git"
+    url: "https://github.com/netty/netty.git"
     revision: "netty-4.1.9.Final"
-    path: ""
+    path: "netty-buffer"
 - id:
     package_manager: "Maven"
     namespace: "io.netty"
@@ -540,10 +540,10 @@ packages:
     revision: "netty-4.1.9.Final"
     path: ""
   vcs_processed:
-    provider: "git"
-    url: "https://github.com/netty/netty.git/netty-codec"
+    provider: "Git"
+    url: "https://github.com/netty/netty.git"
     revision: "netty-4.1.9.Final"
-    path: ""
+    path: "netty-codec"
 - id:
     package_manager: "Maven"
     namespace: "io.netty"
@@ -569,10 +569,10 @@ packages:
     revision: "netty-4.1.9.Final"
     path: ""
   vcs_processed:
-    provider: "git"
-    url: "https://github.com/netty/netty.git/netty-common"
+    provider: "Git"
+    url: "https://github.com/netty/netty.git"
     revision: "netty-4.1.9.Final"
-    path: ""
+    path: "netty-common"
 - id:
     package_manager: "Maven"
     namespace: "io.netty"
@@ -598,10 +598,10 @@ packages:
     revision: "netty-4.1.9.Final"
     path: ""
   vcs_processed:
-    provider: "git"
-    url: "https://github.com/netty/netty.git/netty-resolver"
+    provider: "Git"
+    url: "https://github.com/netty/netty.git"
     revision: "netty-4.1.9.Final"
-    path: ""
+    path: "netty-resolver"
 - id:
     package_manager: "Maven"
     namespace: "io.netty"
@@ -627,10 +627,10 @@ packages:
     revision: "netty-4.1.9.Final"
     path: ""
   vcs_processed:
-    provider: "git"
-    url: "https://github.com/netty/netty.git/netty-transport"
+    provider: "Git"
+    url: "https://github.com/netty/netty.git"
     revision: "netty-4.1.9.Final"
-    path: ""
+    path: "netty-transport"
 - id:
     package_manager: "Maven"
     namespace: "jgnash"
@@ -653,10 +653,10 @@ packages:
     revision: "HEAD"
     path: ""
   vcs_processed:
-    provider: "git"
-    url: "https://github.com/ccavanaugh/jgnash.git/jgnash-resources"
+    provider: "Git"
+    url: "https://github.com/ccavanaugh/jgnash.git"
     revision: "HEAD"
-    path: ""
+    path: "jgnash-resources"
 - id:
     package_manager: "Maven"
     namespace: "junit"
@@ -681,7 +681,7 @@ packages:
     revision: "r4.12"
     path: ""
   vcs_processed:
-    provider: "git"
+    provider: "Git"
     url: "https://github.com/junit-team/junit.git"
     revision: "r4.12"
     path: ""
@@ -903,10 +903,10 @@ packages:
     revision: "HEAD"
     path: ""
   vcs_processed:
-    provider: "git"
-    url: "ssh://git@github.com/hamcrest/JavaHamcrest.git/hamcrest-all"
+    provider: "Git"
+    url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
     revision: "HEAD"
-    path: ""
+    path: "hamcrest-all"
 - id:
     package_manager: "Maven"
     namespace: "org.hibernate.common"
@@ -930,7 +930,7 @@ packages:
     revision: "HEAD"
     path: ""
   vcs_processed:
-    provider: "git"
+    provider: "Git"
     url: "https://github.com/hibernate/hibernate-commons-annotations.git"
     revision: "HEAD"
     path: ""
@@ -959,7 +959,7 @@ packages:
     revision: "HEAD"
     path: ""
   vcs_processed:
-    provider: "git"
+    provider: "Git"
     url: "https://github.com/hibernate/hibernate-jpa-api.git"
     revision: "HEAD"
     path: ""
@@ -986,7 +986,7 @@ packages:
     revision: "HEAD"
     path: ""
   vcs_processed:
-    provider: "git"
+    provider: "Git"
     url: "https://github.com/hibernate/hibernate-orm.git"
     revision: "HEAD"
     path: ""
@@ -1013,7 +1013,7 @@ packages:
     revision: "HEAD"
     path: ""
   vcs_processed:
-    provider: "git"
+    provider: "Git"
     url: "https://github.com/hibernate/hibernate-orm.git"
     revision: "HEAD"
     path: ""
@@ -1070,7 +1070,7 @@ packages:
     revision: "HEAD"
     path: ""
   vcs_processed:
-    provider: "git"
+    provider: "Git"
     url: "ssh://git@github.com/jboss-javassist/javassist.git"
     revision: "HEAD"
     path: ""
@@ -1097,7 +1097,7 @@ packages:
     revision: "HEAD"
     path: ""
   vcs_processed:
-    provider: "git"
+    provider: "Git"
     url: "https://github.com/jboss-logging/jboss-logging.git"
     revision: "HEAD"
     path: ""
@@ -1125,7 +1125,7 @@ packages:
     revision: "jboss-transaction-api_1.2_spec-1.0.1.Final"
     path: ""
   vcs_processed:
-    provider: "git"
+    provider: "Git"
     url: "ssh://git@github.com/jboss/jboss-transaction-api_spec.git"
     revision: "jboss-transaction-api_1.2_spec-1.0.1.Final"
     path: ""
@@ -1152,10 +1152,10 @@ packages:
     revision: "HEAD"
     path: ""
   vcs_processed:
-    provider: "git"
-    url: "ssh://git@github.com/jboss/jboss-parent-pom.git/jandex"
+    provider: "Git"
+    url: "ssh://git@github.com/jboss/jboss-parent-pom.git"
     revision: "HEAD"
-    path: ""
+    path: "jandex"
 - id:
     package_manager: "Maven"
     namespace: "org.slf4j"

--- a/analyzer/src/funTest/assets/projects/external/jgnash-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/jgnash-expected-output.yml
@@ -14,7 +14,7 @@ project:
     revision: "HEAD"
     path: ""
   vcs_processed:
-    provider: "git"
+    provider: "Git"
     url: "https://github.com/ccavanaugh/jgnash.git"
     revision: "HEAD"
     path: ""
@@ -58,7 +58,7 @@ packages:
     revision: "r4.12"
     path: ""
   vcs_processed:
-    provider: "git"
+    provider: "Git"
     url: "https://github.com/junit-team/junit.git"
     revision: "r4.12"
     path: ""
@@ -86,8 +86,8 @@ packages:
     revision: "HEAD"
     path: ""
   vcs_processed:
-    provider: "git"
-    url: "ssh://git@github.com/hamcrest/JavaHamcrest.git/hamcrest-all"
+    provider: "Git"
+    url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
     revision: "HEAD"
-    path: ""
+    path: "hamcrest-all"
 errors: []

--- a/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
@@ -14,9 +14,9 @@ project:
     revision: ""
     path: ""
   vcs_processed:
-    provider: ""
-    url: ""
-    revision: ""
+    provider: "Git"
+    url: "https://github.com/spdx/tools-python.git"
+    revision: "a48022e65a8897d0e4f2e93d8e53695d2c13ea23"
     path: ""
   homepage_url: "https://github.com/spdx/tools-python"
   scopes:

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
@@ -14,10 +14,10 @@ project:
     revision: ""
     path: ""
   vcs_processed:
-    provider: ""
-    url: ""
-    revision: ""
-    path: ""
+    provider: "Git"
+    url: "<REPLACE>"
+    revision: "<REPLACE>"
+    path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
   homepage_url: ""
   scopes:
   - name: "archives"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
@@ -14,10 +14,10 @@ project:
     revision: ""
     path: ""
   vcs_processed:
-    provider: ""
-    url: ""
-    revision: ""
-    path: ""
+    provider: "Git"
+    url: "<REPLACE>"
+    revision: "<REPLACE>"
+    path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
   homepage_url: ""
   scopes:
   - name: "archives"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
@@ -14,10 +14,10 @@ project:
     revision: ""
     path: ""
   vcs_processed:
-    provider: ""
-    url: ""
-    revision: ""
-    path: ""
+    provider: "Git"
+    url: "<REPLACE>"
+    revision: "<REPLACE>"
+    path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
   homepage_url: ""
   scopes:
   - name: "archives"
@@ -211,7 +211,7 @@ packages:
     revision: "r4.12"
     path: ""
   vcs_processed:
-    provider: "git"
+    provider: "Git"
     url: "https://github.com/junit-team/junit.git"
     revision: "r4.12"
     path: ""
@@ -297,8 +297,8 @@ packages:
     revision: "HEAD"
     path: ""
   vcs_processed:
-    provider: "git"
-    url: "ssh://git@github.com/hamcrest/JavaHamcrest.git/hamcrest-core"
+    provider: "Git"
+    url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
     revision: "HEAD"
-    path: ""
+    path: "hamcrest-core"
 errors: []

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-root.yml
@@ -14,10 +14,10 @@ project:
     revision: ""
     path: ""
   vcs_processed:
-    provider: ""
-    url: ""
-    revision: ""
-    path: ""
+    provider: "Git"
+    url: "<REPLACE>"
+    revision: "<REPLACE>"
+    path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
   homepage_url: ""
   scopes: []
 packages: []

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-app.yml
@@ -14,10 +14,10 @@ project:
     revision: ""
     path: ""
   vcs_processed:
-    provider: ""
-    url: ""
-    revision: ""
-    path: ""
+    provider: "Git"
+    url: "<REPLACE>"
+    revision: "<REPLACE>"
+    path: "analyzer/src/funTest/assets/projects/synthetic/maven"
   homepage_url: "http://maven.apache.org"
   scopes:
   - name: "compile"

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-lib.yml
@@ -14,10 +14,10 @@ project:
     revision: ""
     path: ""
   vcs_processed:
-    provider: ""
-    url: ""
-    revision: ""
-    path: ""
+    provider: "Git"
+    url: "<REPLACE>"
+    revision: "<REPLACE>"
+    path: "analyzer/src/funTest/assets/projects/synthetic/maven"
   homepage_url: "http://maven.apache.org"
   scopes:
   - name: "compile"

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-root.yml
@@ -14,10 +14,10 @@ project:
     revision: ""
     path: ""
   vcs_processed:
-    provider: ""
-    url: ""
-    revision: ""
-    path: ""
+    provider: "Git"
+    url: "<REPLACE>"
+    revision: "<REPLACE>"
+    path: "analyzer/src/funTest/assets/projects/synthetic/maven"
   homepage_url: "http://maven.apache.org"
   scopes: []
 packages: []

--- a/analyzer/src/funTest/kotlin/MavenTest.kt
+++ b/analyzer/src/funTest/kotlin/MavenTest.kt
@@ -30,13 +30,13 @@ import io.kotlintest.specs.StringSpec
 import java.io.File
 
 class MavenTest : StringSpec() {
-    private val syntheticProjectDir = File("src/funTest/assets/projects/synthetic/maven")
-    private val vcsDir = VersionControlSystem.forDirectory(syntheticProjectDir)!!
+    private val projectDir = File("src/funTest/assets/projects/synthetic/maven")
+    private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()
 
     private fun patchExpectedResult(filename: String) =
-            File(syntheticProjectDir.parentFile, filename)
+            File(projectDir.parentFile, filename)
                     .readText()
                     // vcs_processed:
                     .replaceFirst("url: \"<REPLACE>\"", "url: \"${normalizeVcsUrl(vcsUrl)}\"")
@@ -71,17 +71,17 @@ class MavenTest : StringSpec() {
         }
 
         "Root project dependencies are detected correctly" {
-            val pomFile = File(syntheticProjectDir, "pom.xml")
+            val pomFile = File(projectDir, "pom.xml")
             val expectedResult = patchExpectedResult("maven-expected-output-root.yml")
 
-            val result = Maven.create().resolveDependencies(syntheticProjectDir, listOf(pomFile))[pomFile]
+            val result = Maven.create().resolveDependencies(projectDir, listOf(pomFile))[pomFile]
 
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
 
         "Project dependencies are detected correctly" {
-            val pomFileApp = File(syntheticProjectDir, "app/pom.xml")
-            val pomFileLib = File(syntheticProjectDir, "lib/pom.xml")
+            val pomFileApp = File(projectDir, "app/pom.xml")
+            val pomFileLib = File(projectDir, "lib/pom.xml")
 
             val expectedResult = patchExpectedResult("maven-expected-output-app.yml")
 
@@ -89,16 +89,16 @@ class MavenTest : StringSpec() {
             // available in the Maven.projectsByIdentifier cache. Otherwise resolution of transitive dependencies would
             // not work.
             val result = Maven.create()
-                    .resolveDependencies(syntheticProjectDir, listOf(pomFileApp, pomFileLib))[pomFileApp]
+                    .resolveDependencies(projectDir, listOf(pomFileApp, pomFileLib))[pomFileApp]
 
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
 
         "External dependencies are detected correctly" {
-            val pomFile = File(syntheticProjectDir, "lib/pom.xml")
+            val pomFile = File(projectDir, "lib/pom.xml")
             val expectedResult = patchExpectedResult("maven-expected-output-lib.yml")
 
-            val result = Maven.create().resolveDependencies(syntheticProjectDir, listOf(pomFile))[pomFile]
+            val result = Maven.create().resolveDependencies(projectDir, listOf(pomFile))[pomFile]
 
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }

--- a/analyzer/src/main/kotlin/Main.kt
+++ b/analyzer/src/main/kotlin/Main.kt
@@ -206,7 +206,8 @@ object Main {
                     ),
                     declaredLicenses = sortedSetOf(),
                     aliases = emptyList(),
-                    vcs = vcsDir?.getInfo(absoluteProjectPath) ?: VcsInfo.EMPTY,
+                    vcs = VcsInfo.EMPTY,
+                    vcsProcessed = vcsDir?.getInfo(absoluteProjectPath) ?: VcsInfo.EMPTY,
                     homepageUrl = "",
                     scopes = sortedSetOf()
             )

--- a/analyzer/src/main/kotlin/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/MavenSupport.kt
@@ -275,6 +275,8 @@ class MavenSupport(localRepositoryManagerConverter: (LocalRepositoryManager) -> 
 
         val sourceRemoteArtifact = requestRemoteArtifact(sourceArtifact, repositories)
 
+        val vcsFromPackage = parseVcsInfo(mavenProject)
+
         return Package(
                 id = Identifier(
                         packageManager = packageManager,
@@ -287,7 +289,8 @@ class MavenSupport(localRepositoryManagerConverter: (LocalRepositoryManager) -> 
                 homepageUrl = mavenProject.url ?: "",
                 binaryArtifact = binaryRemoteArtifact,
                 sourceArtifact = sourceRemoteArtifact,
-                vcs = parseVcsInfo(mavenProject)
+                vcs = vcsFromPackage,
+                vcsProcessed = PackageManager.processPackageVcs(vcsFromPackage)
         )
     }
 

--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -127,7 +127,7 @@ abstract class PackageManager {
          */
         fun processProjectVcs(projectDir: File, vcsFromProject: VcsInfo = VcsInfo.EMPTY): VcsInfo {
             val vcsFromWorkingTree = VersionControlSystem.forDirectory(projectDir)
-                    ?.getInfo(projectDir) ?: VcsInfo.EMPTY
+                    ?.getInfo(projectDir)?.normalize() ?: VcsInfo.EMPTY
 
             return processPackageVcs(vcsFromProject).merge(vcsFromWorkingTree)
         }

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -134,6 +134,7 @@ class Gradle : PackageManager() {
                     declaredLicenses = sortedSetOf(),
                     aliases = emptyList(),
                     vcs = VcsInfo.EMPTY,
+                    vcsProcessed = processProjectVcs(projectDir),
                     homepageUrl = "",
                     scopes = scopes.toSortedSet()
             )
@@ -157,7 +158,7 @@ class Gradle : PackageManager() {
         if (dependency.error == null) {
             // Only look for a package when there was no error resolving the dependency.
             packages.getOrPut("${dependency.groupId}:${dependency.artifactId}:${dependency.version}") {
-                if (dependency.pomFile.isNotBlank()) {
+                val pkg = if (dependency.pomFile.isNotBlank()) {
                     // TODO: Provide extension and classifier.
                     val artifact = DefaultArtifact(dependency.groupId, dependency.artifactId, "jar",
                             dependency.version)
@@ -178,6 +179,8 @@ class Gradle : PackageManager() {
                             vcs = VcsInfo.EMPTY
                     )
                 }
+
+                pkg.copy(vcsProcessed = processPackageVcs(pkg.vcs))
             }
         }
 

--- a/analyzer/src/main/kotlin/managers/Maven.kt
+++ b/analyzer/src/main/kotlin/managers/Maven.kt
@@ -139,6 +139,7 @@ class Maven : PackageManager() {
                 declaredLicenses = maven.parseLicenses(mavenProject),
                 aliases = emptyList(),
                 vcs = vcsFromPackage,
+                vcsProcessed = processProjectVcs(projectDir, vcsFromPackage),
                 homepageUrl = mavenProject.url ?: "",
                 scopes = scopes.values.toSortedSet()
         )

--- a/analyzer/src/main/kotlin/managers/PIP.kt
+++ b/analyzer/src/main/kotlin/managers/PIP.kt
@@ -261,7 +261,8 @@ class PIP : PackageManager() {
                                         hashAlgorithm = "MD5"
                                 ),
                                 sourceArtifact = RemoteArtifact.EMPTY,
-                                vcs = pkg.vcs
+                                vcs = pkg.vcs,
+                                vcsProcessed = processPackageVcs(pkg.vcs)
                         )
                     } catch (e: NullPointerException) {
                         log.warn { "Unable to parse PyPI meta-data for package '${pkg.id}': ${e.message}" }
@@ -290,6 +291,7 @@ class PIP : PackageManager() {
                 declaredLicenses = sortedSetOf(), // TODO: Get the licenses for local projects.
                 aliases = emptyList(),
                 vcs = VcsInfo.EMPTY,
+                vcsProcessed = processProjectVcs(projectDir),
                 homepageUrl = projectHomepage,
                 scopes = scopes
         )


### PR DESCRIPTION
Use the functions from PackageManager to process VcsInfo when creating
projects and packages in all package managers. Also consistently only
assign raw data coming from the package manager to the "vcs" field, and all
deduced data to the "vcsProcessed" field.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/231)
<!-- Reviewable:end -->
