### PR TITLE
Fixup CVS URLs returned by the Maven SCM plugin

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
@@ -478,12 +478,12 @@ packages:
     hash_algorithm: "SHA-1"
   vcs:
     provider: "cvs"
-    url: "pserver:anonymous@cvs.sourceforge.net:/cvsroot/dom4j:dom4j"
+    url: ":pserver:anonymous@cvs.sourceforge.net:/cvsroot/dom4j:dom4j"
     revision: "HEAD"
     path: ""
   vcs_processed:
     provider: "cvs"
-    url: "pserver:anonymous@cvs.sourceforge.net:/cvsroot/dom4j:dom4j"
+    url: ":pserver:anonymous@cvs.sourceforge.net:/cvsroot/dom4j:dom4j"
     revision: "HEAD"
     path: ""
 - id:

--- a/analyzer/src/main/kotlin/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/MavenSupport.kt
@@ -307,7 +307,16 @@ class MavenSupport(localRepositoryManagerConverter: (LocalRepositoryManager) -> 
             val tag = scm.tag ?: ""
 
             val (provider, url) = SCM_REGEX.matchEntire(connection)?.groups?.let { match ->
-                Pair(match.get("provider")!!.value, match.get("url")!!.value)
+                val provider = match["provider"]!!.value
+                val url = match["url"]!!.value
+
+                // CVS URLs usually start with ":pserver:" or ":ext:", but as ":" is also the delimiter used by the
+                // Maven SCM plugin, no double ":" is used in the connection string and we need to fix it up here.
+                if (provider == "cvs" && !url.startsWith(":")) {
+                    Pair(provider, ":" + url)
+                } else {
+                    Pair(provider, url)
+                }
             } ?: Pair("", "")
 
             VcsInfo(provider, url, tag, "")

--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -123,7 +123,7 @@ fun getUserConfigDirectory() = File(System.getProperty("user.home"), ".ort")
 fun normalizeVcsUrl(vcsUrl: String): String {
     var url = vcsUrl.trimEnd('/')
 
-    if (url.startsWith("pserver:")) {
+    if (url.startsWith(":pserver:") || url.startsWith(":ext:")) {
         // Do not touch CVS URLs for now.
         return url
     }


### PR DESCRIPTION
The SCM plugin returns bogus VCS URLs that do not start with ":" as ":"
is also used as the delimiter in SCM connection strings, see

https://maven.apache.org/scm/cvs.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/270)
<!-- Reviewable:end -->
