### PR TITLE
Bundler: Improve regex for matching GitHub URLs

### DIFF
--- a/analyzer/src/main/kotlin/managers/Bundler.kt
+++ b/analyzer/src/main/kotlin/managers/Bundler.kt
@@ -337,7 +337,7 @@ data class GemSpec(
             )
         }
 
-        private val GITHUB_REGEX = Regex("https*:\\/\\/github.com\\/(?<owner>[\\w-]+)\\/(?<repo>[\\w-]+)")
+        private val GITHUB_REGEX = Regex("https*:\\/\\/github.com\\/(?<owner>[\\w-]+)\\/(?<repo>[\\w-\\.]+)")
 
         // Gems tend to have GitHub URL set as homepage. Seems like it is the only way to get any VCS information out of
         // gemspec files.


### PR DESCRIPTION
Allow dots in repository names so that for example
"http://github.com/tmm1/http_parser.rb" is recognized
as a valid GitHub repository URL.