### PR TITLE
analyzer: Prefer VCS info from directory for projects

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
@@ -16,8 +16,8 @@ project:
     path: ""
   vcs_processed:
     provider: "Git"
-    url: "ssh://git@github.com/soc/directories.git"
-    revision: "HEAD"
+    url: "https://github.com/soc/directories.git"
+    revision: "ed193b425d5c184029481e2330baaf5628bbefac"
     path: ""
   homepage_url: "https://github.com/soc/directories"
   scopes:

--- a/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
@@ -16,7 +16,7 @@ project:
   vcs_processed:
     provider: "Git"
     url: "https://github.com/ccavanaugh/jgnash.git"
-    revision: "HEAD"
+    revision: "2aa4cce7d7fd46164030f2b4d244c4b89e77f722"
     path: "jgnash-core"
   homepage_url: "http://sourceforge.net/projects/jgnash/jgnash-core/"
   scopes:

--- a/analyzer/src/funTest/assets/projects/external/jgnash-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/jgnash-expected-output.yml
@@ -16,7 +16,7 @@ project:
   vcs_processed:
     provider: "Git"
     url: "https://github.com/ccavanaugh/jgnash.git"
-    revision: "HEAD"
+    revision: "2aa4cce7d7fd46164030f2b4d244c4b89e77f722"
     path: ""
   homepage_url: "http://sourceforge.net/projects/jgnash/"
   scopes:

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
@@ -16,7 +16,7 @@ project:
     path: ""
   vcs_processed:
     provider: "Git"
-    url: "https://github.com/heremaps/oss-review-toolkit.git"
+    url: "<REPLACE_URL>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/npm-babel"
   homepage_url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output.yml
@@ -16,7 +16,7 @@ project:
     path: ""
   vcs_processed:
     provider: "Git"
-    url: "https://github.com/heremaps/oss-review-toolkit.git"
+    url: "<REPLACE_URL>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/analyzer/src/funTest/kotlin/BabelTest.kt
+++ b/analyzer/src/funTest/kotlin/BabelTest.kt
@@ -21,6 +21,7 @@ package com.here.ort.analyzer
 
 import com.here.ort.analyzer.managers.NPM
 import com.here.ort.downloader.VersionControlSystem
+import com.here.ort.utils.normalizeVcsUrl
 import com.here.ort.utils.safeDeleteRecursively
 import com.here.ort.utils.yamlMapper
 
@@ -34,6 +35,7 @@ class BabelTest : WordSpec() {
     private val projectDir = File("src/funTest/assets/projects/synthetic/npm-babel")
     private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     private val vcsRevision = vcsDir.getRevision()
+    private val vcsUrl = normalizeVcsUrl(vcsDir.getRemoteUrl())
 
     override fun interceptTestCase(context: TestCaseContext, test: () -> Unit) {
         try {
@@ -56,6 +58,7 @@ class BabelTest : WordSpec() {
     private fun patchExpectedResult(filename: String) =
             File(projectDir.parentFile, filename).readText()
                     // project.vcs_processed:
+                    .replaceFirst("<REPLACE_URL>", vcsUrl)
                     .replaceFirst("<REPLACE_REVISION>", vcsRevision)
 
     init {

--- a/analyzer/src/funTest/kotlin/NpmTest.kt
+++ b/analyzer/src/funTest/kotlin/NpmTest.kt
@@ -22,6 +22,7 @@ package com.here.ort.analyzer
 import com.here.ort.analyzer.managers.NPM
 import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.Project
+import com.here.ort.utils.normalizeVcsUrl
 import com.here.ort.utils.safeDeleteRecursively
 import com.here.ort.utils.yamlMapper
 
@@ -39,6 +40,7 @@ class NpmTest : FreeSpec() {
     private val projectDir = File("src/funTest/assets/projects/synthetic/npm")
     private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     private val vcsRevision = vcsDir.getRevision()
+    private val vcsUrl = normalizeVcsUrl(vcsDir.getRemoteUrl())
 
     override fun interceptTestCase(context: TestCaseContext, test: () -> Unit) {
         try {
@@ -64,6 +66,7 @@ class NpmTest : FreeSpec() {
                 // project.name:
                 .replaceFirst("npm-project", "npm-${workingDir.name}")
                 // project.vcs_processed:
+                .replaceFirst("<REPLACE_URL>", vcsUrl)
                 .replaceFirst("<REPLACE_REVISION>", vcsRevision)
                 .replaceFirst("<REPLACE_PATH>", vcsPath)
     }

--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -129,7 +129,7 @@ abstract class PackageManager {
             val vcsFromWorkingTree = VersionControlSystem.forDirectory(projectDir)
                     ?.getInfo(projectDir)?.normalize() ?: VcsInfo.EMPTY
 
-            return processPackageVcs(vcsFromProject).merge(vcsFromWorkingTree)
+            return vcsFromWorkingTree.merge(processPackageVcs(vcsFromProject))
         }
     }
 


### PR DESCRIPTION
Prefer the VCS info from the project directory over VCS info parsed from the
projects metadata. The metadata could be different to the actually cloned
project which would lead to unexpected results.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/275)
<!-- Reviewable:end -->
