### PR TITLE
downloader: Enable CVS tests again that were disabled due to SF's outage

### DIFF
--- a/downloader/src/funTest/kotlin/CvsDownloadTest.kt
+++ b/downloader/src/funTest/kotlin/CvsDownloadTest.kt
@@ -72,7 +72,7 @@ class CvsDownloadTest : StringSpec() {
 
             // Only tag "RELEASE_0_52" has revision 1.159 of "xmlenc/build.xml".
             buildXmlStatus.stdout().contains("Working revision:\t1.159") shouldBe true
-        }.config(tags = setOf(ExpensiveTag), enabled = false)
+        }.config(tags = setOf(ExpensiveTag))
 
         "CVS can download only a single path" {
             val pkg = Package.EMPTY.copy(vcsProcessed = VcsInfo("CVS", REPO_URL, REPO_REV, REPO_PATH))
@@ -89,7 +89,7 @@ class CvsDownloadTest : StringSpec() {
 
             workingTree.isValid() shouldBe true
             actualFiles.joinToString("\n") shouldBe expectedFiles.joinToString("\n")
-        }.config(tags = setOf(ExpensiveTag), enabled = false)
+        }.config(tags = setOf(ExpensiveTag))
 
         "CVS can download based on a version" {
             val pkg = Package.EMPTY.copy(
@@ -107,7 +107,7 @@ class CvsDownloadTest : StringSpec() {
 
             // Only tag "RELEASE_0_52" has revision 1.159 of "xmlenc/build.xml".
             buildXmlStatus.stdout().contains("Working revision:\t1.159") shouldBe true
-        }.config(tags = setOf(ExpensiveTag), enabled = false)
+        }.config(tags = setOf(ExpensiveTag))
 
         "CVS can download only a single path based on a version" {
             val pkg = Package.EMPTY.copy(
@@ -127,6 +127,6 @@ class CvsDownloadTest : StringSpec() {
 
             workingTree.isValid() shouldBe true
             actualFiles.joinToString("\n") shouldBe expectedFiles.joinToString("\n")
-        }.config(tags = setOf(ExpensiveTag), enabled = false)
+        }.config(tags = setOf(ExpensiveTag))
     }
 }

--- a/downloader/src/test/kotlin/CvsTest.kt
+++ b/downloader/src/test/kotlin/CvsTest.kt
@@ -77,7 +77,7 @@ class CvsTest : StringSpec() {
             workingTree.getRevision() shouldBe "8707a14c78c6e77ffc59e685360fa20071c1afb6"
             workingTree.getRootPath() shouldBe zipContentDir.path.replace(File.separatorChar, '/')
             workingTree.getPathToRoot(File(zipContentDir, "tomcat")) shouldBe "tomcat"
-        }.config(enabled = false)
+        }
 
         "CVS correctly lists remote tags" {
             val expectedTags = listOf(
@@ -97,6 +97,6 @@ class CvsTest : StringSpec() {
 
             val workingTree = Cvs.getWorkingTree(zipContentDir)
             workingTree.listRemoteTags().joinToString("\n") shouldBe expectedTags.joinToString("\n")
-        }.config(enabled = false)
+        }
     }
 }


### PR DESCRIPTION
According to

https://sourceforge.net/p/forge/site-support/16554/

CVS repositories should be up again. SVN repositories do not seem to be
(yet).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/396)
<!-- Reviewable:end -->
