### PR TITLE
scanner: Remove the unused "executable" argument from getVersion()

### DIFF
--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -71,9 +71,9 @@ abstract class LocalScanner : Scanner() {
     protected open fun bootstrap(): File? = null
 
     /**
-     * Return the version of the specified scanner [executable], or an empty string in case of failure.
+     * Return the version of the scanner, or an empty string in case of failure.
      */
-    abstract fun getVersion(executable: String): String
+    abstract fun getVersion(): String
 
     override fun scan(packages: List<Package>, outputDirectory: File, downloadDirectory: File?): Map<Package, Result> {
         return packages.associate { pkg ->
@@ -136,8 +136,8 @@ abstract class LocalScanner : Scanner() {
             throw ScanException("Package '${pkg.id}' could not be scanned.", e)
         }
 
-        val version = getVersion(scannerPath.absolutePath)
-        println("Running $this version $version on directory '${downloadResult.downloadDirectory.canonicalPath}'.")
+        println("Running $this version ${getVersion()} on directory " +
+                "'${downloadResult.downloadDirectory.canonicalPath}'.")
 
         return scanPath(downloadResult.downloadDirectory, resultsFile).also {
             println("Stored $this results in '${resultsFile.absolutePath}'.")
@@ -171,8 +171,7 @@ abstract class LocalScanner : Scanner() {
         val resultsFile = File(scanResultsDirectory,
                 "${path.nameWithoutExtension}_$scannerName.$resultFileExt")
 
-        val version = getVersion(scannerPath.absolutePath)
-        println("Running $this version $version on path '${path.canonicalPath}'.")
+        println("Running $this version ${getVersion()} on path '${path.canonicalPath}'.")
 
         return scanPath(path, resultsFile).also {
             println("Stored $this results in '${resultsFile.absolutePath}'.")

--- a/scanner/src/main/kotlin/scanners/BoyterLc.kt
+++ b/scanner/src/main/kotlin/scanners/BoyterLc.kt
@@ -87,7 +87,7 @@ object BoyterLc : LocalScanner() {
         }
     }
 
-    override fun getVersion(executable: String) =
+    override fun getVersion() =
             getCommandVersion(scannerPath.absolutePath, transform = {
                 // "lc --version" returns a string like "licensechecker version 1.1.1", so simply remove the prefix.
                 it.substringAfter("licensechecker version ")

--- a/scanner/src/main/kotlin/scanners/Licensee.kt
+++ b/scanner/src/main/kotlin/scanners/Licensee.kt
@@ -43,7 +43,7 @@ object Licensee : LocalScanner() {
         return File(userDir, "bin")
     }
 
-    override fun getVersion(executable: String) = getCommandVersion(scannerPath.absolutePath, "version")
+    override fun getVersion() = getCommandVersion(scannerPath.absolutePath, "version")
 
     override fun scanPath(path: File, resultsFile: File): Result {
         // Licensee has issues with absolute Windows paths passed as an argument. Work around that by using the path to

--- a/scanner/src/main/kotlin/scanners/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/ScanCode.kt
@@ -72,7 +72,7 @@ object ScanCode : LocalScanner() {
         return scancodeDir
     }
 
-    override fun getVersion(executable: String) =
+    override fun getVersion() =
             getCommandVersion(scannerPath.absolutePath, transform = {
                 // "scancode --version" returns a string like "ScanCode version 2.0.1.post1.fb67a181", so simply remove
                 // the prefix.


### PR DESCRIPTION
As of 6d49505 local scanner implementations need to implement the
"scannerExe" property instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/466)
<!-- Reviewable:end -->
