### PR TITLE
scanner: Also check the provenance of a cached scan result

### DIFF
--- a/scanner/src/funTest/kotlin/HttpCacheTest.kt
+++ b/scanner/src/funTest/kotlin/HttpCacheTest.kt
@@ -22,6 +22,7 @@ package com.here.ort.scanner
 import com.here.ort.model.EMPTY_JSON_NODE
 import com.here.ort.model.HashAlgorithm
 import com.here.ort.model.Identifier
+import com.here.ort.model.Package
 import com.here.ort.model.Provenance
 import com.here.ort.model.RemoteArtifact
 import com.here.ort.model.ScanResult
@@ -84,17 +85,31 @@ class HttpCacheTest : StringSpec() {
 
     private val id = Identifier("provider", "namespace", "name", "version")
 
+    private val sourceArtifact = RemoteArtifact(
+            "url",
+            "0123456789abcdef0123456789abcdef01234567",
+            HashAlgorithm.SHA1)
+
+    private val vcs = VcsInfo("type", "url", "revision", "resolvedRevision", "path")
+
+    private val pkg = Package.EMPTY.copy(
+            id = id,
+            sourceArtifact = sourceArtifact,
+            vcs = vcs,
+            vcsProcessed = vcs.normalize()
+    )
+
     private val downloadTime1 = Instant.EPOCH + Duration.ofDays(1)
     private val downloadTime2 = Instant.EPOCH + Duration.ofDays(2)
     private val downloadTime3 = Instant.EPOCH + Duration.ofDays(3)
 
     private val provenanceWithSourceArtifact = Provenance(
             downloadTime = downloadTime1,
-            sourceArtifact = RemoteArtifact("url", "hash", HashAlgorithm.SHA1)
+            sourceArtifact = sourceArtifact
     )
     private val provenanceWithVcsInfo = Provenance(
             downloadTime = downloadTime2,
-            vcsInfo = VcsInfo("type", "url", "revision", "resolvedRevision", "path")
+            vcsInfo = vcs
     )
     private val provenanceEmpty = Provenance(downloadTime3)
 
@@ -198,7 +213,7 @@ class HttpCacheTest : StringSpec() {
             val result1 = cache.add(id, scanResult1)
             val result2 = cache.add(id, scanResult2)
             val result3 = cache.add(id, scanResult3)
-            val cachedResults = cache.read(id, scannerDetails1)
+            val cachedResults = cache.read(pkg, scannerDetails1)
 
             result1 shouldBe true
             result2 shouldBe true
@@ -223,7 +238,7 @@ class HttpCacheTest : StringSpec() {
             val resultCompatible1 = cache.add(id, scanResultCompatible1)
             val resultCompatible2 = cache.add(id, scanResultCompatible2)
             val resultIncompatible = cache.add(id, scanResultIncompatible)
-            val cachedResults = cache.read(id, scannerDetails1)
+            val cachedResults = cache.read(pkg, scannerDetails1)
 
             result shouldBe true
             resultCompatible1 shouldBe true
@@ -233,6 +248,36 @@ class HttpCacheTest : StringSpec() {
             cachedResults.results should contain(scanResult)
             cachedResults.results should contain(scanResultCompatible1)
             cachedResults.results should contain(scanResultCompatible2)
+        }
+
+        "Returns only packages with matching provenance" {
+            val cache = ArtifactoryCache("http://${loopback.hostAddress}:$port", "apiToken")
+            val scanResultSourceArtifactMatching = ScanResult(provenanceWithSourceArtifact, scannerDetails1,
+                    scanSummaryWithFiles, rawResultWithContent)
+            val scanResultVcsMatching = ScanResult(provenanceWithVcsInfo, scannerDetails1, scanSummaryWithFiles,
+                    rawResultWithContent)
+            val provenanceSourceArtifactNonMatching = provenanceWithSourceArtifact.copy(
+                    sourceArtifact = sourceArtifact.copy(url = "url2"))
+            val scanResultSourceArtifactNonMatching = ScanResult(provenanceSourceArtifactNonMatching, scannerDetails1,
+                    scanSummaryWithFiles, rawResultWithContent)
+            val provenanceVcsInfoNonMatching = provenanceWithVcsInfo.copy(
+                    vcsInfo = vcs.copy(revision = "revision2", resolvedRevision = "resolvedRevision2"))
+            val scanResultVcsInfoNonMatching = ScanResult(provenanceVcsInfoNonMatching, scannerDetails1,
+                    scanSummaryWithFiles, rawResultWithContent)
+
+            val result1 = cache.add(id, scanResultSourceArtifactMatching)
+            val result2 = cache.add(id, scanResultVcsMatching)
+            val result3 = cache.add(id, scanResultSourceArtifactNonMatching)
+            val result4 = cache.add(id, scanResultVcsInfoNonMatching)
+            val cachedResults = cache.read(pkg, scannerDetails1)
+
+            result1 shouldBe true
+            result2 shouldBe true
+            result3 shouldBe true
+            result4 shouldBe true
+            cachedResults.results.size shouldBe 2
+            cachedResults.results should contain(scanResultSourceArtifactMatching)
+            cachedResults.results should contain(scanResultVcsMatching)
         }
     }
 }

--- a/scanner/src/main/kotlin/ArtifactoryCache.kt
+++ b/scanner/src/main/kotlin/ArtifactoryCache.kt
@@ -22,6 +22,7 @@ package com.here.ort.scanner
 import ch.frankel.slf4k.*
 
 import com.here.ort.model.Identifier
+import com.here.ort.model.Package
 import com.here.ort.model.ScanResult
 import com.here.ort.model.ScanResultContainer
 import com.here.ort.model.ScannerDetails
@@ -87,10 +88,10 @@ class ArtifactoryCache(
         return ScanResultContainer(id, emptyList())
     }
 
-    override fun read(id: Identifier, scannerDetails: ScannerDetails): ScanResultContainer {
-        val scanResults = read(id)
+    override fun read(pkg: Package, scannerDetails: ScannerDetails): ScanResultContainer {
+        val scanResults = read(pkg.id)
         val filteredResults = scanResults.results.filter {
-            scannerDetails.isCompatible(it.scanner)
+            scannerDetails.isCompatible(it.scanner) && it.provenance.matches(pkg)
         }
 
         if (filteredResults.isEmpty() && scanResults.results.isNotEmpty()) {
@@ -100,7 +101,7 @@ class ArtifactoryCache(
             log.info { "Found ${filteredResults.size} cached scan results for scanner '$scannerDetails'." }
         }
 
-        return ScanResultContainer(id, filteredResults)
+        return ScanResultContainer(pkg.id, filteredResults)
     }
 
     override fun add(id: Identifier, scanResult: ScanResult): Boolean {

--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -139,7 +139,7 @@ abstract class LocalScanner : Scanner() {
         val scanResultsForPackageDirectory = File(scanResultsDirectory, pkg.id.toPath()).apply { safeMkdirs() }
         val resultsFile = File(scanResultsForPackageDirectory, "scan-results_${details.name}.$resultFileExt")
 
-        val cachedResults = ScanResultsCache.read(pkg.id, details)
+        val cachedResults = ScanResultsCache.read(pkg, details)
 
         if (cachedResults.results.isNotEmpty()) {
             // Some external tools rely on the raw results filer to be written to the scan results directory, so write


### PR DESCRIPTION
When reading the scan results for a package also verify that the provenance
of the scan result matches the sourceArtifact, vcs, or vcsProcessed fields
of the package. Otherwise wrong scan results could be returned if different
revisions of a package using the same version name were scanned.

If the vcs info of a package only contains symbolic names the scanned
revision could be wrong if the symbolic name is changed to point to another
commit. This could be improved by resolving the symbolic name already in
the analyzer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/474)
<!-- Reviewable:end -->
