### PR TITLE
Revert "normalizeVcsUrl: Simplify the regex to fixup scp-like URLs bit"

### DIFF
--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -131,7 +131,7 @@ fun normalizeVcsUrl(vcsUrl: String): String {
     // URLs to Git repos may omit the scheme and use an scp-like URL that uses ":" to separate the host from the path,
     // see https://git-scm.com/docs/git-clone#_git_urls_a_id_urls_a. Make this an explicit ssh URL so it can be parsed
     // by Java's URI class.
-    url = url.replace(Regex("^(.*)(\\w+):(\\w+)(.*)$")) {
+    url = url.replace(Regex("^(.*)([a-zA-Z]+):([a-zA-Z]+)(.*)$")) {
         val tail = "${it.groupValues[1]}${it.groupValues[2]}/${it.groupValues[3]}${it.groupValues[4]}"
         if (url.contains("://")) tail else "ssh://" + tail
     }

--- a/utils/src/test/kotlin/UtilsTest.kt
+++ b/utils/src/test/kotlin/UtilsTest.kt
@@ -83,7 +83,9 @@ class UtilsTest : WordSpec({
                     "git+ssh://git@github.com/logicalparadox/idris.git"
                             to "ssh://git@github.com/logicalparadox/idris.git",
                     "git@github.com:heremaps/oss-review-toolkit.git"
-                            to "ssh://git@github.com/heremaps/oss-review-toolkit.git"
+                            to "ssh://git@github.com/heremaps/oss-review-toolkit.git",
+                    "ssh://gerrit.server.com:29418/parent/project"
+                            to "ssh://gerrit.server.com:29418/parent/project"
             )
 
             packages.forEach { actualUrl, expectedUrl ->


### PR DESCRIPTION
This reverts commit b741dd3 as it breaks SSH URLs with ports. Add a test
on top of the revert.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/271)
<!-- Reviewable:end -->
