### PR TITLE
UtilsTest: Add a user name to the Gerrit URL to really make it authenticated

### DIFF
--- a/utils/src/test/kotlin/UtilsTest.kt
+++ b/utils/src/test/kotlin/UtilsTest.kt
@@ -84,8 +84,8 @@ class UtilsTest : WordSpec({
                             to "ssh://git@github.com/logicalparadox/idris.git",
                     "git@github.com:heremaps/oss-review-toolkit.git"
                             to "ssh://git@github.com/heremaps/oss-review-toolkit.git",
-                    "ssh://gerrit.server.com:29418/parent/project"
-                            to "ssh://gerrit.server.com:29418/parent/project"
+                    "ssh://user@gerrit.server.com:29418/parent/project"
+                            to "ssh://user@gerrit.server.com:29418/parent/project"
             )
 
             packages.forEach { actualUrl, expectedUrl ->


### PR DESCRIPTION
This is a fixup for 47a3c50.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/272)
<!-- Reviewable:end -->
