### PR TITLE
model: Ignore case when comparing the VCS type in Provenance.matches()

### DIFF
--- a/model/src/main/kotlin/Provenance.kt
+++ b/model/src/main/kotlin/Provenance.kt
@@ -70,7 +70,8 @@ data class Provenance(
         return listOf(pkg.vcs, pkg.vcsProcessed).any {
             // If "it" has a resolved revision it must be equal to the resolved revision of vcsInfo, otherwise the
             // revision of "it" has to equal either the revision or the resolved revision of vcsInfo.
-            it.type == vcsInfo.type && it.url == vcsInfo.url && it.path == vcsInfo.path && it.resolvedRevision?.let {
+            it.type.equals(vcsInfo.type, true) && it.url == vcsInfo.url && it.path == vcsInfo.path
+                    && it.resolvedRevision?.let {
                 vcsInfo.resolvedRevision == it
             } ?: vcsInfo.resolvedRevision == it.revision || vcsInfo.revision == it.revision
         }


### PR DESCRIPTION
Otherwise e.g. "git" and "Git" would not be recognized as equal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/496)
<!-- Reviewable:end -->
