### PR TITLE
Gradle: Add an error message when a project uses a flat dir repository

### DIFF
--- a/analyzer/src/main/resources/init.gradle
+++ b/analyzer/src/main/resources/init.gradle
@@ -21,6 +21,8 @@ import groovy.transform.Immutable
 
 import javax.inject.Inject
 
+import org.gradle.api.internal.artifacts.repositories.DefaultFlatDirArtifactRepository
+import org.gradle.api.internal.artifacts.repositories.DefaultMavenArtifactRepository
 import org.gradle.tooling.provider.model.ToolingModelBuilder
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
 
@@ -119,7 +121,18 @@ class DependencyTreePlugin implements Plugin<Gradle> {
                 }
             }
 
-            List<String> repositories = project.repositories.collect { it.url.toString() }
+            List<String> repositories = project.repositories.findResults {
+                if (it instanceof DefaultMavenArtifactRepository) {
+                    it.url.toString()
+                } else if (it instanceof DefaultFlatDirArtifactRepository) {
+                    errors.add("Project uses a flat dir repository, dependencies from this repository will be " +
+                            "ignored: ${it.dirs}")
+                    null
+                } else {
+                    errors.add("Unknown repository type: ${it.getClass().name}")
+                    null
+                }
+            }
 
             return new DependencyTreeModelImpl(project.name, configurations, repositories, errors)
         }


### PR DESCRIPTION
Currently dependencies in flat dir repositories [1] cannot be handled.
Add an error message to the analyzer result if a project uses a flat dir
repository.

[1] https://docs.gradle.org/4.4.1/userguide/dependency_management.html#sec:flat_dir_resolver

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/251)
<!-- Reviewable:end -->
