### PR TITLE
model: Make AnalyzerResultBuilder.addResult fluent

### DIFF
--- a/model/src/main/kotlin/AnalyzerResult.kt
+++ b/model/src/main/kotlin/AnalyzerResult.kt
@@ -85,7 +85,7 @@ class AnalyzerResultBuilder(
         return AnalyzerResult(allowDynamicVersions, vcsInfo, vcsInfo.normalize(), projects, packages, errors)
     }
 
-    fun addResult(projectAnalyzerResult: ProjectAnalyzerResult) {
+    fun addResult(projectAnalyzerResult: ProjectAnalyzerResult) = this.apply {
         projects.add(projectAnalyzerResult.project)
         packages.addAll(projectAnalyzerResult.packages)
         errors[projectAnalyzerResult.project.id] = projectAnalyzerResult.errors

--- a/model/src/test/kotlin/AnalyzerResultTest.kt
+++ b/model/src/test/kotlin/AnalyzerResultTest.kt
@@ -53,23 +53,19 @@ class AnalyzerResultTest : WordSpec() {
     init {
         "AnalyzerResult" should {
             "create the correct ProjectAnalyzerResults" {
-                val builder = AnalyzerResultBuilder(true, vcs)
-
-                builder.addResult(analyzerResult1)
-                builder.addResult(analyzerResult2)
-
-                val mergedResults = builder.build()
+                val mergedResults = AnalyzerResultBuilder(true, vcs)
+                        .addResult(analyzerResult1)
+                        .addResult(analyzerResult2)
+                        .build()
 
                 mergedResults.createProjectAnalyzerResults() shouldBe listOf(analyzerResult1, analyzerResult2)
             }
 
             "can be serialized and deserialized" {
-                val builder = AnalyzerResultBuilder(true, vcs)
-
-                builder.addResult(analyzerResult1)
-                builder.addResult(analyzerResult2)
-
-                val mergedResults = builder.build()
+                val mergedResults = AnalyzerResultBuilder(true, vcs)
+                        .addResult(analyzerResult1)
+                        .addResult(analyzerResult2)
+                        .build()
 
                 val serializedMergedResults = yamlMapper.writeValueAsString(mergedResults)
                 val deserializedMergedResults =
@@ -81,12 +77,10 @@ class AnalyzerResultTest : WordSpec() {
 
         "AnalyzerResultBuilder" should {
             "merge results from all files" {
-                val builder = AnalyzerResultBuilder(true, vcs)
-
-                builder.addResult(analyzerResult1)
-                builder.addResult(analyzerResult2)
-
-                val mergedResults = builder.build()
+                val mergedResults = AnalyzerResultBuilder(true, vcs)
+                        .addResult(analyzerResult1)
+                        .addResult(analyzerResult2)
+                        .build()
 
                 mergedResults.allowDynamicVersions shouldBe true
                 mergedResults.vcs shouldBe vcs


### PR DESCRIPTION
This saves code when calling the addResult function multiple times in a
row.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/523)
<!-- Reviewable:end -->
