### PR TITLE
GoDep: Extend the list of errors messages to ignore

### DIFF
--- a/analyzer/src/main/kotlin/managers/GoDep.kt
+++ b/analyzer/src/main/kotlin/managers/GoDep.kt
@@ -235,8 +235,13 @@ class GoDep : PackageManager() {
         if (pc.isError()) {
             val msg = pc.stderr()
 
-            if (!msg.contains("no Go files in") &&
-                    !msg.contains("build constraints exclude all Go files in")) {
+            val errorMessagesToIgnore = listOf(
+                    "no Go files in",
+                    "no buildable Go source files in",
+                    "build constraints exclude all Go files in"
+            )
+
+            if (!errorMessagesToIgnore.any { msg.contains(it) }) {
                 throw IOException(msg)
             }
         }


### PR DESCRIPTION
It seems the wording of the "no Go files" error message changed
somewhere between Go version 1.8 and 1.10, so include the new wording
here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/533)
<!-- Reviewable:end -->
