### PR TITLE
Maven: Remove paths appended to SCM URLs by Maven

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
@@ -84,12 +84,12 @@ packages:
     hash_algorithm: "SHA-1"
   vcs:
     type: "git"
-    url: "git@github.com:hamcrest/JavaHamcrest.git/hamcrest-core"
+    url: "git@github.com:hamcrest/JavaHamcrest.git"
     revision: ""
     path: ""
   vcs_processed:
     type: "Git"
     url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
     revision: ""
-    path: "hamcrest-core"
+    path: ""
 errors: []

--- a/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
@@ -10,7 +10,7 @@ project:
   aliases: []
   vcs:
     type: "git"
-    url: "git://github.com:ccavanaugh/jgnash.git/jgnash-core"
+    url: "git://github.com:ccavanaugh/jgnash.git"
     revision: ""
     path: ""
   vcs_processed:
@@ -395,14 +395,14 @@ packages:
     hash_algorithm: "SHA-1"
   vcs:
     type: "git"
-    url: "https://github.com/x-stream/xstream.git/xstream-hibernate"
+    url: "https://github.com/x-stream/xstream.git"
     revision: "v-1.4.x"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/x-stream/xstream.git"
     revision: "v-1.4.x"
-    path: "xstream-hibernate"
+    path: ""
 - id:
     provider: "Maven"
     namespace: "com.thoughtworks.xstream"
@@ -422,14 +422,14 @@ packages:
     hash_algorithm: "SHA-1"
   vcs:
     type: "git"
-    url: "https://github.com/x-stream/xstream.git/xstream"
+    url: "https://github.com/x-stream/xstream.git"
     revision: "v-1.4.x"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/x-stream/xstream.git"
     revision: "v-1.4.x"
-    path: "xstream"
+    path: ""
 - id:
     provider: "Maven"
     namespace: "commons-codec"
@@ -507,14 +507,14 @@ packages:
     hash_algorithm: "SHA-1"
   vcs:
     type: "git"
-    url: "git://github.com/netty/netty.git/netty-buffer"
+    url: "git://github.com/netty/netty.git"
     revision: "netty-4.1.9.Final"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/netty/netty.git"
     revision: "netty-4.1.9.Final"
-    path: "netty-buffer"
+    path: ""
 - id:
     provider: "Maven"
     namespace: "io.netty"
@@ -536,14 +536,14 @@ packages:
     hash_algorithm: "SHA-1"
   vcs:
     type: "git"
-    url: "git://github.com/netty/netty.git/netty-codec"
+    url: "git://github.com/netty/netty.git"
     revision: "netty-4.1.9.Final"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/netty/netty.git"
     revision: "netty-4.1.9.Final"
-    path: "netty-codec"
+    path: ""
 - id:
     provider: "Maven"
     namespace: "io.netty"
@@ -565,14 +565,14 @@ packages:
     hash_algorithm: "SHA-1"
   vcs:
     type: "git"
-    url: "git://github.com/netty/netty.git/netty-common"
+    url: "git://github.com/netty/netty.git"
     revision: "netty-4.1.9.Final"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/netty/netty.git"
     revision: "netty-4.1.9.Final"
-    path: "netty-common"
+    path: ""
 - id:
     provider: "Maven"
     namespace: "io.netty"
@@ -594,14 +594,14 @@ packages:
     hash_algorithm: "SHA-1"
   vcs:
     type: "git"
-    url: "git://github.com/netty/netty.git/netty-resolver"
+    url: "git://github.com/netty/netty.git"
     revision: "netty-4.1.9.Final"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/netty/netty.git"
     revision: "netty-4.1.9.Final"
-    path: "netty-resolver"
+    path: ""
 - id:
     provider: "Maven"
     namespace: "io.netty"
@@ -623,14 +623,14 @@ packages:
     hash_algorithm: "SHA-1"
   vcs:
     type: "git"
-    url: "git://github.com/netty/netty.git/netty-transport"
+    url: "git://github.com/netty/netty.git"
     revision: "netty-4.1.9.Final"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/netty/netty.git"
     revision: "netty-4.1.9.Final"
-    path: "netty-transport"
+    path: ""
 - id:
     provider: "Maven"
     namespace: "jgnash"
@@ -649,14 +649,14 @@ packages:
     hash_algorithm: ""
   vcs:
     type: "git"
-    url: "git://github.com:ccavanaugh/jgnash.git/jgnash-resources"
+    url: "git://github.com:ccavanaugh/jgnash.git"
     revision: ""
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/ccavanaugh/jgnash.git"
     revision: ""
-    path: "jgnash-resources"
+    path: ""
 - id:
     provider: "Maven"
     namespace: "junit"
@@ -899,14 +899,14 @@ packages:
     hash_algorithm: "SHA-1"
   vcs:
     type: "git"
-    url: "git@github.com:hamcrest/JavaHamcrest.git/hamcrest-all"
+    url: "git@github.com:hamcrest/JavaHamcrest.git"
     revision: ""
     path: ""
   vcs_processed:
     type: "Git"
     url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
     revision: ""
-    path: "hamcrest-all"
+    path: ""
 - id:
     provider: "Maven"
     namespace: "org.hibernate.common"
@@ -1148,14 +1148,14 @@ packages:
     hash_algorithm: "SHA-1"
   vcs:
     type: "git"
-    url: "git@github.com:jboss/jboss-parent-pom.git/jandex"
+    url: "git@github.com:jboss/jboss-parent-pom.git"
     revision: ""
     path: ""
   vcs_processed:
     type: "Git"
     url: "ssh://git@github.com/jboss/jboss-parent-pom.git"
     revision: ""
-    path: "jandex"
+    path: ""
 - id:
     provider: "Maven"
     namespace: "org.slf4j"

--- a/analyzer/src/funTest/assets/projects/external/jgnash-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/jgnash-expected-output.yml
@@ -82,12 +82,12 @@ packages:
     hash_algorithm: "SHA-1"
   vcs:
     type: "git"
-    url: "git@github.com:hamcrest/JavaHamcrest.git/hamcrest-all"
+    url: "git@github.com:hamcrest/JavaHamcrest.git"
     revision: ""
     path: ""
   vcs_processed:
     type: "Git"
     url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
     revision: ""
-    path: "hamcrest-all"
+    path: ""
 errors: []

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
@@ -339,12 +339,12 @@ packages:
     hash_algorithm: ""
   vcs:
     type: "git"
-    url: "https://gitbox.apache.org/repos/asf/struts.git/struts2-assembly"
+    url: "https://gitbox.apache.org/repos/asf/struts.git"
     revision: "STRUTS_2_5_14_1"
     path: ""
   vcs_processed:
     type: "git"
-    url: "https://gitbox.apache.org/repos/asf/struts.git/struts2-assembly"
+    url: "https://gitbox.apache.org/repos/asf/struts.git"
     revision: "STRUTS_2_5_14_1"
     path: ""
 errors: []

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
@@ -336,12 +336,12 @@ packages:
     hash_algorithm: ""
   vcs:
     type: "git"
-    url: "https://gitbox.apache.org/repos/asf/struts.git/struts2-assembly"
+    url: "https://gitbox.apache.org/repos/asf/struts.git"
     revision: "STRUTS_2_5_14_1"
     path: ""
   vcs_processed:
     type: "git"
-    url: "https://gitbox.apache.org/repos/asf/struts.git/struts2-assembly"
+    url: "https://gitbox.apache.org/repos/asf/struts.git"
     revision: "STRUTS_2_5_14_1"
     path: ""
 - id:
@@ -365,12 +365,12 @@ packages:
     hash_algorithm: "SHA-1"
   vcs:
     type: "git"
-    url: "git@github.com:hamcrest/JavaHamcrest.git/hamcrest-core"
+    url: "git@github.com:hamcrest/JavaHamcrest.git"
     revision: ""
     path: ""
   vcs_processed:
     type: "Git"
     url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
     revision: ""
-    path: "hamcrest-core"
+    path: ""
 errors: []

--- a/analyzer/src/main/kotlin/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/MavenSupport.kt
@@ -327,28 +327,51 @@ class MavenSupport(localRepositoryManagerConverter: (LocalRepositoryManager) -> 
             mavenProject.licenses.mapNotNull { it.name ?: it.url ?: it.comments }.toSortedSet()
 
     fun parseVcsInfo(mavenProject: MavenProject): VcsInfo {
-        return mavenProject.scm?.let { scm ->
-            val connection = scm.connection ?: ""
-            val tag = scm.tag?.takeIf { it != "HEAD" } ?: ""
+        // When asking Maven for the SCM URL of a POM that does not itself define an SCM URL, Maven returns the SCM
+        // URL of the parent POM (if any) and appends the child POM's artifactId to it. This behavior is
+        // fundamentally broken because it invalidates the URL for many SCMs that cannot clone / checkout a specific
+        // path from a repository. Also, the assumption that the source code for a child artifact is stored in a
+        // top-level directory named like the artifactId inside the parent artifact's repository is often not
+        // correct.
+        // To fix this, determine the SCM URL of the root parent (if there are parents) and use that as the child's
+        // SCM URL.
+        var scm = mavenProject.scm
+        var parent = mavenProject.parent
 
-            val (type, url) = SCM_REGEX.matcher(connection).let {
-                if (it.matches()) {
-                    val type = it.group("type")
-                    val url = it.group("url")
-
-                    // CVS URLs usually start with ":pserver:" or ":ext:", but as ":" is also the delimiter used by the
-                    // Maven SCM plugin, no double ":" is used in the connection string and we need to fix it up here.
-                    if (type == "cvs" && !url.startsWith(":")) {
-                        Pair(type, ":" + url)
-                    } else {
-                        Pair(type, url)
+        while (parent != null) {
+            parent.scm?.let {
+                it.connection?.let {
+                    if (it.isNotBlank() && scm.connection.startsWith(it)) {
+                        scm = parent.scm
                     }
-                } else {
-                    Pair("", "")
                 }
             }
 
-            VcsInfo(type, url, tag, "")
-        } ?: VcsInfo.EMPTY
+            parent = parent.parent
+        }
+
+        if (scm == null) return VcsInfo.EMPTY
+
+        val connection = scm.connection ?: ""
+        val tag = scm.tag?.takeIf { it != "HEAD" } ?: ""
+
+        val (type, url) = SCM_REGEX.matcher(connection).let {
+            if (it.matches()) {
+                val type = it.group("type")
+                val url = it.group("url")
+
+                // CVS URLs usually start with ":pserver:" or ":ext:", but as ":" is also the delimiter used by the
+                // Maven SCM plugin, no double ":" is used in the connection string and we need to fix it up here.
+                if (type == "cvs" && !url.startsWith(":")) {
+                    Pair(type, ":" + url)
+                } else {
+                    Pair(type, url)
+                }
+            } else {
+                Pair("", "")
+            }
+        }
+
+        return VcsInfo(type, url, tag, "")
     }
 }


### PR DESCRIPTION
When asking Maven for the SCM URL of a POM that does not itself define an SCM URL, Maven returns the SCM URL of the parent POM (if any) and appends the child POM's artifactId to it. This behavior is fundamentally broken because it invalidates the URL for many SCMs that cannot clone / checkout a specific path from a repository. Also, the assumption that the source code for a child artifact is stored in a top-level directory named like the artifactId inside the parent artifact's repository is often not correct.

To fix this, determine the SCM URL of the root parent (if there are parents) and use that as the child's SCM URL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/362)
<!-- Reviewable:end -->
