### PR TITLE
Gradle: Remove the customized plugin repository order

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,12 +1,3 @@
-pluginManagement {
-    repositories {
-        // jcenter needs to come before gradlePluginPortal because of a broken dokka POM in the plugin portal:
-        // https://github.com/Kotlin/dokka/issues/146#issuecomment-349091680
-        jcenter()
-        gradlePluginPortal()
-    }
-}
-
 rootProject.name = 'oss-review-toolkit'
 
 include 'analyzer'


### PR DESCRIPTION
The issue with the broken POM has been resolved with dokka 0.9.16 which
is what we are using now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/457)
<!-- Reviewable:end -->
