### PR TITLE
scanner: Allow small versions diffs when looking up results from the cache

### DIFF
--- a/model/src/main/kotlin/ScannerDetails.kt
+++ b/model/src/main/kotlin/ScannerDetails.kt
@@ -19,6 +19,8 @@
 
 package com.here.ort.model
 
+import com.vdurmont.semver4j.Semver
+
 /**
  * Details about the used source code scanner.
  */
@@ -37,4 +39,19 @@ data class ScannerDetails(
          * The configuration of the scanner, could be command line arguments for example.
          */
         val configuration: String
-)
+) {
+    private val incompatibleVersionDiffs = listOf(
+            Semver.VersionDiff.MAJOR,
+            Semver.VersionDiff.MINOR
+    )
+
+    /**
+     * True if the [other] scanner has the same name and configuration, and the [Semver] version differs only in other
+     * parts than [major][Semver.VersionDiff.MAJOR] and [minor][Semver.VersionDiff.MINOR]. For the comparison the
+     * [loose][Semver.SemverType.LOOSE] Semver type is used for maximum compatibility with the versions returned from
+     * the scanners.
+     */
+    fun isCompatible(other: ScannerDetails) =
+            Semver(version, Semver.SemverType.LOOSE).diff(Semver(other.version, Semver.SemverType.LOOSE)) !in
+                    incompatibleVersionDiffs
+}

--- a/scanner/src/main/kotlin/ArtifactoryCache.kt
+++ b/scanner/src/main/kotlin/ArtifactoryCache.kt
@@ -90,7 +90,7 @@ class ArtifactoryCache(
     override fun read(id: Identifier, scannerDetails: ScannerDetails): ScanResultContainer {
         val scanResults = read(id)
         val filteredResults = scanResults.results.filter {
-            it.scanner == scannerDetails
+            scannerDetails.isCompatible(it.scanner)
         }
 
         if (filteredResults.isEmpty() && scanResults.results.isNotEmpty()) {

--- a/scanner/src/main/kotlin/ScanResultsCache.kt
+++ b/scanner/src/main/kotlin/ScanResultsCache.kt
@@ -46,9 +46,8 @@ interface ScanResultsCache {
     fun read(id: Identifier): ScanResultContainer
 
     /**
-     * Read the [ScanResult]s matching this [id] and [scannerDetails] from the cache.
-     *
-     * TODO: This method should support a version range for the scanner in case minor version differences do not matter.
+     * Read the [ScanResult]s matching this [id] and [scannerDetails] from the cache. [ScannerDetails.isCompatible] is
+     * used to check if the results are compatible with the provided [scannerDetails].
      *
      * @param id The [Identifier] of the scanned [Package].
      * @param scannerDetails Details about the scanner that was used to scan the [Package].


### PR DESCRIPTION
When looking up results from the cache allow the version of the scanner to
differ in the patch, suffix, and build parts, but not in the major or
minor parts. This way the scan results can be reused if there are no
significant changes between the used scanner versions, assuming the scanner
uses semantic versioning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/472)
<!-- Reviewable:end -->
