### PR TITLE
downloader: Do not abort if a package cannot be archived

### DIFF
--- a/downloader/src/main/kotlin/Main.kt
+++ b/downloader/src/main/kotlin/Main.kt
@@ -45,6 +45,7 @@ import com.here.ort.utils.fileSystemEncode
 import com.here.ort.utils.jsonMapper
 import com.here.ort.utils.log
 import com.here.ort.utils.packZip
+import com.here.ort.utils.printStackTrace
 import com.here.ort.utils.safeDeleteRecursively
 import com.here.ort.utils.safeMkdirs
 import com.here.ort.utils.unpack
@@ -264,11 +265,19 @@ object Main {
                         "Archiving directory '${result.downloadDirectory.absolutePath}' to '${zipFile.absolutePath}'."
                     }
 
-                    result.downloadDirectory.packZip(zipFile,
-                            "${pkg.id.name.encodeOrUnknown()}/${pkg.id.version.encodeOrUnknown()}/")
+                    try {
+                        result.downloadDirectory.packZip(zipFile,
+                                "${pkg.id.name.encodeOrUnknown()}/${pkg.id.version.encodeOrUnknown()}/")
+                    } catch (e: IllegalArgumentException) {
+                        if (com.here.ort.utils.printStackTrace) {
+                            e.printStackTrace()
+                        }
 
-                    val relativePath = outputDir.toPath().relativize(result.downloadDirectory.toPath()).first()
-                    File(outputDir, relativePath.toString()).safeDeleteRecursively()
+                        log.error { "Could not archive '${pkg.id}': ${e.message}" }
+                    } finally {
+                        val relativePath = outputDir.toPath().relativize(result.downloadDirectory.toPath()).first()
+                        File(outputDir, relativePath.toString()).safeDeleteRecursively()
+                    }
                 }
             } catch (e: DownloadException) {
                 if (com.here.ort.utils.printStackTrace) {


### PR DESCRIPTION
Catch the IllegalArgumentException that occurs if the target ZIP file for a
package already exists. This can happen if there are a project and a
package with the same identifier in the dependencies file, or if the
output directory was not cleaned.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/428)
<!-- Reviewable:end -->
