### PR TITLE
Fixup scp-like Git URLs that do not use a ':' after the server part

### DIFF
--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -136,6 +136,11 @@ fun normalizeVcsUrl(vcsUrl: String): String {
         if (url.contains("://")) tail else "ssh://" + tail
     }
 
+    // Fixup scp-like Git URLs that do not use a ':' after the server part.
+    if (url.startsWith("git@")) {
+        url = "ssh://" + url
+    }
+
     // Drop any VCS name with "+" from the scheme.
     url = url.replace(Regex("^(.+)\\+(.+)(://.+)$")) {
         // Use the string to the right of "+" which should be the protocol.

--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -131,7 +131,7 @@ fun normalizeVcsUrl(vcsUrl: String): String {
     // URLs to Git repos may omit the scheme and use an scp-like URL that uses ":" to separate the host from the path,
     // see https://git-scm.com/docs/git-clone#_git_urls_a_id_urls_a. Make this an explicit ssh URL so it can be parsed
     // by Java's URI class.
-    url = url.replace(Regex("^(.*)([a-zA-Z]+):([a-zA-Z]+)(.*)$")) {
+    url = url.replace(Regex("^(.*)(\\w+):(\\w+)(.*)$")) {
         val tail = "${it.groupValues[1]}${it.groupValues[2]}/${it.groupValues[3]}${it.groupValues[4]}"
         if (url.contains("://")) tail else "ssh://" + tail
     }

--- a/utils/src/test/kotlin/UtilsTest.kt
+++ b/utils/src/test/kotlin/UtilsTest.kt
@@ -160,6 +160,8 @@ class UtilsTest : WordSpec({
 
         "fixup crazy URLs" {
             val packages = mapOf(
+                    "git@github.com/cisco/node-jose.git"
+                            to "ssh://git@github.com/cisco/node-jose.git",
                     "https://git@github.com:hacksparrow/node-easyimage.git"
                             to "https://github.com/hacksparrow/node-easyimage.git"
             )


### PR DESCRIPTION
Please have a look at the individual commit messages for the details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/269)
<!-- Reviewable:end -->
