### PR TITLE
scanner: Correctly print the detected licenses

### DIFF
--- a/scanner/src/main/kotlin/Main.kt
+++ b/scanner/src/main/kotlin/Main.kt
@@ -258,7 +258,7 @@ object Main {
             }
 
             println("Declared licenses for '${pkg.id}': ${pkg.declaredLicenses.joinToString()}")
-            println("Detected licenses for '${pkg.id}': ${result.flatMap { it.summary.errors }.joinToString()}")
+            println("Detected licenses for '${pkg.id}': ${result.flatMap { it.summary.licenses }.joinToString()}")
         }
 
         val resultContainers = results.map { (pkg, results) ->


### PR DESCRIPTION
This is a fixup for 0579bcf.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/573)
<!-- Reviewable:end -->
