### PR TITLE
model: Add definition file path to Project

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
@@ -2,6 +2,7 @@
 allowDynamicVersions: true
 project:
   id: "SBT:io.github.soc:directories:6"
+  definition_file_path: "target/directories-6.pom"
   declared_licenses:
   - "Mozilla Public License 2.0"
   aliases: []

--- a/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
@@ -2,6 +2,7 @@
 allowDynamicVersions: true
 project:
   id: "PIP::example-python-flask:"
+  definition_file_path: "requirements.txt"
   declared_licenses: []
   aliases: []
   vcs:

--- a/analyzer/src/funTest/assets/projects/external/godep-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/godep-expected-output.yml
@@ -2,6 +2,7 @@
 allowDynamicVersions: false
 project:
   id: "GoDep::godep:ce0bfadeb516ab23c845a85c4b0eae421ec9614b"
+  definition_file_path: "Godeps/Godeps.json"
   declared_licenses: []
   aliases: []
   vcs:

--- a/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
@@ -2,6 +2,7 @@
 allowDynamicVersions: true
 project:
   id: "Maven:jgnash:jgnash-core:2.30.0"
+  definition_file_path: "jgnash-core/pom.xml"
   declared_licenses: []
   aliases: []
   vcs:

--- a/analyzer/src/funTest/assets/projects/external/jgnash-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/jgnash-expected-output.yml
@@ -2,6 +2,7 @@
 allowDynamicVersions: true
 project:
   id: "Maven:jgnash:jgnash2:2.30.0"
+  definition_file_path: "pom.xml"
   declared_licenses: []
   aliases: []
   vcs:

--- a/analyzer/src/funTest/assets/projects/external/qmstr-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/qmstr-expected-output.yml
@@ -2,6 +2,7 @@
 allowDynamicVersions: false
 project:
   id: "GoDep::qmstr:0cd17d10b931c9108450ca5a68d4f85b6e4953ef"
+  definition_file_path: "Gopkg.toml"
   declared_licenses: []
   aliases: []
   vcs:

--- a/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
@@ -2,6 +2,7 @@
 allowDynamicVersions: true
 project:
   id: "PIP::spdx-tools:0.5.4"
+  definition_file_path: "setup.py"
   declared_licenses:
   - "Apache Software"
   - "Apache-2.0"

--- a/analyzer/src/funTest/assets/projects/external/sprig-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/sprig-expected-output.yml
@@ -2,6 +2,7 @@
 allowDynamicVersions: false
 project:
   id: "GoDep::sprig:9d9aa1f74c86fd9d36ecfe3f2a44a3093c3d4c15"
+  definition_file_path: "glide.yaml"
   declared_licenses: []
   aliases: []
   vcs:

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
@@ -12,6 +12,7 @@ vcs_processed:
   path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
 projects:
 - id: "Gradle::Gradle-Example:"
+  definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/build.gradle"
   declared_licenses: []
   aliases: []
   vcs:
@@ -27,6 +28,7 @@ projects:
   homepage_url: ""
   scopes: []
 - id: "Gradle:com.here.ort.gradle.example:app:1.0.0"
+  definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app/build.gradle"
   declared_licenses: []
   aliases: []
   vcs:
@@ -132,6 +134,7 @@ projects:
         errors: []
       errors: []
 - id: "Gradle:com.here.ort.gradle.example:lib-without-repo:1.0.0"
+  definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo/build.gradle"
   declared_licenses: []
   aliases: []
   vcs:
@@ -212,6 +215,7 @@ projects:
       - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
         \ org.apache.commons:commons-text:1.1 because no repositories are defined."
 - id: "Gradle:com.here.ort.gradle.example:lib:1.0.0"
+  definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
   declared_licenses: []
   aliases: []
   vcs:

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
@@ -12,6 +12,7 @@ vcs_processed:
   path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
 projects:
 - id: "Gradle::Gradle-Example:"
+  definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/build.gradle"
   declared_licenses: []
   aliases: []
   vcs:
@@ -27,6 +28,7 @@ projects:
   homepage_url: ""
   scopes: []
 - id: "Gradle:com.here.ort.gradle.example:app:1.0.0"
+  definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app/build.gradle"
   declared_licenses: []
   aliases: []
   vcs:
@@ -132,6 +134,7 @@ projects:
         errors: []
       errors: []
 - id: "Gradle:com.here.ort.gradle.example:lib-without-repo:1.0.0"
+  definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo/build.gradle"
   declared_licenses: []
   aliases: []
   vcs:
@@ -212,6 +215,7 @@ projects:
       - "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency\
         \ org.apache.commons:commons-text:1.1 because no repositories are defined."
 - id: "Gradle:com.here.ort.gradle.example:lib:1.0.0"
+  definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
   declared_licenses: []
   aliases: []
   vcs:

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-2.14.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-2.14.yml
@@ -2,6 +2,7 @@
 allowDynamicVersions: true
 project:
   id: "Gradle:com.here.ort.gradle.example:app:1.0.0"
+  definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app/build.gradle"
   declared_licenses: []
   aliases: []
   vcs:

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-3.4.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-3.4.yml
@@ -2,6 +2,7 @@
 allowDynamicVersions: true
 project:
   id: "Gradle:com.here.ort.gradle.example:app:1.0.0"
+  definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app/build.gradle"
   declared_licenses: []
   aliases: []
   vcs:

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
@@ -2,6 +2,7 @@
 allowDynamicVersions: true
 project:
   id: "Gradle:com.here.ort.gradle.example:app:1.0.0"
+  definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app/build.gradle"
   declared_licenses: []
   aliases: []
   vcs:

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
@@ -2,6 +2,7 @@
 allowDynamicVersions: true
 project:
   id: "Gradle:com.here.ort.gradle.example:lib-without-repo:1.0.0"
+  definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo/build.gradle"
   declared_licenses: []
   aliases: []
   vcs:

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
@@ -2,6 +2,7 @@
 allowDynamicVersions: true
 project:
   id: "Gradle:com.here.ort.gradle.example:lib:1.0.0"
+  definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
   declared_licenses: []
   aliases: []
   vcs:

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-root.yml
@@ -2,6 +2,7 @@
 allowDynamicVersions: true
 project:
   id: "Gradle::Gradle-Example:"
+  definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/build.gradle"
   declared_licenses: []
   aliases: []
   vcs:

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-unsupported-version.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-unsupported-version.yml
@@ -2,6 +2,7 @@
 allowDynamicVersions: true
 project:
   id: "Gradle:com.here.ort.gradle.example:gradle-unsupported-version:1.0.0"
+  definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-unsupported-version/build.gradle"
   declared_licenses: []
   aliases: []
   vcs:

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-app.yml
@@ -2,6 +2,7 @@
 allowDynamicVersions: true
 project:
   id: "Maven:com.here.ort.maven:maven-app:1.0-SNAPSHOT"
+  definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/maven/app/pom.xml"
   declared_licenses: []
   aliases: []
   vcs:

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-lib.yml
@@ -2,6 +2,7 @@
 allowDynamicVersions: true
 project:
   id: "Maven:com.here.ort.maven:maven-lib:1.0-SNAPSHOT"
+  definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/maven/lib/pom.xml"
   declared_licenses: []
   aliases: []
   vcs:

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-root.yml
@@ -2,6 +2,7 @@
 allowDynamicVersions: true
 project:
   id: "Maven:com.here.ort.maven:maven-project:1.0-SNAPSHOT"
+  definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/maven/pom.xml"
   declared_licenses: []
   aliases: []
   vcs:

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-parent-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-parent-expected-output-root.yml
@@ -2,6 +2,7 @@
 allowDynamicVersions: true
 project:
   id: "Maven:com.here.ort.maven:maven-parent-project:1.0-SNAPSHOT"
+  definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/maven-parent/pom.xml"
   declared_licenses:
   - "Apache License, Version 2.0"
   aliases: []

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
@@ -2,6 +2,7 @@
 allowDynamicVersions: false
 project:
   id: "NPM::npm-project-that-depends-on-babel:1.0.0"
+  definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/npm-babel/package.json"
   declared_licenses:
   - "Apache-2.0"
   aliases: []

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output.yml
@@ -2,6 +2,7 @@
 allowDynamicVersions: false
 project:
   id: "NPM::npm-project:2.0.0"
+  definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
   declared_licenses:
   - "Apache-2.0"
   aliases: []

--- a/analyzer/src/funTest/assets/projects/synthetic/pip-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pip-expected-output.yml
@@ -2,6 +2,7 @@
 allowDynamicVersions: true
 project:
   id: "PIP::Example-App:2.4.0"
+  definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/pip/requirements.txt"
   declared_licenses:
   - "MIT"
   aliases: []

--- a/analyzer/src/funTest/kotlin/NpmTest.kt
+++ b/analyzer/src/funTest/kotlin/NpmTest.kt
@@ -67,6 +67,8 @@ class NpmTest : FreeSpec() {
         return File(projectDir.parentFile, "npm-expected-output.yml").readText()
                 // project.name:
                 .replaceFirst("npm-project", "npm-${workingDir.name}")
+                // project.definitionFilePath
+                .replaceFirst("<REPLACE_DEFINITION_FILE_PATH>", "$vcsPath/package.json")
                 // project.vcs_processed:
                 .replaceFirst("<REPLACE_URL>", normalizeVcsUrl(vcsUrl))
                 .replaceFirst("<REPLACE_REVISION>", vcsRevision)

--- a/analyzer/src/main/kotlin/managers/GoDep.kt
+++ b/analyzer/src/main/kotlin/managers/GoDep.kt
@@ -124,6 +124,7 @@ class GoDep : PackageManager() {
                 allowDynamicVersions = Main.allowDynamicVersions,
                 project = Project(
                         id = Identifier(provider, "", projectDir.name, projectVcs.revision),
+                        definitionFilePath = VersionControlSystem.getPathToRoot(definitionFile) ?: "",
                         declaredLicenses = sortedSetOf(),
                         aliases = emptyList(),
                         vcs = VcsInfo.EMPTY,

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -28,6 +28,7 @@ import com.here.ort.analyzer.MavenSupport
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.analyzer.PackageManagerFactory
 import com.here.ort.analyzer.identifier
+import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.AnalyzerResult
 import com.here.ort.model.Identifier
 import com.here.ort.model.Package
@@ -123,6 +124,7 @@ class Gradle : PackageManager() {
                             name = dependencyTreeModel.name,
                             version = dependencyTreeModel.version
                     ),
+                    definitionFilePath = VersionControlSystem.getPathToRoot(definitionFile) ?: "",
                     declaredLicenses = sortedSetOf(),
                     aliases = emptyList(),
                     vcs = VcsInfo.EMPTY,

--- a/analyzer/src/main/kotlin/managers/Maven.kt
+++ b/analyzer/src/main/kotlin/managers/Maven.kt
@@ -25,6 +25,7 @@ import com.here.ort.analyzer.MavenSupport
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.analyzer.PackageManagerFactory
 import com.here.ort.analyzer.identifier
+import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.AnalyzerResult
 import com.here.ort.model.Identifier
 import com.here.ort.model.Package
@@ -151,6 +152,7 @@ class Maven : PackageManager() {
                         name = mavenProject.artifactId,
                         version = mavenProject.version
                 ),
+                definitionFilePath = VersionControlSystem.getPathToRoot(definitionFile) ?: "",
                 declaredLicenses = maven.parseLicenses(mavenProject),
                 aliases = emptyList(),
                 vcs = vcsFromPackage,

--- a/analyzer/src/main/kotlin/managers/NPM.kt
+++ b/analyzer/src/main/kotlin/managers/NPM.kt
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode
 import com.here.ort.analyzer.Main
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.analyzer.PackageManagerFactory
+import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.AnalyzerResult
 import com.here.ort.model.HashAlgorithm
 import com.here.ort.model.Identifier
@@ -457,6 +458,7 @@ class NPM : PackageManager() {
                         version = version
                 ),
                 declaredLicenses = declaredLicenses,
+                definitionFilePath = VersionControlSystem.getPathToRoot(packageJson) ?: "",
                 aliases = emptyList(),
                 vcs = vcsFromPackage,
                 vcsProcessed = processProjectVcs(projectDir, vcsFromPackage),

--- a/analyzer/src/main/kotlin/managers/PIP.kt
+++ b/analyzer/src/main/kotlin/managers/PIP.kt
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode
 import com.here.ort.analyzer.Main
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.analyzer.PackageManagerFactory
+import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.Package
 import com.here.ort.model.PackageReference
 import com.here.ort.model.Project
@@ -257,6 +258,7 @@ class PIP : PackageManager() {
                         name = projectName,
                         version = projectVersion
                 ),
+                definitionFilePath = VersionControlSystem.getPathToRoot(definitionFile) ?: "",
                 declaredLicenses = declaredLicenses,
                 aliases = emptyList(),
                 vcs = VcsInfo.EMPTY,

--- a/analyzer/src/main/kotlin/managers/Unmanaged.kt
+++ b/analyzer/src/main/kotlin/managers/Unmanaged.kt
@@ -22,6 +22,7 @@ package com.here.ort.analyzer.managers
 import com.here.ort.analyzer.Main
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.analyzer.PackageManagerFactory
+import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.AnalyzerResult
 import com.here.ort.model.Identifier
 import com.here.ort.model.Project
@@ -53,6 +54,7 @@ class Unmanaged : PackageManager() {
                         name = definitionFile.name,
                         version = ""
                 ),
+                definitionFilePath = VersionControlSystem.getPathToRoot(definitionFile) ?: "",
                 declaredLicenses = sortedSetOf(),
                 aliases = emptyList(),
                 vcs = VcsInfo.EMPTY,

--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -83,6 +83,14 @@ abstract class VersionControlSystem {
                 }
 
         /**
+         * Return the relative path to [file] with respect to the VCS root or null if [file] is not in a VCS repository.
+         * This is a convenience wrapper around [WorkingTree.getPathToRoot] that creates a temporary working tree based
+         * on [file].
+         */
+        fun getPathToRoot(file: File) = forDirectory(file.takeIf { it.isDirectory } ?: file.parentFile)
+                ?.getPathToRoot(file)
+
+        /**
          * Decompose a [vcsUrl] into any contained VCS information.
          */
         fun splitUrl(vcsUrl: String): VcsInfo {

--- a/model/src/main/kotlin/Project.kt
+++ b/model/src/main/kotlin/Project.kt
@@ -35,6 +35,13 @@ data class Project(
         val id: Identifier,
 
         /**
+         * The path to the definition file of this project, relative to the root of the repository described in [vcs]
+         * and [vcsProcessed].
+         */
+        @JsonProperty("definition_file_path")
+        val definitionFilePath: String,
+
+        /**
          * The list of licenses the authors have declared for this package. This does not necessarily correspond to the
          * licenses as detected by a scanner. Both need to be taken into account for any conclusions.
          */
@@ -98,6 +105,7 @@ data class Project(
         @JvmField
         val EMPTY = Project(
                 id = Identifier.EMPTY,
+                definitionFilePath = "",
                 declaredLicenses = sortedSetOf(),
                 aliases = emptyList(),
                 vcs = VcsInfo.EMPTY,

--- a/model/src/test/kotlin/AnalyzerResultTest.kt
+++ b/model/src/test/kotlin/AnalyzerResultTest.kt
@@ -30,6 +30,7 @@ class AnalyzerResultTest : StringSpec({
                     allowDynamicVersions = true,
                     project = Project(
                             id = Identifier("provider", "namespace", "name", "version"),
+                            definitionFilePath = "definitionFilePath",
                             declaredLicenses = sortedSetOf(),
                             aliases = listOf(),
                             vcs = VcsInfo.EMPTY,


### PR DESCRIPTION
Store the path to the definition file of the project relative to the root
of the VCS repository in the project class. This is required to be able to
track which definition file the project was created from.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/516)
<!-- Reviewable:end -->
