### PR TITLE
NPM: Teach expandShortcutURL() to leave crazy URLs untouched

### DIFF
--- a/analyzer/src/main/kotlin/managers/NPM.kt
+++ b/analyzer/src/main/kotlin/managers/NPM.kt
@@ -97,6 +97,10 @@ class NPM : PackageManager() {
             }
 
             val path = uri.schemeSpecificPart
+
+            // Do not mess with crazy URLs.
+            if (path.startsWith("git@")) return url
+
             return if (!path.isNullOrEmpty() && listOf(uri.authority, uri.query, uri.fragment).all { it == null }) {
                 // See https://docs.npmjs.com/files/package.json#repository.
                 when (uri.scheme) {

--- a/analyzer/src/test/kotlin/NpmTest.kt
+++ b/analyzer/src/test/kotlin/NpmTest.kt
@@ -46,5 +46,18 @@ class NpmTest : WordSpec({
                 NPM.expandShortcutURL(actualUrl) shouldBe expectedUrl
             }
         }
+
+        "not mess with crazy URLs" {
+            val packages = mapOf(
+                    "git@github.com/cisco/node-jose.git"
+                            to "git@github.com/cisco/node-jose.git",
+                    "https://git@github.com:hacksparrow/node-easyimage.git"
+                            to "https://git@github.com:hacksparrow/node-easyimage.git"
+            )
+
+            packages.forEach { actualUrl, expectedUrl ->
+                NPM.expandShortcutURL(actualUrl) shouldBe expectedUrl
+            }
+        }
     }
 })


### PR DESCRIPTION
These URLs will be handled by normalizeVcsUrl(). This fixes the analyzer
to handle the "git@github.com/cisco/node-jose.git" NPM URL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/545)
<!-- Reviewable:end -->
