### PR TITLE
FileCounterTest: Use matchers from the new kotlintest 3 package

### DIFF
--- a/scanner/src/funTest/kotlin/scanners/FileCounterTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/FileCounterTest.kt
@@ -26,7 +26,7 @@ import com.here.ort.utils.safeDeleteRecursively
 
 import io.kotlintest.Description
 import io.kotlintest.TestResult
-import io.kotlintest.matchers.shouldBe
+import io.kotlintest.shouldBe
 import io.kotlintest.specs.StringSpec
 
 import java.io.File


### PR DESCRIPTION
To avoid a deprecation warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/584)
<!-- Reviewable:end -->
