### PR TITLE
SBT: Relax the existence check for generated POMs

### DIFF
--- a/analyzer/src/main/kotlin/managers/SBT.kt
+++ b/analyzer/src/main/kotlin/managers/SBT.kt
@@ -101,7 +101,7 @@ class SBT : PackageManager() {
             // Check if a POM was already generated if this is a sub-module in a multi-module project.
             val targetDir = File(workingDir, "target")
             val hasPom = targetDir.isDirectory && targetDir.listFiles { _, name ->
-                name.startsWith(workingDir.name + "-") && name.endsWith(".pom")
+                name.endsWith(".pom")
             }.isNotEmpty()
 
             if (!hasPom) {


### PR DESCRIPTION
The name of the generated POM might be different from the Scala project
directory name as the project name might have been set programatically.
So just check if any POM was generated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/333)
<!-- Reviewable:end -->
