### PR TITLE
NPM: Make the warning about circular dependencies a debug message

### DIFF
--- a/analyzer/src/main/kotlin/managers/NPM.kt
+++ b/analyzer/src/main/kotlin/managers/NPM.kt
@@ -377,7 +377,7 @@ class NPM : PackageManager() {
             val identifier = "$rawName@$version"
 
             if (dependencyBranch.contains(identifier)) {
-                log.warn {
+                log.debug {
                     "Not adding circular dependency $identifier to the tree, it is already on this branch of the " +
                             "dependency tree: ${dependencyBranch.joinToString(" -> ")}"
                 }


### PR DESCRIPTION
Circular dependencies are common in NPM, so instead of printing a warning
for them make it a debug message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/383)
<!-- Reviewable:end -->
