### PR TITLE
scanner: Align the two implementations that scan a path

### DIFF
--- a/scanner/src/funTest/kotlin/ScanPathTest.kt
+++ b/scanner/src/funTest/kotlin/ScanPathTest.kt
@@ -51,19 +51,19 @@ class ScanPathTest : StringSpec() {
 
     init {
         "BoyterLc recognizes our own LICENSE" {
-            val result = BoyterLc.scan(File(rootDir, "LICENSE"), outputDir)
+            val result = BoyterLc.scanPath(File(rootDir, "LICENSE"), outputDir)
             result.summary.fileCount shouldBe 1
             result.summary.licenses shouldBe setOf("Apache-2.0", "ECL-2.0")
         }.config(tags = setOf(ExpensiveTag))
 
         "Licensee recognizes our own LICENSE" {
-            val result = Licensee.scan(File(rootDir, "LICENSE"), outputDir)
+            val result = Licensee.scanPath(File(rootDir, "LICENSE"), outputDir)
             result.summary.fileCount shouldBe 1
             result.summary.licenses shouldBe setOf("Apache-2.0")
         }.config(tags = setOf(ExpensiveTag))
 
         "ScanCode recognizes our own LICENSE" {
-            val result = ScanCode.scan(File(rootDir, "LICENSE"), outputDir)
+            val result = ScanCode.scanPath(File(rootDir, "LICENSE"), outputDir)
             result.summary.fileCount shouldBe 1
             result.summary.licenses shouldBe setOf("Apache-2.0")
         }.config(tags = setOf(ExpensiveTag, ScanCodeTag))

--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -187,17 +187,17 @@ abstract class LocalScanner : Scanner() {
     }
 
     /**
-     * Scan the provided [path] for license information, writing results to [outputDirectory]. Note that no caching will
-     * be used in this mode.
+     * Scan the provided [path] for license information, writing results to [outputDirectory] using the scanner's native
+     * output file format. Note that no scan results cache is used by this function.
      *
      * @param path The directory or file to scan.
      * @param outputDirectory The base directory to store scan results in.
      *
-     * @return The set of found licenses.
+     * @return The [ScanResult] with empty [Provenance] except for the download time.
      *
-     * @throws ScanException In case the package could not be scanned.
+     * @throws ScanException In case the path could not be scanned.
      */
-    fun scan(path: File, outputDirectory: File): ScanResult {
+    fun scanPath(path: File, outputDirectory: File): ScanResult {
         val scanResultsDirectory = File(outputDirectory, "scanResults").apply { safeMkdirs() }
         val scannerName = toString().toLowerCase()
         val resultsFile = File(scanResultsDirectory,
@@ -210,7 +210,17 @@ abstract class LocalScanner : Scanner() {
     }
 
     /**
-     * Scan the provided [path] for license information, writing results to [resultsFile].
+     * Scan the provided [path] for license information, writing results to [resultsFile] using the scanner's native
+     * output file format. Note that no scan results cache is used by this function.
+     *
+     * @param path The directory or file to scan.
+     * @param resultsFile The file to store scan results in.
+     * @param provenance [Provenance] information about the files in [path].
+     * @param scannerDetails The [ScannerDetails] of the current scanner.
+     *
+     * @return The [ScanResult], containing the provided [provenance] and [scannerDetails].
+     *
+     * @throws ScanException In case the path could not be scanned.
      */
     protected abstract fun scanPath(path: File, resultsFile: File, provenance: Provenance,
                                     scannerDetails: ScannerDetails): ScanResult

--- a/scanner/src/main/kotlin/Main.kt
+++ b/scanner/src/main/kotlin/Main.kt
@@ -286,7 +286,7 @@ object Main {
                 println("Scanning path '${inputPath.absolutePath}'...")
 
                 val entry = try {
-                    val result = localScanner.scan(inputPath, outputDir)
+                    val result = localScanner.scanPath(inputPath, outputDir)
 
                     println("Detected licenses for path '${inputPath.absolutePath}': " +
                             result.summary.licenses.joinToString())


### PR DESCRIPTION
Name both "scanPath" as both scan a single path. Also improve the
documentation accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/513)
<!-- Reviewable:end -->
