### PR TITLE
downloader: Temporarily disable CVS tests that require online access

### DIFF
--- a/downloader/src/test/kotlin/CvsTest.kt
+++ b/downloader/src/test/kotlin/CvsTest.kt
@@ -77,7 +77,7 @@ class CvsTest : StringSpec() {
             workingTree.getRevision() shouldBe "8707a14c78c6e77ffc59e685360fa20071c1afb6"
             workingTree.getRootPath() shouldBe zipContentDir.path.replace(File.separatorChar, '/')
             workingTree.getPathToRoot(File(zipContentDir, "tomcat")) shouldBe "tomcat"
-        }
+        }.config(enabled = false)
 
         "CVS correctly lists remote tags" {
             val expectedTags = listOf(
@@ -97,6 +97,6 @@ class CvsTest : StringSpec() {
 
             val workingTree = Cvs.getWorkingTree(zipContentDir)
             workingTree.listRemoteTags().joinToString("\n") shouldBe expectedTags.joinToString("\n")
-        }
+        }.config(enabled = false)
     }
 }


### PR DESCRIPTION
SourceForge seems to have some permission problems that read-only locks
cannot be created on the server side.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/325)
<!-- Reviewable:end -->
