### PR TITLE
Gradle: Upgrade Kotlin and other dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     // We need to hard-code the version here because of
     // https://github.com/gradle/gradle/issues/1697
-    id 'org.jetbrains.kotlin.jvm' version '1.2.31' apply false
+    id 'org.jetbrains.kotlin.jvm' version '1.2.40' apply false
     id 'org.jetbrains.dokka' version '0.9.16' apply false
 
     // Note that the detekt Gradle plugin version does not necessarily
@@ -52,7 +52,7 @@ subprojects {
     }
 
     dependencies {
-        compile 'org.jetbrains.kotlin:kotlin-stdlib-jre8:1.2.31'
+        compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.40'
 
         testCompile "io.kotlintest:kotlintest:$kotlintestVersion"
         testCompile project(':utils-test')
@@ -69,7 +69,7 @@ subprojects {
     // TODO: Remove this once jackson-module-kotlin and kotlintest are updated.
     configurations.all {
         resolutionStrategy {
-            force 'org.jetbrains.kotlin:kotlin-reflect:1.2.31'
+            force 'org.jetbrains.kotlin:kotlin-reflect:1.2.40'
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 commonsCodecVersion = 1.11
 commonsCompressVersion = 1.16.1
 disklrucacheVersion = 2.0.2
-jacksonVersion = 2.9.4
-jcommanderVersion = 1.72
+jacksonVersion = 2.9.5
+jcommanderVersion = 1.74
 kotlintestVersion = 2.0.7
-mavenVersion = 3.5.2
+mavenVersion = 3.5.3
 mavenResolverVersion = 1.1.1
 okhttpVersion = 3.10.0
 semverVersion = 2.2.0


### PR DESCRIPTION
See https://blog.jetbrains.com/kotlin/2018/04/kotlin-1-2-40-is-out/

Note that kotlin-stdlib-jre* were deprecated in favor of
kotlin-stdlib-jdk*.

Also upgrade a few dependencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/483)
<!-- Reviewable:end -->
