### PR TITLE
analyzer: Use "GoDep" as provider for package references

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/godep-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/godep-expected-output.yml
@@ -20,19 +20,19 @@ project:
   - name: "default"
     delivered: true
     dependencies:
-    - id: "::github.com/kr/fs:2788f0dbd16903de03cb8186e5c7d97b69ad387b"
+    - id: "GoDep::github.com/kr/fs:2788f0dbd16903de03cb8186e5c7d97b69ad387b"
       dependencies: []
       errors: []
-    - id: "::github.com/kr/pretty:f31442d60e51465c69811e2107ae978868dbea5c"
+    - id: "GoDep::github.com/kr/pretty:f31442d60e51465c69811e2107ae978868dbea5c"
       dependencies: []
       errors: []
-    - id: "::github.com/kr/text:6807e777504f54ad073ecef66747de158294b639"
+    - id: "GoDep::github.com/kr/text:6807e777504f54ad073ecef66747de158294b639"
       dependencies: []
       errors: []
-    - id: "::github.com/pmezard/go-difflib:f78a839676152fd9f4863704f5d516195c18fc14"
+    - id: "GoDep::github.com/pmezard/go-difflib:f78a839676152fd9f4863704f5d516195c18fc14"
       dependencies: []
       errors: []
-    - id: "::golang.org/x/tools:1f1b3322f67af76803c942fd237291538ec68262"
+    - id: "GoDep::golang.org/x/tools:1f1b3322f67af76803c942fd237291538ec68262"
       dependencies: []
       errors: []
 packages:

--- a/analyzer/src/funTest/assets/projects/external/qmstr-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/qmstr-expected-output.yml
@@ -20,40 +20,40 @@ project:
   - name: "default"
     delivered: true
     dependencies:
-    - id: "::github.com/dgraph-io/dgo:939c270eac93a70e63162abd53f78dbc9e928ff6"
+    - id: "GoDep::github.com/dgraph-io/dgo:939c270eac93a70e63162abd53f78dbc9e928ff6"
       dependencies: []
       errors: []
-    - id: "::github.com/gogo/protobuf:v0.5"
+    - id: "GoDep::github.com/gogo/protobuf:v0.5"
       dependencies: []
       errors: []
-    - id: "::github.com/golang/protobuf:v1.0.0"
+    - id: "GoDep::github.com/golang/protobuf:v1.0.0"
       dependencies: []
       errors: []
-    - id: "::github.com/inconshreveable/mousetrap:v1.0"
+    - id: "GoDep::github.com/inconshreveable/mousetrap:v1.0"
       dependencies: []
       errors: []
-    - id: "::github.com/pkg/errors:v0.8.0"
+    - id: "GoDep::github.com/pkg/errors:v0.8.0"
       dependencies: []
       errors: []
-    - id: "::github.com/spf13/cobra:v0.0.1"
+    - id: "GoDep::github.com/spf13/cobra:v0.0.1"
       dependencies: []
       errors: []
-    - id: "::github.com/spf13/pflag:v1.0.0"
+    - id: "GoDep::github.com/spf13/pflag:v1.0.0"
       dependencies: []
       errors: []
-    - id: "::golang.org/x/net:b417086c80e91bfa321ef761574721644b8b9f61"
+    - id: "GoDep::golang.org/x/net:b417086c80e91bfa321ef761574721644b8b9f61"
       dependencies: []
       errors: []
-    - id: "::golang.org/x/text:e19ae1496984b1c655b8044a65c0300a3c878dd3"
+    - id: "GoDep::golang.org/x/text:e19ae1496984b1c655b8044a65c0300a3c878dd3"
       dependencies: []
       errors: []
-    - id: "::google.golang.org/genproto:4eb30f4778eed4c258ba66527a0d4f9ec8a36c45"
+    - id: "GoDep::google.golang.org/genproto:4eb30f4778eed4c258ba66527a0d4f9ec8a36c45"
       dependencies: []
       errors: []
-    - id: "::google.golang.org/grpc:v1.9.2"
+    - id: "GoDep::google.golang.org/grpc:v1.9.2"
       dependencies: []
       errors: []
-    - id: "::gopkg.in/yaml.v2:d670f9405373e636a5a2765eea47fac0c9bc91a4"
+    - id: "GoDep::gopkg.in/yaml.v2:d670f9405373e636a5a2765eea47fac0c9bc91a4"
       dependencies: []
       errors: []
 packages:

--- a/analyzer/src/funTest/assets/projects/external/sprig-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/sprig-expected-output.yml
@@ -20,31 +20,31 @@ project:
   - name: "default"
     delivered: true
     dependencies:
-    - id: "::github.com/Masterminds/semver:v1.2.2"
+    - id: "GoDep::github.com/Masterminds/semver:v1.2.2"
       dependencies: []
       errors: []
-    - id: "::github.com/aokoli/goutils:9c37978a95bd5c709a15883b6242714ea6709e64"
+    - id: "GoDep::github.com/aokoli/goutils:9c37978a95bd5c709a15883b6242714ea6709e64"
       dependencies: []
       errors: []
-    - id: "::github.com/davecgh/go-spew:5215b55f46b2b919f50a1df0eaa5886afe4e3b3d"
+    - id: "GoDep::github.com/davecgh/go-spew:5215b55f46b2b919f50a1df0eaa5886afe4e3b3d"
       dependencies: []
       errors: []
-    - id: "::github.com/huandu/xstrings:3959339b333561bf62a38b424fd41517c2c90f40"
+    - id: "GoDep::github.com/huandu/xstrings:3959339b333561bf62a38b424fd41517c2c90f40"
       dependencies: []
       errors: []
-    - id: "::github.com/imdario/mergo:0.2.2"
+    - id: "GoDep::github.com/imdario/mergo:0.2.2"
       dependencies: []
       errors: []
-    - id: "::github.com/pmezard/go-difflib:d8ed2627bdf02c080bf22230dbb337003b7aba2d"
+    - id: "GoDep::github.com/pmezard/go-difflib:d8ed2627bdf02c080bf22230dbb337003b7aba2d"
       dependencies: []
       errors: []
-    - id: "::github.com/satori/go.uuid:v1.1.0"
+    - id: "GoDep::github.com/satori/go.uuid:v1.1.0"
       dependencies: []
       errors: []
-    - id: "::github.com/stretchr/testify:e3a8ff8ce36581f87a15341206f205b1da467059"
+    - id: "GoDep::github.com/stretchr/testify:e3a8ff8ce36581f87a15341206f205b1da467059"
       dependencies: []
       errors: []
-    - id: "::golang.org/x/crypto:d172538b2cfce0c13cee31e647d0367aa8cd2486"
+    - id: "GoDep::golang.org/x/crypto:d172538b2cfce0c13cee31e647d0367aa8cd2486"
       dependencies: []
       errors: []
 packages:

--- a/analyzer/src/main/kotlin/managers/GoDep.kt
+++ b/analyzer/src/main/kotlin/managers/GoDep.kt
@@ -109,7 +109,7 @@ class GoDep : PackageManager() {
             packages.add(pkg)
 
             packageRefs.add(PackageReference(
-                    id = Identifier("", "", pkg.id.name, pkg.id.version),
+                    id = Identifier(provider, "", pkg.id.name, pkg.id.version),
                     dependencies = sortedSetOf(),
                     errors = errors)
             )


### PR DESCRIPTION
Otherwise the package references cannot be matched with the packages where
"GoDep" is already used as provider.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/551)
<!-- Reviewable:end -->
