### PR TITLE
scanner: Encode paths to scan result files

### DIFF
--- a/downloader/src/main/kotlin/Main.kt
+++ b/downloader/src/main/kotlin/Main.kt
@@ -41,7 +41,7 @@ import com.here.ort.utils.PARAMETER_ORDER_HELP
 import com.here.ort.utils.PARAMETER_ORDER_LOGGING
 import com.here.ort.utils.PARAMETER_ORDER_MANDATORY
 import com.here.ort.utils.PARAMETER_ORDER_OPTIONAL
-import com.here.ort.utils.fileSystemEncode
+import com.here.ort.utils.encodeOrUnknown
 import com.here.ort.utils.log
 import com.here.ort.utils.packZip
 import com.here.ort.utils.printStackTrace
@@ -437,6 +437,4 @@ object Main {
             throw DownloadException("Calculated $hashAlgorithm hash '$digest' differs from expected hash '$hash'.")
         }
     }
-
-    private fun String.encodeOrUnknown() = this.fileSystemEncode().takeUnless { it.isBlank() } ?: "unknown"
 }

--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -25,6 +25,7 @@ import com.here.ort.downloader.DownloadException
 import com.here.ort.downloader.Main
 import com.here.ort.model.Package
 import com.here.ort.utils.collectMessages
+import com.here.ort.utils.encodeOrUnknown
 import com.here.ort.utils.getPathFromEnvironment
 import com.here.ort.utils.log
 import com.here.ort.utils.safeMkdirs
@@ -111,7 +112,7 @@ abstract class LocalScanner : Scanner() {
         val pkgRevision = pkg.id.version.takeUnless { it.isBlank() } ?: pkg.vcsProcessed.revision.take(7)
 
         val resultsFile = File(scanResultsDirectory,
-                "${pkg.id.name}-${pkgRevision}_$scannerName.$resultFileExt")
+                "${pkg.id.name.encodeOrUnknown()}-${pkgRevision}_$scannerName.$resultFileExt")
 
         if (ScanResultsCache.read(pkg, resultsFile)) {
             val results = getResult(resultsFile)

--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -395,6 +395,11 @@ fun String.fileSystemDecode(): String =
         java.net.URLDecoder.decode(this, "UTF-8")
 
 /**
+ * Return the string encoded for safe use as a file name or "unknown", if the string is empty.
+ */
+fun String.encodeOrUnknown() = fileSystemEncode().takeUnless { it.isBlank() } ?: "unknown"
+
+/**
  * Print the stack trace of the [Throwable] if [printStackTrace] is set to true.
  */
 fun Throwable.showStackTrace() {


### PR DESCRIPTION
This change extracts `String.encodeOrUnknown()` from the downloader to utils and calls it in the scanner as well, when constructing the path to result files.

The issue this fixes came up when testing the toolkit with Go projects, where import paths are used as package names (e.g. `k8s.io/apiserver`). The scanner would then expect a directory `scanResults/k8s.io` to exist and fail to write the result file there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/456)
<!-- Reviewable:end -->
