### PR TITLE
LocalScanner: Reduce the number of calls to getDetails() and friends

### DIFF
--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -196,7 +196,7 @@ abstract class LocalScanner : Scanner() {
 
         val provenance = Provenance(downloadResult.dateTime, downloadResult.sourceArtifact, downloadResult.vcsInfo,
                 downloadResult.originalVcsInfo)
-        val scanResult = scanPath(downloadResult.downloadDirectory, resultsFile, provenance, scannerDetails)
+        val scanResult = scanPath(scannerDetails, downloadResult.downloadDirectory, provenance, resultsFile)
 
         ScanResultsCache.add(pkg.id, scanResult)
 
@@ -222,7 +222,7 @@ abstract class LocalScanner : Scanner() {
 
         println("Running $this version ${scannerDetails.version} on path '${path.canonicalPath}'.")
 
-        return scanPath(path, resultsFile, Provenance(downloadTime = Instant.now()), scannerDetails)
+        return scanPath(scannerDetails, path, Provenance(downloadTime = Instant.now()), resultsFile)
                 .also { println("Stored $this results in '${resultsFile.absolutePath}'.") }
     }
 
@@ -230,17 +230,17 @@ abstract class LocalScanner : Scanner() {
      * Scan the provided [path] for license information, writing results to [resultsFile] using the scanner's native
      * output file format. Note that no scan results cache is used by this function.
      *
-     * @param path The directory or file to scan.
-     * @param resultsFile The file to store scan results in.
-     * @param provenance [Provenance] information about the files in [path].
      * @param scannerDetails The [ScannerDetails] of the current scanner.
+     * @param path The directory or file to scan.
+     * @param provenance [Provenance] information about the files in [path].
+     * @param resultsFile The file to store scan results in.
      *
      * @return The [ScanResult], containing the provided [provenance] and [scannerDetails].
      *
      * @throws ScanException In case the path could not be scanned.
      */
-    protected abstract fun scanPath(path: File, resultsFile: File, provenance: Provenance,
-                                    scannerDetails: ScannerDetails): ScanResult
+    protected abstract fun scanPath(scannerDetails: ScannerDetails, path: File, provenance: Provenance,
+                                    resultsFile: File): ScanResult
 
     internal abstract fun getResult(resultsFile: File): Result
 }

--- a/scanner/src/main/kotlin/scanners/Askalono.kt
+++ b/scanner/src/main/kotlin/scanners/Askalono.kt
@@ -98,7 +98,7 @@ object Askalono : LocalScanner() {
                 it.substringAfter("askalono ")
             })
 
-    override fun scanPath(path: File, resultsFile: File, provenance: Provenance, scannerDetails: ScannerDetails)
+    override fun scanPath(scannerDetails: ScannerDetails, path: File, provenance: Provenance, resultsFile: File)
             : ScanResult {
         val startTime = Instant.now()
 

--- a/scanner/src/main/kotlin/scanners/BoyterLc.kt
+++ b/scanner/src/main/kotlin/scanners/BoyterLc.kt
@@ -108,7 +108,7 @@ object BoyterLc : LocalScanner() {
                 it.substringAfter("licensechecker version ")
             })
 
-    override fun scanPath(path: File, resultsFile: File, provenance: Provenance, scannerDetails: ScannerDetails)
+    override fun scanPath(scannerDetails: ScannerDetails, path: File, provenance: Provenance, resultsFile: File)
             : ScanResult {
         val startTime = Instant.now()
 

--- a/scanner/src/main/kotlin/scanners/FileCounter.kt
+++ b/scanner/src/main/kotlin/scanners/FileCounter.kt
@@ -45,7 +45,7 @@ object FileCounter : LocalScanner() {
 
     override fun getVersion(dir: File) = scannerVersion
 
-    override fun scanPath(path: File, resultsFile: File, provenance: Provenance, scannerDetails: ScannerDetails)
+    override fun scanPath(scannerDetails: ScannerDetails, path: File, provenance: Provenance, resultsFile: File)
             : ScanResult {
         val startTime = Instant.now()
         val result = FileCountResult(path.walk().count())

--- a/scanner/src/main/kotlin/scanners/Licensee.kt
+++ b/scanner/src/main/kotlin/scanners/Licensee.kt
@@ -71,7 +71,7 @@ object Licensee : LocalScanner() {
 
     override fun getVersion(dir: File) = getCommandVersion(dir.resolve(scannerExe).canonicalPath, "version")
 
-    override fun scanPath(path: File, resultsFile: File, provenance: Provenance, scannerDetails: ScannerDetails)
+    override fun scanPath(scannerDetails: ScannerDetails, path: File, provenance: Provenance, resultsFile: File)
             : ScanResult {
         // Licensee has issues with absolute Windows paths passed as an argument. Work around that by using the path to
         // scan as the working directory.

--- a/scanner/src/main/kotlin/scanners/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/ScanCode.kt
@@ -123,7 +123,7 @@ object ScanCode : LocalScanner() {
                 it.substringAfter("ScanCode version ")
             })
 
-    override fun scanPath(path: File, resultsFile: File, provenance: Provenance, scannerDetails: ScannerDetails)
+    override fun scanPath(scannerDetails: ScannerDetails, path: File, provenance: Provenance, resultsFile: File)
             : ScanResult {
         val options = (DEFAULT_CONFIGURATION_OPTIONS + DEFAULT_NON_CONFIGURATION_OPTIONS).toMutableList()
 


### PR DESCRIPTION
Perform some minor refactoring to reduce the number of times getDetails()
is called. It in turn calls getVersion() which, depending on the
scanner, might take a few seconds. So doing this call for each package
to scan might sum up to a significant amount of time for projects with
several hundrets or even thousands of packages. Assuming that the
scanner executable is not changed while scanning packages, only call
getDetails() once when starting to scan a list of packages.

While at it, also call Instant.now() only once in specific places. This
is not to improve performance, but to have exactly matching time stamps
in those places.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/555)
<!-- Reviewable:end -->
