### PR TITLE
DiskCache: Do not try to remove keys before closing the snapshot

### DIFF
--- a/utils/src/main/kotlin/DiskCache.kt
+++ b/utils/src/main/kotlin/DiskCache.kt
@@ -112,12 +112,13 @@ class DiskCache(
         try {
             diskLruCache.get(diskKey)?.use { entry ->
                 val time = entry.getString(INDEX_TIMESTAMP).toLong()
-                if (time + timeToLive < timeInSeconds()) {
-                    diskLruCache.remove(diskKey)
-                } else {
+                if (time + timeToLive >= timeInSeconds()) {
                     return entry.getString(INDEX_DATA)
                 }
             }
+
+            // Remove the expired entry after the snapshot was closed.
+            diskLruCache.remove(diskKey)
         } catch (e: IOException) {
             log.error { "Could not read cache entry for key '$diskKey': ${e.message}" }
         }


### PR DESCRIPTION
On Windows, where open files cannot be deleted, this had caused many
errors about "unreadable" cache entries being logged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/387)
<!-- Reviewable:end -->
