### PR TITLE
LocalScanner: Improve readability of scan()

### DIFF
--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -76,16 +76,18 @@ abstract class LocalScanner : Scanner() {
     abstract fun getVersion(executable: String): String
 
     override fun scan(packages: List<Package>, outputDirectory: File, downloadDirectory: File?): Map<Package, Result> {
-        return packages.associateBy { it }.mapValues {
-            try {
-                scan(it.value, outputDirectory, downloadDirectory)
+        return packages.associate { pkg ->
+            val result = try {
+                scan(pkg, outputDirectory, downloadDirectory)
             } catch (e: ScanException) {
                 e.showStackTrace()
 
-                log.error { "Could not scan package '${it.key.id}': ${e.message}" }
+                log.error { "Could not scan package '${pkg.id}': ${e.message}" }
 
                 Result(fileCount = 0, licenses = sortedSetOf(), errors = e.collectMessages().toSortedSet())
             }
+
+            Pair(pkg, result)
         }
     }
 


### PR DESCRIPTION
It is a bit weird to first use wrong values in order to map them
immediately. Instead, associate to the right values from the start.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/462)
<!-- Reviewable:end -->
