### PR TITLE
downloader: Use "unknown" for the version if a package has a blank version

### DIFF
--- a/downloader/src/main/kotlin/Main.kt
+++ b/downloader/src/main/kotlin/Main.kt
@@ -242,7 +242,7 @@ object Main {
             allowMovingRevisions = true
             val vcs = VcsInfo.EMPTY.copy(url = projectUrl!!)
 
-            val dummyId = Identifier.EMPTY.copy(name = projectName, version = "unknown")
+            val dummyId = Identifier.EMPTY.copy(name = projectName)
             val dummyPackage = Package.EMPTY.copy(id = dummyId, vcs = vcs, vcsProcessed = vcs)
 
             listOf(dummyPackage)
@@ -293,7 +293,8 @@ object Main {
      */
     fun download(target: Package, outputDirectory: File): DownloadResult {
         // TODO: add namespace to path
-        val targetDir = File(outputDirectory, "${target.normalizedName}/${target.id.version}").apply { safeMkdirs() }
+        val version = target.id.version.takeUnless { it.isBlank() } ?: "unknown"
+        val targetDir = File(outputDirectory, "${target.normalizedName}/$version").apply { safeMkdirs() }
 
         if (target.vcsProcessed.url.isBlank()) {
             log.info { "No VCS URL provided for '${target.id}'." }


### PR DESCRIPTION
Previously if a package had a blank version the source was downloaded to
the directory "outputDir/packageName" while packages with a version were
downloaded to the directory "outputDir/packageName/version". To remove this
inconsistency use "unknown" as the version if the package version is blank.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/421)
<!-- Reviewable:end -->
