### PR TITLE
MergedAnalyzerResult: Add missing key deserializer for the errors map

### DIFF
--- a/model/src/main/kotlin/MergedAnalyzerResult.kt
+++ b/model/src/main/kotlin/MergedAnalyzerResult.kt
@@ -64,6 +64,7 @@ data class MergedAnalyzerResult(
         /**
          * The list of all errors.
          */
+        @JsonDeserialize(keyUsing = IdentifierFromStringKeyDeserializer::class)
         val errors: SortedMap<Identifier, List<String>>
 )
 


### PR DESCRIPTION
Without this the MergedAnalyzerResult cannot be deserialized.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/449)
<!-- Reviewable:end -->
