### PR TITLE
README: Update links to Travis CI

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,8 +5,8 @@
 | [![Linux build status][1]][2]  | [![Windows build status][3]][4] |
 | [![Linux code coverage][5]][6] |                                 |
 
-[1]: https://travis-ci.org/heremaps/oss-review-toolkit.svg?branch=master
-[2]: https://travis-ci.org/heremaps/oss-review-toolkit
+[1]: https://travis-ci.com/heremaps/oss-review-toolkit.svg?branch=master
+[2]: https://travis-ci.com/heremaps/oss-review-toolkit
 [3]: https://ci.appveyor.com/api/projects/status/hbc1mn5hpo9a4hcq/branch/master?svg=true
 [4]: https://ci.appveyor.com/project/heremaps/oss-review-toolkit/branch/master
 [5]: https://codecov.io/gh/heremaps/oss-review-toolkit/branch/master/graph/badge.svg


### PR DESCRIPTION
We have migrated from .org to .com, see

https://blog.travis-ci.com/2018-05-02-open-source-projects-on-travis-ci-com-with-github-apps

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/532)
<!-- Reviewable:end -->
