### PR TITLE
Remove single-project analyzer results

### DIFF
--- a/analyzer/src/main/kotlin/Main.kt
+++ b/analyzer/src/main/kotlin/Main.kt
@@ -223,7 +223,7 @@ object Main {
 
         val failedAnalysis = sortedSetOf<String>()
 
-        val mergedResultsBuilder = if (createMergedResult) {
+        val analyzerResultBuilder = if (createMergedResult) {
             AnalyzerResultBuilder(allowDynamicVersions, vcs?.getInfo(absoluteProjectPath) ?: VcsInfo.EMPTY)
         } else {
             null
@@ -256,14 +256,14 @@ object Main {
 
             curatedResults.forEach { definitionFile, analyzerResult ->
                 writeResultFile(absoluteProjectPath, definitionFile, absoluteOutputPath, analyzerResult)
-                mergedResultsBuilder?.addResult(analyzerResult)
+                analyzerResultBuilder?.addResult(analyzerResult)
                 if (analyzerResult.hasErrors()) {
                     failedAnalysis.add(definitionFile.absolutePath)
                 }
             }
         }
 
-        mergedResultsBuilder?.build()?.let {
+        analyzerResultBuilder?.build()?.let {
             val outputFile = File(absoluteOutputPath, "all-dependencies." + outputFormat.fileExtension)
 
             println("Writing merged results\nto\n\t$outputFile")

--- a/analyzer/src/main/kotlin/Main.kt
+++ b/analyzer/src/main/kotlin/Main.kt
@@ -40,7 +40,6 @@ import com.here.ort.utils.PARAMETER_ORDER_MANDATORY
 import com.here.ort.utils.PARAMETER_ORDER_OPTIONAL
 import com.here.ort.utils.log
 import com.here.ort.utils.printStackTrace
-import com.here.ort.utils.safeMkdirs
 
 import java.io.File
 
@@ -130,21 +129,6 @@ object Main {
             help = true,
             order = PARAMETER_ORDER_HELP)
     private var help = false
-
-    private fun writeResultFile(projectRoot: File, currentPath: File, outputRoot: File, result: ProjectAnalyzerResult)
-            : File {
-        // Mirror the directory structure from the project in the output.
-        val currentDir = if (currentPath.isFile) currentPath.parentFile else currentPath
-        val outputDir = File(outputRoot, currentDir.toRelativeString(projectRoot)).apply { safeMkdirs() }
-        val outputFile = File(outputDir, currentPath.name.replace('.', '-') +
-                "-dependencies." + outputFormat.fileExtension)
-
-        println("Writing results for\n\t$currentPath\nto\n\t$outputFile")
-        mapper.writerWithDefaultPrettyPrinter().writeValue(outputFile, result)
-        println("done.")
-
-        return outputFile
-    }
 
     /**
      * The entry point for the application.
@@ -245,7 +229,6 @@ object Main {
             } ?: results
 
             curatedResults.forEach { definitionFile, analyzerResult ->
-                writeResultFile(absoluteProjectPath, definitionFile, absoluteOutputPath, analyzerResult)
                 analyzerResultBuilder.addResult(analyzerResult)
                 if (analyzerResult.hasErrors()) {
                     failedAnalysis.add(definitionFile.absolutePath)
@@ -256,7 +239,7 @@ object Main {
         analyzerResultBuilder.build().let {
             val outputFile = File(absoluteOutputPath, "all-dependencies." + outputFormat.fileExtension)
 
-            println("Writing merged results\nto\n\t$outputFile")
+            println("Writing analyzer result\nto\n\t$outputFile")
             mapper.writerWithDefaultPrettyPrinter().writeValue(outputFile, it)
             println("done.")
         }

--- a/analyzer/src/main/kotlin/Main.kt
+++ b/analyzer/src/main/kotlin/Main.kt
@@ -85,13 +85,6 @@ object Main {
     @Suppress("LateinitUsage")
     private lateinit var outputDir: File
 
-    @Parameter(
-            description = "Merge all results into a single results file. The individual scan results files " +
-                    "for each build file will still be created.",
-            names = ["--merge-results"],
-            order = PARAMETER_ORDER_OPTIONAL)
-    private var createMergedResult = false
-
     @Parameter(description = "The data format used for dependency information.",
             names = ["--output-format", "-f"],
             order = PARAMETER_ORDER_OPTIONAL)
@@ -223,11 +216,8 @@ object Main {
 
         val failedAnalysis = sortedSetOf<String>()
 
-        val analyzerResultBuilder = if (createMergedResult) {
-            AnalyzerResultBuilder(allowDynamicVersions, vcs?.getInfo(absoluteProjectPath) ?: VcsInfo.EMPTY)
-        } else {
-            null
-        }
+        val analyzerResultBuilder = AnalyzerResultBuilder(allowDynamicVersions, vcs?.getInfo(absoluteProjectPath)
+                ?: VcsInfo.EMPTY)
 
         // Resolve dependencies per package manager.
         managedDefinitionFiles.forEach { manager, files ->
@@ -256,14 +246,14 @@ object Main {
 
             curatedResults.forEach { definitionFile, analyzerResult ->
                 writeResultFile(absoluteProjectPath, definitionFile, absoluteOutputPath, analyzerResult)
-                analyzerResultBuilder?.addResult(analyzerResult)
+                analyzerResultBuilder.addResult(analyzerResult)
                 if (analyzerResult.hasErrors()) {
                     failedAnalysis.add(definitionFile.absolutePath)
                 }
             }
         }
 
-        analyzerResultBuilder?.build()?.let {
+        analyzerResultBuilder.build().let {
             val outputFile = File(absoluteOutputPath, "all-dependencies." + outputFormat.fileExtension)
 
             println("Writing merged results\nto\n\t$outputFile")


### PR DESCRIPTION
Remove the feature to write individual analyzer result files per project, instead always create the merged analyzer result.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/570)
<!-- Reviewable:end -->
