### PR TITLE
Gradle: Improve the error message for Ivy repositories

### DIFF
--- a/analyzer/src/main/resources/init.gradle
+++ b/analyzer/src/main/resources/init.gradle
@@ -22,6 +22,7 @@ import groovy.transform.Immutable
 import javax.inject.Inject
 
 import org.gradle.api.internal.artifacts.repositories.DefaultFlatDirArtifactRepository
+import org.gradle.api.internal.artifacts.repositories.DefaultIvyArtifactRepository
 import org.gradle.api.internal.artifacts.repositories.DefaultMavenArtifactRepository
 import org.gradle.tooling.provider.model.ToolingModelBuilder
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
@@ -142,8 +143,12 @@ class DependencyTreePlugin implements Plugin<Gradle> {
                 if (it instanceof DefaultMavenArtifactRepository) {
                     it.url.toString()
                 } else if (it instanceof DefaultFlatDirArtifactRepository) {
-                    errors.add('Project uses a flat dir repository, dependencies from this repository will be ' +
-                            "ignored: ${it.dirs}".toString())
+                    errors.add('Project uses a flat dir repository which is not supported by the analyzer. ' +
+                            "Dependencies from this repository will be ignored: ${it.dirs}".toString())
+                    null
+                } else if (it instanceof DefaultIvyArtifactRepository) {
+                    errors.add('Project uses an Ivy repository which is not supported by the analyzer. ' +
+                            "Dependencies from this repository will be ignored: ${it.url}".toString())
                     null
                 } else {
                     errors.add("Unknown repository type: ${it.getClass().name}".toString())


### PR DESCRIPTION
Ivy repositories are not yet supported by the analyzer. Print a more
specific error message if they are used in a Gradle project. Also improve
the error message for flat dir repositories.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/376)
<!-- Reviewable:end -->
