### PR TITLE
VersionControlSystem: Generalize isApplicableType

### DIFF
--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -226,6 +226,11 @@ abstract class VersionControlSystem {
     }
 
     /**
+     * A list of lowercase names that clearly identify the VCS. For example ["svn", "subversion"] for Subversion.
+     */
+    protected abstract val aliases: List<String>
+
+    /**
      * The name of the command line program to run for this VCS implementation.
      */
     protected abstract val commandName: String
@@ -252,10 +257,9 @@ abstract class VersionControlSystem {
     abstract fun getWorkingTree(vcsDirectory: File): WorkingTree
 
     /**
-     * Return true if the type name matches this VCS. For example for SVN it should return true on "svn",
-     * "subversion", or any other spelling that clearly identifies SVN.
+     * Return true if any of the [aliases] matches [vcsType]. Comparison is done case-insensitively.
      */
-    abstract fun isApplicableType(vcsType: String): Boolean
+    fun isApplicableType(vcsType: String) = vcsType.toLowerCase() in aliases
 
     /**
      * Return true if this VCS can download from the provided URL. Should only return true when it's almost unambiguous,

--- a/downloader/src/main/kotlin/vcs/Cvs.kt
+++ b/downloader/src/main/kotlin/vcs/Cvs.kt
@@ -39,6 +39,7 @@ import java.util.regex.Pattern
 typealias CvsFileRevisions = List<Pair<String, String>>
 
 object Cvs : VersionControlSystem() {
+    override val aliases = listOf("cvs")
     override val commandName = "cvs"
     override val movingRevisionNames = emptyList<String>()
 
@@ -145,8 +146,6 @@ object Cvs : VersionControlSystem() {
                     return tagsList.toSortedSet().toList()
                 }
             }
-
-    override fun isApplicableType(vcsType: String) = vcsType.equals("cvs", true)
 
     override fun isApplicableUrl(vcsUrl: String) = vcsUrl.matches("^:(ext|pserver):[^@]+@.+$".toRegex())
 

--- a/downloader/src/main/kotlin/vcs/Git.kt
+++ b/downloader/src/main/kotlin/vcs/Git.kt
@@ -91,7 +91,7 @@ object Git : GitBase() {
     // TODO: Make this configurable.
     private const val HISTORY_DEPTH = 10
 
-    override fun isApplicableType(vcsType: String) = vcsType.equals("git", true)
+    override val aliases = listOf("git")
 
     override fun isApplicableUrl(vcsUrl: String) = ProcessCapture("git", "ls-remote", vcsUrl).exitValue() == 0
 

--- a/downloader/src/main/kotlin/vcs/GitRepo.kt
+++ b/downloader/src/main/kotlin/vcs/GitRepo.kt
@@ -30,9 +30,9 @@ import java.io.File
 import java.io.IOException
 
 object GitRepo : GitBase() {
-    override fun getWorkingTree(vcsDirectory: File) = super.getWorkingTree(File(vcsDirectory, ".repo/manifests"))
+    override val aliases = listOf("gitrepo", "git-repo", "repo")
 
-    override fun isApplicableType(vcsType: String) = vcsType.toLowerCase() in listOf("gitrepo", "git-repo", "repo")
+    override fun getWorkingTree(vcsDirectory: File) = super.getWorkingTree(File(vcsDirectory, ".repo/manifests"))
 
     override fun isApplicableUrl(vcsUrl: String) = false
 

--- a/downloader/src/main/kotlin/vcs/Mercurial.kt
+++ b/downloader/src/main/kotlin/vcs/Mercurial.kt
@@ -36,6 +36,7 @@ object Mercurial : VersionControlSystem() {
     private const val EXTENSION_LARGE_FILES = "largefiles = "
     private const val EXTENSION_SPARSE = "sparse = "
 
+    override val aliases = listOf("mercurial", "hg")
     override val commandName = "hg"
     override val movingRevisionNames = listOf("tip", "default")
 
@@ -86,8 +87,6 @@ object Mercurial : VersionControlSystem() {
                     }.sorted()
                 }
             }
-
-    override fun isApplicableType(vcsType: String) = vcsType.toLowerCase() in listOf("mercurial", "hg")
 
     override fun isApplicableUrl(vcsUrl: String) = ProcessCapture("hg", "identify", vcsUrl).exitValue() == 0
 

--- a/downloader/src/main/kotlin/vcs/Subversion.kt
+++ b/downloader/src/main/kotlin/vcs/Subversion.kt
@@ -89,6 +89,7 @@ data class SubversionTagsEntry(
         val lock: SubversionInfoLock?)
 
 object Subversion : VersionControlSystem() {
+    override val aliases = listOf("subversion", "svn")
     override val commandName = "svn"
     override val movingRevisionNames = listOf("HEAD")
 
@@ -154,8 +155,6 @@ object Subversion : VersionControlSystem() {
                     return svnInfoReader.readValue(info.stdout())
                 }
             }
-
-    override fun isApplicableType(vcsType: String) = vcsType.toLowerCase() in listOf("subversion", "svn")
 
     override fun isApplicableUrl(vcsUrl: String) =
             vcsUrl.startsWith("svn+") || ProcessCapture("svn", "list", vcsUrl).exitValue() == 0


### PR DESCRIPTION
Add a new property "aliases" which is a list of strings and use it to
generalize the implementation of isApplicableType, because they all work
basically the same way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/350)
<!-- Reviewable:end -->
