### PR TITLE
Gradle: Upgrade Kotlin to version 1.2.30

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     // We need to hard-code the version here because of
     // https://github.com/gradle/gradle/issues/1697
-    id 'org.jetbrains.kotlin.jvm' version '1.2.21' apply false
+    id 'org.jetbrains.kotlin.jvm' version '1.2.30' apply false
     id 'org.jetbrains.dokka' version '0.9.16' apply false
 
     // Note that the detekt Gradle plugin version does not necessarily
@@ -52,7 +52,7 @@ subprojects {
     }
 
     dependencies {
-        compile 'org.jetbrains.kotlin:kotlin-stdlib-jre8:1.2.21'
+        compile 'org.jetbrains.kotlin:kotlin-stdlib-jre8:1.2.30'
 
         testCompile "io.kotlintest:kotlintest:$kotlintestVersion"
         testCompile project(':utils-test')
@@ -69,7 +69,7 @@ subprojects {
     // TODO: Remove this once jackson-module-kotlin and kotlintest are updated.
     configurations.all {
         resolutionStrategy {
-            force 'org.jetbrains.kotlin:kotlin-reflect:1.2.21'
+            force 'org.jetbrains.kotlin:kotlin-reflect:1.2.30'
         }
     }
 


### PR DESCRIPTION
See https://blog.jetbrains.com/kotlin/2018/03/kotlin-1-2-30-is-out/.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/373)
<!-- Reviewable:end -->
