### PR TITLE
PIP: Read "declared licenses" from Python packages

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
@@ -2,7 +2,9 @@
 allowDynamicVersions: true
 project:
   id: "PIP::spdx-tools:0.5.4"
-  declared_licenses: []
+  declared_licenses:
+  - "Apache Software"
+  - "Apache-2.0"
   aliases: []
   vcs:
     type: ""


### PR DESCRIPTION
This change requires a modified version of pydep, which includes the
fields "license" and "classifiers" from setup.py files in its output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/451)
<!-- Reviewable:end -->
