### PR TITLE
analyzer: Do not create empty projects when the dependency resolution fails

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output-multiple-lockfiles.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output-multiple-lockfiles.yml
@@ -1,0 +1,23 @@
+---
+allowDynamicVersions: false
+project:
+  id: "NPM::src/funTest/assets/projects/synthetic/npm/multiple-lockfiles/package.json:"
+  definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
+  declared_licenses: []
+  aliases: []
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "git"
+    url: "<REPLACE_URL>"
+    revision: "<REPLACE_REVISION>"
+    path: "<REPLACE_PATH>"
+  homepage_url: ""
+  scopes: []
+packages: []
+errors:
+- "IllegalArgumentException: src/funTest/assets/projects/synthetic/npm/multiple-lockfiles\
+  \ contains multiple lockfiles. It is ambiguous which one to use."

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output-no-lockfile.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output-no-lockfile.yml
@@ -1,0 +1,23 @@
+---
+allowDynamicVersions: false
+project:
+  id: "NPM::src/funTest/assets/projects/synthetic/npm/no-lockfile/package.json:"
+  definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
+  declared_licenses: []
+  aliases: []
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "git"
+    url: "<REPLACE_URL>"
+    revision: "<REPLACE_REVISION>"
+    path: "<REPLACE_PATH>"
+  homepage_url: ""
+  scopes: []
+packages: []
+errors:
+- "IllegalArgumentException: No lockfile found in src/funTest/assets/projects/synthetic/npm/no-lockfile,\
+  \ dependency versions are unstable."

--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -23,6 +23,7 @@ import ch.frankel.slf4k.*
 
 import com.here.ort.analyzer.managers.*
 import com.here.ort.downloader.VersionControlSystem
+import com.here.ort.model.Identifier
 import com.here.ort.model.Project
 import com.here.ort.model.ProjectAnalyzerResult
 import com.here.ort.model.VcsInfo
@@ -196,7 +197,18 @@ abstract class PackageManager {
                 } catch (e: Exception) {
                     e.showStackTrace()
 
-                    result[definitionFile] = ProjectAnalyzerResult(Main.allowDynamicVersions, Project.EMPTY,
+                    val errorProject = Project.EMPTY.copy(
+                            id = Identifier(
+                                    provider = toString(),
+                                    namespace = "",
+                                    name = definitionFile.path,
+                                    version = ""
+                            ),
+                            definitionFilePath = VersionControlSystem.getPathToRoot(definitionFile) ?: "",
+                            vcsProcessed = processProjectVcs(definitionFile.parentFile)
+                    )
+
+                    result[definitionFile] = ProjectAnalyzerResult(Main.allowDynamicVersions, errorProject,
                             sortedSetOf(), e.collectMessages())
 
                     log.error { "Resolving dependencies for '${definitionFile.name}' failed with: ${e.message}" }

--- a/analyzer/src/main/kotlin/managers/Bower.kt
+++ b/analyzer/src/main/kotlin/managers/Bower.kt
@@ -34,4 +34,6 @@ class Bower : PackageManager() {
     }
 
     override fun command(workingDir: File) = "bower"
+
+    override fun toString() = Bower.toString()
 }

--- a/analyzer/src/main/kotlin/managers/Bundler.kt
+++ b/analyzer/src/main/kotlin/managers/Bundler.kt
@@ -74,6 +74,8 @@ class Bundler : PackageManager() {
 
     override fun command(workingDir: File) = bundle
 
+    override fun toString() = Bundler.toString()
+
     override fun prepareResolution(definitionFiles: List<File>): List<File> {
         // We do not actually depend on any features specific to a version of Bundler, but we still want to stick to
         // fixed versions to be sure to get consistent results.
@@ -107,7 +109,7 @@ class Bundler : PackageManager() {
             installDependencies(workingDir)
 
             val (projectName, version, homepageUrl, declaredLicenses) = parseProject(workingDir)
-            val projectId = Identifier(Bundler.toString(), "", projectName, version)
+            val projectId = Identifier(toString(), "", projectName, version)
             val groupedDeps = getDependencyGroups(workingDir)
 
             for ((groupName, dependencyList) in groupedDeps) {
@@ -167,7 +169,7 @@ class Bundler : PackageManager() {
 
         try {
             var gemSpec = getGemspec(gemName, workingDir)
-            val gemId = Identifier(Bundler.toString(), "", gemSpec.name, gemSpec.version)
+            val gemId = Identifier(toString(), "", gemSpec.name, gemSpec.version)
 
             // The project itself can be listed as a dependency if the project is a Gem (i.e. there is a .gemspec file
             // for it, and the Gemfile refers to it). In that case, skip querying Rubygems and adding Package and

--- a/analyzer/src/main/kotlin/managers/CocoaPods.kt
+++ b/analyzer/src/main/kotlin/managers/CocoaPods.kt
@@ -34,4 +34,6 @@ class CocoaPods : PackageManager() {
     }
 
     override fun command(workingDir: File) = "pod"
+
+    override fun toString() = CocoaPods.toString()
 }

--- a/analyzer/src/main/kotlin/managers/GoDep.kt
+++ b/analyzer/src/main/kotlin/managers/GoDep.kt
@@ -64,6 +64,8 @@ class GoDep : PackageManager() {
 
     override fun command(workingDir: File) = "dep"
 
+    override fun toString() = GoDep.toString()
+
     override fun resolveDependencies(definitionFile: File): ProjectAnalyzerResult? {
         val projectDir = resolveProjectRoot(definitionFile)
         val projectVcs = processProjectVcs(projectDir)
@@ -77,7 +79,7 @@ class GoDep : PackageManager() {
         val projects = parseProjects(workingDir, gopath)
         val packages: MutableList<Package> = mutableListOf()
         val packageRefs: MutableList<PackageReference> = mutableListOf()
-        val provider = GoDep.toString()
+        val provider = toString()
 
         for (project in projects) {
             // parseProjects() made sure that all entries contain these keys

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -80,6 +80,8 @@ class Gradle : PackageManager() {
 
     override fun command(workingDir: File) = if (File(workingDir, wrapper).isFile) wrapper else gradle
 
+    override fun toString() = Gradle.toString()
+
     override fun resolveDependencies(definitionFile: File): ProjectAnalyzerResult? {
         val connection = GradleConnector
                 .newConnector()
@@ -119,7 +121,7 @@ class Gradle : PackageManager() {
 
             val project = Project(
                     id = Identifier(
-                            provider = Gradle.toString(),
+                            provider = toString(),
                             namespace = dependencyTreeModel.group,
                             name = dependencyTreeModel.name,
                             version = dependencyTreeModel.version
@@ -151,7 +153,7 @@ class Gradle : PackageManager() {
             val rawPackage by lazy {
                 Package(
                         id = Identifier(
-                                provider = "Maven",
+                                provider = Maven.toString(),
                                 namespace = dependency.groupId,
                                 name = dependency.artifactId,
                                 version = dependency.version
@@ -192,8 +194,8 @@ class Gradle : PackageManager() {
         }
 
         val transitiveDependencies = dependency.dependencies.map { parseDependency(it, packages, repositories) }
-        return PackageReference(Identifier("Maven", dependency.groupId, dependency.artifactId, dependency.version),
-                transitiveDependencies.toSortedSet(), errors)
+        return PackageReference(Identifier(Maven.toString(), dependency.groupId, dependency.artifactId,
+                dependency.version), transitiveDependencies.toSortedSet(), errors)
     }
 
     /**

--- a/analyzer/src/main/kotlin/managers/Maven.kt
+++ b/analyzer/src/main/kotlin/managers/Maven.kt
@@ -87,6 +87,8 @@ class Maven : PackageManager() {
 
     override fun command(workingDir: File) = "mvn"
 
+    override fun toString() = Maven.toString()
+
     override fun prepareResolution(definitionFiles: List<File>): List<File> {
         val projectBuilder = maven.container.lookup(ProjectBuilder::class.java, "default")
         val projectBuildingRequest = maven.createProjectBuildingRequest(false)
@@ -182,7 +184,7 @@ class Maven : PackageManager() {
             }
 
             return PackageReference(
-                    Identifier("Maven", node.artifact.groupId, node.artifact.artifactId, node.artifact.version),
+                    Identifier(toString(), node.artifact.groupId, node.artifact.artifactId, node.artifact.version),
                     dependencies = sortedSetOf(),
                     errors = e.collectMessages()
             )

--- a/analyzer/src/main/kotlin/managers/NPM.kt
+++ b/analyzer/src/main/kotlin/managers/NPM.kt
@@ -123,6 +123,8 @@ class NPM : PackageManager() {
 
     override fun command(workingDir: File) = if (File(workingDir, "yarn.lock").isFile) yarn else npm
 
+    override fun toString() = NPM.toString()
+
     override fun prepareResolution(definitionFiles: List<File>): List<File> {
         // We do not actually depend on any features specific to an NPM 5.x or Yarn version, but we still want to
         // stick to fixed versions to be sure to get consistent results.
@@ -265,7 +267,7 @@ class NPM : PackageManager() {
 
             val module = Package(
                     id = Identifier(
-                            provider = "NPM",
+                            provider = toString(),
                             namespace = namespace,
                             name = name,
                             version = version
@@ -413,7 +415,7 @@ class NPM : PackageManager() {
             return packageInfo.toReference(dependencies)
         } else if (rootDir == startDir) {
             log.error { "Could not find module $name" }
-            return PackageReference(Identifier("NPM", "", name, "unknown, package not installed"), sortedSetOf())
+            return PackageReference(Identifier(toString(), "", name, "unknown, package not installed"), sortedSetOf())
         } else {
             var parent = startDir.parentFile.parentFile
 
@@ -461,7 +463,7 @@ class NPM : PackageManager() {
 
         val project = Project(
                 id = Identifier(
-                        provider = NPM.toString(),
+                        provider = toString(),
                         namespace = namespace,
                         name = name,
                         version = version

--- a/analyzer/src/main/kotlin/managers/PIP.kt
+++ b/analyzer/src/main/kotlin/managers/PIP.kt
@@ -80,6 +80,8 @@ class PIP : PackageManager() {
 
     override fun command(workingDir: File) = "pip"
 
+    override fun toString() = PIP.toString()
+
     private fun runPipInVirtualEnv(virtualEnvDir: File, workingDir: File, vararg commandArgs: String) =
             runInVirtualEnv(virtualEnvDir, workingDir, command(workingDir), *TRUSTED_HOSTS, *commandArgs)
 
@@ -256,7 +258,7 @@ class PIP : PackageManager() {
 
         val project = Project(
                 id = Identifier(
-                        provider = PIP.toString(),
+                        provider = toString(),
                         namespace = "",
                         name = projectName,
                         version = projectVersion

--- a/analyzer/src/main/kotlin/managers/PhpComposer.kt
+++ b/analyzer/src/main/kotlin/managers/PhpComposer.kt
@@ -80,6 +80,8 @@ class PhpComposer : PackageManager() {
                 }
             }
 
+    override fun toString() = PhpComposer.toString()
+
     override fun prepareResolution(definitionFiles: List<File>): List<File> {
         // If all of the directories we are analyzing contain a composer.phar, no global installation of Composer is
         // required and hence we skip the version check.
@@ -189,7 +191,7 @@ class PhpComposer : PackageManager() {
 
         return Project(
                 id = Identifier(
-                        provider = PhpComposer.toString(),
+                        provider = toString(),
                         namespace = rawName.substringBefore("/"),
                         name = rawName.substringAfter("/"),
                         version = json["version"].asTextOrEmpty()
@@ -223,7 +225,7 @@ class PhpComposer : PackageManager() {
 
                 packages[rawName] = Package(
                         id = Identifier(
-                                provider = PhpComposer.toString(),
+                                provider = toString(),
                                 namespace = rawName.substringBefore("/"),
                                 name = rawName.substringAfter("/"),
                                 version = version

--- a/analyzer/src/main/kotlin/managers/SBT.kt
+++ b/analyzer/src/main/kotlin/managers/SBT.kt
@@ -62,6 +62,8 @@ class SBT : PackageManager() {
 
     override fun command(workingDir: File) = if (OS.isWindows) "sbt.bat" else "sbt"
 
+    override fun toString() = SBT.toString()
+
     private fun extractLowestSbtVersion(stdout: String): String {
         val versions = stdout.lines().mapNotNull {
             VERSION_REGEX.matchEntire(it)?.groupValues?.getOrNull(1)?.let { Semver(it) }

--- a/analyzer/src/main/kotlin/managers/Unmanaged.kt
+++ b/analyzer/src/main/kotlin/managers/Unmanaged.kt
@@ -40,6 +40,8 @@ class Unmanaged : PackageManager() {
 
     override fun command(workingDir: File) = throw NotImplementedError()
 
+    override fun toString() = Unmanaged.toString()
+
     /**
      * Returns an [ProjectAnalyzerResult] containing a [Project] for the passed [definitionFile], but does not perform
      * any dependency resolution.
@@ -49,7 +51,7 @@ class Unmanaged : PackageManager() {
     override fun resolveDependencies(definitionFile: File): ProjectAnalyzerResult? {
         val project = Project(
                 id = Identifier(
-                        provider = "Unmanaged",
+                        provider = toString(),
                         namespace = "",
                         name = definitionFile.name,
                         version = ""


### PR DESCRIPTION
Using empty projects is a problem if the dependency resolution fails for
multiple projects, in this case they would overwrite each other in the
analyzer result. Also it is hard to fix the issue if there is no
information about which project failed.

Instead use the relative path of the definition file as the project name
and also set the VCS info if available.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/559)
<!-- Reviewable:end -->
