### PR TITLE
Gradle: Always replace the colon in the display name of project dependencies

### DIFF
--- a/analyzer/src/main/resources/init.gradle
+++ b/analyzer/src/main/resources/init.gradle
@@ -238,14 +238,14 @@ class AbstractDependencyTreePlugin<T> implements Plugin<T> {
                             dependencyProject.version ?: '', '', '', dependencies, null, '',
                             dependencyProject.projectDir.absolutePath)
                 } else {
-                    return new DependencyImpl('', id.displayName.replace(':', '_'), '', '', '', dependencies,
+                    return new DependencyImpl('', id.displayName.replace('project :', 'project '), '', '', '', dependencies,
                             "Unknown id type: ${id.getClass().simpleName}".toString(), '', null)
                 }
             } else if (dependencyResult instanceof UnresolvedDependencyResult) {
-                return new DependencyImpl('', dependencyResult.attempted.displayName, '', '', '', [],
+                return new DependencyImpl('', dependencyResult.attempted.displayName.replace('project :', 'project '), '', '', '', [],
                         "Unresolved: ${collectCauses(dependencyResult.failure)}".toString(), '', null)
             } else {
-                return new DependencyImpl('', dependencyResult.requested.displayName, '', '', '', [],
+                return new DependencyImpl('', dependencyResult.requested.displayName.replace('project :', 'project '), '', '', '', [],
                         "Unknown result type: ${dependencyResult.getClass().simpleName}".toString(), '', null)
             }
         }


### PR DESCRIPTION
Replace "project :" with "project _" in project dependencies, otherwise the
colon messes up the identifier of the dependency because it uses the colon
as a separator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/418)
<!-- Reviewable:end -->
