### PR TITLE
Support guessing revisions in multi-project repos based on project tags

### DIFF
--- a/downloader/src/funTest/kotlin/CvsDownloadTest.kt
+++ b/downloader/src/funTest/kotlin/CvsDownloadTest.kt
@@ -19,6 +19,8 @@
 
 package com.here.ort.downloader.vcs
 
+import com.here.ort.model.Identifier
+import com.here.ort.model.Package
 import com.here.ort.model.VcsInfo
 import com.here.ort.utils.ExpensiveTag
 import com.here.ort.utils.safeDeleteRecursively
@@ -52,13 +54,13 @@ class CvsDownloadTest : StringSpec() {
 
     init {
         "CVS can download a given revision" {
-            val vcs = VcsInfo("CVS", REPO_URL, REPO_REV, "")
+            val pkg = Package.EMPTY.copy(vcsProcessed = VcsInfo("CVS", REPO_URL, REPO_REV, ""))
             val expectedFiles = listOf(
                     "CVS",
                     "xmlenc"
             )
 
-            val workingTree = Cvs.download(vcs, "", outputDir)
+            val workingTree = Cvs.download(pkg, outputDir)
             val actualFiles = workingTree.workingDir.list().sorted()
 
             // Use forward slashes also on Windows as the CVS client comes from MSYS2.
@@ -73,12 +75,12 @@ class CvsDownloadTest : StringSpec() {
         }.config(tags = setOf(ExpensiveTag))
 
         "CVS can download only a single path" {
-            val vcs = VcsInfo("CVS", REPO_URL, REPO_REV, REPO_PATH)
+            val pkg = Package.EMPTY.copy(vcsProcessed = VcsInfo("CVS", REPO_URL, REPO_REV, REPO_PATH))
             val expectedFiles = listOf(
                     File(REPO_PATH, "changes.xml")
             )
 
-            val workingTree = Cvs.download(vcs, "", outputDir)
+            val workingTree = Cvs.download(pkg, outputDir)
             val actualFiles = workingTree.workingDir.walkBottomUp()
                     .onEnter { it.name != "CVS" }
                     .filter { it.isFile }
@@ -90,9 +92,12 @@ class CvsDownloadTest : StringSpec() {
         }.config(tags = setOf(ExpensiveTag))
 
         "CVS can download based on a version" {
-            val vcs = VcsInfo("CVS", REPO_URL, "", "")
+            val pkg = Package.EMPTY.copy(
+                    id = Identifier.EMPTY.copy(version = REPO_VERSION),
+                    vcsProcessed = VcsInfo("CVS", REPO_URL, "", "")
+            )
 
-            val workingTree = Cvs.download(vcs, REPO_VERSION, outputDir)
+            val workingTree = Cvs.download(pkg, outputDir)
 
             // Use forward slashes also on Windows as the CVS client comes from MSYS2.
             val buildXmlFile = "xmlenc/build.xml"
@@ -105,12 +110,15 @@ class CvsDownloadTest : StringSpec() {
         }.config(tags = setOf(ExpensiveTag))
 
         "CVS can download only a single path based on a version" {
-            val vcs = VcsInfo("CVS", REPO_URL, "", REPO_PATH_FOR_VERSION)
+            val pkg = Package.EMPTY.copy(
+                    id = Identifier.EMPTY.copy(version = REPO_VERSION),
+                    vcsProcessed = VcsInfo("CVS", REPO_URL, "", REPO_PATH_FOR_VERSION)
+            )
             val expectedFiles = listOf(
                     File(REPO_PATH_FOR_VERSION)
             )
 
-            val workingTree = Cvs.download(vcs, REPO_VERSION, outputDir)
+            val workingTree = Cvs.download(pkg, outputDir)
             val actualFiles = workingTree.workingDir.walkBottomUp()
                     .onEnter { it.name != "CVS" }
                     .filter { it.isFile }

--- a/downloader/src/funTest/kotlin/SubversionDownloadTest.kt
+++ b/downloader/src/funTest/kotlin/SubversionDownloadTest.kt
@@ -19,6 +19,8 @@
 
 package com.here.ort.downloader.vcs
 
+import com.here.ort.model.Identifier
+import com.here.ort.model.Package
 import com.here.ort.model.VcsInfo
 import com.here.ort.utils.ExpensiveTag
 import com.here.ort.utils.safeDeleteRecursively
@@ -53,7 +55,7 @@ class SubversionDownloadTest : StringSpec() {
 
     init {
         "Subversion can download a given revision" {
-            val vcs = VcsInfo("Subversion", REPO_URL, REPO_REV, "")
+            val pkg = Package.EMPTY.copy(vcsProcessed = VcsInfo("Subversion", REPO_URL, REPO_REV, ""))
             val expectedFiles = listOf(
                     ".svn",
                     "branches",
@@ -62,7 +64,7 @@ class SubversionDownloadTest : StringSpec() {
                     "wiki"
             )
 
-            val workingTree = Subversion.download(vcs, "", outputDir)
+            val workingTree = Subversion.download(pkg, outputDir)
             val actualFiles = workingTree.workingDir.list().sorted()
 
             workingTree.isValid() shouldBe true
@@ -71,7 +73,7 @@ class SubversionDownloadTest : StringSpec() {
         }.config(tags = setOf(ExpensiveTag))
 
         "Subversion can download only a single path" {
-            val vcs = VcsInfo("Subversion", REPO_URL, REPO_REV, REPO_PATH)
+            val pkg = Package.EMPTY.copy(vcsProcessed = VcsInfo("Subversion", REPO_URL, REPO_REV, REPO_PATH))
             val expectedFiles = listOf(
                     "SendMessage.sln",
                     "default.build",
@@ -83,7 +85,7 @@ class SubversionDownloadTest : StringSpec() {
                     "versioninfo.build"
             )
 
-            val workingTree = Subversion.download(vcs, "", outputDir)
+            val workingTree = Subversion.download(pkg, outputDir)
             val actualFiles = workingTree.workingDir.list().sorted()
 
             workingTree.isValid() shouldBe true
@@ -92,16 +94,22 @@ class SubversionDownloadTest : StringSpec() {
         }.config(tags = setOf(ExpensiveTag))
 
         "Subversion can download based on a version" {
-            val vcs = VcsInfo("Subversion", REPO_URL, "", "")
+            val pkg = Package.EMPTY.copy(
+                    id = Identifier.EMPTY.copy(version = REPO_VERSION),
+                    vcsProcessed = VcsInfo("Subversion", REPO_URL, "", "")
+            )
 
-            val workingTree = Subversion.download(vcs, REPO_VERSION, outputDir)
+            val workingTree = Subversion.download(pkg, outputDir)
 
             workingTree.isValid() shouldBe true
             workingTree.getRevision() shouldBe REPO_REV_FOR_VERSION
         }.config(tags = setOf(ExpensiveTag))
 
         "Subversion can download only a single path based on a version" {
-            val vcs = VcsInfo("Subversion", REPO_URL, "", REPO_PATH_FOR_VERSION)
+            val pkg = Package.EMPTY.copy(
+                    id = Identifier.EMPTY.copy(version = REPO_VERSION),
+                    vcsProcessed = VcsInfo("Subversion", REPO_URL, "", REPO_PATH_FOR_VERSION)
+            )
             val expectedFiles = listOf(
                     "SendMessage.ico",
                     "searchw.cur",
@@ -109,7 +117,7 @@ class SubversionDownloadTest : StringSpec() {
                     "windowmessages.xml"
             )
 
-            val workingTree = Subversion.download(vcs, REPO_VERSION, outputDir)
+            val workingTree = Subversion.download(pkg, outputDir)
             val actualFiles = File(workingTree.workingDir, REPO_PATH_FOR_VERSION).list().sorted()
 
             workingTree.isValid() shouldBe true

--- a/downloader/src/main/kotlin/Main.kt
+++ b/downloader/src/main/kotlin/Main.kt
@@ -269,8 +269,7 @@ object Main {
             throw DownloadException("Could not find an applicable VCS provider.")
         }
 
-        val workingTree = applicableVcs.download(target.vcsProcessed, target.id.version, outputDirectory,
-                allowMovingRevisions)
+        val workingTree = applicableVcs.download(target, outputDirectory, allowMovingRevisions)
         val revision = workingTree.getRevision()
 
         log.info { "Finished downloading source code revision '$revision' to '${outputDirectory.absolutePath}'." }

--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -20,6 +20,7 @@
 package com.here.ort.downloader
 
 import com.here.ort.downloader.vcs.*
+import com.here.ort.model.Package
 import com.here.ort.model.VcsInfo
 import com.here.ort.utils.filterVersionNames
 
@@ -205,12 +206,12 @@ abstract class VersionControlSystem {
         abstract fun listRemoteTags(): List<String>
 
         /**
-         * Search (symbolic) names of VCS revisions for matches with the given version.
+         * Search (symbolic) names of VCS revisions for matches with the given [project] and [version].
          *
          * @return A matching VCS revision or an empty String if no match is found.
          */
-        fun guessRevisionNameForVersion(version: String) =
-                filterVersionNames(version, listRemoteTags()).firstOrNull() ?: ""
+        fun guessRevisionName(project: String, version: String) =
+                filterVersionNames(version, listRemoteTags(), project).firstOrNull() ?: ""
 
         /**
          * Return the relative path to [path] with respect to the VCS root.
@@ -252,14 +253,13 @@ abstract class VersionControlSystem {
     abstract fun isApplicableUrl(vcsUrl: String): Boolean
 
     /**
-     * Download the source code as specified by the VCS information.
+     * Download the source code as specified by the package information.
      *
      * @return An object describing the downloaded working tree.
      *
      * @throws DownloadException In case the download failed.
      */
-    abstract fun download(vcs: VcsInfo, version: String, targetDir: File, allowMovingRevisions: Boolean = false)
-            : WorkingTree
+    abstract fun download(pkg: Package, targetDir: File, allowMovingRevisions: Boolean = false): WorkingTree
 
     /**
      * Check whether the given [revision] is likely to name a fixed revision that does not move.

--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -115,14 +115,14 @@ object OkHttpClientHelper {
 }
 
 /**
- * Filter a list of [names] to include only those that likely belong to the given [version].
+ * Filter a list of [names] to include only those that likely belong to the given [version] of an optional [project].
  */
-fun filterVersionNames(version: String, names: List<String>): List<String> {
+fun filterVersionNames(version: String, names: List<String>, project: String? = null): List<String> {
     if (version.isBlank()) return emptyList()
 
     val versionElementSeparators = listOf('.', '-', '_')
 
-    return names.filter { name ->
+    val filteredByVersion = names.filter { name ->
         versionElementSeparators.any { separator ->
             val versionName = version.replace('.', separator)
 
@@ -141,6 +141,7 @@ fun filterVersionNames(version: String, names: List<String>): List<String> {
                     val last = head.lastOrNull()
                     val forelast = head.dropLast(1).lastOrNull()
                     last == null
+                            || (last !in versionElementSeparators && !last.isDigit())
                             || (last in versionElementSeparators && (forelast == null || !forelast.isDigit()))
                             || (last.toLowerCase() == 'v' && (forelast == null || forelast in versionElementSeparators))
                 }
@@ -148,6 +149,13 @@ fun filterVersionNames(version: String, names: List<String>): List<String> {
                 else -> false
             }
         }
+    }
+
+    return filteredByVersion.filter {
+        // startsWith("") returns "true" for any string, so we get an unfiltered list if "project" is "null".
+        it.startsWith(project ?: "")
+    }.let {
+        if (it.isEmpty()) filteredByVersion else it
     }
 }
 

--- a/utils/src/test/kotlin/UtilsTest.kt
+++ b/utils/src/test/kotlin/UtilsTest.kt
@@ -171,6 +171,17 @@ class UtilsTest : WordSpec({
             filterVersionNames("7.0.0", names).joinToString("\n") shouldBe ""
             filterVersionNames("2.0", names).joinToString("\n") shouldBe ""
         }
+
+        "find names with the project name as the prefix" {
+            val names = listOf(
+                    "babel-plugin-transform-member-expression-literals@6.9.0",
+                    "babel-plugin-transform-simplify-comparison-operators@6.9.0",
+                    "babel-plugin-transform-property-literals@6.9.0"
+            )
+
+            filterVersionNames("6.9.0", names, "babel-plugin-transform-simplify-comparison-operators")
+                    .joinToString("\n") shouldBe "babel-plugin-transform-simplify-comparison-operators@6.9.0"
+        }
     }
 
     "normalizeVcsUrl" should {


### PR DESCRIPTION
Some repositories contain the source code to e.g. multiple NPM packages.
Individual package releases are then typically marked with tags whose
names are prefixed with the package name. Support finding such tags by
passing along the package name to VersionControlSystem.download().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/292)
<!-- Reviewable:end -->
