### PR TITLE
NPM: Add --ignore-scripts option to install

### DIFF
--- a/analyzer/src/main/kotlin/managers/NPM.kt
+++ b/analyzer/src/main/kotlin/managers/NPM.kt
@@ -484,7 +484,7 @@ class NPM : PackageManager() {
         log.debug { "Using '$managerCommand' to install ${javaClass.simpleName} dependencies." }
 
         // Install all NPM dependencies to enable NPM to list dependencies.
-        ProcessCapture(workingDir, managerCommand, "install").requireSuccess()
+        ProcessCapture(workingDir, managerCommand, "install", "--ignore-scripts").requireSuccess()
 
         // TODO: capture warnings from npm output, e.g. "Unsupported platform" which happens for fsevents on all
         // platforms except for Mac.


### PR DESCRIPTION
Run "npm/yarn install" with the "--ignore-scripts" option [1][2]. This
prevents the execution of any build scripts of the node.js project or its
dependencies. Execution arbitrary scripts is a security issue and also has
a high risk of failing, e.g. because the scripts could try to compile
native code.

[1] https://docs.npmjs.com/cli/install#description
[2] https://yarnpkg.com/lang/en/docs/cli/install/#toc-yarn-install-ignore-scripts

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/273)
<!-- Reviewable:end -->
