### PR TITLE
 Bundler: Apply heuristic to find VCS info to meta-data from rubygems

### DIFF
--- a/analyzer/src/main/kotlin/managers/Bundler.kt
+++ b/analyzer/src/main/kotlin/managers/Bundler.kt
@@ -314,11 +314,12 @@ data class GemSpec(
         fun createFromJson(spec: String): GemSpec {
             val json = jsonMapper.readTree(spec)!!
             val runtimeDependencies = json["dependencies"]?.get("runtime")?.mapNotNull { it["name"]?.asText() }?.toSet()
+            val homepage = json["homepage_uri"].asTextOrEmpty()
 
             val vcs = if (json.hasNonNull("source_code_uri")) {
                 VersionControlSystem.splitUrl(json["source_code_uri"].asText())
             } else {
-                VcsInfo.EMPTY
+                parseVcs(homepage)
             }
 
             val binaryArtifact = if (json.hasNonNull("gem_uri") && json.hasNonNull("sha")) {
@@ -330,7 +331,7 @@ data class GemSpec(
             return GemSpec(
                     json["name"].asText(),
                     json["version"].asText(),
-                    json["homepage_uri"].asTextOrEmpty(),
+                    homepage,
                     json["licenses"]?.asIterable()?.map { it.asText() }?.toSortedSet() ?: sortedSetOf(),
                     json["description"].asTextOrEmpty(),
                     runtimeDependencies ?: emptySet(),

--- a/analyzer/src/main/kotlin/managers/Bundler.kt
+++ b/analyzer/src/main/kotlin/managers/Bundler.kt
@@ -297,14 +297,16 @@ data class GemSpec(
                 dependency["name"]?.asText()?.takeIf { dependency["type"]?.asText() == ":runtime" }
             }?.toSet()
 
+            val homepage = yaml["homepage"].asTextOrEmpty()
+
             return GemSpec(
                     yaml["name"].asText(),
                     yaml["version"]["version"].asText(),
-                    yaml["homepage"].asTextOrEmpty(),
+                    homepage,
                     yaml["licenses"]?.asIterable()?.map { it.asText() }?.toSortedSet() ?: sortedSetOf(),
                     yaml["description"].asTextOrEmpty(),
                     runtimeDependencies ?: emptySet(),
-                    parseVcs(yaml["homepage"].asText()),
+                    parseVcs(homepage),
                     RemoteArtifact.EMPTY
             )
         }


### PR DESCRIPTION
It seems the response from the rubygems.org API sometimes contains
different data from the gemspec file, even for the same version.

One case where this occurs is "spork". Installing version 0.9.2
and running "gem specification spork" produces the URL to a
GitHub repository that no longer exists, whereas the data from
rubygems.org ontains the correct URL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/537)
<!-- Reviewable:end -->
