### PR TITLE
Make the --stacktrace parameter globally available

### DIFF
--- a/analyzer/src/main/kotlin/Main.kt
+++ b/analyzer/src/main/kotlin/Main.kt
@@ -123,7 +123,7 @@ object Main {
     @Parameter(description = "Print out the stacktrace for all exceptions.",
             names = ["--stacktrace"],
             order = PARAMETER_ORDER_LOGGING)
-    var stacktrace = false
+    private var stacktrace = false
 
     @Parameter(description = "Display the command line help.",
             names = ["--help", "-h"],
@@ -166,6 +166,9 @@ object Main {
             jc.usage()
             exitProcess(0)
         }
+
+        // Make the parameter globally available.
+        com.here.ort.utils.printStackTrace = stacktrace
 
         val absoluteOutputPath = outputDir.absoluteFile
         if (absoluteOutputPath.exists()) {

--- a/analyzer/src/main/kotlin/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/MavenSupport.kt
@@ -206,7 +206,7 @@ class MavenSupport(localRepositoryManagerConverter: (LocalRepositoryManager) -> 
                     // the first space.
                     tempFile.readText().substringBefore(" ")
                 } catch (e: Exception) {
-                    if (Main.stacktrace) {
+                    if (com.here.ort.utils.printStackTrace) {
                         e.printStackTrace()
                     }
 

--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -157,7 +157,7 @@ abstract class PackageManager {
                         result[definitionFile] = it
                     }
                 } catch (e: Exception) {
-                    if (Main.stacktrace) {
+                    if (com.here.ort.utils.printStackTrace) {
                         e.printStackTrace()
                     }
 

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -24,7 +24,6 @@ import DependencyTreeModel
 
 import ch.frankel.slf4k.*
 
-import com.here.ort.analyzer.Main
 import com.here.ort.analyzer.MavenSupport
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.analyzer.PackageManagerFactory
@@ -142,7 +141,7 @@ class Gradle : PackageManager() {
             return AnalyzerResult(true, project, packages.values.toSortedSet(),
                     dependencyTreeModel.errors)
         } catch (e: BuildException) {
-            if (Main.stacktrace) {
+            if (com.here.ort.utils.printStackTrace) {
                 e.printStackTrace()
             }
 

--- a/analyzer/src/main/kotlin/managers/Maven.kt
+++ b/analyzer/src/main/kotlin/managers/Maven.kt
@@ -21,7 +21,6 @@ package com.here.ort.analyzer.managers
 
 import ch.frankel.slf4k.*
 
-import com.here.ort.analyzer.Main
 import com.here.ort.analyzer.MavenSupport
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.analyzer.PackageManagerFactory
@@ -84,7 +83,7 @@ class Maven : PackageManager() {
         val projectBuildingResults = try {
             projectBuilder.build(definitionFiles, false, projectBuildingRequest)
         } catch (e: ProjectBuildingException) {
-            if (Main.stacktrace) {
+            if (com.here.ort.utils.printStackTrace) {
                 e.printStackTrace()
             }
 
@@ -158,7 +157,7 @@ class Maven : PackageManager() {
 
             return pkg.toReference(dependencies)
         } catch (e: ProjectBuildingException) {
-            if (Main.stacktrace) {
+            if (com.here.ort.utils.printStackTrace) {
                 e.printStackTrace()
             }
 

--- a/analyzer/src/main/kotlin/managers/NPM.kt
+++ b/analyzer/src/main/kotlin/managers/NPM.kt
@@ -239,7 +239,7 @@ class NPM : PackageManager() {
                             vcsFromPackage = parseVcsInfo(versionInfo)
                         }
                     } catch (e: NullPointerException) {
-                        if (Main.stacktrace) {
+                        if (com.here.ort.utils.printStackTrace) {
                             e.printStackTrace()
                         }
                     }

--- a/downloader/src/main/kotlin/Main.kt
+++ b/downloader/src/main/kotlin/Main.kt
@@ -76,7 +76,7 @@ object Main {
             try {
                 return DataEntity.valueOf(name.toUpperCase())
             } catch (e: IllegalArgumentException) {
-                if (stacktrace) {
+                if (com.here.ort.utils.printStackTrace) {
                     e.printStackTrace()
                 }
 
@@ -124,7 +124,7 @@ object Main {
     @Parameter(description = "Print out the stacktrace for all exceptions.",
             names = ["--stacktrace"],
             order = PARAMETER_ORDER_LOGGING)
-    var stacktrace = false
+    private var stacktrace = false
 
     @Parameter(description = "Display the command line help.",
             names = ["--help", "-h"],
@@ -156,6 +156,9 @@ object Main {
             exitProcess(1)
         }
 
+        // Make the parameter globally available.
+        com.here.ort.utils.printStackTrace = stacktrace
+
         require(dependenciesFile.isFile) {
             "Provided path is not a file: ${dependenciesFile.absolutePath}"
         }
@@ -181,7 +184,7 @@ object Main {
             try {
                 download(pkg, outputDir)
             } catch (e: DownloadException) {
-                if (stacktrace) {
+                if (com.here.ort.utils.printStackTrace) {
                     e.printStackTrace()
                 }
 
@@ -209,7 +212,7 @@ object Main {
             try {
                 return downloadFromVcs(target, targetDir)
             } catch (e: DownloadException) {
-                if (stacktrace) {
+                if (com.here.ort.utils.printStackTrace) {
                     e.printStackTrace()
                 }
 

--- a/downloader/src/main/kotlin/vcs/Git.kt
+++ b/downloader/src/main/kotlin/vcs/Git.kt
@@ -22,7 +22,6 @@ package com.here.ort.downloader.vcs
 import ch.frankel.slf4k.*
 
 import com.here.ort.downloader.DownloadException
-import com.here.ort.downloader.Main
 import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.VcsInfo
 import com.here.ort.utils.OS
@@ -137,7 +136,7 @@ object Git : GitBase() {
                 runGitCommand(targetDir, "checkout", "FETCH_HEAD")
                 return workingTree
             } catch (e: IOException) {
-                if (Main.stacktrace) {
+                if (com.here.ort.utils.printStackTrace) {
                     e.printStackTrace()
                 }
 
@@ -154,7 +153,7 @@ object Git : GitBase() {
                 runGitCommand(targetDir, "checkout", revision)
                 return workingTree
             } catch (e: IOException) {
-                if (Main.stacktrace) {
+                if (com.here.ort.utils.printStackTrace) {
                     e.printStackTrace()
                 }
 
@@ -178,7 +177,7 @@ object Git : GitBase() {
                     runGitCommand(targetDir, "checkout", candidate)
                     true
                 } catch (e: IOException) {
-                    if (Main.stacktrace) {
+                    if (com.here.ort.utils.printStackTrace) {
                         e.printStackTrace()
                     }
 
@@ -190,7 +189,7 @@ object Git : GitBase() {
 
             return workingTree
         } catch (e: IOException) {
-            if (Main.stacktrace) {
+            if (com.here.ort.utils.printStackTrace) {
                 e.printStackTrace()
             }
 

--- a/downloader/src/main/kotlin/vcs/GitRepo.kt
+++ b/downloader/src/main/kotlin/vcs/GitRepo.kt
@@ -22,7 +22,6 @@ package com.here.ort.downloader.vcs
 import ch.frankel.slf4k.*
 
 import com.here.ort.downloader.DownloadException
-import com.here.ort.downloader.Main
 import com.here.ort.model.VcsInfo
 import com.here.ort.utils.ProcessCapture
 import com.here.ort.utils.log
@@ -58,7 +57,7 @@ object GitRepo : GitBase() {
 
             return getWorkingTree(targetDir)
         } catch (e: IOException) {
-            if (Main.stacktrace) {
+            if (com.here.ort.utils.printStackTrace) {
                 e.printStackTrace()
             }
 

--- a/downloader/src/main/kotlin/vcs/Mercurial.kt
+++ b/downloader/src/main/kotlin/vcs/Mercurial.kt
@@ -22,7 +22,6 @@ package com.here.ort.downloader.vcs
 import ch.frankel.slf4k.*
 
 import com.here.ort.downloader.DownloadException
-import com.here.ort.downloader.Main
 import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.VcsInfo
 import com.here.ort.utils.ProcessCapture
@@ -136,7 +135,7 @@ object Mercurial : VersionControlSystem() {
 
             return workingTree
         } catch (e: IOException) {
-            if (Main.stacktrace) {
+            if (com.here.ort.utils.printStackTrace) {
                 e.printStackTrace()
             }
 

--- a/downloader/src/main/kotlin/vcs/Subversion.kt
+++ b/downloader/src/main/kotlin/vcs/Subversion.kt
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
 
 import com.here.ort.downloader.DownloadException
-import com.here.ort.downloader.Main
 import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.VcsInfo
 import com.here.ort.utils.ProcessCapture
@@ -183,7 +182,7 @@ object Subversion : VersionControlSystem() {
                 getWorkingTree(File(targetDir, tagPath))
             }
         } catch (e: IOException) {
-            if (Main.stacktrace) {
+            if (com.here.ort.utils.printStackTrace) {
                 e.printStackTrace()
             }
 

--- a/graph/src/main/kotlin/Main.kt
+++ b/graph/src/main/kotlin/Main.kt
@@ -68,7 +68,7 @@ object Main {
     @Parameter(description = "Print out the stacktrace for all exceptions.",
             names = ["--stacktrace"],
             order = PARAMETER_ORDER_LOGGING)
-    var stacktrace = false
+    private var stacktrace = false
 
     @Parameter(description = "Display the command line help.",
             names = ["--help", "-h"],
@@ -99,6 +99,9 @@ object Main {
             jc.usage()
             exitProcess(1)
         }
+
+        // Make the parameter globally available.
+        com.here.ort.utils.printStackTrace = stacktrace
 
         require(dependenciesFile.isFile) {
             "Provided path is not a file: ${dependenciesFile.absolutePath}"

--- a/scanner/src/main/kotlin/Main.kt
+++ b/scanner/src/main/kotlin/Main.kt
@@ -70,7 +70,7 @@ object Main {
             try {
                 return OutputFormat.valueOf(name.toUpperCase())
             } catch (e: IllegalArgumentException) {
-                if (stacktrace) {
+                if (com.here.ort.utils.printStackTrace) {
                     e.printStackTrace()
                 }
 
@@ -142,7 +142,7 @@ object Main {
     @Parameter(description = "Print out the stacktrace for all exceptions.",
             names = ["--stacktrace"],
             order = PARAMETER_ORDER_LOGGING)
-    var stacktrace = false
+    private var stacktrace = false
 
     @Parameter(description = "Display the command line help.",
             names = ["--help", "-h"],
@@ -173,6 +173,9 @@ object Main {
             jc.usage()
             exitProcess(1)
         }
+
+        // Make the parameter globally available.
+        com.here.ort.utils.printStackTrace = stacktrace
 
         if ((dependenciesFile != null) == (inputPath != null)) {
             throw IllegalArgumentException("Either --dependencies-file or --input-path must be specified.")
@@ -250,7 +253,7 @@ object Main {
 
             println("Found licenses for '$identifier': ${entry.licenses.joinToString()}")
         } catch (e: ScanException) {
-            if (stacktrace) {
+            if (com.here.ort.utils.printStackTrace) {
                 e.printStackTrace()
             }
 

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -81,7 +81,7 @@ abstract class Scanner {
         val sourceDirectory = try {
             Main.download(pkg, downloadDirectory ?: File(outputDirectory, "downloads"))
         } catch (e: DownloadException) {
-            if (Main.stacktrace) {
+            if (com.here.ort.utils.printStackTrace) {
                 e.printStackTrace()
             }
 

--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -47,6 +47,11 @@ import java.nio.file.attribute.BasicFileAttributes
 @Suppress("UnsafeCast")
 val log = org.slf4j.LoggerFactory.getLogger({}.javaClass) as ch.qos.logback.classic.Logger
 
+/**
+ * Global variable that gets toggled by a command line parameter parsed in the main entry points of the modules.
+ */
+var printStackTrace = false
+
 val jsonMapper = ObjectMapper().registerKotlinModule()
 val xmlMapper = ObjectMapper(XmlFactory()).registerKotlinModule()
 val yamlMapper = ObjectMapper(YAMLFactory()).registerKotlinModule()


### PR DESCRIPTION
Previously, if the scanner command line tool was calling the downloader
library programatically, a --stacktrace parameter to the scanner was not
passed to the downloader, and the downloader library code would not have
printed any stack traces as its own "Main.stacktrace" variable was still
the default of "false". Solve that by introducing a globally shared
"printStackTrace" variable that gets toggled by each of the Main entry
points.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/244)
<!-- Reviewable:end -->
