### PR TITLE
Ensure LF line endings for all expected results files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*/src/*/assets/**/expected*.yml text eol=lf

--- a/analyzer/src/funTest/assets/.gitattributes
+++ b/analyzer/src/funTest/assets/.gitattributes
@@ -1,2 +1,0 @@
-*expected*.txt	text eol=lf
-*expected*.yml	text eol=lf


### PR DESCRIPTION
Previously, the newly added file at

    model/src/test/assets/expected-scan-results.yml

was not matched. Also remove the entry for "txt" files as there are none
anymore.

This fixes a potential test failure in "ScanResults should serialize as
expected" on Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/478)
<!-- Reviewable:end -->
