### PR TITLE
AppVeyor: Stop caching the Gradle distribution

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,6 @@ cache:
   - $(HOME)\.gradle\caches\jars-3
   - $(HOME)\.gradle\caches\modules-2
   - $(HOME)\.gradle\caches\transforms-1
-  - $(HOME)\.gradle\wrapper\dists
   - $(HOME)\.ivy2
   - $(HOME)\.m2\repository
   - $(HOME)\.ort\analyzer\cache\http


### PR DESCRIPTION
With our limited cache size of 1 GiB we never managed to upload
gradle-4.7-all to the cache anyway, and we should get rid of old
distributions in favor of making space for regular dependency
artifacts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/541)
<!-- Reviewable:end -->
