### PR TITLE
ScanCodeTest: Remove the (unneeded) internal Resources object

### DIFF
--- a/scanner/src/test/kotlin/ScanCodeTest.kt
+++ b/scanner/src/test/kotlin/ScanCodeTest.kt
@@ -26,13 +26,11 @@ import io.kotlintest.specs.WordSpec
 
 import java.io.File
 
-internal object Resources
-
 class ScanCodeTest : WordSpec({
     "mapTimeoutErrors()" should {
         "return true for scan results with only timeout errors" {
             val resultFileName = "/esprima-2.7.3_scancode-2.2.1.post277.4d68f9377.json"
-            val resultFile = File(Resources.javaClass.getResource(resultFileName).toURI())
+            val resultFile = File(javaClass.getResource(resultFileName).toURI())
             val result = ScanCode.getPlainResult(resultFile)
             ScanCode.mapTimeoutErrors(result) shouldBe true
             result.errors.joinToString("\n") shouldBe sortedSetOf(
@@ -65,7 +63,7 @@ class ScanCodeTest : WordSpec({
 
         "return false for scan results without errors" {
             val resultFileName = "/esprima-2.7.3_scancode-2.2.1.json"
-            val resultFile = File(Resources.javaClass.getResource(resultFileName).toURI())
+            val resultFile = File(javaClass.getResource(resultFileName).toURI())
             val result = ScanCode.getResult(resultFile)
             ScanCode.mapTimeoutErrors(result) shouldBe false
         }
@@ -74,7 +72,7 @@ class ScanCodeTest : WordSpec({
     "mapUnknownErrors()" should {
         "return true for scan results with only memory errors" {
             val resultFileName = "/very-long-json-lines_scancode-2.2.1.post277.4d68f9377.json"
-            val resultFile = File(Resources.javaClass.getResource(resultFileName).toURI())
+            val resultFile = File(javaClass.getResource(resultFileName).toURI())
             val result = ScanCode.getPlainResult(resultFile)
             ScanCode.mapUnknownErrors(result) shouldBe true
             result.errors.joinToString("\n") shouldBe sortedSetOf(
@@ -84,7 +82,7 @@ class ScanCodeTest : WordSpec({
 
         "return false for scan results with other unknown errors" {
             val resultFileName = "/kotlin-annotation-processing-gradle-1.2.21_scancode.json"
-            val resultFile = File(Resources.javaClass.getResource(resultFileName).toURI())
+            val resultFile = File(javaClass.getResource(resultFileName).toURI())
             val result = ScanCode.getPlainResult(resultFile)
             ScanCode.mapUnknownErrors(result) shouldBe false
             result.errors.joinToString("\n") shouldBe sortedSetOf(
@@ -95,7 +93,7 @@ class ScanCodeTest : WordSpec({
 
         "return false for scan results without errors" {
             val resultFileName = "/esprima-2.7.3_scancode-2.2.1.json"
-            val resultFile = File(Resources.javaClass.getResource(resultFileName).toURI())
+            val resultFile = File(javaClass.getResource(resultFileName).toURI())
             val result = ScanCode.getResult(resultFile)
             ScanCode.mapUnknownErrors(result) shouldBe false
         }


### PR DESCRIPTION
The new test discovery of kotlintest 3 cannot handle such objects yet, see

https://github.com/kotlintest/kotlintest/issues/294

So simply get rid of it. It was a left-over from when we still had a
global readResource() utility function.