### PR TITLE
GitRepo: Remove the shallow clone optimization

### DIFF
--- a/downloader/src/main/kotlin/vcs/GitRepo.kt
+++ b/downloader/src/main/kotlin/vcs/GitRepo.kt
@@ -32,9 +32,6 @@ import java.io.File
 import java.io.IOException
 
 object GitRepo : GitBase() {
-    // TODO: Make this configurable.
-    private const val HISTORY_DEPTH = 50
-
     override val aliases = listOf("gitrepo", "git-repo", "repo")
 
     override fun getWorkingTree(vcsDirectory: File): WorkingTree {
@@ -79,8 +76,7 @@ object GitRepo : GitBase() {
                 "Initializing git-repo from ${pkg.vcsProcessed.url} with revision '$revision' " +
                         "and manifest '$manifestPath'."
             }
-            runRepoCommand(targetDir, "init", "--depth", HISTORY_DEPTH.toString(), "-b", revision,
-                    "-u", pkg.vcsProcessed.url, "-m", manifestPath)
+            runRepoCommand(targetDir, "init", "-b", revision, "-u", pkg.vcsProcessed.url, "-m", manifestPath)
 
             log.info { "Starting git-repo sync." }
             runRepoCommand(targetDir, "sync", "-c")


### PR DESCRIPTION
As a follow-up to 8a757c7, remove the optimization completely. It turns out
that it happens too often that Git wants to fetch unadvertized objects
(objects not at the tip of a ref), like merge commits generated by
Gerrit, which is not supported by Gerrit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/577)
<!-- Reviewable:end -->
