### PR TITLE
Gradle: Provide default values for properties of DependencyImpl

### DIFF
--- a/analyzer/src/main/resources/init.gradle
+++ b/analyzer/src/main/resources/init.gradle
@@ -84,12 +84,12 @@ interface Dependency {
 class DependencyImpl implements Dependency, Serializable {
     String groupId
     String artifactId
-    String version
-    String classifier
-    String extension
+    String version = ''
+    String classifier = ''
+    String extension = ''
     List<Dependency> dependencies
     String error
-    String pomFile
+    String pomFile = ''
     String localPath
 }
 


### PR DESCRIPTION
Provide default values for properties of DependencyImpl that are expected
to be non-null in the Kotlin code.

This fixes a regression introduced in 5f8dee7.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/481)
<!-- Reviewable:end -->
