### PR TITLE
 Add a work-around for getting the source code of TypeScript definitions

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output.yml
@@ -1273,17 +1273,17 @@ packages:
     hash: "5efe7d4a6d8c453c7e9eaf55d931f4a22fac5169"
     hash_algorithm: "SHA-1"
   source_artifact:
-    url: ""
-    hash: ""
-    hash_algorithm: ""
+    url: "https://registry.npmjs.org/@types/node/-/node-6.0.79.tgz"
+    hash: "5efe7d4a6d8c453c7e9eaf55d931f4a22fac5169"
+    hash_algorithm: "SHA-1"
   vcs:
     provider: "git"
     url: "https://www.github.com/DefinitelyTyped/DefinitelyTyped.git"
     revision: ""
     path: ""
   vcs_processed:
-    provider: "Git"
-    url: "https://github.com/DefinitelyTyped/DefinitelyTyped.git"
+    provider: ""
+    url: ""
     revision: ""
     path: ""
 errors: []

--- a/analyzer/src/main/kotlin/managers/NPM.kt
+++ b/analyzer/src/main/kotlin/managers/NPM.kt
@@ -239,7 +239,6 @@ class NPM : PackageManager() {
                 downloadUrl = dist["tarball"].asText()
 
                 hash = dist["shasum"].asText()
-                // TODO: add detection of hash algorithm
 
                 parseVcsInfo(infoJson)
             } catch (e: Exception) {
@@ -256,7 +255,6 @@ class NPM : PackageManager() {
                         downloadUrl = json["_resolved"].asTextOrEmpty()
 
                         hash = json["_integrity"].asTextOrEmpty()
-                        // TODO: add detection of hash algorithm
 
                         parseVcsInfo(json)
                     }


### PR DESCRIPTION
Please have a look at the individual commit messages for the details.

/cc @jeffmcaffer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/242)
<!-- Reviewable:end -->
