### PR TITLE
SBT: Relax the POM existence check even further

### DIFF
--- a/analyzer/src/main/kotlin/managers/SBT.kt
+++ b/analyzer/src/main/kotlin/managers/SBT.kt
@@ -100,9 +100,9 @@ class SBT : PackageManager() {
 
             // Check if a POM was already generated if this is a sub-module in a multi-module project.
             val targetDir = File(workingDir, "target")
-            val hasPom = targetDir.isDirectory && targetDir.listFiles { _, name ->
-                name.endsWith(".pom")
-            }.isNotEmpty()
+            val hasPom = targetDir.isDirectory && targetDir.walkTopDown().filter {
+                it.isFile && it.extension == "pom"
+            }.any()
 
             if (!hasPom) {
                 val sbt = ProcessCapture(workingDir, command(workingDir), SBT_BATCH_MODE, SBT_LOG_NO_FORMAT, "makePom")


### PR DESCRIPTION
Allow the POM to be in any sub-directory of the "target" directory. This
is because there might by intermediate directories that denote the used
Scala version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/334)
<!-- Reviewable:end -->
