### PR TITLE
Also make the Licensee ScanPathTest expensive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,9 @@ cache:
 
 install:
   - npm install -g npm@5.5.1 yarn@1.3.2
-  - gem install licensee -v 9.8.0
+  - if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
+      gem install licensee -v 9.8.0;
+    fi
 
 script:
   - if git grep -L "Copyright" -- "*.kt"; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,9 @@ install:
   - cinst sbt --version 1.0.2 -y
   - refreshenv
   - set PATH=C:\Ruby25\bin;%PATH%
-  - gem install licensee -v 9.8.0
+  - if "%APPVEYOR_SCHEDULED_BUILD%"=="True" (
+      gem install licensee -v 9.8.0
+    )
 
 # Do something useful here to override the default MSBuild (which would fail otherwise).
 build_script:

--- a/scanner/src/funTest/kotlin/ScanPathTest.kt
+++ b/scanner/src/funTest/kotlin/ScanPathTest.kt
@@ -55,6 +55,6 @@ class ScanPathTest : StringSpec() {
         "Licensee recognizes our own LICENSE" {
             val result = Licensee.scan(File("../LICENSE"), outputDir)
             result.licenses shouldBe setOf("Apache License 2.0")
-        }
+        }.config(tags = setOf(ExpensiveTag))
     }
 }


### PR DESCRIPTION
While running Licensee is much faster than running ScanCode, installing
Licensee takes at least a minute due to building the native extension
dependencies. So only install and run Licensee if we enable expensive
tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/290)
<!-- Reviewable:end -->
