### PR TITLE
Gradle: Ignore classpath configurations

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
@@ -81,29 +81,6 @@ projects:
         dependencies: []
         errors: []
       errors: []
-  - name: "compileClasspath"
-    delivered: true
-    dependencies:
-    - namespace: "com.here.ort.gradle.example"
-      name: "lib"
-      version: "1.0.0"
-      dependencies:
-      - namespace: "org.apache.commons"
-        name: "commons-text"
-        version: "1.1"
-        dependencies:
-        - namespace: "org.apache.commons"
-          name: "commons-lang3"
-          version: "3.5"
-          dependencies: []
-          errors: []
-        errors: []
-      - namespace: "org.apache.struts"
-        name: "struts2-assembly"
-        version: "2.5.14.1"
-        dependencies: []
-        errors: []
-      errors: []
   - name: "compileOnly"
     delivered: true
     dependencies: []
@@ -153,29 +130,6 @@ projects:
         dependencies: []
         errors: []
       errors: []
-  - name: "runtimeClasspath"
-    delivered: true
-    dependencies:
-    - namespace: "com.here.ort.gradle.example"
-      name: "lib"
-      version: "1.0.0"
-      dependencies:
-      - namespace: "org.apache.commons"
-        name: "commons-text"
-        version: "1.1"
-        dependencies:
-        - namespace: "org.apache.commons"
-          name: "commons-lang3"
-          version: "3.5"
-          dependencies: []
-          errors: []
-        errors: []
-      - namespace: "org.apache.struts"
-        name: "struts2-assembly"
-        version: "2.5.14.1"
-        dependencies: []
-        errors: []
-      errors: []
   - name: "testAnnotationProcessor"
     delivered: true
     dependencies: []
@@ -202,56 +156,10 @@ projects:
         dependencies: []
         errors: []
       errors: []
-  - name: "testCompileClasspath"
-    delivered: true
-    dependencies:
-    - namespace: "com.here.ort.gradle.example"
-      name: "lib"
-      version: "1.0.0"
-      dependencies:
-      - namespace: "org.apache.commons"
-        name: "commons-text"
-        version: "1.1"
-        dependencies:
-        - namespace: "org.apache.commons"
-          name: "commons-lang3"
-          version: "3.5"
-          dependencies: []
-          errors: []
-        errors: []
-      - namespace: "org.apache.struts"
-        name: "struts2-assembly"
-        version: "2.5.14.1"
-        dependencies: []
-        errors: []
-      errors: []
   - name: "testCompileOnly"
     delivered: true
     dependencies: []
   - name: "testRuntime"
-    delivered: true
-    dependencies:
-    - namespace: "com.here.ort.gradle.example"
-      name: "lib"
-      version: "1.0.0"
-      dependencies:
-      - namespace: "org.apache.commons"
-        name: "commons-text"
-        version: "1.1"
-        dependencies:
-        - namespace: "org.apache.commons"
-          name: "commons-lang3"
-          version: "3.5"
-          dependencies: []
-          errors: []
-        errors: []
-      - namespace: "org.apache.struts"
-        name: "struts2-assembly"
-        version: "2.5.14.1"
-        dependencies: []
-        errors: []
-      errors: []
-  - name: "testRuntimeClasspath"
     delivered: true
     dependencies:
     - namespace: "com.here.ort.gradle.example"
@@ -309,16 +217,6 @@ projects:
       errors:
       - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
         \ org.apache.commons:commons-text:1.1 because no repositories are defined."
-  - name: "compileClasspath"
-    delivered: true
-    dependencies:
-    - namespace: ""
-      name: "org.apache.commons:commons-text:1.1"
-      version: ""
-      dependencies: []
-      errors:
-      - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
-        \ org.apache.commons:commons-text:1.1 because no repositories are defined."
   - name: "compileOnly"
     delivered: true
     dependencies: []
@@ -333,16 +231,6 @@ projects:
       - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
         \ org.apache.commons:commons-text:1.1 because no repositories are defined."
   - name: "runtime"
-    delivered: true
-    dependencies:
-    - namespace: ""
-      name: "org.apache.commons:commons-text:1.1"
-      version: ""
-      dependencies: []
-      errors:
-      - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
-        \ org.apache.commons:commons-text:1.1 because no repositories are defined."
-  - name: "runtimeClasspath"
     delivered: true
     dependencies:
     - namespace: ""
@@ -372,44 +260,10 @@ projects:
       errors:
       - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
         \ org.apache.commons:commons-text:1.1 because no repositories are defined."
-  - name: "testCompileClasspath"
-    delivered: true
-    dependencies:
-    - namespace: ""
-      name: "junit:junit:4.12"
-      version: ""
-      dependencies: []
-      errors:
-      - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
-        \ junit:junit:4.12 because no repositories are defined."
-    - namespace: ""
-      name: "org.apache.commons:commons-text:1.1"
-      version: ""
-      dependencies: []
-      errors:
-      - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
-        \ org.apache.commons:commons-text:1.1 because no repositories are defined."
   - name: "testCompileOnly"
     delivered: true
     dependencies: []
   - name: "testRuntime"
-    delivered: true
-    dependencies:
-    - namespace: ""
-      name: "junit:junit:4.12"
-      version: ""
-      dependencies: []
-      errors:
-      - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
-        \ junit:junit:4.12 because no repositories are defined."
-    - namespace: ""
-      name: "org.apache.commons:commons-text:1.1"
-      version: ""
-      dependencies: []
-      errors:
-      - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
-        \ org.apache.commons:commons-text:1.1 because no repositories are defined."
-  - name: "testRuntimeClasspath"
     delivered: true
     dependencies:
     - namespace: ""
@@ -469,24 +323,6 @@ projects:
       version: "2.5.14.1"
       dependencies: []
       errors: []
-  - name: "compileClasspath"
-    delivered: true
-    dependencies:
-    - namespace: "org.apache.commons"
-      name: "commons-text"
-      version: "1.1"
-      dependencies:
-      - namespace: "org.apache.commons"
-        name: "commons-lang3"
-        version: "3.5"
-        dependencies: []
-        errors: []
-      errors: []
-    - namespace: "org.apache.struts"
-      name: "struts2-assembly"
-      version: "2.5.14.1"
-      dependencies: []
-      errors: []
   - name: "compileOnly"
     delivered: true
     dependencies: []
@@ -509,24 +345,6 @@ projects:
       dependencies: []
       errors: []
   - name: "runtime"
-    delivered: true
-    dependencies:
-    - namespace: "org.apache.commons"
-      name: "commons-text"
-      version: "1.1"
-      dependencies:
-      - namespace: "org.apache.commons"
-        name: "commons-lang3"
-        version: "3.5"
-        dependencies: []
-        errors: []
-      errors: []
-    - namespace: "org.apache.struts"
-      name: "struts2-assembly"
-      version: "2.5.14.1"
-      dependencies: []
-      errors: []
-  - name: "runtimeClasspath"
     delivered: true
     dependencies:
     - namespace: "org.apache.commons"
@@ -575,66 +393,10 @@ projects:
       version: "2.5.14.1"
       dependencies: []
       errors: []
-  - name: "testCompileClasspath"
-    delivered: true
-    dependencies:
-    - namespace: "junit"
-      name: "junit"
-      version: "4.12"
-      dependencies:
-      - namespace: "org.hamcrest"
-        name: "hamcrest-core"
-        version: "1.3"
-        dependencies: []
-        errors: []
-      errors: []
-    - namespace: "org.apache.commons"
-      name: "commons-text"
-      version: "1.1"
-      dependencies:
-      - namespace: "org.apache.commons"
-        name: "commons-lang3"
-        version: "3.5"
-        dependencies: []
-        errors: []
-      errors: []
-    - namespace: "org.apache.struts"
-      name: "struts2-assembly"
-      version: "2.5.14.1"
-      dependencies: []
-      errors: []
   - name: "testCompileOnly"
     delivered: true
     dependencies: []
   - name: "testRuntime"
-    delivered: true
-    dependencies:
-    - namespace: "junit"
-      name: "junit"
-      version: "4.12"
-      dependencies:
-      - namespace: "org.hamcrest"
-        name: "hamcrest-core"
-        version: "1.3"
-        dependencies: []
-        errors: []
-      errors: []
-    - namespace: "org.apache.commons"
-      name: "commons-text"
-      version: "1.1"
-      dependencies:
-      - namespace: "org.apache.commons"
-        name: "commons-lang3"
-        version: "3.5"
-        dependencies: []
-        errors: []
-      errors: []
-    - namespace: "org.apache.struts"
-      name: "struts2-assembly"
-      version: "2.5.14.1"
-      dependencies: []
-      errors: []
-  - name: "testRuntimeClasspath"
     delivered: true
     dependencies:
     - namespace: "junit"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-3.3.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-3.3.yml
@@ -46,29 +46,6 @@ project:
         dependencies: []
         errors: []
       errors: []
-  - name: "compileClasspath"
-    delivered: true
-    dependencies:
-    - namespace: ""
-      name: "project _lib"
-      version: ""
-      dependencies:
-      - namespace: "org.apache.commons"
-        name: "commons-text"
-        version: "1.1"
-        dependencies:
-        - namespace: "org.apache.commons"
-          name: "commons-lang3"
-          version: "3.5"
-          dependencies: []
-          errors: []
-        errors: []
-      - namespace: "org.apache.struts"
-        name: "struts2-assembly"
-        version: "2.5.14.1"
-        dependencies: []
-        errors: []
-      errors: []
   - name: "compileOnly"
     delivered: true
     dependencies:
@@ -139,29 +116,6 @@ project:
         errors: []
       errors: []
   - name: "testCompile"
-    delivered: true
-    dependencies:
-    - namespace: ""
-      name: "project _lib"
-      version: ""
-      dependencies:
-      - namespace: "org.apache.commons"
-        name: "commons-text"
-        version: "1.1"
-        dependencies:
-        - namespace: "org.apache.commons"
-          name: "commons-lang3"
-          version: "3.5"
-          dependencies: []
-          errors: []
-        errors: []
-      - namespace: "org.apache.struts"
-        name: "struts2-assembly"
-        version: "2.5.14.1"
-        dependencies: []
-        errors: []
-      errors: []
-  - name: "testCompileClasspath"
     delivered: true
     dependencies:
     - namespace: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-3.4.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-3.4.yml
@@ -46,29 +46,6 @@ project:
         dependencies: []
         errors: []
       errors: []
-  - name: "compileClasspath"
-    delivered: true
-    dependencies:
-    - namespace: ""
-      name: "project _lib"
-      version: ""
-      dependencies:
-      - namespace: "org.apache.commons"
-        name: "commons-text"
-        version: "1.1"
-        dependencies:
-        - namespace: "org.apache.commons"
-          name: "commons-lang3"
-          version: "3.5"
-          dependencies: []
-          errors: []
-        errors: []
-      - namespace: "org.apache.struts"
-        name: "struts2-assembly"
-        version: "2.5.14.1"
-        dependencies: []
-        errors: []
-      errors: []
   - name: "compileOnly"
     delivered: true
     dependencies: []
@@ -118,53 +95,7 @@ project:
         dependencies: []
         errors: []
       errors: []
-  - name: "runtimeClasspath"
-    delivered: true
-    dependencies:
-    - namespace: ""
-      name: "project _lib"
-      version: ""
-      dependencies:
-      - namespace: "org.apache.commons"
-        name: "commons-text"
-        version: "1.1"
-        dependencies:
-        - namespace: "org.apache.commons"
-          name: "commons-lang3"
-          version: "3.5"
-          dependencies: []
-          errors: []
-        errors: []
-      - namespace: "org.apache.struts"
-        name: "struts2-assembly"
-        version: "2.5.14.1"
-        dependencies: []
-        errors: []
-      errors: []
   - name: "testCompile"
-    delivered: true
-    dependencies:
-    - namespace: ""
-      name: "project _lib"
-      version: ""
-      dependencies:
-      - namespace: "org.apache.commons"
-        name: "commons-text"
-        version: "1.1"
-        dependencies:
-        - namespace: "org.apache.commons"
-          name: "commons-lang3"
-          version: "3.5"
-          dependencies: []
-          errors: []
-        errors: []
-      - namespace: "org.apache.struts"
-        name: "struts2-assembly"
-        version: "2.5.14.1"
-        dependencies: []
-        errors: []
-      errors: []
-  - name: "testCompileClasspath"
     delivered: true
     dependencies:
     - namespace: ""
@@ -191,29 +122,6 @@ project:
     delivered: true
     dependencies: []
   - name: "testRuntime"
-    delivered: true
-    dependencies:
-    - namespace: ""
-      name: "project _lib"
-      version: ""
-      dependencies:
-      - namespace: "org.apache.commons"
-        name: "commons-text"
-        version: "1.1"
-        dependencies:
-        - namespace: "org.apache.commons"
-          name: "commons-lang3"
-          version: "3.5"
-          dependencies: []
-          errors: []
-        errors: []
-      - namespace: "org.apache.struts"
-        name: "struts2-assembly"
-        version: "2.5.14.1"
-        dependencies: []
-        errors: []
-      errors: []
-  - name: "testRuntimeClasspath"
     delivered: true
     dependencies:
     - namespace: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
@@ -49,29 +49,6 @@ project:
         dependencies: []
         errors: []
       errors: []
-  - name: "compileClasspath"
-    delivered: true
-    dependencies:
-    - namespace: "com.here.ort.gradle.example"
-      name: "lib"
-      version: "1.0.0"
-      dependencies:
-      - namespace: "org.apache.commons"
-        name: "commons-text"
-        version: "1.1"
-        dependencies:
-        - namespace: "org.apache.commons"
-          name: "commons-lang3"
-          version: "3.5"
-          dependencies: []
-          errors: []
-        errors: []
-      - namespace: "org.apache.struts"
-        name: "struts2-assembly"
-        version: "2.5.14.1"
-        dependencies: []
-        errors: []
-      errors: []
   - name: "compileOnly"
     delivered: true
     dependencies: []
@@ -121,29 +98,6 @@ project:
         dependencies: []
         errors: []
       errors: []
-  - name: "runtimeClasspath"
-    delivered: true
-    dependencies:
-    - namespace: "com.here.ort.gradle.example"
-      name: "lib"
-      version: "1.0.0"
-      dependencies:
-      - namespace: "org.apache.commons"
-        name: "commons-text"
-        version: "1.1"
-        dependencies:
-        - namespace: "org.apache.commons"
-          name: "commons-lang3"
-          version: "3.5"
-          dependencies: []
-          errors: []
-        errors: []
-      - namespace: "org.apache.struts"
-        name: "struts2-assembly"
-        version: "2.5.14.1"
-        dependencies: []
-        errors: []
-      errors: []
   - name: "testAnnotationProcessor"
     delivered: true
     dependencies: []
@@ -170,56 +124,10 @@ project:
         dependencies: []
         errors: []
       errors: []
-  - name: "testCompileClasspath"
-    delivered: true
-    dependencies:
-    - namespace: "com.here.ort.gradle.example"
-      name: "lib"
-      version: "1.0.0"
-      dependencies:
-      - namespace: "org.apache.commons"
-        name: "commons-text"
-        version: "1.1"
-        dependencies:
-        - namespace: "org.apache.commons"
-          name: "commons-lang3"
-          version: "3.5"
-          dependencies: []
-          errors: []
-        errors: []
-      - namespace: "org.apache.struts"
-        name: "struts2-assembly"
-        version: "2.5.14.1"
-        dependencies: []
-        errors: []
-      errors: []
   - name: "testCompileOnly"
     delivered: true
     dependencies: []
   - name: "testRuntime"
-    delivered: true
-    dependencies:
-    - namespace: "com.here.ort.gradle.example"
-      name: "lib"
-      version: "1.0.0"
-      dependencies:
-      - namespace: "org.apache.commons"
-        name: "commons-text"
-        version: "1.1"
-        dependencies:
-        - namespace: "org.apache.commons"
-          name: "commons-lang3"
-          version: "3.5"
-          dependencies: []
-          errors: []
-        errors: []
-      - namespace: "org.apache.struts"
-        name: "struts2-assembly"
-        version: "2.5.14.1"
-        dependencies: []
-        errors: []
-      errors: []
-  - name: "testRuntimeClasspath"
     delivered: true
     dependencies:
     - namespace: "com.here.ort.gradle.example"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
@@ -36,16 +36,6 @@ project:
       errors:
       - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
         \ org.apache.commons:commons-text:1.1 because no repositories are defined."
-  - name: "compileClasspath"
-    delivered: true
-    dependencies:
-    - namespace: ""
-      name: "org.apache.commons:commons-text:1.1"
-      version: ""
-      dependencies: []
-      errors:
-      - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
-        \ org.apache.commons:commons-text:1.1 because no repositories are defined."
   - name: "compileOnly"
     delivered: true
     dependencies: []
@@ -60,16 +50,6 @@ project:
       - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
         \ org.apache.commons:commons-text:1.1 because no repositories are defined."
   - name: "runtime"
-    delivered: true
-    dependencies:
-    - namespace: ""
-      name: "org.apache.commons:commons-text:1.1"
-      version: ""
-      dependencies: []
-      errors:
-      - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
-        \ org.apache.commons:commons-text:1.1 because no repositories are defined."
-  - name: "runtimeClasspath"
     delivered: true
     dependencies:
     - namespace: ""
@@ -99,44 +79,10 @@ project:
       errors:
       - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
         \ org.apache.commons:commons-text:1.1 because no repositories are defined."
-  - name: "testCompileClasspath"
-    delivered: true
-    dependencies:
-    - namespace: ""
-      name: "junit:junit:4.12"
-      version: ""
-      dependencies: []
-      errors:
-      - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
-        \ junit:junit:4.12 because no repositories are defined."
-    - namespace: ""
-      name: "org.apache.commons:commons-text:1.1"
-      version: ""
-      dependencies: []
-      errors:
-      - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
-        \ org.apache.commons:commons-text:1.1 because no repositories are defined."
   - name: "testCompileOnly"
     delivered: true
     dependencies: []
   - name: "testRuntime"
-    delivered: true
-    dependencies:
-    - namespace: ""
-      name: "junit:junit:4.12"
-      version: ""
-      dependencies: []
-      errors:
-      - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
-        \ junit:junit:4.12 because no repositories are defined."
-    - namespace: ""
-      name: "org.apache.commons:commons-text:1.1"
-      version: ""
-      dependencies: []
-      errors:
-      - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
-        \ org.apache.commons:commons-text:1.1 because no repositories are defined."
-  - name: "testRuntimeClasspath"
     delivered: true
     dependencies:
     - namespace: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
@@ -44,24 +44,6 @@ project:
       version: "2.5.14.1"
       dependencies: []
       errors: []
-  - name: "compileClasspath"
-    delivered: true
-    dependencies:
-    - namespace: "org.apache.commons"
-      name: "commons-text"
-      version: "1.1"
-      dependencies:
-      - namespace: "org.apache.commons"
-        name: "commons-lang3"
-        version: "3.5"
-        dependencies: []
-        errors: []
-      errors: []
-    - namespace: "org.apache.struts"
-      name: "struts2-assembly"
-      version: "2.5.14.1"
-      dependencies: []
-      errors: []
   - name: "compileOnly"
     delivered: true
     dependencies: []
@@ -84,24 +66,6 @@ project:
       dependencies: []
       errors: []
   - name: "runtime"
-    delivered: true
-    dependencies:
-    - namespace: "org.apache.commons"
-      name: "commons-text"
-      version: "1.1"
-      dependencies:
-      - namespace: "org.apache.commons"
-        name: "commons-lang3"
-        version: "3.5"
-        dependencies: []
-        errors: []
-      errors: []
-    - namespace: "org.apache.struts"
-      name: "struts2-assembly"
-      version: "2.5.14.1"
-      dependencies: []
-      errors: []
-  - name: "runtimeClasspath"
     delivered: true
     dependencies:
     - namespace: "org.apache.commons"
@@ -150,66 +114,10 @@ project:
       version: "2.5.14.1"
       dependencies: []
       errors: []
-  - name: "testCompileClasspath"
-    delivered: true
-    dependencies:
-    - namespace: "junit"
-      name: "junit"
-      version: "4.12"
-      dependencies:
-      - namespace: "org.hamcrest"
-        name: "hamcrest-core"
-        version: "1.3"
-        dependencies: []
-        errors: []
-      errors: []
-    - namespace: "org.apache.commons"
-      name: "commons-text"
-      version: "1.1"
-      dependencies:
-      - namespace: "org.apache.commons"
-        name: "commons-lang3"
-        version: "3.5"
-        dependencies: []
-        errors: []
-      errors: []
-    - namespace: "org.apache.struts"
-      name: "struts2-assembly"
-      version: "2.5.14.1"
-      dependencies: []
-      errors: []
   - name: "testCompileOnly"
     delivered: true
     dependencies: []
   - name: "testRuntime"
-    delivered: true
-    dependencies:
-    - namespace: "junit"
-      name: "junit"
-      version: "4.12"
-      dependencies:
-      - namespace: "org.hamcrest"
-        name: "hamcrest-core"
-        version: "1.3"
-        dependencies: []
-        errors: []
-      errors: []
-    - namespace: "org.apache.commons"
-      name: "commons-text"
-      version: "1.1"
-      dependencies:
-      - namespace: "org.apache.commons"
-        name: "commons-lang3"
-        version: "3.5"
-        dependencies: []
-        errors: []
-      errors: []
-    - namespace: "org.apache.struts"
-      name: "struts2-assembly"
-      version: "2.5.14.1"
-      dependencies: []
-      errors: []
-  - name: "testRuntimeClasspath"
     delivered: true
     dependencies:
     - namespace: "junit"

--- a/analyzer/src/main/resources/init.gradle
+++ b/analyzer/src/main/resources/init.gradle
@@ -123,7 +123,7 @@ class DependencyTreePlugin implements Plugin<Gradle> {
             }
 
             List<Configuration> configurations = project.configurations.findResults { configuration ->
-                if (configuration.canBeResolved) {
+                if (configuration.canBeResolved && !configuration.name.endsWith('Classpath')) {
                     ResolutionResult result = configuration.getIncoming().getResolutionResult()
                     Set<ResolvedArtifact> resolvedArtifacts
                     try {


### PR DESCRIPTION
Ignore configurations ending on "Classpath" because these represent the
classpaths for their respective configurations, e.g. "compileClasspath" is
the classpath for the "compile" configuration [1].

This removes a lot of duplication from the results and especially helps
with Android projects where the classpath configurations often cannot be
resolved when they contain dependencies to Android library projects which
have multiple variants. This leads to errors like this:

"ResolveException: Could not resolve all dependencies for configuration
':lib:...Classpath'. Caused by: AmbiguousVariantSelectionException: More
than one variant of project :lib matches the consumer attributes."

[1] https://discuss.gradle.org/t/sourcesets-main-compileclasspath-vs-configurations-compile/6782

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/415)
<!-- Reviewable:end -->
