### PR TITLE
utils: Do not strip svn+ prefix from Subversion URLs

### DIFF
--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -223,10 +223,12 @@ fun normalizeVcsUrl(vcsUrl: String): String {
         url = "ssh://" + url
     }
 
-    // Drop any VCS name with "+" from the scheme.
-    url = url.replace(Regex("^(.+)\\+(.+)(://.+)$")) {
-        // Use the string to the right of "+" which should be the protocol.
-        "${it.groupValues[2]}${it.groupValues[3]}"
+    // Drop any non-SVN VCS name with "+" from the scheme.
+    if (!url.startsWith("svn+")) {
+        url = url.replace(Regex("^(.+)\\+(.+)(://.+)$")) {
+            // Use the string to the right of "+" which should be the protocol.
+            "${it.groupValues[2]}${it.groupValues[3]}"
+        }
     }
 
     // A hierarchical URI looks like

--- a/utils/src/test/kotlin/UtilsTest.kt
+++ b/utils/src/test/kotlin/UtilsTest.kt
@@ -331,6 +331,17 @@ class UtilsTest : WordSpec({
             }
         }
 
+        "not strip svn+ prefix from Subversion URLs" {
+            val packages = mapOf(
+                    "svn+ssh://svn.code.sf.net/p/stddecimal/code/trunk"
+                            to "svn+ssh://svn.code.sf.net/p/stddecimal/code/trunk"
+            )
+
+            packages.forEach { actualUrl, expectedUrl ->
+                normalizeVcsUrl(actualUrl) shouldBe expectedUrl
+            }
+        }
+
         "fixup crazy URLs" {
             val packages = mapOf(
                     "git@github.com/cisco/node-jose.git"


### PR DESCRIPTION
The SVN client actually requires the prefix; it cannot clone from "pure"
ssh URLs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/332)
<!-- Reviewable:end -->
