### PR TITLE
Maven: Add an empty lifecycle mapping for "zip" packaging

### DIFF
--- a/analyzer/src/main/resources/META-INF/plexus/components.xml
+++ b/analyzer/src/main/resources/META-INF/plexus/components.xml
@@ -65,5 +65,22 @@
             </configuration>
         </component>
 
+        <!--
+         | ZIP
+         |-->
+        <component>
+            <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
+            <role-hint>zip</role-hint>
+            <implementation>org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping</implementation>
+            <configuration>
+                <lifecycles>
+                    <lifecycle>
+                        <id>default</id>
+                        <phases>
+                        </phases>
+                    </lifecycle>
+                </lifecycles>
+            </configuration>
+        </component>
     </components>
 </component-set>


### PR DESCRIPTION
This enables parsing of POM files that use "zip" packaging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/366)
<!-- Reviewable:end -->
