### PR TITLE
downloader: Return DownloadResult from download function

### DIFF
--- a/analyzer/src/funTest/kotlin/integration/GradleIntegrationTest.kt
+++ b/analyzer/src/funTest/kotlin/integration/GradleIntegrationTest.kt
@@ -56,7 +56,8 @@ class GradleIntegrationTest : AbstractIntegrationSpec() {
         // The Gradle project contains far too many definition files to list them all here. Use this tests to double
         // check that all of them are found, and that they are assigned to the correct package manager.
         val gradleFilenames = listOf("build.gradle", "settings.gradle")
-        val gradleFiles = downloadDir.walkTopDown().filter { it.name in gradleFilenames }.toMutableList()
+        val gradleFiles =
+                downloadResult.downloadDirectory.walkTopDown().filter { it.name in gradleFilenames }.toMutableList()
 
         // settings.gradle shall only be detected if there is no build.gradle file in the same directory.
         gradleFiles.removeAll {
@@ -65,11 +66,12 @@ class GradleIntegrationTest : AbstractIntegrationSpec() {
 
         mapOf(
                 Gradle to gradleFiles,
-                Maven to downloadDir.walkTopDown().filter { it.name == "pom.xml" }.toList()
+                Maven to downloadResult.downloadDirectory.walkTopDown().filter { it.name == "pom.xml" }.toList()
         )
     }
 
     override val definitionFilesForTest by lazy {
-        mapOf(Gradle as PackageManagerFactory<PackageManager> to listOf(File(downloadDir, "buildSrc/build.gradle")))
+        mapOf(Gradle as PackageManagerFactory<PackageManager> to
+                listOf(File(downloadResult.downloadDirectory, "buildSrc/build.gradle")))
     }
 }

--- a/analyzer/src/funTest/kotlin/integration/VueJsIntegrationTest.kt
+++ b/analyzer/src/funTest/kotlin/integration/VueJsIntegrationTest.kt
@@ -52,6 +52,7 @@ class VueJsIntegrationTest : AbstractIntegrationSpec() {
     )
 
     override val expectedDefinitionFiles by lazy {
+        val downloadDir = downloadResult.downloadDirectory
         mapOf(
                 NPM as PackageManagerFactory<PackageManager> to listOf(
                         File(downloadDir, "package.json"),
@@ -64,6 +65,7 @@ class VueJsIntegrationTest : AbstractIntegrationSpec() {
     }
 
     override val definitionFilesForTest by lazy {
-        mapOf(NPM as PackageManagerFactory<PackageManager> to listOf(File(downloadDir, "package.json")))
+        mapOf(NPM as PackageManagerFactory<PackageManager> to
+                listOf(File(downloadResult.downloadDirectory, "package.json")))
     }
 }

--- a/downloader/src/funTest/kotlin/BabelTest.kt
+++ b/downloader/src/funTest/kotlin/BabelTest.kt
@@ -80,14 +80,22 @@ class BabelTest : StringSpec() {
                     vcsProcessed = vcsMerged
             )
 
-            val downloadDir = Main.download(pkg, outputDir)
-            val workingTree = VersionControlSystem.forDirectory(downloadDir)
+            val downloadResult = Main.download(pkg, outputDir)
+
+            downloadResult.sourceArtifact shouldBe null
+            downloadResult.vcsInfo shouldNotBe null
+            downloadResult.vcsInfo!!.type shouldBe pkg.vcsProcessed.type
+            downloadResult.vcsInfo!!.url shouldBe pkg.vcsProcessed.url
+            downloadResult.vcsInfo!!.revision shouldBe "cee4cde53e4f452d89229986b9368ecdb41e00da"
+            downloadResult.vcsInfo!!.path shouldBe pkg.vcsProcessed.path
+
+            val workingTree = VersionControlSystem.forDirectory(downloadResult.downloadDirectory)
 
             workingTree shouldNotBe null
             workingTree!!.isValid() shouldBe true
             workingTree.getRevision() shouldBe "cee4cde53e4f452d89229986b9368ecdb41e00da"
 
-            val babelCliDir = File(downloadDir, "packages/babel-cli")
+            val babelCliDir = File(downloadResult.downloadDirectory, "packages/babel-cli")
             babelCliDir.isDirectory shouldBe true
             babelCliDir.walkTopDown().count() shouldBe 242
         }

--- a/downloader/src/funTest/kotlin/BeanUtilsTest.kt
+++ b/downloader/src/funTest/kotlin/BeanUtilsTest.kt
@@ -71,14 +71,21 @@ class BeanUtilsTest : StringSpec() {
                     vcs = vcsFromCuration
             )
 
-            val downloadDir = Main.download(pkg, outputDir)
-            val workingTree = VersionControlSystem.forDirectory(downloadDir)
+            val downloadResult = Main.download(pkg, outputDir)
+            downloadResult.sourceArtifact shouldBe null
+            downloadResult.vcsInfo shouldNotBe null
+            downloadResult.vcsInfo!!.type shouldBe "Subversion"
+            downloadResult.vcsInfo!!.url shouldBe vcsFromCuration.url
+            downloadResult.vcsInfo!!.revision shouldBe "928490"
+            downloadResult.vcsInfo!!.path shouldBe vcsFromCuration.path
+
+            val workingTree = VersionControlSystem.forDirectory(downloadResult.downloadDirectory)
 
             workingTree shouldNotBe null
             workingTree!!.isValid() shouldBe true
             workingTree.getRevision() shouldBe "1823084"
 
-            val tagsBeanUtils183Dir = File(downloadDir, "tags/BEANUTILS_1_8_3")
+            val tagsBeanUtils183Dir = File(downloadResult.downloadDirectory, "tags/BEANUTILS_1_8_3")
             tagsBeanUtils183Dir.isDirectory shouldBe true
             tagsBeanUtils183Dir.walkTopDown().count() shouldBe 302
         }

--- a/downloader/src/funTest/kotlin/DownloaderTest.kt
+++ b/downloader/src/funTest/kotlin/DownloaderTest.kt
@@ -29,6 +29,7 @@ import com.here.ort.utils.safeDeleteRecursively
 
 import io.kotlintest.TestCaseContext
 import io.kotlintest.matchers.shouldBe
+import io.kotlintest.matchers.shouldNotBe
 import io.kotlintest.matchers.shouldThrow
 import io.kotlintest.specs.StringSpec
 
@@ -70,13 +71,18 @@ class DownloaderTest : StringSpec() {
                     vcs = VcsInfo.EMPTY
             )
 
-            val downloadDir = Main.download(pkg, outputDir)
+            val downloadResult = Main.download(pkg, outputDir)
+            downloadResult.vcsInfo shouldBe null
+            downloadResult.sourceArtifact shouldNotBe null
+            downloadResult.sourceArtifact!!.url shouldBe pkg.sourceArtifact.url
+            downloadResult.sourceArtifact!!.hash shouldBe pkg.sourceArtifact.hash
+            downloadResult.sourceArtifact!!.hashAlgorithm shouldBe pkg.sourceArtifact.hashAlgorithm
 
-            val licenseFile = File(downloadDir, "LICENSE-junit.txt")
+            val licenseFile = File(downloadResult.downloadDirectory, "LICENSE-junit.txt")
             licenseFile.isFile shouldBe true
             licenseFile.length() shouldBe 11376L
 
-            downloadDir.walkTopDown().count() shouldBe 234
+            downloadResult.downloadDirectory.walkTopDown().count() shouldBe 234
         }.config(tags = setOf(ExpensiveTag))
 
         "Download of JAR source package fails when hash is incorrect" {
@@ -132,13 +138,18 @@ class DownloaderTest : StringSpec() {
                     )
             )
 
-            val downloadDir = Main.download(pkg, outputDir)
+            val downloadResult = Main.download(pkg, outputDir)
+            downloadResult.vcsInfo shouldBe null
+            downloadResult.sourceArtifact shouldNotBe null
+            downloadResult.sourceArtifact!!.url shouldBe pkg.sourceArtifact.url
+            downloadResult.sourceArtifact!!.hash shouldBe pkg.sourceArtifact.hash
+            downloadResult.sourceArtifact!!.hashAlgorithm shouldBe pkg.sourceArtifact.hashAlgorithm
 
-            val licenseFile = File(downloadDir, "LICENSE-junit.txt")
+            val licenseFile = File(downloadResult.downloadDirectory, "LICENSE-junit.txt")
             licenseFile.isFile shouldBe true
             licenseFile.length() shouldBe 11376L
 
-            downloadDir.walkTopDown().count() shouldBe 234
+            downloadResult.downloadDirectory.walkTopDown().count() shouldBe 234
         }.config(tags = setOf(ExpensiveTag))
 
         "Can download source artifact from SourceForce" {
@@ -162,8 +173,14 @@ class DownloaderTest : StringSpec() {
                     vcs = VcsInfo.EMPTY
             )
 
-            val downloadDir = Main.download(pkg, outputDir)
-            val tyrexDir = File(downloadDir, "tyrex-1.0.1")
+            val downloadResult = Main.download(pkg, outputDir)
+            downloadResult.vcsInfo shouldBe null
+            downloadResult.sourceArtifact shouldNotBe null
+            downloadResult.sourceArtifact!!.url shouldBe pkg.sourceArtifact.url
+            downloadResult.sourceArtifact!!.hash shouldBe pkg.sourceArtifact.hash
+            downloadResult.sourceArtifact!!.hashAlgorithm shouldBe pkg.sourceArtifact.hashAlgorithm
+
+            val tyrexDir = File(downloadResult.downloadDirectory, "tyrex-1.0.1")
 
             tyrexDir.isDirectory shouldBe true
             tyrexDir.walkTopDown().count() shouldBe 409

--- a/downloader/src/main/kotlin/Main.kt
+++ b/downloader/src/main/kotlin/Main.kt
@@ -32,6 +32,7 @@ import com.here.ort.model.Identifier
 import com.here.ort.model.OutputFormat
 import com.here.ort.model.Package
 import com.here.ort.model.Project
+import com.here.ort.model.RemoteArtifact
 import com.here.ort.model.VcsInfo
 import com.here.ort.utils.OkHttpClientHelper
 import com.here.ort.utils.PARAMETER_ORDER_HELP
@@ -72,6 +73,22 @@ object Main {
              */
             @JvmField
             val ALL = DataEntity.values().asList()
+        }
+    }
+
+    /**
+     * This class describes what was downloaded by [download] or if any exception occured. Either [sourceArtifact] or
+     * [vcsInfo] is set to a non-null value.
+     */
+    data class DownloadResult(
+        val downloadDirectory: File,
+        val sourceArtifact: RemoteArtifact? = null,
+        val vcsInfo: VcsInfo? = null
+    ) {
+        init {
+            require((sourceArtifact == null) != (vcsInfo == null)) {
+                "Either sourceArtifact or vcsInfo must be set, but not both."
+            }
         }
     }
 
@@ -233,11 +250,11 @@ object Main {
      * @param target The description of the package to download.
      * @param outputDirectory The parent directory to download the source code to.
      *
-     * @return The directory the source code was downloaded to.
+     * @return The [DownloadResult].
      *
      * @throws DownloadException In case the download failed.
      */
-    fun download(target: Package, outputDirectory: File): File {
+    fun download(target: Package, outputDirectory: File): DownloadResult {
         // TODO: add namespace to path
         val targetDir = File(outputDirectory, "${target.normalizedName}/${target.id.version}").apply { safeMkdirs() }
 
@@ -262,7 +279,7 @@ object Main {
         return downloadSourceArtifact(target, targetDir)
     }
 
-    private fun downloadFromVcs(target: Package, outputDirectory: File): File {
+    private fun downloadFromVcs(target: Package, outputDirectory: File): DownloadResult {
         log.info {
             "Trying to download '${target.id}' sources to '${outputDirectory.absolutePath}' from VCS..."
         }
@@ -307,10 +324,16 @@ object Main {
 
         log.info { "Finished downloading source code revision '$revision' to '${outputDirectory.absolutePath}'." }
 
-        return outputDirectory
+        val vcsInfo = VcsInfo(
+                type = applicableVcs.javaClass.simpleName,
+                url = target.vcsProcessed.url,
+                revision = revision,
+                path = target.vcsProcessed.path // TODO: Needs to check if the VCS used the sparse checkout.
+        )
+        return DownloadResult(outputDirectory, vcsInfo = vcsInfo)
     }
 
-    private fun downloadSourceArtifact(target: Package, outputDirectory: File): File {
+    private fun downloadSourceArtifact(target: Package, outputDirectory: File): DownloadResult {
         if (target.sourceArtifact.url.isBlank()) {
             throw DownloadException("No source artifact URL provided for '${target.id}'.")
         }
@@ -347,7 +370,7 @@ object Main {
             "Successfully downloaded source artifact for '${target.id}' to '${outputDirectory.absolutePath}'..."
         }
 
-        return outputDirectory
+        return DownloadResult(outputDirectory, sourceArtifact = target.sourceArtifact)
     }
 
     private fun verifyChecksum(file: File, hash: String, hashAlgorithm: HashAlgorithm) {

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -102,7 +102,7 @@ abstract class Scanner {
             return getResult(resultsFile)
         }
 
-        val sourceDirectory = try {
+        val downloadResult = try {
             Main.download(pkg, downloadDirectory ?: File(outputDirectory, "downloads"))
         } catch (e: DownloadException) {
             if (com.here.ort.utils.printStackTrace) {
@@ -113,9 +113,9 @@ abstract class Scanner {
         }
 
         val version = getVersion(scannerPath.absolutePath)
-        println("Running $this version $version on directory '${sourceDirectory.absolutePath}'.")
+        println("Running $this version $version on directory '${downloadResult.downloadDirectory.absolutePath}'.")
 
-        return scanPath(sourceDirectory, resultsFile).also {
+        return scanPath(downloadResult.downloadDirectory, resultsFile).also {
             println("Stored $this results in '${resultsFile.absolutePath}'.")
             ScanResultsCache.write(pkg, resultsFile)
         }


### PR DESCRIPTION
Instead of only returning the download directory let the download function
also return information about what was downloaded. This is described by
either the VcsInfo if the source was downloaded from a VCS or the
RemoteArtifact if a source artifact was downloaded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/342)
<!-- Reviewable:end -->
