### PR TITLE
scanner: Prepare for integrating remote scanners

### DIFF
--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2017-2018 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.scanner
+
+import ch.frankel.slf4k.*
+
+import com.here.ort.downloader.DownloadException
+import com.here.ort.downloader.Main
+import com.here.ort.model.Package
+import com.here.ort.utils.getPathFromEnvironment
+import com.here.ort.utils.log
+import com.here.ort.utils.safeMkdirs
+
+import java.io.File
+
+/**
+ * Implementation of [Scanner] for scanners that operate locally. Packages passed to [scan] are processed in serial
+ * order. Scan results can be cached in a [ScanResultsCache].
+ */
+abstract class LocalScanner : Scanner() {
+    /**
+     * A property containing the file name extension of the scanner's native output format, without the dot.
+     */
+    protected abstract val resultFileExt: String
+
+    /**
+     * The directory the scanner was bootstrapped to, if so.
+     */
+    protected val scannerDir by lazy {
+        getPathFromEnvironment(scannerExe)?.parentFile ?: run {
+            log.info { "Bootstrapping scanner '$this' as it was not found in PATH." }
+            bootstrap()
+        }
+    }
+
+    /**
+     * The scanner's executable file name.
+     */
+    protected abstract val scannerExe: String
+
+    /**
+     * The full path to the scanner executable.
+     */
+    protected val scannerPath by lazy { File(scannerDir, scannerExe) }
+
+    /**
+     * Bootstrap the scanner to be ready for use, like downloading and / or configuring it.
+     *
+     * @return The directory the scanner is installed in, or null if the scanner was not bootstrapped.
+     */
+    protected open fun bootstrap(): File? = null
+
+    /**
+     * Return the version of the specified scanner [executable], or an empty string in case of failure.
+     */
+    abstract fun getVersion(executable: String): String
+
+    override fun scan(packages: List<Package>, outputDirectory: File, downloadDirectory: File?): Map<Package, Result> {
+        return packages.associateBy { it }.mapValues { scan(it.value, outputDirectory, downloadDirectory) }
+    }
+
+    /**
+     * Scan the provided [pkg] for license information, writing results to [outputDirectory]. If a scan result is found
+     * in the cache, it is used without running the actual scan. If no cached scan result is found, the package's source
+     * code is downloaded and scanned afterwards.
+     *
+     * @param pkg The package to scan.
+     * @param outputDirectory The base directory to store scan results in.
+     * @param downloadDirectory The directory to download source code to. Defaults to [outputDirectory]/downloads if
+     *                          null.
+     *
+     * @return The set of found licenses.
+     *
+     * @throws ScanException In case the package could not be scanned.
+     */
+    fun scan(pkg: Package, outputDirectory: File, downloadDirectory: File? = null): Result {
+        val scanResultsDirectory = File(outputDirectory, "scanResults").apply { safeMkdirs() }
+        val scannerName = toString().toLowerCase()
+
+        // TODO: Consider implementing this logic in the Package class itself when creating the identifier.
+        // Also, think about what to use if we have neither a version nor a hash.
+        val pkgRevision = pkg.id.version.let { if (it.isBlank()) pkg.vcsProcessed.revision.take(7) else it }
+
+        val resultsFile = File(scanResultsDirectory,
+                "${pkg.id.name}-${pkgRevision}_$scannerName.$resultFileExt")
+
+        if (ScanResultsCache.read(pkg, resultsFile)) {
+            return getResult(resultsFile)
+        }
+
+        val downloadResult = try {
+            Main.download(pkg, downloadDirectory ?: File(outputDirectory, "downloads"))
+        } catch (e: DownloadException) {
+            if (com.here.ort.utils.printStackTrace) {
+                e.printStackTrace()
+            }
+
+            throw ScanException("Package '${pkg.id}' could not be scanned.", e)
+        }
+
+        val version = getVersion(scannerPath.absolutePath)
+        println("Running $this version $version on directory '${downloadResult.downloadDirectory.absolutePath}'.")
+
+        return scanPath(downloadResult.downloadDirectory, resultsFile).also {
+            println("Stored $this results in '${resultsFile.absolutePath}'.")
+            ScanResultsCache.write(pkg, resultsFile)
+        }
+    }
+
+    /**
+     * Scan the provided [path] for license information, writing results to [outputDirectory]. Note that no caching will
+     * be used in this mode.
+     *
+     * @param path The directory or file to scan.
+     * @param outputDirectory The base directory to store scan results in.
+     *
+     * @return The set of found licenses.
+     *
+     * @throws ScanException In case the package could not be scanned.
+     */
+    fun scan(path: File, outputDirectory: File): Result {
+        val scanResultsDirectory = File(outputDirectory, "scanResults").apply { safeMkdirs() }
+        val scannerName = toString().toLowerCase()
+        val resultsFile = File(scanResultsDirectory,
+                "${path.nameWithoutExtension}_$scannerName.$resultFileExt")
+
+        val version = getVersion(scannerPath.absolutePath)
+        println("Running $this version $version on path '${path.absolutePath}'.")
+
+        return scanPath(path, resultsFile).also {
+            println("Stored $this results in '${resultsFile.absolutePath}'.")
+        }
+    }
+
+    /**
+     * Scan the provided [path] for license information, writing results to [resultsFile].
+     */
+    protected abstract fun scanPath(path: File, resultsFile: File): Result
+
+    /**
+     * Convert the scanner's native file format to a [Result].
+     */
+    internal abstract fun getResult(resultsFile: File): Result
+}

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -19,45 +19,13 @@
 
 package com.here.ort.scanner
 
-import ch.frankel.slf4k.*
-
-import com.here.ort.downloader.DownloadException
-import com.here.ort.downloader.Main
 import com.here.ort.model.Package
 import com.here.ort.scanner.scanners.*
-import com.here.ort.utils.getPathFromEnvironment
-import com.here.ort.utils.log
-import com.here.ort.utils.safeMkdirs
 
 import java.io.File
 import java.util.SortedSet
 
 abstract class Scanner {
-    /**
-     * The directory the scanner was bootstrapped to, if so.
-     */
-    protected val scannerDir by lazy {
-        getPathFromEnvironment(scannerExe)?.parentFile ?: run {
-            log.info { "Bootstrapping scanner '$this' as it was not found in PATH." }
-            bootstrap()
-        }
-    }
-
-    /**
-     * The scanner's executable file name.
-     */
-    protected abstract val scannerExe: String
-
-    /**
-     * The full path to the scanner executable.
-     */
-    protected val scannerPath by lazy { File(scannerDir, scannerExe) }
-
-    /**
-     * A property containing the file name extension of the scanner's native output format, without the dot.
-     */
-    protected abstract val resultFileExt: String
-
     companion object {
         /**
          * The list of all available scanners. This needs to be initialized lazily to ensure the referred objects,
@@ -74,103 +42,11 @@ abstract class Scanner {
 
     data class Result(val licenses: SortedSet<String>, val errors: SortedSet<String>)
 
+    abstract fun scan(packages: List<Package>, outputDirectory: File, downloadDirectory: File? = null)
+            : Map<Package, Result>
+
     /**
      * Return the Java class name as a simple way to refer to the scanner.
      */
     override fun toString(): String = javaClass.simpleName
-
-    /**
-     * Scan the provided [pkg] for license information, writing results to [outputDirectory]. If a scan result is found
-     * in the cache, it is used without running the actual scan. If no cached scan result is found, the package's source
-     * code is downloaded and scanned afterwards.
-     *
-     * @param pkg The package to scan.
-     * @param outputDirectory The base directory to store scan results in.
-     * @param downloadDirectory The directory to download source code to. Defaults to [outputDirectory]/downloads if
-     *                          null.
-     *
-     * @return The set of found licenses.
-     *
-     * @throws ScanException In case the package could not be scanned.
-     */
-    fun scan(pkg: Package, outputDirectory: File, downloadDirectory: File? = null): Result {
-        val scanResultsDirectory = File(outputDirectory, "scanResults").apply { safeMkdirs() }
-        val scannerName = toString().toLowerCase()
-
-        // TODO: Consider implementing this logic in the Package class itself when creating the identifier.
-        // Also, think about what to use if we have neither a version nor a hash.
-        val pkgRevision = pkg.id.version.let { if (it.isBlank()) pkg.vcsProcessed.revision.take(7) else it }
-
-        val resultsFile = File(scanResultsDirectory,
-                "${pkg.id.name}-${pkgRevision}_$scannerName.$resultFileExt")
-
-        if (ScanResultsCache.read(pkg, resultsFile)) {
-            return getResult(resultsFile)
-        }
-
-        val downloadResult = try {
-            Main.download(pkg, downloadDirectory ?: File(outputDirectory, "downloads"))
-        } catch (e: DownloadException) {
-            if (com.here.ort.utils.printStackTrace) {
-                e.printStackTrace()
-            }
-
-            throw ScanException("Package '${pkg.id}' could not be scanned.", e)
-        }
-
-        val version = getVersion(scannerPath.absolutePath)
-        println("Running $this version $version on directory '${downloadResult.downloadDirectory.absolutePath}'.")
-
-        return scanPath(downloadResult.downloadDirectory, resultsFile).also {
-            println("Stored $this results in '${resultsFile.absolutePath}'.")
-            ScanResultsCache.write(pkg, resultsFile)
-        }
-    }
-
-    /**
-     * Scan the provided [path] for license information, writing results to [outputDirectory]. Note that no caching will
-     * be used in this mode.
-     *
-     * @param path The directory or file to scan.
-     * @param outputDirectory The base directory to store scan results in.
-     *
-     * @return The set of found licenses.
-     *
-     * @throws ScanException In case the package could not be scanned.
-     */
-    fun scan(path: File, outputDirectory: File): Result {
-        val scanResultsDirectory = File(outputDirectory, "scanResults").apply { safeMkdirs() }
-        val scannerName = toString().toLowerCase()
-        val resultsFile = File(scanResultsDirectory,
-                "${path.nameWithoutExtension}_$scannerName.$resultFileExt")
-
-        val version = getVersion(scannerPath.absolutePath)
-        println("Running $this version $version on path '${path.absolutePath}'.")
-
-        return scanPath(path, resultsFile).also {
-            println("Stored $this results in '${resultsFile.absolutePath}'.")
-        }
-    }
-
-    /**
-     * Bootstrap the scanner to be ready for use, like downloading and / or configuring it.
-     *
-     * @return The directory the scanner is installed in, or null if the scanner was not bootstrapped.
-     */
-    protected open fun bootstrap(): File? = null
-
-    /**
-     * Return the version of the specified scanner [executable], or an empty string in case of failure.
-     */
-    abstract fun getVersion(executable: String): String
-
-    /**
-     * Scan the provided [path] for license information, writing results to [resultsFile].
-     */
-    protected abstract fun scanPath(path: File, resultsFile: File): Result
-
-    /**
-     * Convert the scanner's native file format to a [Result].
-     */
-    internal abstract fun getResult(resultsFile: File): Result
 }

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -75,7 +75,7 @@ abstract class Scanner {
     data class Result(val licenses: SortedSet<String>, val errors: SortedSet<String>)
 
     /**
-     * Return the Java class name as a simply way to refer to the scanner.
+     * Return the Java class name as a simple way to refer to the scanner.
      */
     override fun toString(): String = javaClass.simpleName
 

--- a/scanner/src/main/kotlin/scanners/BoyterLc.kt
+++ b/scanner/src/main/kotlin/scanners/BoyterLc.kt
@@ -21,25 +21,26 @@ package com.here.ort.scanner.scanners
 
 import ch.frankel.slf4k.*
 
-import com.here.ort.utils.unpack
+import com.here.ort.scanner.LocalScanner
 import com.here.ort.scanner.Main
 import com.here.ort.scanner.ScanException
-import com.here.ort.scanner.Scanner
 import com.here.ort.utils.OkHttpClientHelper
 import com.here.ort.utils.OS
 import com.here.ort.utils.ProcessCapture
 import com.here.ort.utils.getCommandVersion
 import com.here.ort.utils.jsonMapper
 import com.here.ort.utils.log
+import com.here.ort.utils.unpack
 
 import okhttp3.Request
+
 import okio.Okio
 
 import java.io.File
 import java.io.IOException
 import java.net.HttpURLConnection
 
-object BoyterLc : Scanner() {
+object BoyterLc : LocalScanner() {
     const val VERSION = "1.1.1"
 
     override val scannerExe = if (OS.isWindows) "lc.exe" else "lc"

--- a/scanner/src/main/kotlin/scanners/Licensee.kt
+++ b/scanner/src/main/kotlin/scanners/Licensee.kt
@@ -21,8 +21,8 @@ package com.here.ort.scanner.scanners
 
 import ch.frankel.slf4k.*
 
+import com.here.ort.scanner.LocalScanner
 import com.here.ort.scanner.ScanException
-import com.here.ort.scanner.Scanner
 import com.here.ort.utils.OS
 import com.here.ort.utils.ProcessCapture
 import com.here.ort.utils.yamlMapper
@@ -30,7 +30,7 @@ import com.here.ort.utils.log
 
 import java.io.File
 
-object Licensee : Scanner() {
+object Licensee : LocalScanner() {
     override val scannerExe = if (OS.isWindows) "licensee.bat" else "licensee"
     override val resultFileExt = "yml"
 

--- a/scanner/src/main/kotlin/scanners/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/ScanCode.kt
@@ -21,9 +21,9 @@ package com.here.ort.scanner.scanners
 
 import ch.frankel.slf4k.*
 import ch.qos.logback.classic.Level
+import com.here.ort.scanner.LocalScanner
 
 import com.here.ort.scanner.ScanException
-import com.here.ort.scanner.Scanner
 import com.here.ort.utils.OS
 import com.here.ort.utils.ProcessCapture
 import com.here.ort.utils.getCommandVersion
@@ -33,7 +33,7 @@ import com.here.ort.utils.log
 import java.io.File
 import java.util.regex.Pattern
 
-object ScanCode : Scanner() {
+object ScanCode : LocalScanner() {
     private const val OUTPUT_FORMAT = "json-pp"
     private const val TIMEOUT = 300
 


### PR DESCRIPTION
Move all code that is only required for local scanners to the new
LocalScanner class. Also change the scan() method in Scanner to take a list
of packages. This allows the Scanner implementation to decide if they are
process in serial order or in parallel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/345)
<!-- Reviewable:end -->
