### PR TITLE
analyzer: Convert GStrings to plain Strings in two more missing places

### DIFF
--- a/analyzer/src/main/resources/init.gradle
+++ b/analyzer/src/main/resources/init.gradle
@@ -143,10 +143,10 @@ class DependencyTreePlugin implements Plugin<Gradle> {
                     it.url.toString()
                 } else if (it instanceof DefaultFlatDirArtifactRepository) {
                     errors.add('Project uses a flat dir repository, dependencies from this repository will be ' +
-                            "ignored: ${it.dirs}")
+                            "ignored: ${it.dirs}".toString())
                     null
                 } else {
-                    errors.add("Unknown repository type: ${it.getClass().name}")
+                    errors.add("Unknown repository type: ${it.getClass().name}".toString())
                     null
                 }
             }


### PR DESCRIPTION
This should avoid the

    IllegalArgumentException: java.lang.String is not an interface

error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/375)
<!-- Reviewable:end -->
