### PR TITLE
Record original VCS info in Provenance

### DIFF
--- a/downloader/src/main/kotlin/Main.kt
+++ b/downloader/src/main/kotlin/Main.kt
@@ -90,7 +90,8 @@ object Main {
             val dateTime: Instant,
             val downloadDirectory: File,
             val sourceArtifact: RemoteArtifact? = null,
-            val vcsInfo: VcsInfo? = null
+            val vcsInfo: VcsInfo? = null,
+            val originalVcsInfo: VcsInfo? = null
     ) {
         init {
             require((sourceArtifact == null) != (vcsInfo == null)) {
@@ -373,7 +374,8 @@ object Main {
                 resolvedRevision = revision,
                 path = target.vcsProcessed.path // TODO: Needs to check if the VCS used the sparse checkout.
         )
-        return DownloadResult(startTime, outputDirectory, vcsInfo = vcsInfo)
+        return DownloadResult(startTime, outputDirectory, vcsInfo = vcsInfo,
+                originalVcsInfo = target.vcsProcessed.takeIf { it != vcsInfo })
     }
 
     private fun downloadSourceArtifact(target: Package, outputDirectory: File): DownloadResult {

--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -173,7 +173,8 @@ abstract class LocalScanner : Scanner() {
         println("Running $this version ${getVersion()} on directory " +
                 "'${downloadResult.downloadDirectory.canonicalPath}'.")
 
-        val provenance = Provenance(downloadResult.dateTime, downloadResult.sourceArtifact, downloadResult.vcsInfo)
+        val provenance = Provenance(downloadResult.dateTime, downloadResult.sourceArtifact, downloadResult.vcsInfo,
+                downloadResult.originalVcsInfo)
         val scanResult = scanPath(downloadResult.downloadDirectory, resultsFile, provenance, details)
 
         ScanResultsCache.add(pkg.id, scanResult)


### PR DESCRIPTION
Record the original VCS info in the Provenance class. This is important if
the original VCS info does not have a revision or the revision cannot be
downloaded, and the downloader detects the revision for example by
searching for a tag matching the version of the package. Without storing
the original VCS info there would be no way to find out that the Provenance
matches the package without downloading the source code and detecting the
revision again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/497)
<!-- Reviewable:end -->
