### PR TITLE
analyzer: Remove the ExpensiveTag from the Bundler tests

### DIFF
--- a/analyzer/src/funTest/kotlin/BundlerTest.kt
+++ b/analyzer/src/funTest/kotlin/BundlerTest.kt
@@ -21,7 +21,7 @@ package com.here.ort.analyzer
 
 import com.here.ort.analyzer.managers.Bundler
 import com.here.ort.downloader.VersionControlSystem
-import com.here.ort.model.Project
+import com.here.ort.model.Identifier
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
 import com.here.ort.utils.safeDeleteRecursively
@@ -67,7 +67,10 @@ class BundlerTest : WordSpec() {
                 val actualResult = Bundler.create().resolveDependencies(listOf(definitionFile))[definitionFile]
 
                 actualResult shouldNotBe null
-                actualResult!!.project shouldBe Project.EMPTY
+                actualResult!!.project.id shouldBe Identifier
+                        .fromString("Bundler::src/funTest/assets/projects/synthetic/bundler/no-lockfile/Gemfile:")
+                actualResult.project.definitionFilePath shouldBe
+                        "analyzer/src/funTest/assets/projects/synthetic/bundler/no-lockfile/Gemfile"
                 actualResult.packages.size shouldBe 0
                 actualResult.errors.size shouldBe 1
                 actualResult.errors.first() should startWith("IllegalArgumentException: No lockfile found in")

--- a/analyzer/src/funTest/kotlin/BundlerTest.kt
+++ b/analyzer/src/funTest/kotlin/BundlerTest.kt
@@ -25,7 +25,6 @@ import com.here.ort.model.Identifier
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
 import com.here.ort.utils.safeDeleteRecursively
-import com.here.ort.utils.test.ExpensiveTag
 import com.here.ort.utils.test.patchExpectedResult
 
 import io.kotlintest.shouldBe
@@ -43,7 +42,7 @@ class BundlerTest : WordSpec() {
 
     init {
         "Bundler" should {
-            "resolve dependencies correctly".config(tags = setOf(ExpensiveTag)) {
+            "resolve dependencies correctly" {
                 val definitionFile = File(projectsDir, "lockfile/Gemfile")
 
                 try {
@@ -61,7 +60,7 @@ class BundlerTest : WordSpec() {
                 }
             }
 
-            "show error if no lockfile is present".config(tags = setOf(ExpensiveTag)) {
+            "show error if no lockfile is present" {
                 val definitionFile = File(projectsDir, "no-lockfile/Gemfile")
 
                 val actualResult = Bundler.create().resolveDependencies(listOf(definitionFile))[definitionFile]
@@ -76,7 +75,7 @@ class BundlerTest : WordSpec() {
                 actualResult.errors.first() should startWith("IllegalArgumentException: No lockfile found in")
             }
 
-            "resolve dependencies correctly when the project is a Gem".config(tags = setOf(ExpensiveTag)) {
+            "resolve dependencies correctly when the project is a Gem" {
                 val definitionFile = File(projectsDir, "gemspec/Gemfile")
 
                 try {


### PR DESCRIPTION
These tests should run for all PRs, otherwise it is too risky that the
Bundler implementation breaks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/582)
<!-- Reviewable:end -->
