### PR TITLE
model: Convert the VCS type to lower case in VcsInfo.normalize()

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
@@ -11,7 +11,7 @@ project:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/soc/directories.git"
     revision: "ed193b425d5c184029481e2330baaf5628bbefac"
     path: ""
@@ -47,7 +47,7 @@ packages:
     revision: "r4.12"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/junit-team/junit.git"
     revision: "r4.12"
     path: ""
@@ -72,7 +72,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
     revision: ""
     path: ""

--- a/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
@@ -10,7 +10,7 @@ project:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/deis/example-python-flask.git"
     revision: "0773991e36a4c69b121cdb05146d6140347d4065"
     path: ""

--- a/analyzer/src/funTest/assets/projects/external/godep-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/godep-expected-output.yml
@@ -10,7 +10,7 @@ project:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/tools/godep.git"
     revision: "ce0bfadeb516ab23c845a85c4b0eae421ec9614b"
     path: ""
@@ -53,7 +53,7 @@ packages:
     revision: "2788f0dbd16903de03cb8186e5c7d97b69ad387b"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/kr/fs.git"
     revision: "2788f0dbd16903de03cb8186e5c7d97b69ad387b"
     path: ""
@@ -75,7 +75,7 @@ packages:
     revision: "f31442d60e51465c69811e2107ae978868dbea5c"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/kr/pretty.git"
     revision: "f31442d60e51465c69811e2107ae978868dbea5c"
     path: ""
@@ -97,7 +97,7 @@ packages:
     revision: "6807e777504f54ad073ecef66747de158294b639"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/kr/text.git"
     revision: "6807e777504f54ad073ecef66747de158294b639"
     path: ""
@@ -119,7 +119,7 @@ packages:
     revision: "f78a839676152fd9f4863704f5d516195c18fc14"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/pmezard/go-difflib.git"
     revision: "f78a839676152fd9f4863704f5d516195c18fc14"
     path: ""
@@ -141,7 +141,7 @@ packages:
     revision: "1f1b3322f67af76803c942fd237291538ec68262"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://go.googlesource.com/tools"
     revision: "1f1b3322f67af76803c942fd237291538ec68262"
     path: ""

--- a/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
@@ -10,7 +10,7 @@ project:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/ccavanaugh/jgnash.git"
     revision: "2aa4cce7d7fd46164030f2b4d244c4b89e77f722"
     path: "jgnash-core"
@@ -175,7 +175,7 @@ packages:
     revision: "classmate-1.3.0"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "ssh://git@github.com/cowtowncoder/java-classmate.git"
     revision: "classmate-1.3.0"
     path: ""
@@ -201,7 +201,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/virtuald/curvesapi.git"
     revision: ""
     path: ""
@@ -224,7 +224,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/h2database/h2database.git"
     revision: ""
     path: ""
@@ -248,7 +248,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "ssh://git@github.com/swaldman/c3p0.git"
     revision: ""
     path: ""
@@ -272,7 +272,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "ssh://git@github.com/swaldman/mchange-commons-java.git"
     revision: ""
     path: ""
@@ -295,7 +295,7 @@ packages:
     revision: "v-1.4.x"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/x-stream/xstream.git"
     revision: "v-1.4.x"
     path: ""
@@ -318,7 +318,7 @@ packages:
     revision: "v-1.4.x"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/x-stream/xstream.git"
     revision: "v-1.4.x"
     path: ""
@@ -391,7 +391,7 @@ packages:
     revision: "netty-4.1.9.Final"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/netty/netty.git"
     revision: "netty-4.1.9.Final"
     path: ""
@@ -416,7 +416,7 @@ packages:
     revision: "netty-4.1.9.Final"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/netty/netty.git"
     revision: "netty-4.1.9.Final"
     path: ""
@@ -441,7 +441,7 @@ packages:
     revision: "netty-4.1.9.Final"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/netty/netty.git"
     revision: "netty-4.1.9.Final"
     path: ""
@@ -466,7 +466,7 @@ packages:
     revision: "netty-4.1.9.Final"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/netty/netty.git"
     revision: "netty-4.1.9.Final"
     path: ""
@@ -491,7 +491,7 @@ packages:
     revision: "netty-4.1.9.Final"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/netty/netty.git"
     revision: "netty-4.1.9.Final"
     path: ""
@@ -513,7 +513,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/ccavanaugh/jgnash.git"
     revision: "2aa4cce7d7fd46164030f2b4d244c4b89e77f722"
     path: "jgnash-resources"
@@ -537,7 +537,7 @@ packages:
     revision: "r4.12"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/junit-team/junit.git"
     revision: "r4.12"
     path: ""
@@ -727,7 +727,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
     revision: ""
     path: ""
@@ -750,7 +750,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/hibernate/hibernate-commons-annotations.git"
     revision: ""
     path: ""
@@ -775,7 +775,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/hibernate/hibernate-jpa-api.git"
     revision: ""
     path: ""
@@ -798,7 +798,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/hibernate/hibernate-orm.git"
     revision: ""
     path: ""
@@ -821,7 +821,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/hibernate/hibernate-orm.git"
     revision: ""
     path: ""
@@ -870,7 +870,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "ssh://git@github.com/jboss-javassist/javassist.git"
     revision: ""
     path: ""
@@ -893,7 +893,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jboss-logging/jboss-logging.git"
     revision: ""
     path: ""
@@ -917,7 +917,7 @@ packages:
     revision: "jboss-transaction-api_1.2_spec-1.0.1.Final"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "ssh://git@github.com/jboss/jboss-transaction-api_spec.git"
     revision: "jboss-transaction-api_1.2_spec-1.0.1.Final"
     path: ""
@@ -940,7 +940,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "ssh://git@github.com/jboss/jboss-parent-pom.git"
     revision: ""
     path: ""

--- a/analyzer/src/funTest/assets/projects/external/jgnash-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/jgnash-expected-output.yml
@@ -10,7 +10,7 @@ project:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/ccavanaugh/jgnash.git"
     revision: "2aa4cce7d7fd46164030f2b4d244c4b89e77f722"
     path: ""
@@ -46,7 +46,7 @@ packages:
     revision: "r4.12"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/junit-team/junit.git"
     revision: "r4.12"
     path: ""
@@ -70,7 +70,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
     revision: ""
     path: ""

--- a/analyzer/src/funTest/assets/projects/external/qmstr-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/qmstr-expected-output.yml
@@ -10,7 +10,7 @@ project:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/QMSTR/qmstr.git"
     revision: "0cd17d10b931c9108450ca5a68d4f85b6e4953ef"
     path: ""
@@ -74,7 +74,7 @@ packages:
     revision: "939c270eac93a70e63162abd53f78dbc9e928ff6"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/dgraph-io/dgo.git"
     revision: "939c270eac93a70e63162abd53f78dbc9e928ff6"
     path: ""
@@ -96,7 +96,7 @@ packages:
     revision: "342cbe0a04158f6dcb03ca0079991a51a4248c02"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/gogo/protobuf.git"
     revision: "342cbe0a04158f6dcb03ca0079991a51a4248c02"
     path: ""
@@ -118,7 +118,7 @@ packages:
     revision: "925541529c1fa6821df4e44ce2723319eb2be768"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/golang/protobuf.git"
     revision: "925541529c1fa6821df4e44ce2723319eb2be768"
     path: ""
@@ -140,7 +140,7 @@ packages:
     revision: "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/inconshreveable/mousetrap.git"
     revision: "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
     path: ""
@@ -162,7 +162,7 @@ packages:
     revision: "645ef00459ed84a119197bfb8d8205042c6df63d"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/pkg/errors.git"
     revision: "645ef00459ed84a119197bfb8d8205042c6df63d"
     path: ""
@@ -184,7 +184,7 @@ packages:
     revision: "7b2c5ac9fc04fc5efafb60700713d4fa609b777b"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/spf13/cobra.git"
     revision: "7b2c5ac9fc04fc5efafb60700713d4fa609b777b"
     path: ""
@@ -206,7 +206,7 @@ packages:
     revision: "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/spf13/pflag.git"
     revision: "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
     path: ""
@@ -228,7 +228,7 @@ packages:
     revision: "b417086c80e91bfa321ef761574721644b8b9f61"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://go.googlesource.com/net"
     revision: "b417086c80e91bfa321ef761574721644b8b9f61"
     path: ""
@@ -250,7 +250,7 @@ packages:
     revision: "e19ae1496984b1c655b8044a65c0300a3c878dd3"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://go.googlesource.com/text"
     revision: "e19ae1496984b1c655b8044a65c0300a3c878dd3"
     path: ""
@@ -272,7 +272,7 @@ packages:
     revision: "4eb30f4778eed4c258ba66527a0d4f9ec8a36c45"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/google/go-genproto.git"
     revision: "4eb30f4778eed4c258ba66527a0d4f9ec8a36c45"
     path: ""
@@ -294,7 +294,7 @@ packages:
     revision: "6b51017f791ae1cfbec89c52efdf444b13b550ef"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/grpc/grpc-go.git"
     revision: "6b51017f791ae1cfbec89c52efdf444b13b550ef"
     path: ""
@@ -316,7 +316,7 @@ packages:
     revision: "d670f9405373e636a5a2765eea47fac0c9bc91a4"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://gopkg.in/yaml.v2"
     revision: "d670f9405373e636a5a2765eea47fac0c9bc91a4"
     path: ""

--- a/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
@@ -12,7 +12,7 @@ project:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/spdx/tools-python.git"
     revision: "a48022e65a8897d0e4f2e93d8e53695d2c13ea23"
     path: ""

--- a/analyzer/src/funTest/assets/projects/external/sprig-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/sprig-expected-output.yml
@@ -10,7 +10,7 @@ project:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/Masterminds/sprig.git"
     revision: "9d9aa1f74c86fd9d36ecfe3f2a44a3093c3d4c15"
     path: ""
@@ -65,7 +65,7 @@ packages:
     revision: "59c29afe1a994eacb71c833025ca7acf874bb1da"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/Masterminds/semver.git"
     revision: "59c29afe1a994eacb71c833025ca7acf874bb1da"
     path: ""
@@ -87,7 +87,7 @@ packages:
     revision: "9c37978a95bd5c709a15883b6242714ea6709e64"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/aokoli/goutils.git"
     revision: "9c37978a95bd5c709a15883b6242714ea6709e64"
     path: ""
@@ -109,7 +109,7 @@ packages:
     revision: "5215b55f46b2b919f50a1df0eaa5886afe4e3b3d"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/davecgh/go-spew.git"
     revision: "5215b55f46b2b919f50a1df0eaa5886afe4e3b3d"
     path: ""
@@ -131,7 +131,7 @@ packages:
     revision: "3959339b333561bf62a38b424fd41517c2c90f40"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/huandu/xstrings.git"
     revision: "3959339b333561bf62a38b424fd41517c2c90f40"
     path: ""
@@ -153,7 +153,7 @@ packages:
     revision: "3e95a51e0639b4cf372f2ccf74c86749d747fbdc"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/imdario/mergo.git"
     revision: "3e95a51e0639b4cf372f2ccf74c86749d747fbdc"
     path: ""
@@ -175,7 +175,7 @@ packages:
     revision: "d8ed2627bdf02c080bf22230dbb337003b7aba2d"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/pmezard/go-difflib.git"
     revision: "d8ed2627bdf02c080bf22230dbb337003b7aba2d"
     path: ""
@@ -197,7 +197,7 @@ packages:
     revision: "879c5887cd475cd7864858769793b2ceb0d44feb"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/satori/go.uuid.git"
     revision: "879c5887cd475cd7864858769793b2ceb0d44feb"
     path: ""
@@ -219,7 +219,7 @@ packages:
     revision: "e3a8ff8ce36581f87a15341206f205b1da467059"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/stretchr/testify.git"
     revision: "e3a8ff8ce36581f87a15341206f205b1da467059"
     path: ""
@@ -241,7 +241,7 @@ packages:
     revision: "d172538b2cfce0c13cee31e647d0367aa8cd2486"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://go.googlesource.com/crypto"
     revision: "d172538b2cfce0c13cee31e647d0367aa8cd2486"
     path: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
@@ -9,7 +9,7 @@ repository:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
@@ -23,7 +23,7 @@ projects:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
@@ -38,7 +38,7 @@ projects:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app"
@@ -143,7 +143,7 @@ projects:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo"
@@ -223,7 +223,7 @@ projects:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
@@ -340,7 +340,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
@@ -364,7 +364,7 @@ packages:
     revision: "r4.12"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/junit-team/junit.git"
     revision: "r4.12"
     path: ""
@@ -461,7 +461,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
     revision: ""
     path: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-2.14.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-2.14.yml
@@ -10,7 +10,7 @@ project:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "<REPLACE_URL>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app"
@@ -143,7 +143,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "<REPLACE_URL>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-3.4.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-3.4.yml
@@ -10,7 +10,7 @@ project:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "<REPLACE_URL>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app"
@@ -119,7 +119,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "<REPLACE_URL>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
@@ -10,7 +10,7 @@ project:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "<REPLACE_URL>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app"
@@ -125,7 +125,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "<REPLACE_URL>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
@@ -10,7 +10,7 @@ project:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "<REPLACE_URL>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
@@ -10,7 +10,7 @@ project:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "<REPLACE_URL>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
@@ -124,7 +124,7 @@ packages:
     revision: "r4.12"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/junit-team/junit.git"
     revision: "r4.12"
     path: ""
@@ -221,7 +221,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
     revision: ""
     path: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-root.yml
@@ -10,7 +10,7 @@ project:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "<REPLACE_URL>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-unsupported-version.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-unsupported-version.yml
@@ -10,7 +10,7 @@ project:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "<REPLACE_URL>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle-unsupported-version"

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-app.yml
@@ -10,7 +10,7 @@ project:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "<REPLACE_URL>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/maven/app"
@@ -53,7 +53,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "<REPLACE_URL>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/maven/lib"
@@ -150,7 +150,7 @@ packages:
     revision: "version-number-1.4"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jenkinsci/lib-version-number.git"
     revision: "version-number-1.4"
     path: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-lib.yml
@@ -10,7 +10,7 @@ project:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "<REPLACE_URL>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/maven/lib"
@@ -155,7 +155,7 @@ packages:
     revision: "version-number-1.4"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jenkinsci/lib-version-number.git"
     revision: "version-number-1.4"
     path: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-root.yml
@@ -10,7 +10,7 @@ project:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "<REPLACE_URL>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/maven"

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-parent-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-parent-expected-output-root.yml
@@ -11,7 +11,7 @@ project:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "<REPLACE_URL>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/maven-parent"

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
@@ -11,7 +11,7 @@ project:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "<REPLACE_URL>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/npm-babel"
@@ -1654,7 +1654,7 @@ packages:
     revision: "7c908e7b4eb6cd82bfe1295e33fdf6d166c7ed85"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/chalk/ansi-regex.git"
     revision: "7c908e7b4eb6cd82bfe1295e33fdf6d166c7ed85"
     path: ""
@@ -1677,7 +1677,7 @@ packages:
     revision: "95c59b23be760108b6530ca1c89477c21b258032"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/chalk/ansi-styles.git"
     revision: "95c59b23be760108b6530ca1c89477c21b258032"
     path: ""
@@ -1701,7 +1701,7 @@ packages:
     revision: "a16f5bd07f1e36c4eef08c1291c6c119d1663639"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/es128/anymatch.git"
     revision: "a16f5bd07f1e36c4eef08c1291c6c119d1663639"
     path: ""
@@ -1725,7 +1725,7 @@ packages:
     revision: "b89f54eb88ca51afd0e0ea6be9a4a63e5ccecf27"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jonschlinkert/arr-diff.git"
     revision: "b89f54eb88ca51afd0e0ea6be9a4a63e5ccecf27"
     path: ""
@@ -1748,7 +1748,7 @@ packages:
     revision: "76a1ae28b03fdb1cbe5d49fa521bc4807b9f94d3"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jonschlinkert/arr-flatten.git"
     revision: "76a1ae28b03fdb1cbe5d49fa521bc4807b9f94d3"
     path: ""
@@ -1771,7 +1771,7 @@ packages:
     revision: "36fde8e586fb7cf880b8b3aa6515df889e64ed85"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jonschlinkert/array-unique.git"
     revision: "36fde8e586fb7cf880b8b3aa6515df889e64ed85"
     path: ""
@@ -1795,7 +1795,7 @@ packages:
     revision: "f2342d85633d0dc1034a49387ca01c08c1189823"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/paulmillr/async-each.git"
     revision: "f2342d85633d0dc1034a49387ca01c08c1189823"
     path: ""
@@ -1818,7 +1818,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/babel/babel.git"
     revision: "master"
     path: "packages/babel-cli"
@@ -1841,7 +1841,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/babel/babel.git"
     revision: "master"
     path: "packages/babel-code-frame"
@@ -1864,7 +1864,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/babel/babel.git"
     revision: "master"
     path: "packages/babel-core"
@@ -1887,7 +1887,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/babel/babel.git"
     revision: "master"
     path: "packages/babel-generator"
@@ -1910,7 +1910,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/babel/babel.git"
     revision: "master"
     path: "packages/babel-helpers"
@@ -1933,7 +1933,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/babel/babel.git"
     revision: "master"
     path: "packages/babel-messages"
@@ -1956,7 +1956,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/babel/babel.git"
     revision: "master"
     path: "packages/babel-polyfill"
@@ -1979,7 +1979,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/babel/babel.git"
     revision: "master"
     path: "packages/babel-register"
@@ -2002,7 +2002,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/babel/babel.git"
     revision: "master"
     path: "packages/babel-runtime"
@@ -2025,7 +2025,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/babel/babel.git"
     revision: "master"
     path: "packages/babel-template"
@@ -2049,7 +2049,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/babel/babel.git"
     revision: "master"
     path: "packages/babel-traverse"
@@ -2072,7 +2072,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/babel/babel.git"
     revision: "master"
     path: "packages/babel-types"
@@ -2095,7 +2095,7 @@ packages:
     revision: "da66d3f65b0d305c0bb042873d57f26f0c0b0538"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/babel/babylon.git"
     revision: "da66d3f65b0d305c0bb042873d57f26f0c0b0538"
     path: ""
@@ -2118,7 +2118,7 @@ packages:
     revision: "d701a549a7653a874eebce7eca25d3577dc868ac"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/juliangruber/balanced-match.git"
     revision: "d701a549a7653a874eebce7eca25d3577dc868ac"
     path: ""
@@ -2141,7 +2141,7 @@ packages:
     revision: "a2370df9507ac5c618c32334ea259370b34ad3be"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/sindresorhus/binary-extensions.git"
     revision: "a2370df9507ac5c618c32334ea259370b34ad3be"
     path: ""
@@ -2164,7 +2164,7 @@ packages:
     revision: "8f59e68bd5c915a0d624e8e39354e1ccf672edf6"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/juliangruber/brace-expansion.git"
     revision: "8f59e68bd5c915a0d624e8e39354e1ccf672edf6"
     path: ""
@@ -2188,7 +2188,7 @@ packages:
     revision: "24874614ebeda1c5405180f1f6c9f374bcf384ce"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jonschlinkert/braces.git"
     revision: "24874614ebeda1c5405180f1f6c9f374bcf384ce"
     path: ""
@@ -2211,7 +2211,7 @@ packages:
     revision: "0d8d8c204eb87a4038219131ad4d8369c9f59d24"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/chalk/chalk.git"
     revision: "0d8d8c204eb87a4038219131ad4d8369c9f59d24"
     path: ""
@@ -2234,7 +2234,7 @@ packages:
     revision: "3b1071a6dd82397842f4f7dc63b72c703bd06275"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/paulmillr/chokidar.git"
     revision: "3b1071a6dd82397842f4f7dc63b72c703bd06275"
     path: ""
@@ -2257,7 +2257,7 @@ packages:
     revision: "6864c953d781d4f665afecbdace84d9d80e45060"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/tj/commander.js.git"
     revision: "6864c953d781d4f665afecbdace84d9d80e45060"
     path: ""
@@ -2280,7 +2280,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/substack/node-concat-map.git"
     revision: ""
     path: ""
@@ -2304,7 +2304,7 @@ packages:
     revision: "0771098071f3b7c48ec6604291cad28b3b679d02"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/thlorenz/convert-source-map.git"
     revision: "0771098071f3b7c48ec6604291cad28b3b679d02"
     path: ""
@@ -2327,7 +2327,7 @@ packages:
     revision: "a03fd191eaea071fa56eb6a1a806470272deb9d7"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/zloirock/core-js.git"
     revision: "a03fd191eaea071fa56eb6a1a806470272deb9d7"
     path: ""
@@ -2350,7 +2350,7 @@ packages:
     revision: "a177da234df5638b363ddc15fa324619a38577c8"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/isaacs/core-util-is.git"
     revision: "a177da234df5638b363ddc15fa324619a38577c8"
     path: ""
@@ -2373,7 +2373,7 @@ packages:
     revision: "13abeae468fea297d0dccc50bc55590809241083"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/visionmedia/debug.git"
     revision: "13abeae468fea297d0dccc50bc55590809241083"
     path: ""
@@ -2396,7 +2396,7 @@ packages:
     revision: "dbbc78fcb37907116eb120a8324070a1df0e8d86"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/sindresorhus/detect-indent.git"
     revision: "dbbc78fcb37907116eb120a8324070a1df0e8d86"
     path: ""
@@ -2419,7 +2419,7 @@ packages:
     revision: "db124a3e1aae9d692c4899e42a5c6c3e329eaa20"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/sindresorhus/escape-string-regexp.git"
     revision: "db124a3e1aae9d692c4899e42a5c6c3e329eaa20"
     path: ""
@@ -2442,7 +2442,7 @@ packages:
     revision: "3ffd1c403f3f29db9e8a9574b1895682e57b6a7f"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/estools/esutils.git"
     revision: "3ffd1c403f3f29db9e8a9574b1895682e57b6a7f"
     path: ""
@@ -2465,7 +2465,7 @@ packages:
     revision: "1b07fda8ee8b6426d95e6539785b74c57e9ee542"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jonschlinkert/expand-brackets.git"
     revision: "1b07fda8ee8b6426d95e6539785b74c57e9ee542"
     path: ""
@@ -2489,7 +2489,7 @@ packages:
     revision: "4c873af0870df8382bafc66a93d5c89e3aad3d4d"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jonschlinkert/expand-range.git"
     revision: "4c873af0870df8382bafc66a93d5c89e3aad3d4d"
     path: ""
@@ -2513,7 +2513,7 @@ packages:
     revision: "8c3f38bbd9e0afaf31a87e411c0d15532434ef41"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jonschlinkert/extglob.git"
     revision: "8c3f38bbd9e0afaf31a87e411c0d15532434ef41"
     path: ""
@@ -2536,7 +2536,7 @@ packages:
     revision: "821fec482acdb1ce3f23a804ce8a86724d02b4e6"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/regexhq/filename-regex.git"
     revision: "821fec482acdb1ce3f23a804ce8a86724d02b4e6"
     path: ""
@@ -2560,7 +2560,7 @@ packages:
     revision: "6cb50d5c679d9e6d9e8ad97bb2efd63a8c8da610"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jonschlinkert/fill-range.git"
     revision: "6cb50d5c679d9e6d9e8ad97bb2efd63a8c8da610"
     path: ""
@@ -2585,7 +2585,7 @@ packages:
     revision: "5f97ad4f6556e938d9b71614259ddd8044a081e3"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jonschlinkert/for-in.git"
     revision: "5f97ad4f6556e938d9b71614259ddd8044a081e3"
     path: ""
@@ -2610,7 +2610,7 @@ packages:
     revision: "e64ee3492f218c812011ec3feff4194e9272d2a1"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jonschlinkert/for-own.git"
     revision: "e64ee3492f218c812011ec3feff4194e9272d2a1"
     path: ""
@@ -2633,7 +2633,7 @@ packages:
     revision: "f810b44477696081ebef9c0d5eafb24005c8e82b"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/fs-utils/fs-readdir-recursive.git"
     revision: "f810b44477696081ebef9c0d5eafb24005c8e82b"
     path: ""
@@ -2657,7 +2657,7 @@ packages:
     revision: "03e7c884431fe185dfebbc9b771aeca339c1807a"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/isaacs/fs.realpath.git"
     revision: "03e7c884431fe185dfebbc9b771aeca339c1807a"
     path: ""
@@ -2680,7 +2680,7 @@ packages:
     revision: "adbc0ab07ec8a85f76ffd1b54dd41cdb9d1d0b83"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jonschlinkert/glob-base.git"
     revision: "adbc0ab07ec8a85f76ffd1b54dd41cdb9d1d0b83"
     path: ""
@@ -2703,7 +2703,7 @@ packages:
     revision: "a956910c7ccb5eafd1b3fe900ceb6335cc5b6d3d"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/es128/glob-parent.git"
     revision: "a956910c7ccb5eafd1b3fe900ceb6335cc5b6d3d"
     path: ""
@@ -2726,7 +2726,7 @@ packages:
     revision: "8fa8d561e08c9eed1d286c6a35be2cd8123b2fb7"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/isaacs/node-glob.git"
     revision: "8fa8d561e08c9eed1d286c6a35be2cd8123b2fb7"
     path: ""
@@ -2749,7 +2749,7 @@ packages:
     revision: "09ba8754235e5953507b8d0543d65098bc7bb78d"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/sindresorhus/globals.git"
     revision: "09ba8754235e5953507b8d0543d65098bc7bb78d"
     path: ""
@@ -2772,7 +2772,7 @@ packages:
     revision: "65cf80d1fd3413b823c16c626c1e7c326452bee5"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/isaacs/node-graceful-fs.git"
     revision: "65cf80d1fd3413b823c16c626c1e7c326452bee5"
     path: ""
@@ -2795,7 +2795,7 @@ packages:
     revision: "0722275e1bef139fcd09137da6e5550c3cd368b9"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/sindresorhus/has-ansi.git"
     revision: "0722275e1bef139fcd09137da6e5550c3cd368b9"
     path: ""
@@ -2818,7 +2818,7 @@ packages:
     revision: "dd1411a0b2531a4e2c592ae733fd45dd0f9c7163"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/sindresorhus/home-or-tmp.git"
     revision: "dd1411a0b2531a4e2c592ae733fd45dd0f9c7163"
     path: ""
@@ -2841,7 +2841,7 @@ packages:
     revision: "a547881738c8f57b27795e584071d67cf6ac1a57"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/npm/inflight.git"
     revision: "a547881738c8f57b27795e584071d67cf6ac1a57"
     path: ""
@@ -2865,7 +2865,7 @@ packages:
     revision: "e05d0fb27c61a3ec687214f0476386b765364d5f"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/isaacs/inherits.git"
     revision: "e05d0fb27c61a3ec687214f0476386b765364d5f"
     path: ""
@@ -2888,7 +2888,7 @@ packages:
     revision: "49ae54d5a09c99a447e7dafa46bd3aa8f6923d98"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/zertosh/invariant.git"
     revision: "49ae54d5a09c99a447e7dafa46bd3aa8f6923d98"
     path: ""
@@ -2911,7 +2911,7 @@ packages:
     revision: "ed26bd7be5e29dad159c2771cb99dd48913f9de0"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/sindresorhus/is-binary-path.git"
     revision: "ed26bd7be5e29dad159c2771cb99dd48913f9de0"
     path: ""
@@ -2934,7 +2934,7 @@ packages:
     revision: "1e84e7ee31cf6b660b12500f3111a05501da387f"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/feross/is-buffer.git"
     revision: "1e84e7ee31cf6b660b12500f3111a05501da387f"
     path: ""
@@ -2958,7 +2958,7 @@ packages:
     revision: "1548d0045c182dfb0ac7b747e2d484dcd382b09d"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jonschlinkert/is-dotfile.git"
     revision: "1548d0045c182dfb0ac7b747e2d484dcd382b09d"
     path: ""
@@ -2982,7 +2982,7 @@ packages:
     revision: "dceb47dd9c9c21066958116e3b54b3c8c251ee4a"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jonschlinkert/is-equal-shallow.git"
     revision: "dceb47dd9c9c21066958116e3b54b3c8c251ee4a"
     path: ""
@@ -3007,7 +3007,7 @@ packages:
     revision: "c36a0732e6a76931c6f66c5931d1f3e54fa44380"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jonschlinkert/is-extendable.git"
     revision: "c36a0732e6a76931c6f66c5931d1f3e54fa44380"
     path: ""
@@ -3030,7 +3030,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jonschlinkert/is-extglob.git"
     revision: ""
     path: ""
@@ -3053,7 +3053,7 @@ packages:
     revision: "43f8bb814834d8573d11ba4a631d19006d0c8897"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/sindresorhus/is-finite.git"
     revision: "43f8bb814834d8573d11ba4a631d19006d0c8897"
     path: ""
@@ -3079,7 +3079,7 @@ packages:
     revision: "d7db1b2dd559b3d5a73f89dbe72d9e9f4d6587d7"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jonschlinkert/is-glob.git"
     revision: "d7db1b2dd559b3d5a73f89dbe72d9e9f4d6587d7"
     path: ""
@@ -3102,7 +3102,7 @@ packages:
     revision: "d06c6e2cc048d3cad016cb8dfb055bb14d86fffa"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jonschlinkert/is-number.git"
     revision: "d06c6e2cc048d3cad016cb8dfb055bb14d86fffa"
     path: ""
@@ -3125,7 +3125,7 @@ packages:
     revision: "af885e2e890b9ef0875edd2b117305119ee5bdc5"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jonschlinkert/is-number.git"
     revision: "af885e2e890b9ef0875edd2b117305119ee5bdc5"
     path: ""
@@ -3149,7 +3149,7 @@ packages:
     revision: "43972556cfdbb681a15072da75c97952c4e4deba"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jonschlinkert/is-posix-bracket.git"
     revision: "43972556cfdbb681a15072da75c97952c4e4deba"
     path: ""
@@ -3172,7 +3172,7 @@ packages:
     revision: "c512b7c95fb049aa9b1f039ddc0670611b66cce2"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jonschlinkert/is-primitive.git"
     revision: "c512b7c95fb049aa9b1f039ddc0670611b66cce2"
     path: ""
@@ -3195,7 +3195,7 @@ packages:
     revision: "2a23a281f369e9ae06394c0fb4d2381355a6ba33"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/juliangruber/isarray.git"
     revision: "2a23a281f369e9ae06394c0fb4d2381355a6ba33"
     path: ""
@@ -3218,7 +3218,7 @@ packages:
     revision: "d693ec8d31b02b42a19b2d806407a4ecb2f9fb73"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jonschlinkert/isobject.git"
     revision: "d693ec8d31b02b42a19b2d806407a4ecb2f9fb73"
     path: ""
@@ -3241,7 +3241,7 @@ packages:
     revision: "8315904c840b14d28de1b0a4968194555f61bea3"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/lydell/js-tokens.git"
     revision: "8315904c840b14d28de1b0a4968194555f61bea3"
     path: ""
@@ -3265,7 +3265,7 @@ packages:
     revision: "2c43a8a223e297155b2b2ccca344df4d6ee4233c"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/mathiasbynens/jsesc.git"
     revision: "2c43a8a223e297155b2b2ccca344df4d6ee4233c"
     path: ""
@@ -3288,7 +3288,7 @@ packages:
     revision: "6be6a70e250e6fbbf42db75cd1f6a1aadeeeeb07"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/aseemk/json5.git"
     revision: "6be6a70e250e6fbbf42db75cd1f6a1aadeeeeb07"
     path: ""
@@ -3311,7 +3311,7 @@ packages:
     revision: "0ffe67cf12f5396047c1bacf04232b7deeb24063"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jonschlinkert/kind-of.git"
     revision: "0ffe67cf12f5396047c1bacf04232b7deeb24063"
     path: ""
@@ -3334,7 +3334,7 @@ packages:
     revision: "30bee16e8dffa67417ba35d31bd9bc31517a2d83"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jonschlinkert/kind-of.git"
     revision: "30bee16e8dffa67417ba35d31bd9bc31517a2d83"
     path: ""
@@ -3357,7 +3357,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/lodash/lodash.git"
     revision: ""
     path: ""
@@ -3381,7 +3381,7 @@ packages:
     revision: "7b2d41e61a7ddba5335154b4aba327f6e850f7fd"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/zertosh/loose-envify.git"
     revision: "7b2d41e61a7ddba5335154b4aba327f6e850f7fd"
     path: ""
@@ -3405,7 +3405,7 @@ packages:
     revision: "f194c187d04677b03047bb7d8d25643725f7a577"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jonschlinkert/micromatch.git"
     revision: "f194c187d04677b03047bb7d8d25643725f7a577"
     path: ""
@@ -3428,7 +3428,7 @@ packages:
     revision: "e46989a323d5f0aa4781eff5e2e6e7aafa223321"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/isaacs/minimatch.git"
     revision: "e46989a323d5f0aa4781eff5e2e6e7aafa223321"
     path: ""
@@ -3451,7 +3451,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/substack/minimist.git"
     revision: ""
     path: ""
@@ -3474,7 +3474,7 @@ packages:
     revision: "d4eff0f06093aed4f387e88e9fc301cb76beedc7"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/substack/node-mkdirp.git"
     revision: "d4eff0f06093aed4f387e88e9fc301cb76beedc7"
     path: ""
@@ -3497,7 +3497,7 @@ packages:
     revision: "9b88d1568a52ec9bb67ecc8d2aa224fa38fd41f4"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/zeit/ms.git"
     revision: "9b88d1568a52ec9bb67ecc8d2aa224fa38fd41f4"
     path: ""
@@ -3522,7 +3522,7 @@ packages:
     revision: "da1a45e7a514910ce39875b5327b1d0fa9be3d3e"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jonschlinkert/normalize-path.git"
     revision: "da1a45e7a514910ce39875b5327b1d0fa9be3d3e"
     path: ""
@@ -3545,7 +3545,7 @@ packages:
     revision: "ed9cdac3f428cc929b61bb230da42c87477af4b9"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/sindresorhus/number-is-nan.git"
     revision: "ed9cdac3f428cc929b61bb230da42c87477af4b9"
     path: ""
@@ -3568,7 +3568,7 @@ packages:
     revision: "a89774b252c91612203876984bbd6addbe3b5a0e"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/sindresorhus/object-assign.git"
     revision: "a89774b252c91612203876984bbd6addbe3b5a0e"
     path: ""
@@ -3592,7 +3592,7 @@ packages:
     revision: "6634673e6e88c65796f1df4bcb787dede6dc7ffc"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jonschlinkert/object.omit.git"
     revision: "6634673e6e88c65796f1df4bcb787dede6dc7ffc"
     path: ""
@@ -3615,7 +3615,7 @@ packages:
     revision: "0e614d9f5a7e6f0305c625f6b581f6d80b33b8a6"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/isaacs/once.git"
     revision: "0e614d9f5a7e6f0305c625f6b581f6d80b33b8a6"
     path: ""
@@ -3638,7 +3638,7 @@ packages:
     revision: "b1b0ae70a5965fef7005ff6509a5dd1a78c95e36"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/sindresorhus/os-homedir.git"
     revision: "b1b0ae70a5965fef7005ff6509a5dd1a78c95e36"
     path: ""
@@ -3661,7 +3661,7 @@ packages:
     revision: "1abf9cf5611b4be7377060ea67054b45cbf6813c"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/sindresorhus/os-tmpdir.git"
     revision: "1abf9cf5611b4be7377060ea67054b45cbf6813c"
     path: ""
@@ -3685,7 +3685,7 @@ packages:
     revision: "42d4b6792bbaee919805b2cb9afc95233addb239"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/shinnn/output-file-sync.git"
     revision: "42d4b6792bbaee919805b2cb9afc95233addb239"
     path: ""
@@ -3708,7 +3708,7 @@ packages:
     revision: "9bfccb63acdeb3b1ed62035b3adef0e5081d8fc6"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jonschlinkert/parse-glob.git"
     revision: "9bfccb63acdeb3b1ed62035b3adef0e5081d8fc6"
     path: ""
@@ -3731,7 +3731,7 @@ packages:
     revision: "edc91d348b21dac2ab65ea2fbec2868e2eff5eb6"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/sindresorhus/path-is-absolute.git"
     revision: "edc91d348b21dac2ab65ea2fbec2868e2eff5eb6"
     path: ""
@@ -3755,7 +3755,7 @@ packages:
     revision: "1bf405d35e4aea06a2ee83db2d34dc54abc0a1f9"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jonschlinkert/preserve.git"
     revision: "1bf405d35e4aea06a2ee83db2d34dc54abc0a1f9"
     path: ""
@@ -3778,7 +3778,7 @@ packages:
     revision: "8fde2c4c9f760c0ae17f3ff375c02d6498472fbc"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/benjamn/private.git"
     revision: "8fde2c4c9f760c0ae17f3ff375c02d6498472fbc"
     path: ""
@@ -3801,7 +3801,7 @@ packages:
     revision: "5c00899ab01dd32f93ad4b5743da33da91404f39"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/calvinmetcalf/process-nextick-args.git"
     revision: "5c00899ab01dd32f93ad4b5743da33da91404f39"
     path: ""
@@ -3826,7 +3826,7 @@ packages:
     revision: "d91c5f90e785db08a9b9e518926b444671092f26"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jonschlinkert/randomatic.git"
     revision: "d91c5f90e785db08a9b9e518926b444671092f26"
     path: ""
@@ -3849,7 +3849,7 @@ packages:
     revision: "cd59995050105b946884ee20e3bcadc252feda8c"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/nodejs/readable-stream.git"
     revision: "cd59995050105b946884ee20e3bcadc252feda8c"
     path: ""
@@ -3872,7 +3872,7 @@ packages:
     revision: "5a3751f86a1c2bbbb8e3a42685d4191992631e6c"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/thlorenz/readdirp.git"
     revision: "5a3751f86a1c2bbbb8e3a42685d4191992631e6c"
     path: ""
@@ -3895,7 +3895,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/facebook/regenerator.git"
     revision: "master"
     path: "packages/regenerator-runtime"
@@ -3918,7 +3918,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/facebook/regenerator.git"
     revision: "master"
     path: "packages/regenerator-runtime"
@@ -3943,7 +3943,7 @@ packages:
     revision: "e5ced08e45d2cc2d286a9e7b5a574963f6577712"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jonschlinkert/regex-cache.git"
     revision: "e5ced08e45d2cc2d286a9e7b5a574963f6577712"
     path: ""
@@ -3966,7 +3966,7 @@ packages:
     revision: "f4e8acca09106efeef5a5164f1ad2192fe97fd69"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/darsain/remove-trailing-separator.git"
     revision: "f4e8acca09106efeef5a5164f1ad2192fe97fd69"
     path: ""
@@ -3989,7 +3989,7 @@ packages:
     revision: "7a6b21d58eafcc44fc8de133c70a8398ee9fdd8d"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jonschlinkert/repeat-element.git"
     revision: "7a6b21d58eafcc44fc8de133c70a8398ee9fdd8d"
     path: ""
@@ -4013,7 +4013,7 @@ packages:
     revision: "1a95c5d99a02999ccd2cf4663959a18bd2def7b8"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jonschlinkert/repeat-string.git"
     revision: "1a95c5d99a02999ccd2cf4663959a18bd2def7b8"
     path: ""
@@ -4036,7 +4036,7 @@ packages:
     revision: "be02bcaf9a674b3c155477b3bf282136bcf44770"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/sindresorhus/repeating.git"
     revision: "be02bcaf9a674b3c155477b3bf282136bcf44770"
     path: ""
@@ -4059,7 +4059,7 @@ packages:
     revision: "5261e0c19dd820c31dd21cb4116902b0ed0f9e57"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/feross/safe-buffer.git"
     revision: "5261e0c19dd820c31dd21cb4116902b0ed0f9e57"
     path: ""
@@ -4082,7 +4082,7 @@ packages:
     revision: "4c50df7ade5a368e106fee82351ee0a378c990f7"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/sindresorhus/set-immediate-shim.git"
     revision: "4c50df7ade5a368e106fee82351ee0a378c990f7"
     path: ""
@@ -4105,7 +4105,7 @@ packages:
     revision: "c801dd4568ad9380b534067eabe88942394f82ff"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/sindresorhus/slash.git"
     revision: "c801dd4568ad9380b534067eabe88942394f82ff"
     path: ""
@@ -4128,7 +4128,7 @@ packages:
     revision: "b9b5a5576272916237a253393220770c858685d6"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/evanw/node-source-map-support.git"
     revision: "b9b5a5576272916237a253393220770c858685d6"
     path: ""
@@ -4151,7 +4151,7 @@ packages:
     revision: "326dd955a366569759d9537ef5f0f167c89d92d2"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "ssh://git@github.com/mozilla/source-map.git"
     revision: "326dd955a366569759d9537ef5f0f167c89d92d2"
     path: ""
@@ -4174,7 +4174,7 @@ packages:
     revision: "e97f24dd3d047b72b9836518e2a0788e2a6a2fdb"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/rvagg/string_decoder.git"
     revision: "e97f24dd3d047b72b9836518e2a0788e2a6a2fdb"
     path: ""
@@ -4197,7 +4197,7 @@ packages:
     revision: "8270705c704956da865623e564eba4875c3ea17f"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/chalk/strip-ansi.git"
     revision: "8270705c704956da865623e564eba4875c3ea17f"
     path: ""
@@ -4220,7 +4220,7 @@ packages:
     revision: "8400d98ade32b2adffd50902c06d9e725a5c6588"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/chalk/supports-color.git"
     revision: "8400d98ade32b2adffd50902c06d9e725a5c6588"
     path: ""
@@ -4243,7 +4243,7 @@ packages:
     revision: "76e30a0b6040781a705cb351fb2e4a1d879f1adb"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/sindresorhus/to-fast-properties.git"
     revision: "76e30a0b6040781a705cb351fb2e4a1d879f1adb"
     path: ""
@@ -4266,7 +4266,7 @@ packages:
     revision: "105fb46669afb0deb49d14bd688b276297e59dff"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/sindresorhus/trim-right.git"
     revision: "105fb46669afb0deb49d14bd688b276297e59dff"
     path: ""
@@ -4289,7 +4289,7 @@ packages:
     revision: "cf6ba885d3e6bf625fb3c15ad0334fa623968481"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/sindresorhus/user-home.git"
     revision: "cf6ba885d3e6bf625fb3c15ad0334fa623968481"
     path: ""
@@ -4312,7 +4312,7 @@ packages:
     revision: "475fb6857cd23fafff20c1be846c1350abf8e6d4"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/TooTallNate/util-deprecate.git"
     revision: "475fb6857cd23fafff20c1be846c1350abf8e6d4"
     path: ""
@@ -4335,7 +4335,7 @@ packages:
     revision: "4c628146efa7eda11df0e10c73b3d8687873569e"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/tkellen/node-v8flags.git"
     revision: "4c628146efa7eda11df0e10c73b3d8687873569e"
     path: ""
@@ -4358,7 +4358,7 @@ packages:
     revision: "71d91b6dc5bdeac37e218c2cf03f9ab55b60d214"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/npm/wrappy.git"
     revision: "71d91b6dc5bdeac37e218c2cf03f9ab55b60d214"
     path: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output.yml
@@ -11,7 +11,7 @@ project:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "<REPLACE_URL>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
@@ -211,7 +211,7 @@ packages:
     revision: "e7f3d29eed4967ecfcaddbfc9542e2ee12b76227"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/kriskowal/asap.git"
     revision: "e7f3d29eed4967ecfcaddbfc9542e2ee12b76227"
     path: ""
@@ -234,7 +234,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/fb55/boolbase.git"
     revision: ""
     path: ""
@@ -258,7 +258,7 @@ packages:
     revision: "f21ffef971826d1ba64ccbdf96adbc44964d30c5"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/cheeriojs/cheerio.git"
     revision: "f21ffef971826d1ba64ccbdf96adbc44964d30c5"
     path: ""
@@ -281,7 +281,7 @@ packages:
     revision: "f0e9837dca51244ef994ff535768d3a606912020"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/jashkenas/coffeescript.git"
     revision: "f0e9837dca51244ef994ff535768d3a606912020"
     path: ""
@@ -304,7 +304,7 @@ packages:
     revision: "a177da234df5638b363ddc15fa324619a38577c8"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/isaacs/core-util-is.git"
     revision: "a177da234df5638b363ddc15fa324619a38577c8"
     path: ""
@@ -327,7 +327,7 @@ packages:
     revision: "fa37e04bc6c516eb76ef01df2d105a413c0253a0"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "ssh://git@github.com/groupon/cson-parser.git"
     revision: "fa37e04bc6c516eb76ef01df2d105a413c0253a0"
     path: ""
@@ -351,7 +351,7 @@ packages:
     revision: "0e913a90be66b2f29d2d75433b06ed52e83ba810"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/bevry/cson.git"
     revision: "0e913a90be66b2f29d2d75433b06ed52e83ba810"
     path: ""
@@ -374,7 +374,7 @@ packages:
     revision: "09c405d8296bd97a660256604d8cdfb23fca47b6"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/fb55/css-select.git"
     revision: "09c405d8296bd97a660256604d8cdfb23fca47b6"
     path: ""
@@ -397,7 +397,7 @@ packages:
     revision: "fd6b9f62146efec8e17ee80ddaebdfb6ede21d7b"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/fb55/css-what.git"
     revision: "fd6b9f62146efec8e17ee80ddaebdfb6ede21d7b"
     path: ""
@@ -420,7 +420,7 @@ packages:
     revision: "249b9a921e6ba318c52b87de21e8475bcb4050e5"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/cheeriojs/dom-renderer.git"
     revision: "249b9a921e6ba318c52b87de21e8475bcb4050e5"
     path: ""
@@ -442,7 +442,7 @@ packages:
     revision: "012a97a1d38737e096de2045b2b5f28768d8187e"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/FB55/domelementtype.git"
     revision: "012a97a1d38737e096de2045b2b5f28768d8187e"
     path: ""
@@ -464,7 +464,7 @@ packages:
     revision: "2a95eed4c829ef479a88984d117cb5f4b379e6e8"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/FB55/domelementtype.git"
     revision: "2a95eed4c829ef479a88984d117cb5f4b379e6e8"
     path: ""
@@ -487,7 +487,7 @@ packages:
     revision: "9b17cc6cc9387a87dde6eb8ddbae11c753e7d23d"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/fb55/DomHandler.git"
     revision: "9b17cc6cc9387a87dde6eb8ddbae11c753e7d23d"
     path: ""
@@ -509,7 +509,7 @@ packages:
     revision: "7d4bd16cd36ffce62362ef91616806ea27e30d95"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/FB55/domutils.git"
     revision: "7d4bd16cd36ffce62362ef91616806ea27e30d95"
     path: ""
@@ -534,7 +534,7 @@ packages:
     revision: "57ef794d001c16fd906b2558137e8ea51c1f6330"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "ssh://git@github.com/bevry/eachr.git"
     revision: "57ef794d001c16fd906b2558137e8ea51c1f6330"
     path: ""
@@ -558,7 +558,7 @@ packages:
     revision: "272530079d941652a2679cf2152e83ed2f3f2129"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/bevry/editions.git"
     revision: "272530079d941652a2679cf2152e83ed2f3f2129"
     path: ""
@@ -581,7 +581,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/fb55/node-entities.git"
     revision: ""
     path: ""
@@ -604,7 +604,7 @@ packages:
     revision: "87e349bbf92a6f95d1ecc8b064a1631def105dc8"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "ssh://git@github.com/bevry/extract-opts.git"
     revision: "87e349bbf92a6f95d1ecc8b064a1631def105dc8"
     path: ""
@@ -627,7 +627,7 @@ packages:
     revision: "65cf80d1fd3413b823c16c626c1e7c326452bee5"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/isaacs/node-graceful-fs.git"
     revision: "65cf80d1fd3413b823c16c626c1e7c326452bee5"
     path: ""
@@ -650,7 +650,7 @@ packages:
     revision: "e1f12f626f65cf4a082f89bdde89081b54187818"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/fb55/htmlparser2.git"
     revision: "e1f12f626f65cf4a082f89bdde89081b54187818"
     path: ""
@@ -674,7 +674,7 @@ packages:
     revision: "e05d0fb27c61a3ec687214f0476386b765364d5f"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/isaacs/inherits.git"
     revision: "e05d0fb27c61a3ec687214f0476386b765364d5f"
     path: ""
@@ -697,7 +697,7 @@ packages:
     revision: "2a23a281f369e9ae06394c0fb4d2381355a6ba33"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/juliangruber/isarray.git"
     revision: "2a23a281f369e9ae06394c0fb4d2381355a6ba33"
     path: ""
@@ -720,7 +720,7 @@ packages:
     revision: ""
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/lodash/lodash.git"
     revision: ""
     path: ""
@@ -743,7 +743,7 @@ packages:
     revision: "8cdc1f74ced4f771aa844f1cbc565b1d4c4451b8"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/dcodeIO/long.js.git"
     revision: "8cdc1f74ced4f771aa844f1cbc565b1d4c4451b8"
     path: ""
@@ -766,7 +766,7 @@ packages:
     revision: "257338e5bbd53228236abd4cc09539b66b27dd11"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/fb55/nth-check.git"
     revision: "257338e5bbd53228236abd4cc09539b66b27dd11"
     path: ""
@@ -790,7 +790,7 @@ packages:
     revision: "969ed22f53db38c101449e05a1b804ea456d4e04"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/inikulin/parse5.git"
     revision: "969ed22f53db38c101449e05a1b804ea456d4e04"
     path: ""
@@ -813,7 +813,7 @@ packages:
     revision: "5c00899ab01dd32f93ad4b5743da33da91404f39"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/calvinmetcalf/process-nextick-args.git"
     revision: "5c00899ab01dd32f93ad4b5743da33da91404f39"
     path: ""
@@ -836,7 +836,7 @@ packages:
     revision: "cebfa6049cc08843f428c6fc92dde918f8687e6d"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/then/promise.git"
     revision: "cebfa6049cc08843f428c6fc92dde918f8687e6d"
     path: ""
@@ -859,7 +859,7 @@ packages:
     revision: "cd59995050105b946884ee20e3bcadc252feda8c"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/nodejs/readable-stream.git"
     revision: "cd59995050105b946884ee20e3bcadc252feda8c"
     path: ""
@@ -882,7 +882,7 @@ packages:
     revision: "f0c589db055ba21ebb30da442742cd19e64e3efa"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "ssh://git@github.com/bevry/requirefresh.git"
     revision: "f0c589db055ba21ebb30da442742cd19e64e3efa"
     path: ""
@@ -905,7 +905,7 @@ packages:
     revision: "5261e0c19dd820c31dd21cb4116902b0ed0f9e57"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/feross/safe-buffer.git"
     revision: "5261e0c19dd820c31dd21cb4116902b0ed0f9e57"
     path: ""
@@ -929,7 +929,7 @@ packages:
     revision: "51d15eaa03e53aaedd3002dc67814355073e8a55"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "ssh://git@github.com/bevry/safefs.git"
     revision: "51d15eaa03e53aaedd3002dc67814355073e8a55"
     path: ""
@@ -952,7 +952,7 @@ packages:
     revision: "e97f24dd3d047b72b9836518e2a0788e2a6a2fdb"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/rvagg/string_decoder.git"
     revision: "e97f24dd3d047b72b9836518e2a0788e2a6a2fdb"
     path: ""
@@ -976,7 +976,7 @@ packages:
     revision: "ab3925bc0270f8df65f5c05ae1ba09e648aaff8e"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "ssh://git@github.com/bevry/typechecker.git"
     revision: "ab3925bc0270f8df65f5c05ae1ba09e648aaff8e"
     path: ""
@@ -999,7 +999,7 @@ packages:
     revision: "475fb6857cd23fafff20c1be846c1350abf8e6d4"
     path: ""
   vcs_processed:
-    type: "Git"
+    type: "git"
     url: "https://github.com/TooTallNate/util-deprecate.git"
     revision: "475fb6857cd23fafff20c1be846c1350abf8e6d4"
     path: ""

--- a/downloader/src/funTest/kotlin/BabelTest.kt
+++ b/downloader/src/funTest/kotlin/BabelTest.kt
@@ -83,7 +83,7 @@ class BabelTest : StringSpec() {
 
             downloadResult.sourceArtifact shouldBe null
             downloadResult.vcsInfo shouldNotBe null
-            downloadResult.vcsInfo!!.type shouldBe pkg.vcsProcessed.type
+            downloadResult.vcsInfo!!.type.toLowerCase() shouldBe pkg.vcsProcessed.type
             downloadResult.vcsInfo!!.url shouldBe pkg.vcsProcessed.url
             downloadResult.vcsInfo!!.revision shouldBe "master"
             downloadResult.vcsInfo!!.resolvedRevision shouldBe "cee4cde53e4f452d89229986b9368ecdb41e00da"

--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -162,7 +162,7 @@ abstract class VersionControlSystem {
                         }
                     }
 
-                    VcsInfo("Git", url, revision, path = path)
+                    VcsInfo("git", url, revision, path = path)
                 }
 
                 else -> VcsInfo("", vcsUrl, "")

--- a/downloader/src/test/kotlin/VersionControlSystemTest.kt
+++ b/downloader/src/test/kotlin/VersionControlSystemTest.kt
@@ -110,7 +110,7 @@ class VersionControlSystemTest : WordSpec({
                     "https://github.com/heremaps/oss-review-toolkit.git"
             )
             val expected = VcsInfo(
-                    type = "Git",
+                    type = "git",
                     url = "https://github.com/heremaps/oss-review-toolkit.git",
                     revision = ""
             )
@@ -122,7 +122,7 @@ class VersionControlSystemTest : WordSpec({
                     "https://github.com/blob/tree.git"
             )
             val expected = VcsInfo(
-                    type = "Git",
+                    type = "git",
                     url = "https://github.com/blob/tree.git",
                     revision = ""
             )
@@ -134,7 +134,7 @@ class VersionControlSystemTest : WordSpec({
                     "https://github.com/babel/babel/tree/master/packages/babel-code-frame.git"
             )
             val expected = VcsInfo(
-                    type = "Git",
+                    type = "git",
                     url = "https://github.com/babel/babel.git",
                     revision = "master",
                     path = "packages/babel-code-frame"
@@ -147,7 +147,7 @@ class VersionControlSystemTest : WordSpec({
                     "https://github.com/crypto-browserify/crypto-browserify/blob/6aebafa/test/create-hmac.js"
             )
             val expected = VcsInfo(
-                    type = "Git",
+                    type = "git",
                     url = "https://github.com/crypto-browserify/crypto-browserify.git",
                     revision = "6aebafa",
                     path = "test/create-hmac.js"
@@ -160,7 +160,7 @@ class VersionControlSystemTest : WordSpec({
                     "ssh://git@github.com/EsotericSoftware/kryo.git/kryo-shaded"
             )
             val expected = VcsInfo(
-                    type = "Git",
+                    type = "git",
                     url = "ssh://git@github.com/EsotericSoftware/kryo.git",
                     revision = "",
                     path = "kryo-shaded"
@@ -175,7 +175,7 @@ class VersionControlSystemTest : WordSpec({
                     "https://gitlab.com/rich-harris/rollup-plugin-buble.git"
             )
             val expected = VcsInfo(
-                    type = "Git",
+                    type = "git",
                     url = "https://gitlab.com/rich-harris/rollup-plugin-buble.git",
                     revision = ""
             )
@@ -187,7 +187,7 @@ class VersionControlSystemTest : WordSpec({
                     "https://gitlab.com/Rich-Harris/rollup-plugin-buble/tree/master/src"
             )
             val expected = VcsInfo(
-                    type = "Git",
+                    type = "git",
                     url = "https://gitlab.com/Rich-Harris/rollup-plugin-buble.git",
                     revision = "master",
                     path = "src"
@@ -200,7 +200,7 @@ class VersionControlSystemTest : WordSpec({
                     "https://gitlab.com/Rich-Harris/rollup-plugin-buble/blob/v0.15.0/README.md"
             )
             val expected = VcsInfo(
-                    type = "Git",
+                    type = "git",
                     url = "https://gitlab.com/Rich-Harris/rollup-plugin-buble.git",
                     revision = "v0.15.0",
                     path = "README.md"

--- a/model/src/main/kotlin/VcsInfo.kt
+++ b/model/src/main/kotlin/VcsInfo.kt
@@ -120,9 +120,10 @@ data class VcsInfo(
     }
 
     /**
-     * Returns this [VcsInfo] in normalized form. Currently, this only applies [normalizeVcsUrl] to the [url].
+     * Returns this [VcsInfo] in normalized form. This transforms the [type] to a lower case string and applies
+     * [normalizeVcsUrl] to the [url].
      */
-    fun normalize() = copy(url = normalizeVcsUrl(url))
+    fun normalize() = copy(type = type.toLowerCase(), url = normalizeVcsUrl(url))
 }
 
 class VcsInfoDeserializer : StdDeserializer<VcsInfo>(VcsInfo::class.java) {


### PR DESCRIPTION
To have more consistent VCS types. Also adapt the default value for type in
VersionControlSystem.splitUrl() accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/498)
<!-- Reviewable:end -->
