### PR TITLE
MavenSupport: De-duplicate the list of all repositories

### DIFF
--- a/analyzer/src/main/kotlin/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/MavenSupport.kt
@@ -165,7 +165,7 @@ class MavenSupport(localRepositoryManagerConverter: (LocalRepositoryManager) -> 
         val artifactDescriptorRequest = ArtifactDescriptorRequest(artifact, repositories, "project")
         val artifactDescriptorResult = repoSystem
                 .readArtifactDescriptor(repositorySystemSession, artifactDescriptorRequest)
-        val allRepositories = artifactDescriptorResult.repositories + repositories
+        val allRepositories = (artifactDescriptorResult.repositories + repositories).distinct()
 
         // Filter local repositories, as remote artifacts should never point to files on the local disk.
         val remoteRepositories = allRepositories.filterNot { it.url.startsWith("file:/") }


### PR DESCRIPTION
This avoids duplicates as visible in warning logs like

WARN  - Unable to find 'artifact' in any of [https://repo.maven.apache.org/maven2, ..., https://repo.maven.apache.org/maven2].

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/361)
<!-- Reviewable:end -->
