### PR TITLE
Gradle: Do not catch BuildException in parseDependencies()

### DIFF
--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -56,7 +56,6 @@ import org.eclipse.aether.repository.LocalRepository
 import org.eclipse.aether.repository.LocalRepositoryManager
 import org.eclipse.aether.repository.RemoteRepository
 
-import org.gradle.tooling.BuildException
 import org.gradle.tooling.GradleConnector
 
 import java.io.File
@@ -133,13 +132,6 @@ class Gradle : PackageManager() {
 
             return AnalyzerResult(true, project, packages.values.toSortedSet(),
                     dependencyTreeModel.errors)
-        } catch (e: BuildException) {
-            if (com.here.ort.utils.printStackTrace) {
-                e.printStackTrace()
-            }
-
-            log.error { "Could not analyze '${definitionFile.absolutePath}': ${e.message}" }
-            return null
         } finally {
             connection.close()
         }


### PR DESCRIPTION
The exception will be catched in PackageManager.resolveDependencies() which
also creates a valid AnalyzerResult. Also catching it in the Gradle class
is duplicated code which in this case also was less functional.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/411)
<!-- Reviewable:end -->
