### PR TITLE
Maven: Use the Maven defaults when building a project

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
@@ -222,9 +222,9 @@ packages:
     hash: "83cd2cd674a217ade95a4bb83a8a14f351f48bd0"
     hash_algorithm: "SHA-1"
   source_artifact:
-    url: ""
-    hash: ""
-    hash_algorithm: ""
+    url: "http://jasperreports.sourceforge.net/maven2/antlr/antlr/2.7.7/antlr-2.7.7-sources.jar"
+    hash: "Project"
+    hash_algorithm: "SHA-1"
   vcs:
     type: ""
     url: ""
@@ -640,13 +640,13 @@ packages:
   description: "jGnash Resources"
   homepage_url: "http://sourceforge.net/projects/jgnash/jgnash-resources/"
   binary_artifact:
-    url: ""
-    hash: ""
-    hash_algorithm: ""
+    url: "http://jasperreports.sourceforge.net/maven2/jgnash/jgnash-resources/2.30.0/jgnash-resources-2.30.0.jar"
+    hash: "Project"
+    hash_algorithm: "SHA-1"
   source_artifact:
-    url: ""
-    hash: ""
-    hash_algorithm: ""
+    url: "http://jasperreports.sourceforge.net/maven2/jgnash/jgnash-resources/2.30.0/jgnash-resources-2.30.0-sources.jar"
+    hash: "Project"
+    hash_algorithm: "SHA-1"
   vcs:
     type: "git"
     url: "git://github.com:ccavanaugh/jgnash.git/jgnash-resources"
@@ -785,9 +785,9 @@ packages:
     hash: "97fe4bfdef7f103bfd9ec63c98ea90469afeec7b"
     hash_algorithm: "SHA-1"
   source_artifact:
-    url: ""
-    hash: ""
-    hash_algorithm: ""
+    url: "http://jasperreports.sourceforge.net/maven2/org/apache/poi/poi-ooxml-schemas/3.14/poi-ooxml-schemas-3.14-sources.jar"
+    hash: "Project"
+    hash_algorithm: "SHA-1"
   vcs:
     type: ""
     url: ""
@@ -866,9 +866,9 @@ packages:
     hash: "29e80d2dd51f9dcdef8f9ffaee0d4dc1c9bbfc87"
     hash_algorithm: "SHA-1"
   source_artifact:
-    url: ""
-    hash: ""
-    hash_algorithm: ""
+    url: "http://jasperreports.sourceforge.net/maven2/org/apache/xmlbeans/xmlbeans/2.6.0/xmlbeans-2.6.0-sources.jar"
+    hash: "Project"
+    hash_algorithm: "SHA-1"
   vcs:
     type: "svn"
     url: "https://svn.apache.org/repos/asf/xmlbeans/"

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-parent-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-parent-expected-output-root.yml
@@ -1,0 +1,25 @@
+---
+allowDynamicVersions: true
+project:
+  id:
+    package_manager: "Maven"
+    namespace: "com.here.ort.maven"
+    name: "maven-parent-project"
+    version: "1.0-SNAPSHOT"
+  declared_licenses:
+  - "Apache License, Version 2.0"
+  aliases: []
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "<REPLACE_URL>"
+    revision: "<REPLACE_REVISION>"
+    path: "analyzer/src/funTest/assets/projects/synthetic/maven-parent"
+  homepage_url: "http://maven.apache.org"
+  scopes: []
+packages: []
+errors: []

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-parent/pom.xml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-parent/pom.xml
@@ -1,0 +1,19 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.here.ort.maven</groupId>
+    <artifactId>maven-parent-project</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <name>maven-project</name>
+    <url>http://maven.apache.org</url>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>1.5.3.RELEASE</version>
+    </parent>
+
+</project>

--- a/analyzer/src/funTest/kotlin/MavenTest.kt
+++ b/analyzer/src/funTest/kotlin/MavenTest.kt
@@ -22,6 +22,7 @@ package com.here.ort.analyzer
 import com.here.ort.analyzer.managers.Maven
 import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.utils.normalizeVcsUrl
+import com.here.ort.utils.safeDeleteRecursively
 import com.here.ort.utils.yamlMapper
 
 import io.kotlintest.matchers.shouldBe
@@ -96,6 +97,21 @@ class MavenTest : StringSpec() {
         "External dependencies are detected correctly" {
             val pomFile = File(projectDir, "lib/pom.xml")
             val expectedResult = patchExpectedResult("maven-expected-output-lib.yml")
+
+            val result = Maven.create().resolveDependencies(listOf(pomFile))[pomFile]
+
+            yamlMapper.writeValueAsString(result) shouldBe expectedResult
+        }
+
+        "Parent POM from Maven central can be resolved" {
+            // Delete the parent POM from the local repository to make sure it has to be resolved from Maven central.
+            val userHome = File(System.getProperty("user.home"))
+            File(userHome, ".m2/repository/org/springframework/boot/spring-boot-starter-parent/1.5.3.RELEASE")
+                    .safeDeleteRecursively()
+
+            val projectDir = File("src/funTest/assets/projects/synthetic/maven-parent")
+            val pomFile = File(projectDir, "pom.xml")
+            val expectedResult = patchExpectedResult("maven-parent-expected-output-root.yml")
 
             val result = Maven.create().resolveDependencies(listOf(pomFile))[pomFile]
 

--- a/analyzer/src/main/kotlin/managers/Maven.kt
+++ b/analyzer/src/main/kotlin/managers/Maven.kt
@@ -80,10 +80,7 @@ class Maven : PackageManager() {
     /**
      * Enable compatibility mode with POM files generated from SBT using "sbt makePom".
      */
-    fun enableSbtMode(): Maven {
-        sbtMode = true
-        return this
-    }
+    fun enableSbtMode() = this.apply { sbtMode = true }
 
     override fun command(workingDir: File) = "mvn"
 


### PR DESCRIPTION
Populate all ProjectBuildingRequests with the Maven default values by using
the MavenExecutionRequestPopulator. This better aligns the tool with the
behavior of Maven.

The main reason for this is that it adds the default Maven central
repository to the remote repositories of the request. This is important for
projects that use a parent POM from the central repository because it could
otherwise not be resolved. Usually the remote repository for a parent POM
would have to be defined in the POM itself, the only exception is if the
parent POM comes from Maven central, because this repository is always used
by Maven.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/329)
<!-- Reviewable:end -->
