### PR TITLE
PackageManager: Normalize the whole package VCS when processing it

### DIFF
--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -28,7 +28,6 @@ import com.here.ort.model.ProjectAnalyzerResult
 import com.here.ort.model.VcsInfo
 import com.here.ort.utils.collectMessages
 import com.here.ort.utils.log
-import com.here.ort.utils.normalizeVcsUrl
 import com.here.ort.utils.showStackTrace
 
 import java.io.File
@@ -134,8 +133,9 @@ abstract class PackageManager {
          * Merge the [VcsInfo] read from the package with [VcsInfo] deduced from the VCS URL.
          */
         fun processPackageVcs(vcsFromPackage: VcsInfo): VcsInfo {
-            val vcsFromUrl = VersionControlSystem.splitUrl(normalizeVcsUrl(vcsFromPackage.url))
-            return vcsFromUrl.merge(vcsFromPackage)
+            val normalizedVcsFromPackage = vcsFromPackage.normalize()
+            val vcsFromUrl = VersionControlSystem.splitUrl(normalizedVcsFromPackage.url)
+            return vcsFromUrl.merge(normalizedVcsFromPackage)
         }
 
         /**


### PR DESCRIPTION
Previously, only the URL was normalized and the VCS information from the
URL was merged with the original / non-normalized package VCS information.
Normalizing the VCS information only partly is somewhat arbitrary. Also,
we should be agnostic about what VcsInfo.normalize() actually does at this
point. Finally, we should be consistent about only merging normalized
information with other normalized information here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/534)
<!-- Reviewable:end -->
