### PR TITLE
scanner: Map ScanCode error messages as part of getResult()

### DIFF
--- a/scanner/src/main/kotlin/scanners/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/ScanCode.kt
@@ -105,7 +105,7 @@ object ScanCode : LocalScanner() {
             log.debug { process.stderr() }
         }
 
-        val result = getResult(resultsFile)
+        val result = getPlainResult(resultsFile)
 
         val hasOnlyMemoryErrors = mapMemoryErrors(result)
         val hasOnlyTimeoutErrors = mapTimeoutErrors(result)
@@ -123,7 +123,7 @@ object ScanCode : LocalScanner() {
         // TODO: Add results of license scan to YAML model
     }
 
-    override fun getResult(resultsFile: File): Result {
+    internal fun getPlainResult(resultsFile: File): Result {
         val licenses = sortedSetOf<String>()
         val errors = sortedSetOf<String>()
 
@@ -146,6 +146,12 @@ object ScanCode : LocalScanner() {
 
         return Result(licenses, errors)
     }
+
+    override fun getResult(resultsFile: File) =
+            getPlainResult(resultsFile).also {
+                mapMemoryErrors(it)
+                mapTimeoutErrors(it)
+            }
 
     /**
      * Map messages about memory errors to a more compact form. Return true if solely memory errors occurred, return

--- a/scanner/src/test/kotlin/ScanCodeTest.kt
+++ b/scanner/src/test/kotlin/ScanCodeTest.kt
@@ -33,7 +33,7 @@ class ScanCodeTest : WordSpec({
         "return true for scan results with only timeout errors" {
             val resultFileName = "/esprima-2.7.3_scancode-2.2.1.post277.4d68f9377.json"
             val resultFile = File(Resources.javaClass.getResource(resultFileName).toURI())
-            val result = ScanCode.getResult(resultFile)
+            val result = ScanCode.getPlainResult(resultFile)
             ScanCode.mapTimeoutErrors(result) shouldBe true
             result.errors.joinToString("\n") shouldBe sortedSetOf(
                     "ERROR: Timeout after 300 seconds in copyrights scanner " +
@@ -99,7 +99,7 @@ class ScanCodeTest : WordSpec({
         "return true for scan results with only memory errors" {
             val resultFileName = "/very-long-json-lines_scancode-2.2.1.post277.4d68f9377.json"
             val resultFile = File(Resources.javaClass.getResource(resultFileName).toURI())
-            val result = ScanCode.getResult(resultFile)
+            val result = ScanCode.getPlainResult(resultFile)
             ScanCode.mapMemoryErrors(result) shouldBe true
             result.errors.joinToString("\n") shouldBe sortedSetOf(
                     "ERROR: MemoryError in copyrights scanner (File: data.json)",


### PR DESCRIPTION
Otherwise results retrieved from the cache do not get mapped.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/392)
<!-- Reviewable:end -->
