### PR TITLE
VcsInfo: Remove awkward "type" merging logic

### DIFF
--- a/model/src/main/kotlin/VcsInfo.kt
+++ b/model/src/main/kotlin/VcsInfo.kt
@@ -83,17 +83,8 @@ data class VcsInfo(
         }
 
         var type = this.type
-        if (type.isBlank()) {
-            if (other.type.isNotBlank()) {
-                type = other.type
-            }
-        } else {
-            if (type.equals(other.type, true)) {
-                // Prefer the other type only if its spelling matches the VCS class names.
-                if (other.type.toLowerCase().capitalize() == other.type) {
-                    type = other.type
-                }
-            }
+        if (type.isBlank() && other.type.isNotBlank()) {
+            type = other.type
         }
 
         var url = this.url

--- a/model/src/test/kotlin/VcsInfoTest.kt
+++ b/model/src/test/kotlin/VcsInfoTest.kt
@@ -100,23 +100,6 @@ class VcsInfoTest : StringSpec({
             inputA.merge(inputB) shouldBe output
         }
 
-        "prefer type spelling that matches VCS class names" {
-            val inputA = VcsInfo(
-                    type = "Git",
-                    url = "",
-                    revision = ""
-            )
-
-            val inputB = VcsInfo(
-                    type = "git",
-                    url = "",
-                    revision = ""
-            )
-
-            inputA.merge(inputB).type shouldBe "Git"
-            inputB.merge(inputA).type shouldBe "Git"
-        }
-
         "prefer more complete information for GitHub" {
             val inputA = VcsInfo(
                     type = "Git",


### PR DESCRIPTION
There is no real point in preferring a specific spelling of the type as
in most places we deal with normalized VcsInfo with lower-cased type
anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/535)
<!-- Reviewable:end -->
