### PR TITLE
SimpleFormIntegrationTest: Upgrade simple_form to version 4.0.0

### DIFF
--- a/analyzer/src/funTest/kotlin/integration/SimpleFormIntegrationTest.kt
+++ b/analyzer/src/funTest/kotlin/integration/SimpleFormIntegrationTest.kt
@@ -45,7 +45,7 @@ class SimpleFormIntegrationTest : AbstractIntegrationSpec() {
             vcs = VcsInfo(
                     type = "Git",
                     url = "https://github.com/plataformatec/simple_form.git",
-                    revision = "5b43d10a0867cc01d2430213b8bb92a3827de0e9",
+                    revision = "516e31ce8f3eb32c5bac9d2a4902fba0783363fb",
                     path = ""
             )
     )


### PR DESCRIPTION
The previous version depends on a version of nokogiri that requires Ruby
version < 2.4. Upgrade simple_form (and thus nokogiri) to support Ruby
2.4.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/540)
<!-- Reviewable:end -->
