### PR TITLE
MavenSupport: Maintain the default list of remote repositories

### DIFF
--- a/analyzer/src/main/kotlin/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/MavenSupport.kt
@@ -306,7 +306,7 @@ class MavenSupport(localRepositoryManagerConverter: (LocalRepositoryManager) -> 
             // ID as the URL is likely to contain characters like ":" which not all file systems support.
             val id = repo.id.takeUnless { it == repo.url } ?: repo.host
             mavenRepositorySystem.createRepository(repo.url, id, true, null, true, null, null)
-        }
+        } + projectBuildingRequest.remoteRepositories
 
         val localProject = localProjects[artifact.identifier()]
 


### PR DESCRIPTION
Instead of overwriting the default remote repositories, keep them at the
end of the list of repositories to search in. This ensures that Maven
Central is always searched as a fall-back, which resembles standard
Maven behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/546)
<!-- Reviewable:end -->
