### PR TITLE
GoDep: Fix the revision to be the one from Gopkg.lock again

### DIFF
--- a/analyzer/src/main/kotlin/managers/GoDep.kt
+++ b/analyzer/src/main/kotlin/managers/GoDep.kt
@@ -248,7 +248,7 @@ class GoDep : PackageManager() {
 
         val repoRoot = Paths.get(gopath.path, "src", importPath).toFile()
 
-        // We want the revision recorded in Gopkg.lock, not the one "go get" fetched.
-        return processProjectVcs(repoRoot, vcs)
+        // We want the revision recorded in Gopkg.lock contained in "vcs", not the one "go get" fetched.
+        return processProjectVcs(repoRoot, vcs).copy(revision = vcs.revision)
     }
 }


### PR DESCRIPTION
This fixes a regression introduced by 2022201. The commit went in
unnoticed due to an issue with the test being skipped, see

https://ci.appveyor.com/project/heremaps/oss-review-toolkit/build/1.0.2569/tests

This yet needs to be investigated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/564)
<!-- Reviewable:end -->
