### PR TITLE
Gradle: Replace "unspecified" version with empty string

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
@@ -18,7 +18,7 @@ projects:
     provider: "Gradle"
     namespace: ""
     name: "Gradle-Example"
-    version: "unspecified"
+    version: ""
   declared_licenses: []
   aliases: []
   vcs:

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-root.yml
@@ -5,7 +5,7 @@ project:
     provider: "Gradle"
     namespace: ""
     name: "Gradle-Example"
-    version: "unspecified"
+    version: ""
   declared_licenses: []
   aliases: []
   vcs:

--- a/analyzer/src/main/resources/init.gradle
+++ b/analyzer/src/main/resources/init.gradle
@@ -183,8 +183,9 @@ class AbstractDependencyTreePlugin<T> implements Plugin<T> {
                 }
             }
 
-            return new DependencyTreeModelImpl(project.group ?: '', project.name, project.version ?: '',
-                    configurations, repositories, errors)
+            def version = project.version == 'unspecified' ? '' : project.version
+            return new DependencyTreeModelImpl(project.group ?: '', project.name, version ?: '', configurations,
+                    repositories, errors)
         }
 
         Dependency parseDependency(DependencyResult dependencyResult, Project project,


### PR DESCRIPTION
If a project does not define a version Gradle returns the default value
"unspecified". Replace this with the empty string to not have to handle
"unspecified" in the rest of the code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/434)
<!-- Reviewable:end -->
