### PR TITLE
ScanCode: Include all scanned files in the native output file

### DIFF
--- a/scanner/src/main/kotlin/scanners/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/ScanCode.kt
@@ -43,7 +43,6 @@ object ScanCode : LocalScanner() {
             "--license",
             "--license-text",
             "--info",
-            "--only-findings",
             "--strip-root"
     )
 


### PR DESCRIPTION
Otherwise, if only files with findings are included, and we have a
"files_count" of "0", we do not know whether really no files have been
scanned (e.g. due to a bug) or simply no files contained any findings.

Note that our internal Scanner Results will still only contain files
with findings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/410)
<!-- Reviewable:end -->
