### PR TITLE
VCS: Fail if multiple matching tags for a version are found

### DIFF
--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -221,12 +221,21 @@ abstract class VersionControlSystem {
         abstract fun listRemoteTags(): List<String>
 
         /**
-         * Search (symbolic) names of VCS revisions for matches with the given [project] and [version].
+         * Search (symbolic) names of VCS revisions for a match with the given [project] and [version].
          *
-         * @return A matching VCS revision or an empty String if no match is found.
+         * @return The matching VCS revision, never blank.
+         * @throws IOException If no or multiple matching revisions are found.
          */
-        fun guessRevisionName(project: String, version: String) =
-                filterVersionNames(version, listRemoteTags(), project).firstOrNull() ?: ""
+        fun guessRevisionName(project: String, version: String): String {
+            val versionNames = filterVersionNames(version, listRemoteTags(), project)
+            return when {
+                versionNames.isEmpty() ->
+                    throw IOException("No matching tag found for version '$version'.")
+                versionNames.size > 1 ->
+                    throw IOException("Multiple matching tags found for version '$version': $versionNames")
+                else -> versionNames.first()
+            }
+        }
 
         /**
          * Return the relative path to [path] with respect to the VCS root.

--- a/downloader/src/main/kotlin/vcs/Cvs.kt
+++ b/downloader/src/main/kotlin/vcs/Cvs.kt
@@ -160,16 +160,16 @@ object Cvs : VersionControlSystem() {
 
                 log.info { "Trying to guess a $this revision for version '${pkg.id.version}'." }
 
-                workingTree.guessRevisionName(pkg.id.name, pkg.id.version).also {
-                    if (it.isBlank()) {
-                        throw IOException("Unable to determine a revision to checkout.")
+                try {
+                    workingTree.guessRevisionName(pkg.id.name, pkg.id.version).also { revision ->
+                        log.warn {
+                            "Using guessed $this revision '$revision' for version '${pkg.id.version}'. This might " +
+                                    "cause the downloaded source code to not match the package version."
+                        }
                     }
-
-                    log.warn {
-                        "Using guessed $this revision '$it' for version '${pkg.id.version}'. This might cause the " +
-                                "downloaded source code to not match the package version."
-                    }
-
+                } catch (e: IOException) {
+                    throw IOException("Unable to determine a revision to checkout.", e)
+                } finally {
                     // Clean the temporarily updated working tree again.
                     targetDir.listFiles().forEach {
                         if (it.isDirectory) {

--- a/downloader/src/main/kotlin/vcs/Git.kt
+++ b/downloader/src/main/kotlin/vcs/Git.kt
@@ -145,13 +145,13 @@ object Git : GitBase() {
         }
 
         log.info { "Trying to guess a $this revision for version '${pkg.id.version}' to fall back to." }
-        workingTree.guessRevisionName(pkg.id.name, pkg.id.version).also { revision ->
-            if (revision.isNotBlank()) {
+        try {
+            workingTree.guessRevisionName(pkg.id.name, pkg.id.version).also { revision ->
                 revisionCandidates.add(revision)
                 log.info { "Found $this revision '$revision' for version '${pkg.id.version}'." }
-            } else {
-                log.info { "No $this revision for version '${pkg.id.version}' found." }
             }
+        } catch (e: IOException) {
+            log.info { "No $this revision for version '${pkg.id.version}' found: ${e.message}" }
         }
 
         val revision = revisionCandidates.firstOrNull()

--- a/downloader/src/main/kotlin/vcs/Mercurial.kt
+++ b/downloader/src/main/kotlin/vcs/Mercurial.kt
@@ -123,15 +123,15 @@ object Mercurial : VersionControlSystem() {
                 pkg.vcsProcessed.revision
             } else {
                 log.info { "Trying to guess a $this revision for version '${pkg.id.version}'." }
-                workingTree.guessRevisionName(pkg.id.name, pkg.id.version).also { revision ->
-                    if (revision.isBlank()) {
-                        throw IOException("Unable to determine a revision to checkout.")
+                try {
+                    workingTree.guessRevisionName(pkg.id.name, pkg.id.version).also { revision ->
+                        log.warn {
+                            "Using guessed $this revision '$revision' for version '${pkg.id.version}'. This might " +
+                                    "cause the downloaded source code to not match the package version."
+                        }
                     }
-
-                    log.warn {
-                        "Using guessed $this revision '$revision' for version '${pkg.id.version}'. This might cause " +
-                                "the downloaded source code to not match the package version."
-                    }
+                } catch (e: IOException) {
+                    throw IOException("Unable to determine a revision to checkout.", e)
                 }
             }
 

--- a/downloader/src/main/kotlin/vcs/Subversion.kt
+++ b/downloader/src/main/kotlin/vcs/Subversion.kt
@@ -198,10 +198,10 @@ object Subversion : VersionControlSystem() {
                 } else {
                     log.info { "Trying to guess a $this revision for version '${pkg.id.version}'." }
 
-                    revision = getWorkingTree(targetDir).guessRevisionName(pkg.id.name, pkg.id.version)
-
-                    if (revision.isBlank()) {
-                        throw IOException("Unable to determine a revision to checkout.")
+                    revision = try {
+                        getWorkingTree(targetDir).guessRevisionName(pkg.id.name, pkg.id.version)
+                    } catch (e: IOException) {
+                        throw IOException("Unable to determine a revision to checkout.", e)
                     }
 
                     log.warn {


### PR DESCRIPTION
If multiple matching tags are found for a version fail instead of taking
the first one. This helps preventing false positives for example if a
repository contains multiple projects where each project has its own set of
release tags (like "project-a-1.0" and "project-b-1.0").

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/436)
<!-- Reviewable:end -->
