### PR TITLE
Scanner: add Askalono support

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,10 @@ Usage: scanner [options]
       The dependencies analysis file to use. Source code will be downloaded
       automatically if needed. This parameter and --input-path are mutually
       exclusive.
+    --askalono-path
+      The path to executable of Askalono tool. Makes sense only with
+      '--scanner askalono'.
+      Default: <empty string>
     --input-path, -i
       The input directory or file to scan. This parameter and
       --dependencies-file are mutually exclusive.
@@ -232,14 +236,14 @@ Usage: scanner [options]
       Default: ScanCode
     --config, -c
       The path to the configuration file.
-    --info
-      Enable info logging.
-      Default: false
     --debug
       Enable debug logging and keep any temporary files.
       Default: false
     --stacktrace
       Print out the stacktrace for all exceptions.
+      Default: false
+    --info
+      Enable info logging.
       Default: false
     --help, -h
       Display the command line help.

--- a/scanner/src/main/kotlin/Main.kt
+++ b/scanner/src/main/kotlin/Main.kt
@@ -139,6 +139,11 @@ object Main {
             order = PARAMETER_ORDER_OPTIONAL)
     private var summaryFormats = listOf(OutputFormat.YAML)
 
+    @Parameter(description = "The path to executable of Askalono tool. Makes sense only with '--scanner askalono'.",
+            names = ["--askalono-path"],
+            order = PARAMETER_ORDER_OPTIONAL)
+    var askalanoPath = ""
+
     @Parameter(description = "Enable info logging.",
             names = ["--info"],
             order = PARAMETER_ORDER_LOGGING)

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -33,6 +33,7 @@ abstract class Scanner {
          */
         val ALL by lazy {
             listOf(
+                    Askalono,
                     BoyterLc,
                     Licensee,
                     ScanCode

--- a/scanner/src/main/kotlin/scanners/Askalono.kt
+++ b/scanner/src/main/kotlin/scanners/Askalono.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2017-2018 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.scanner.scanners
+
+import ch.frankel.slf4k.*
+import com.here.ort.scanner.Main
+
+import com.here.ort.scanner.Scanner
+import com.here.ort.utils.ProcessCapture
+import com.here.ort.utils.log
+import com.here.ort.utils.yamlMapper
+
+import java.io.File
+
+data class AskalonoResult(
+        val filePath: String,
+        val output: String,
+        val error: String
+)
+
+object Askalono : Scanner() {
+    override val resultFileExtension = "yml"
+
+    override fun scanPath(path: File, resultsFile: File): Result {
+        println("Running Askalono in directory '${path.absolutePath}'")
+
+        val allResults = mutableSetOf<AskalonoResult>()
+
+        if (path.isDirectory) {
+            path.walkTopDown().filter { file ->
+                file.isFile
+            }.forEach { licenseFile ->
+                        val licenseFilePath = licenseFile.toRelativeString(path)
+                        allResults.add(runAskalano(path.absoluteFile, licenseFilePath))
+                    }
+        } else {
+            allResults.add(runAskalano(targetFile = path.absolutePath))
+        }
+
+        yamlMapper.writerWithDefaultPrettyPrinter().writeValue(resultsFile, allResults)
+        println("Stored Askalono results in '${resultsFile.absolutePath}'.")
+        return getResult(allResults)
+    }
+
+    private fun runAskalano(workDir: File? = null, targetFile: String): AskalonoResult {
+        println("Running Askalono for file '$targetFile'...")
+        val process = ProcessCapture(
+                workDir,
+                Main.askalanoPath,
+                "id",
+                targetFile
+        )
+
+        with(process) {
+            if (stderr().isNotBlank()) {
+                log.debug { process.stderr() }
+            }
+
+            return AskalonoResult(targetFile, stdout(), stderr())
+        }
+    }
+
+    override fun getResult(resultsFile: File): Result {
+        val valueType = yamlMapper.typeFactory.constructCollectionLikeType(Set::class.java, AskalonoResult::class.java)
+        val resultsMap: Set<AskalonoResult> = yamlMapper.readValue(resultsFile, valueType)
+
+        return getResult(resultsMap)
+    }
+
+    private fun getResult(results: Set<AskalonoResult>): Result {
+        val licenses = sortedSetOf<String>()
+        val errors = sortedSetOf<String>()
+        results.forEach { result ->
+            if (result.error.isNotBlank()) {
+                errors.add(result.error)
+            }
+
+            if (result.output.isNotBlank()) {
+                licenses.add(result.output.lines().first().substringAfter("License:").trim())
+            }
+        }
+
+        return Result(licenses, errors)
+    }
+}


### PR DESCRIPTION
Askalono cannot currently be installed into local OS with a single
command, therefore additional parameter to main entry point is added
`--askalono-path`. It should point to a local Askalono executable.

Askalono is incapable of scanning directories, if scanner is run with
`--input-path` parameter, all files matching one of possible license
file patterns (license, copying, readme) are scanned one by one.
ScanException is not thrown if process fails for any of the files, in
order not to stop the scan for rest of the files. Instead errors are
populated to ScanSummary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/286)
<!-- Reviewable:end -->
