### PR TITLE
Remove code that works around the wrong IntelliJ IDEA working directory

### DIFF
--- a/analyzer/src/funTest/kotlin/BabelTest.kt
+++ b/analyzer/src/funTest/kotlin/BabelTest.kt
@@ -24,7 +24,6 @@ import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
 import com.here.ort.utils.safeDeleteRecursively
-import com.here.ort.utils.searchUpwardsForSubdirectory
 
 import io.kotlintest.Description
 import io.kotlintest.TestResult
@@ -34,9 +33,8 @@ import io.kotlintest.specs.WordSpec
 import java.io.File
 
 class BabelTest : WordSpec() {
-    private val rootDir = File(".").searchUpwardsForSubdirectory(".git")!!
-    private val projectDir = File(rootDir, "analyzer/src/funTest/assets/projects/synthetic/npm-babel")
-    private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
+    private val projectDir = File("src/funTest/assets/projects/synthetic/npm-babel")
+    private val vcsDir = VersionControlSystem.forDirectory(projectDir.absoluteFile)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()
 

--- a/analyzer/src/funTest/kotlin/BundlerTest.kt
+++ b/analyzer/src/funTest/kotlin/BundlerTest.kt
@@ -26,7 +26,6 @@ import com.here.ort.model.yamlMapper
 import com.here.ort.utils.ExpensiveTag
 import com.here.ort.utils.normalizeVcsUrl
 import com.here.ort.utils.safeDeleteRecursively
-import com.here.ort.utils.searchUpwardsForSubdirectory
 
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldNotBe
@@ -36,8 +35,7 @@ import io.kotlintest.specs.WordSpec
 import java.io.File
 
 class BundlerTest : WordSpec() {
-    private val rootDir = File(".").searchUpwardsForSubdirectory(".git")!!
-    private val projectsDir = File(rootDir, "analyzer/src/funTest/assets/projects/synthetic/bundler")
+    private val projectsDir = File("src/funTest/assets/projects/synthetic/bundler")
     private val vcsDir = VersionControlSystem.forDirectory(projectsDir)!!
     private val vcsRevision = vcsDir.getRevision()
     private val vcsUrl = vcsDir.getRemoteUrl()
@@ -86,13 +84,10 @@ class BundlerTest : WordSpec() {
         }
     }
 
-    private fun patchExpectedResult(workingDir: File, result: String): String {
-        val vcsPath = workingDir.relativeTo(rootDir).invariantSeparatorsPath
-
-        return result
-                // vcs_processed:
-                .replaceFirst("<REPLACE_URL>", normalizeVcsUrl(vcsUrl))
-                .replaceFirst("<REPLACE_REVISION>", vcsRevision)
-                .replaceFirst("<REPLACE_PATH>", vcsPath)
-    }
+    private fun patchExpectedResult(projectDir: File, result: String) =
+            result
+                    // vcs_processed:
+                    .replaceFirst("<REPLACE_URL>", normalizeVcsUrl(vcsUrl))
+                    .replaceFirst("<REPLACE_REVISION>", vcsRevision)
+                    .replaceFirst("<REPLACE_PATH>", vcsDir.getPathToRoot(projectDir))
 }

--- a/analyzer/src/funTest/kotlin/GoDepTest.kt
+++ b/analyzer/src/funTest/kotlin/GoDepTest.kt
@@ -24,7 +24,6 @@ import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.Project
 import com.here.ort.model.VcsInfo
 import com.here.ort.model.yamlMapper
-import com.here.ort.utils.searchUpwardsForSubdirectory
 
 import io.kotlintest.matchers.startWith
 import io.kotlintest.shouldBe
@@ -34,8 +33,7 @@ import io.kotlintest.specs.WordSpec
 import java.io.File
 
 class GoDepTest : WordSpec() {
-    private val rootDir = File(".").searchUpwardsForSubdirectory(".git")!!
-    private val projectsDir = File(rootDir, "analyzer/src/funTest/assets/projects")
+    private val projectsDir = File("src/funTest/assets/projects")
 
     init {
         "GoDep" should {

--- a/analyzer/src/funTest/kotlin/GradleTest.kt
+++ b/analyzer/src/funTest/kotlin/GradleTest.kt
@@ -26,7 +26,6 @@ import com.here.ort.model.yamlMapper
 import com.here.ort.utils.ExpensiveTag
 import com.here.ort.utils.ProcessCapture
 import com.here.ort.utils.normalizeVcsUrl
-import com.here.ort.utils.searchUpwardsForSubdirectory
 
 import io.kotlintest.Description
 import io.kotlintest.Spec
@@ -41,8 +40,7 @@ import io.kotlintest.tables.table
 import java.io.File
 
 class GradleTest : StringSpec() {
-    private val rootDir = File(".").searchUpwardsForSubdirectory(".git")!!
-    private val projectDir = File(rootDir, "analyzer/src/funTest/assets/projects/synthetic/gradle")
+    private val projectDir = File("src/funTest/assets/projects/synthetic/gradle")
     private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()

--- a/analyzer/src/funTest/kotlin/MainTest.kt
+++ b/analyzer/src/funTest/kotlin/MainTest.kt
@@ -22,7 +22,6 @@ package com.here.ort.analyzer
 import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.utils.normalizeVcsUrl
 import com.here.ort.utils.safeDeleteRecursively
-import com.here.ort.utils.searchUpwardsForSubdirectory
 
 import io.kotlintest.Description
 import io.kotlintest.TestResult
@@ -37,8 +36,7 @@ import java.io.PrintStream
  * A test for the main entry point of the application.
  */
 class MainTest : StringSpec() {
-    private val rootDir = File(".").searchUpwardsForSubdirectory(".git")!!
-    private val projectDir = File(rootDir, "analyzer/src/funTest/assets/projects/synthetic")
+    private val projectDir = File("src/funTest/assets/projects/synthetic")
     private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()

--- a/analyzer/src/funTest/kotlin/MavenTest.kt
+++ b/analyzer/src/funTest/kotlin/MavenTest.kt
@@ -24,7 +24,6 @@ import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
 import com.here.ort.utils.safeDeleteRecursively
-import com.here.ort.utils.searchUpwardsForSubdirectory
 
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.StringSpec
@@ -32,8 +31,7 @@ import io.kotlintest.specs.StringSpec
 import java.io.File
 
 class MavenTest : StringSpec() {
-    private val rootDir = File(".").searchUpwardsForSubdirectory(".git")!!
-    private val projectDir = File(rootDir, "analyzer/src/funTest/assets/projects/synthetic/maven")
+    private val projectDir = File("src/funTest/assets/projects/synthetic/maven")
     private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()
@@ -46,7 +44,7 @@ class MavenTest : StringSpec() {
 
     init {
         "jgnash parent dependencies are detected correctly" {
-            val projectDir = File(rootDir, "analyzer/src/funTest/assets/projects/external/jgnash")
+            val projectDir = File("src/funTest/assets/projects/external/jgnash")
             val pomFile = File(projectDir, "pom.xml")
             val expectedResult = File(projectDir.parentFile, "jgnash-expected-output.yml").readText()
 
@@ -56,7 +54,7 @@ class MavenTest : StringSpec() {
         }
 
         "jgnash-core dependencies are detected correctly" {
-            val projectDir = File(rootDir, "analyzer/src/funTest/assets/projects/external/jgnash")
+            val projectDir = File("src/funTest/assets/projects/external/jgnash")
 
             val pomFileCore = File(projectDir, "jgnash-core/pom.xml")
             val pomFileResources = File(projectDir, "jgnash-resources/pom.xml")
@@ -111,7 +109,7 @@ class MavenTest : StringSpec() {
             File(userHome, ".m2/repository/org/springframework/boot/spring-boot-starter-parent/1.5.3.RELEASE")
                     .safeDeleteRecursively()
 
-            val projectDir = File(rootDir, "analyzer/src/funTest/assets/projects/synthetic/maven-parent")
+            val projectDir = File("src/funTest/assets/projects/synthetic/maven-parent")
             val pomFile = File(projectDir, "pom.xml")
             val expectedResult = patchExpectedResult("maven-parent-expected-output-root.yml")
 

--- a/analyzer/src/funTest/kotlin/PipTest.kt
+++ b/analyzer/src/funTest/kotlin/PipTest.kt
@@ -23,7 +23,6 @@ import com.here.ort.analyzer.managers.PIP
 import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
-import com.here.ort.utils.searchUpwardsForSubdirectory
 
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.StringSpec
@@ -31,35 +30,34 @@ import io.kotlintest.specs.StringSpec
 import java.io.File
 
 class PipTest : StringSpec({
-    val rootDir = File(".").searchUpwardsForSubdirectory(".git")!!
-    val projectDir = File(rootDir, "analyzer/src/funTest/assets/projects")
+    val projectsDir = File("src/funTest/assets/projects")
 
     "setup.py dependencies should be resolved correctly for spdx-tools-python" {
-        val definitionFile = File(projectDir, "external/spdx-tools-python/setup.py")
+        val definitionFile = File(projectsDir, "external/spdx-tools-python/setup.py")
 
         val result = PIP.create().resolveDependencies(listOf(definitionFile))[definitionFile]
-        val expectedResult = File(projectDir, "external/spdx-tools-python-expected-output.yml").readText()
+        val expectedResult = File(projectsDir, "external/spdx-tools-python-expected-output.yml").readText()
 
         yamlMapper.writeValueAsString(result) shouldBe expectedResult
     }
 
     "requirements.txt dependencies should be resolved correctly for example-python-flask" {
-        val definitionFile = File(projectDir, "external/example-python-flask/requirements.txt")
+        val definitionFile = File(projectsDir, "external/example-python-flask/requirements.txt")
 
         val result = PIP.create().resolveDependencies(listOf(definitionFile))[definitionFile]
-        val expectedResult = File(projectDir, "external/example-python-flask-expected-output.yml").readText()
+        val expectedResult = File(projectsDir, "external/example-python-flask-expected-output.yml").readText()
 
         yamlMapper.writeValueAsString(result) shouldBe expectedResult
     }
 
     "metadata should be captured from setup.py even if requirements.txt is present" {
-        val definitionFile = File(projectDir, "synthetic/pip/requirements.txt")
-        val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
+        val definitionFile = File(projectsDir, "synthetic/pip/requirements.txt")
+        val vcsDir = VersionControlSystem.forDirectory(projectsDir)!!
         val vcsUrl = vcsDir.getRemoteUrl()
         val vcsRevision = vcsDir.getRevision()
-        val vcsPath = definitionFile.parentFile.relativeTo(rootDir).invariantSeparatorsPath
+        val vcsPath = vcsDir.getPathToRoot(definitionFile.parentFile)
 
-        val expectedResult = File(projectDir, "synthetic/pip-expected-output.yml").readText()
+        val expectedResult = File(projectsDir, "synthetic/pip-expected-output.yml").readText()
                 // project.vcs_processed:
                 .replaceFirst("<REPLACE_URL>", normalizeVcsUrl(vcsUrl))
                 .replaceFirst("<REPLACE_REVISION>", vcsRevision)

--- a/analyzer/src/funTest/kotlin/SbtTest.kt
+++ b/analyzer/src/funTest/kotlin/SbtTest.kt
@@ -22,7 +22,6 @@ package com.here.ort.analyzer
 import com.here.ort.analyzer.managers.SBT
 import com.here.ort.downloader.vcs.Git
 import com.here.ort.model.yamlMapper
-import com.here.ort.utils.searchUpwardsForSubdirectory
 
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.StringSpec
@@ -34,10 +33,7 @@ class SbtTest : StringSpec({
 
     "Dependencies of the external 'directories' project should be detected correctly" {
         val projectName = "directories"
-
-        val rootDir = File(".").searchUpwardsForSubdirectory(".git")
-        val projectDir = File(rootDir, "analyzer/src/funTest/assets/projects/external/$projectName")
-
+        val projectDir = File("src/funTest/assets/projects/external/$projectName")
         val definitionFile = File(projectDir, "build.sbt")
         val expectedOutputFile = File(projectDir.parentFile, "$projectName-expected-output.yml")
 

--- a/analyzer/src/test/kotlin/PackageManagerTest.kt
+++ b/analyzer/src/test/kotlin/PackageManagerTest.kt
@@ -21,7 +21,6 @@ package com.here.ort.util
 
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.analyzer.managers.*
-import com.here.ort.utils.searchUpwardsForSubdirectory
 
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldThrow
@@ -30,8 +29,7 @@ import io.kotlintest.specs.WordSpec
 import java.io.File
 
 class PackageManagerTest : WordSpec({
-    val rootDir = File(".").searchUpwardsForSubdirectory(".git")
-    val projectDir = File(rootDir, "analyzer/src/funTest/assets/projects/synthetic/all-managers")
+    val projectDir = File("analyzer/src/funTest/assets/projects/synthetic/all-managers")
 
     "findManagedFiles" should {
         "find all managed files" {

--- a/analyzer/src/test/kotlin/YamlFilePackageCurationProviderTest.kt
+++ b/analyzer/src/test/kotlin/YamlFilePackageCurationProviderTest.kt
@@ -20,7 +20,6 @@
 package com.here.ort.analyzer
 
 import com.here.ort.model.Identifier
-import com.here.ort.utils.searchUpwardsForSubdirectory
 
 import io.kotlintest.matchers.haveSize
 import io.kotlintest.should
@@ -30,8 +29,7 @@ import io.kotlintest.specs.StringSpec
 import java.io.File
 
 class YamlFilePackageCurationProviderTest : StringSpec() {
-    private val rootDir = File(".").searchUpwardsForSubdirectory(".git")!!
-    private val curationsFile = File(rootDir, "analyzer/src/test/assets/package-curations.yml")
+    private val curationsFile = File("src/test/assets/package-curations.yml")
 
     init {
         "Provider can read YAML file" {

--- a/downloader/src/test/kotlin/CvsTest.kt
+++ b/downloader/src/test/kotlin/CvsTest.kt
@@ -22,7 +22,6 @@ package com.here.ort.downloader.vcs
 import com.here.ort.utils.unpack
 import com.here.ort.utils.getUserConfigDirectory
 import com.here.ort.utils.safeDeleteRecursively
-import com.here.ort.utils.searchUpwardsForSubdirectory
 
 import io.kotlintest.Description
 import io.kotlintest.Spec
@@ -36,8 +35,7 @@ class CvsTest : StringSpec() {
     private lateinit var zipContentDir: File
 
     override fun beforeSpec(description: Description, spec: Spec) {
-        val rootDir = File(".").searchUpwardsForSubdirectory(".git")!!
-        val zipFile = File(rootDir, "downloader/src/test/assets/tyrex-2018-01-29-cvs.zip")
+        val zipFile = File("src/test/assets/tyrex-2018-01-29-cvs.zip")
 
         zipContentDir = createTempDir()
 

--- a/downloader/src/test/kotlin/GitTest.kt
+++ b/downloader/src/test/kotlin/GitTest.kt
@@ -21,7 +21,6 @@ package com.here.ort.downloader.vcs
 
 import com.here.ort.utils.getUserConfigDirectory
 import com.here.ort.utils.safeDeleteRecursively
-import com.here.ort.utils.searchUpwardsForSubdirectory
 import com.here.ort.utils.unpack
 
 import io.kotlintest.Description
@@ -36,8 +35,7 @@ class GitTest : StringSpec() {
     private lateinit var zipContentDir: File
 
     override fun beforeSpec(description: Description, spec: Spec) {
-        val rootDir = File(".").searchUpwardsForSubdirectory(".git")!!
-        val zipFile = File(rootDir, "downloader/src/test/assets/pipdeptree-2018-01-03-git.zip")
+        val zipFile = File("src/test/assets/pipdeptree-2018-01-03-git.zip")
 
         zipContentDir = createTempDir()
 

--- a/downloader/src/test/kotlin/MercurialTest.kt
+++ b/downloader/src/test/kotlin/MercurialTest.kt
@@ -22,7 +22,6 @@ package com.here.ort.downloader
 import com.here.ort.downloader.vcs.Mercurial
 import com.here.ort.utils.getUserConfigDirectory
 import com.here.ort.utils.safeDeleteRecursively
-import com.here.ort.utils.searchUpwardsForSubdirectory
 import com.here.ort.utils.unpack
 
 import io.kotlintest.Description
@@ -37,8 +36,7 @@ class MercurialTest : StringSpec() {
     private lateinit var zipContentDir: File
 
     override fun beforeSpec(description: Description, spec: Spec) {
-        val rootDir = File(".").searchUpwardsForSubdirectory(".git")!!
-        val zipFile = File(rootDir, "downloader/src/test/assets/lz4revlog-2018-01-03-hg.zip")
+        val zipFile = File("src/test/assets/lz4revlog-2018-01-03-hg.zip")
 
         zipContentDir = createTempDir()
 

--- a/downloader/src/test/kotlin/SubversionTest.kt
+++ b/downloader/src/test/kotlin/SubversionTest.kt
@@ -22,7 +22,6 @@ package com.here.ort.downloader
 import com.here.ort.downloader.vcs.Subversion
 import com.here.ort.utils.getUserConfigDirectory
 import com.here.ort.utils.safeDeleteRecursively
-import com.here.ort.utils.searchUpwardsForSubdirectory
 import com.here.ort.utils.unpack
 
 import io.kotlintest.Description
@@ -37,8 +36,7 @@ class SubversionTest : StringSpec() {
     private lateinit var zipContentDir: File
 
     override fun beforeSpec(description: Description, spec: Spec) {
-        val rootDir = File(".").searchUpwardsForSubdirectory(".git")!!
-        val zipFile = File(rootDir, "downloader/src/test/assets/docutils-2018-01-03-svn-trunk.zip")
+        val zipFile = File("src/test/assets/docutils-2018-01-03-svn-trunk.zip")
 
         zipContentDir = createTempDir()
 

--- a/model/src/test/kotlin/ProjectTest.kt
+++ b/model/src/test/kotlin/ProjectTest.kt
@@ -19,31 +19,25 @@
 
 package com.here.ort.model
 
-import com.here.ort.utils.searchUpwardsForSubdirectory
-
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.StringSpec
 
 import java.io.File
 
-class ProjectTest : StringSpec() {
-    private val rootDir = File(".").searchUpwardsForSubdirectory(".git")!!
+class ProjectTest : StringSpec({
+    "collectAllDependencies contains all dependencies" {
+        val expectedDependencies = listOf(
+                "Maven:junit:junit:4.12",
+                "Maven:org.apache.commons:commons-lang3:3.5",
+                "Maven:org.apache.commons:commons-text:1.1",
+                "Maven:org.apache.struts:struts2-assembly:2.5.14.1",
+                "Maven:org.hamcrest:hamcrest-core:1.3"
+        ).map { Identifier.fromString(it) }.toSortedSet()
 
-    init {
-        "collectAllDependencies contains all dependencies" {
-            val expectedDependencies = listOf(
-                    "Maven:junit:junit:4.12",
-                    "Maven:org.apache.commons:commons-lang3:3.5",
-                    "Maven:org.apache.commons:commons-text:1.1",
-                    "Maven:org.apache.struts:struts2-assembly:2.5.14.1",
-                    "Maven:org.hamcrest:hamcrest-core:1.3"
-            ).map { Identifier.fromString(it) }.toSortedSet()
+        val analyzerResultsFile =
+                File("src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml")
+        val project = yamlMapper.readValue(analyzerResultsFile, ProjectAnalyzerResult::class.java).project
 
-            val analyzerResultsFile =
-                    File(rootDir, "analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml")
-            val project = yamlMapper.readValue(analyzerResultsFile, ProjectAnalyzerResult::class.java).project
-
-            project.collectAllDependencies() shouldBe expectedDependencies
-        }
+        project.collectAllDependencies() shouldBe expectedDependencies
     }
-}
+})

--- a/model/src/test/kotlin/ScanResultContainerTest.kt
+++ b/model/src/test/kotlin/ScanResultContainerTest.kt
@@ -19,8 +19,6 @@
 
 package com.here.ort.model
 
-import com.here.ort.utils.searchUpwardsForSubdirectory
-
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.WordSpec
 
@@ -87,8 +85,7 @@ class ScanResultContainerTest : WordSpec() {
             }
 
             "serialize as expected" {
-                val rootDir = File(".").searchUpwardsForSubdirectory(".git")!!
-                val expectedScanResultsFile = File(rootDir, "model/src/test/assets/expected-scan-results.yml")
+                val expectedScanResultsFile = File("src/test/assets/expected-scan-results.yml")
                 val expectedScanResults = expectedScanResultsFile.readText()
 
                 val serializedScanResults = yamlMapper.writeValueAsString(scanResults)

--- a/scanner/src/funTest/kotlin/ScanPathTest.kt
+++ b/scanner/src/funTest/kotlin/ScanPathTest.kt
@@ -26,7 +26,6 @@ import com.here.ort.scanner.scanners.ScanCode
 import com.here.ort.utils.ExpensiveTag
 import com.here.ort.utils.ScanCodeTag
 import com.here.ort.utils.safeDeleteRecursively
-import com.here.ort.utils.searchUpwardsForSubdirectory
 
 import io.kotlintest.Description
 import io.kotlintest.shouldBe
@@ -36,7 +35,6 @@ import io.kotlintest.specs.StringSpec
 import java.io.File
 
 class ScanPathTest : StringSpec() {
-    private val rootDir = File(".").searchUpwardsForSubdirectory(".git")!!
     private lateinit var outputDir: File
 
     override fun beforeTest(description: Description) {
@@ -49,25 +47,25 @@ class ScanPathTest : StringSpec() {
 
     init {
         "Askalono recognizes our own LICENSE".config(tags = setOf(ExpensiveTag)) {
-            val result = Askalono.scanPath(File(rootDir, "LICENSE"), outputDir)
+            val result = Askalono.scanPath(File("LICENSE"), outputDir)
             result.summary.fileCount shouldBe 1
             result.summary.licenses shouldBe setOf("Apache-2.0")
         }
 
         "BoyterLc recognizes our own LICENSE".config(tags = setOf(ExpensiveTag)) {
-            val result = BoyterLc.scanPath(File(rootDir, "LICENSE"), outputDir)
+            val result = BoyterLc.scanPath(File("LICENSE"), outputDir)
             result.summary.fileCount shouldBe 1
             result.summary.licenses shouldBe setOf("Apache-2.0", "ECL-2.0")
         }
 
         "Licensee recognizes our own LICENSE".config(tags = setOf(ExpensiveTag)) {
-            val result = Licensee.scanPath(File(rootDir, "LICENSE"), outputDir)
+            val result = Licensee.scanPath(File("LICENSE"), outputDir)
             result.summary.fileCount shouldBe 1
             result.summary.licenses shouldBe setOf("Apache-2.0")
         }
 
         "ScanCode recognizes our own LICENSE".config(tags = setOf(ExpensiveTag, ScanCodeTag)) {
-            val result = ScanCode.scanPath(File(rootDir, "LICENSE"), outputDir)
+            val result = ScanCode.scanPath(File("LICENSE"), outputDir)
             result.summary.fileCount shouldBe 1
             result.summary.licenses shouldBe setOf("Apache-2.0")
         }

--- a/utils/src/test/kotlin/ArchiveUtilsTest.kt
+++ b/utils/src/test/kotlin/ArchiveUtilsTest.kt
@@ -27,7 +27,6 @@ import io.kotlintest.specs.StringSpec
 import java.io.File
 
 class ArchiveUtilsTest : StringSpec() {
-    private val rootDir = File(".").searchUpwardsForSubdirectory(".git")!!
     private lateinit var outputDir: File
 
     override fun beforeTest(description: Description) {
@@ -40,7 +39,7 @@ class ArchiveUtilsTest : StringSpec() {
 
     init {
         "Tar GZ archive can be unpacked" {
-            val archive = File(rootDir, "utils/src/test/assets/test.tar.gz")
+            val archive = File("src/test/assets/test.tar.gz")
 
             archive.unpack(outputDir)
 
@@ -54,7 +53,7 @@ class ArchiveUtilsTest : StringSpec() {
         }
 
         "Tar bzip2 archive can be unpacked" {
-            val archive = File(rootDir, "utils/src/test/assets/test.tar.bz2")
+            val archive = File("src/test/assets/test.tar.bz2")
 
             archive.unpack(outputDir)
 
@@ -68,7 +67,7 @@ class ArchiveUtilsTest : StringSpec() {
         }
 
         "Zip archive can be unpacked" {
-            val archive = File(rootDir, "utils/src/test/assets/test.zip")
+            val archive = File("src/test/assets/test.zip")
 
             archive.unpack(outputDir)
 

--- a/utils/src/test/kotlin/UtilsTest.kt
+++ b/utils/src/test/kotlin/UtilsTest.kt
@@ -384,13 +384,8 @@ class UtilsTest : WordSpec({
         "find the root Git directory" {
             val gitRoot = File(".").searchUpwardsForSubdirectory(".git")
 
-            // Work-around for https://youtrack.jetbrains.com/issue/IDEA-188622.
-            val expectedRoot = File("..").canonicalPath.let {
-                File(it.removeSuffix(".idea${File.separator}modules"))
-            }
-
             gitRoot shouldNotBe null
-            gitRoot shouldBe expectedRoot
+            gitRoot shouldBe File("..").canonicalFile
         }
     }
 


### PR DESCRIPTION
This has been fixed in IntelliJ IDEA 2018.1.4, see

https://youtrack.jetbrains.com/issue/IDEA-190100

Perform some minor renaming of variables along the way to avoid name
clashes / use more speaking names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/566)
<!-- Reviewable:end -->
