### PR TITLE
Fix running pipdeptree by pinning the pip version

### DIFF
--- a/analyzer/src/main/kotlin/managers/PIP.kt
+++ b/analyzer/src/main/kotlin/managers/PIP.kt
@@ -119,7 +119,7 @@ class PIP : PackageManager() {
         val virtualEnvDir = setupVirtualEnv(workingDir, definitionFile)
 
         // List all packages installed locally in the virtualenv.
-        val pipdeptreeJsonTree = runInVirtualEnv(virtualEnvDir, workingDir, "pipdeptree", "-l", "--json-tree")
+        val pipdeptree = runInVirtualEnv(virtualEnvDir, workingDir, "pipdeptree", "-l", "--json-tree")
 
         // Install pydep after running any other command but before looking at the dependencies because it
         // downgrades pip to version 7.1.2. Use it to get meta-information from about the project from setup.py. As
@@ -162,8 +162,8 @@ class PIP : PackageManager() {
         val packages = sortedSetOf<Package>()
         val installDependencies = sortedSetOf<PackageReference>()
 
-        if (pipdeptreeJsonTree.isSuccess()) {
-            val fullDependencyTree = jsonMapper.readTree(pipdeptreeJsonTree.stdout())
+        if (pipdeptree.isSuccess()) {
+            val fullDependencyTree = jsonMapper.readTree(pipdeptree.stdout())
 
             val projectDependencies = if (definitionFile.name == "setup.py") {
                 // The tree contains a root node for the project itself and pipdeptree's dependencies are also at the

--- a/analyzer/src/main/kotlin/managers/PIP.kt
+++ b/analyzer/src/main/kotlin/managers/PIP.kt
@@ -237,7 +237,9 @@ class PIP : PackageManager() {
                 }
             }
         } else {
-            log.error { "Unable to determine dependencies for project in directory '$workingDir'." }
+            log.error {
+                "Unable to determine dependencies for project in directory '$workingDir':\n${pipdeptree.stderr()}"
+            }
         }
 
         // TODO: Handle "extras" and "tests" dependencies.


### PR DESCRIPTION
Please have a look at the individual commit messages for the details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/464)
<!-- Reviewable:end -->
