### PR TITLE
PackageReference: Remove property normalizedName

### DIFF
--- a/model/src/main/kotlin/PackageReference.kt
+++ b/model/src/main/kotlin/PackageReference.kt
@@ -21,8 +21,6 @@ package com.here.ort.model
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
-import com.here.ort.utils.fileSystemEncode
-
 import java.util.SortedSet
 
 /**
@@ -63,15 +61,10 @@ data class PackageReference(
     override fun compareTo(other: PackageReference) = compareValuesBy(this, other, { it.identifier })
 
     /**
-     * The normalized package name, can be used to create directories.
-     */
-    val normalizedName = name.fileSystemEncode()
-
-    /**
      * The minimum human readable information to identify the package referred to. As references are specific to the
      * package manager, it is not explicitly included.
      */
-    val identifier = "$namespace:$normalizedName:$version"
+    val identifier = "$namespace:$name:$version"
 
     /**
      * Returns whether the given package is a (transitive) dependency of this reference.


### PR DESCRIPTION
The property was never used to create directories which was the main reason
to have a normalized name. The only usage was to build the identifier
string. This broke PackageReference.dependsOn(pkg: Package) because the
package identifer does not use a normalized name. As a result packages
were often not assigend to the correct scopes in the scan summary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/320)
<!-- Reviewable:end -->
