### PR TITLE
utils: Fix issue with unexpected return value of mkdirs() in safeMkDi…

### DIFF
--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -233,7 +233,10 @@ fun File.safeDeleteRecursively() {
  * @throws IOException if any missing directory could not be created.
  */
 fun File.safeMkdirs() {
-    if (this.isDirectory || this.mkdirs()) {
+    // Do not blindly trust mkdirs() returning "false" as it can fail for edge-cases like
+    // File(File("/tmp/parent1/parent2"), "/").mkdirs() if parent1 does not exist, although the directory is
+    // successfully created.
+    if (this.isDirectory || this.mkdirs() || this.isDirectory) {
         return
     }
 


### PR DESCRIPTION
…rs()

Do not rely on the return value of mkdirs(), because it can return false
even when the directory could be created. For example the code below is
successful but returns false if "/tmp/parent1" does not exist:

File(File("/tmp/parent1/parent2"), "/").mkdirs()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/233)
<!-- Reviewable:end -->
