### PR TITLE
downloader: Temporarily disable tests that depend on SourceForge

### DIFF
--- a/downloader/src/funTest/kotlin/SubversionDownloadTest.kt
+++ b/downloader/src/funTest/kotlin/SubversionDownloadTest.kt
@@ -70,7 +70,7 @@ class SubversionDownloadTest : StringSpec() {
             workingTree.isValid() shouldBe true
             workingTree.getRevision() shouldBe REPO_REV
             actualFiles.joinToString("\n") shouldBe expectedFiles.joinToString("\n")
-        }.config(tags = setOf(ExpensiveTag))
+        }.config(tags = setOf(ExpensiveTag), enabled = false)
 
         "Subversion can download only a single path" {
             val pkg = Package.EMPTY.copy(vcsProcessed = VcsInfo("Subversion", REPO_URL, REPO_REV, REPO_PATH))
@@ -91,7 +91,7 @@ class SubversionDownloadTest : StringSpec() {
             workingTree.isValid() shouldBe true
             workingTree.getRevision() shouldBe REPO_REV
             actualFiles.joinToString("\n") shouldBe expectedFiles.joinToString("\n")
-        }.config(tags = setOf(ExpensiveTag))
+        }.config(tags = setOf(ExpensiveTag), enabled = false)
 
         "Subversion can download based on a version" {
             val pkg = Package.EMPTY.copy(
@@ -103,7 +103,7 @@ class SubversionDownloadTest : StringSpec() {
 
             workingTree.isValid() shouldBe true
             workingTree.getRevision() shouldBe REPO_REV_FOR_VERSION
-        }.config(tags = setOf(ExpensiveTag))
+        }.config(tags = setOf(ExpensiveTag), enabled = false)
 
         "Subversion can download only a single path based on a version" {
             val pkg = Package.EMPTY.copy(
@@ -123,6 +123,6 @@ class SubversionDownloadTest : StringSpec() {
             workingTree.isValid() shouldBe true
             workingTree.getRevision() shouldBe REPO_REV_FOR_VERSION
             actualFiles.joinToString("\n") shouldBe expectedFiles.joinToString("\n")
-        }.config(tags = setOf(ExpensiveTag))
+        }.config(tags = setOf(ExpensiveTag), enabled = false)
     }
 }


### PR DESCRIPTION
Because SourceForge still has connectivity problems due to its data
center migration.

This is a follow-up for 4a9b185.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/377)
<!-- Reviewable:end -->
