### PR TITLE
analyzer: Improve testing of curations in MainTest

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
@@ -1,0 +1,503 @@
+---
+allow_dynamic_versions: false
+repository:
+  name: "gradle"
+  path: "<REPLACE_REPOSITORY_PATH>/analyzer/src/funTest/assets/projects/synthetic/gradle"
+  vcs:
+    type: "Git"
+    url: "<REPLACE_URL>"
+    revision: "<REPLACE_REVISION>"
+    path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
+  vcs_processed:
+    type: "git"
+    url: "<REPLACE_URL_PROCESSED>"
+    revision: "<REPLACE_REVISION>"
+    path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
+projects:
+- id: "Gradle::Gradle-Example:"
+  declared_licenses: []
+  aliases: []
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "git"
+    url: "<REPLACE_URL_PROCESSED>"
+    revision: "<REPLACE_REVISION>"
+    path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
+  homepage_url: ""
+  scopes: []
+- id: "Gradle:com.here.ort.gradle.example:app:1.0.0"
+  declared_licenses: []
+  aliases: []
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "git"
+    url: "<REPLACE_URL_PROCESSED>"
+    revision: "<REPLACE_REVISION>"
+    path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app"
+  homepage_url: ""
+  scopes:
+  - name: "annotationProcessor"
+    delivered: true
+    dependencies: []
+  - name: "archives"
+    delivered: true
+    dependencies: []
+  - name: "compile"
+    delivered: true
+    dependencies:
+    - id: "Maven:com.here.ort.gradle.example:lib:1.0.0"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+          dependencies: []
+          errors: []
+        errors: []
+      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+        dependencies: []
+        errors: []
+      errors: []
+  - name: "compileOnly"
+    delivered: true
+    dependencies: []
+  - name: "default"
+    delivered: true
+    dependencies:
+    - id: "Maven:com.here.ort.gradle.example:lib:1.0.0"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+          dependencies: []
+          errors: []
+        errors: []
+      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+        dependencies: []
+        errors: []
+      errors: []
+  - name: "runtime"
+    delivered: true
+    dependencies:
+    - id: "Maven:com.here.ort.gradle.example:lib:1.0.0"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+          dependencies: []
+          errors: []
+        errors: []
+      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+        dependencies: []
+        errors: []
+      errors: []
+  - name: "testAnnotationProcessor"
+    delivered: true
+    dependencies: []
+  - name: "testCompile"
+    delivered: true
+    dependencies:
+    - id: "Maven:com.here.ort.gradle.example:lib:1.0.0"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+          dependencies: []
+          errors: []
+        errors: []
+      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+        dependencies: []
+        errors: []
+      errors: []
+  - name: "testCompileOnly"
+    delivered: true
+    dependencies: []
+  - name: "testRuntime"
+    delivered: true
+    dependencies:
+    - id: "Maven:com.here.ort.gradle.example:lib:1.0.0"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+          dependencies: []
+          errors: []
+        errors: []
+      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+        dependencies: []
+        errors: []
+      errors: []
+- id: "Gradle:com.here.ort.gradle.example:lib-without-repo:1.0.0"
+  declared_licenses: []
+  aliases: []
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "git"
+    url: "<REPLACE_URL_PROCESSED>"
+    revision: "<REPLACE_REVISION>"
+    path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo"
+  homepage_url: ""
+  scopes:
+  - name: "annotationProcessor"
+    delivered: true
+    dependencies: []
+  - name: "archives"
+    delivered: true
+    dependencies: []
+  - name: "compile"
+    delivered: true
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-text:1.1"
+      dependencies: []
+      errors:
+      - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
+        \ org.apache.commons:commons-text:1.1 because no repositories are defined."
+  - name: "compileOnly"
+    delivered: true
+    dependencies: []
+  - name: "default"
+    delivered: true
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-text:1.1"
+      dependencies: []
+      errors:
+      - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
+        \ org.apache.commons:commons-text:1.1 because no repositories are defined."
+  - name: "runtime"
+    delivered: true
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-text:1.1"
+      dependencies: []
+      errors:
+      - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
+        \ org.apache.commons:commons-text:1.1 because no repositories are defined."
+  - name: "testAnnotationProcessor"
+    delivered: true
+    dependencies: []
+  - name: "testCompile"
+    delivered: true
+    dependencies:
+    - id: "Maven:junit:junit:4.12"
+      dependencies: []
+      errors:
+      - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
+        \ junit:junit:4.12 because no repositories are defined."
+    - id: "Maven:org.apache.commons:commons-text:1.1"
+      dependencies: []
+      errors:
+      - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
+        \ org.apache.commons:commons-text:1.1 because no repositories are defined."
+  - name: "testCompileOnly"
+    delivered: true
+    dependencies: []
+  - name: "testRuntime"
+    delivered: true
+    dependencies:
+    - id: "Maven:junit:junit:4.12"
+      dependencies: []
+      errors:
+      - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
+        \ junit:junit:4.12 because no repositories are defined."
+    - id: "Maven:org.apache.commons:commons-text:1.1"
+      dependencies: []
+      errors:
+      - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
+        \ org.apache.commons:commons-text:1.1 because no repositories are defined."
+- id: "Gradle:com.here.ort.gradle.example:lib:1.0.0"
+  declared_licenses: []
+  aliases: []
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "git"
+    url: "<REPLACE_URL_PROCESSED>"
+    revision: "<REPLACE_REVISION>"
+    path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
+  homepage_url: ""
+  scopes:
+  - name: "annotationProcessor"
+    delivered: true
+    dependencies: []
+  - name: "archives"
+    delivered: true
+    dependencies: []
+  - name: "compile"
+    delivered: true
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-text:1.1"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.5"
+        dependencies: []
+        errors: []
+      errors: []
+    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      dependencies: []
+      errors: []
+  - name: "compileOnly"
+    delivered: true
+    dependencies: []
+  - name: "default"
+    delivered: true
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-text:1.1"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.5"
+        dependencies: []
+        errors: []
+      errors: []
+    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      dependencies: []
+      errors: []
+  - name: "runtime"
+    delivered: true
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-text:1.1"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.5"
+        dependencies: []
+        errors: []
+      errors: []
+    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      dependencies: []
+      errors: []
+  - name: "testAnnotationProcessor"
+    delivered: true
+    dependencies: []
+  - name: "testCompile"
+    delivered: true
+    dependencies:
+    - id: "Maven:junit:junit:4.12"
+      dependencies:
+      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+        dependencies: []
+        errors: []
+      errors: []
+    - id: "Maven:org.apache.commons:commons-text:1.1"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.5"
+        dependencies: []
+        errors: []
+      errors: []
+    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      dependencies: []
+      errors: []
+  - name: "testCompileOnly"
+    delivered: true
+    dependencies: []
+  - name: "testRuntime"
+    delivered: true
+    dependencies:
+    - id: "Maven:junit:junit:4.12"
+      dependencies:
+      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+        dependencies: []
+        errors: []
+      errors: []
+    - id: "Maven:org.apache.commons:commons-text:1.1"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.5"
+        dependencies: []
+        errors: []
+      errors: []
+    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      dependencies: []
+      errors: []
+project_id_result_file_path_map:
+  'Gradle::Gradle-Example:': "<REPLACE_PROJECT_PATH>/build-gradle-dependencies.yml"
+  Gradle:com.here.ort.gradle.example:app:1.0.0: "<REPLACE_PROJECT_PATH>/app/build-gradle-dependencies.yml"
+  Gradle:com.here.ort.gradle.example:lib-without-repo:1.0.0: "<REPLACE_PROJECT_PATH>/lib-without-repo/build-gradle-dependencies.yml"
+  Gradle:com.here.ort.gradle.example:lib:1.0.0: "<REPLACE_PROJECT_PATH>/lib/build-gradle-dependencies.yml"
+packages:
+- package:
+    id: "Maven:com.here.ort.gradle.example:lib:1.0.0"
+    declared_licenses: []
+    description: ""
+    homepage_url: ""
+    binary_artifact:
+      url: ""
+      hash: ""
+      hash_algorithm: ""
+    source_artifact:
+      url: ""
+      hash: ""
+      hash_algorithm: ""
+    vcs:
+      type: ""
+      url: ""
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "git"
+      url: "<REPLACE_URL_PROCESSED>"
+      revision: "<REPLACE_REVISION>"
+      path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
+  curations: []
+- package:
+    id: "Maven:junit:junit:4.12"
+    declared_licenses:
+    - "Eclipse Public License 1.0"
+    description: "JUnit is a unit testing framework for Java, created by Erich Gamma\
+      \ and Kent Beck."
+    homepage_url: "http://junit.org"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12.jar"
+      hash: "2973d150c0dc1fefe998f834810d68f278ea58ec"
+      hash_algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
+      hash: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+      hash_algorithm: "SHA-1"
+    vcs:
+      type: "git"
+      url: "git://github.com/junit-team/junit.git"
+      revision: "r4.12"
+      path: ""
+    vcs_processed:
+      type: "git"
+      url: "https://github.com/junit-team/junit.git"
+      revision: "r4.12"
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.apache.commons:commons-lang3:3.5"
+    declared_licenses:
+    - "Apache License, Version 2.0"
+    description: "Apache Commons Lang, a package of Java utility classes for the\n\
+      \  classes that are in java.lang's hierarchy, or are considered to be so\n \
+      \ standard as to justify existence in java.lang."
+    homepage_url: "http://commons.apache.org/proper/commons-lang/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar"
+      hash: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
+      hash_algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
+      hash: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+      hash_algorithm: "SHA-1"
+    vcs:
+      type: "git"
+      url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
+      revision: "LANG_3_5"
+      path: ""
+    vcs_processed:
+      type: "git"
+      url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
+      revision: "LANG_3_5"
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.apache.commons:commons-text:1.1"
+    declared_licenses:
+    - "Apache License, Version 2.0"
+    description: "Apache Commons Text is a library focused on algorithms working on\
+      \ strings."
+    homepage_url: "http://commons.apache.org/proper/commons-text/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1.jar"
+      hash: "c336bf600f44b88af356c8a85eef4af822b06a4d"
+      hash_algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
+      hash: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+      hash_algorithm: "SHA-1"
+    vcs:
+      type: "git"
+      url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "git"
+      url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
+      revision: ""
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+    declared_licenses:
+    - "The Apache Software License, Version 2.0"
+    description: "Apache Struts 2"
+    homepage_url: "http://struts.apache.org/struts2-assembly/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/struts/struts2-assembly/2.5.14.1/struts2-assembly-2.5.14.1-min-lib.zip"
+      hash: "8e75a38e3b8ceb01e007c5899d8d29e7a075cb7d"
+      hash_algorithm: "SHA-1"
+    source_artifact:
+      url: ""
+      hash: ""
+      hash_algorithm: ""
+    vcs:
+      type: "git"
+      url: "https://gitbox.apache.org/repos/asf/struts.git"
+      revision: "STRUTS_2_5_14_1"
+      path: ""
+    vcs_processed:
+      type: "git"
+      url: "https://gitbox.apache.org/repos/asf/struts.git"
+      revision: "STRUTS_2_5_14_1"
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.hamcrest:hamcrest-core:1.3"
+    declared_licenses:
+    - "curated license a"
+    - "curated license b"
+    description: "Curated description."
+    homepage_url: "http://hamcrest.org/JavaHamcrest/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"
+      hash: "42a25dc3219429f0e5d060061f71acb49bf010a0"
+      hash_algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+      hash: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+      hash_algorithm: "SHA-1"
+    vcs:
+      type: "git"
+      url: "git@github.com:hamcrest/JavaHamcrest.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "git"
+      url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
+      revision: ""
+      path: ""
+  curations:
+  - base:
+      homepage_url: "https://github.com/hamcrest/JavaHamcrest/hamcrest-core"
+    curation:
+      homepage_url: "http://hamcrest.org/JavaHamcrest/"
+      comment: "Use the actual homepage instead of the GitHub page."
+  - base:
+      description: "This is the core API of hamcrest matcher framework to be used\
+        \ by third-party framework providers. This includes the a foundation set of\
+        \ matcher implementations for common operations."
+    curation:
+      description: "Curated description."
+      comment: "Fix description."
+  - base:
+      declared_licenses:
+      - "New BSD License"
+    curation:
+      declared_licenses:
+      - "curated license a"
+      - "curated license b"
+      comment: "Declared license in pom.xml is wrong."
+errors:
+  'Gradle::Gradle-Example:': []
+  Gradle:com.here.ort.gradle.example:app:1.0.0: []
+  Gradle:com.here.ort.gradle.example:lib-without-repo:1.0.0: []
+  Gradle:com.here.ort.gradle.example:lib:1.0.0: []

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle/curations.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle/curations.yml
@@ -2,11 +2,14 @@
 - id: "Maven:org.hamcrest::"
   curations:
     homepage_url: "http://hamcrest.org/JavaHamcrest/"
+    comment: "Use the actual homepage instead of the GitHub page."
 - id: "Maven:org.hamcrest:hamcrest-core:"
   curations:
     description: "Curated description."
+    comment: "Fix description."
 - id: "Maven:org.hamcrest:hamcrest-core:1.3"
   curations:
     declared_licenses:
     - "curated license a"
     - "curated license b"
+    comment: "Declared license in pom.xml is wrong."


### PR DESCRIPTION
Compare the full analyzer results file in "Package curation data file is
applied correctly" because it requires less code and makes it easier to
view the diff if the test fails.

Also align the test code with "Merging into single results file creates
correct output".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/506)
<!-- Reviewable:end -->
