### PR TITLE
analyzer: Make sure the name for failed projects is relative to the root

### DIFF
--- a/analyzer/src/funTest/kotlin/BabelTest.kt
+++ b/analyzer/src/funTest/kotlin/BabelTest.kt
@@ -24,6 +24,7 @@ import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
 import com.here.ort.utils.safeDeleteRecursively
+import com.here.ort.utils.test.ANALYZER_ROOT
 import com.here.ort.utils.test.patchExpectedResult
 
 import io.kotlintest.Description
@@ -64,7 +65,7 @@ class BabelTest : WordSpec() {
                         url = normalizeVcsUrl(vcsUrl),
                         revision = vcsRevision
                 )
-                val actualResult = npm.resolveDependencies(listOf(packageFile))[packageFile]
+                val actualResult = npm.resolveDependencies(ANALYZER_ROOT, listOf(packageFile))[packageFile]
 
                 yamlMapper.writeValueAsString(actualResult) shouldBe expectedResult
             }

--- a/analyzer/src/funTest/kotlin/BundlerTest.kt
+++ b/analyzer/src/funTest/kotlin/BundlerTest.kt
@@ -25,6 +25,7 @@ import com.here.ort.model.Identifier
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
 import com.here.ort.utils.safeDeleteRecursively
+import com.here.ort.utils.test.ANALYZER_ROOT
 import com.here.ort.utils.test.patchExpectedResult
 
 import io.kotlintest.shouldBe
@@ -46,7 +47,8 @@ class BundlerTest : WordSpec() {
                 val definitionFile = File(projectsDir, "lockfile/Gemfile")
 
                 try {
-                    val actualResult = Bundler.create().resolveDependencies(listOf(definitionFile))[definitionFile]
+                    val actualResult = Bundler.create()
+                            .resolveDependencies(ANALYZER_ROOT, listOf(definitionFile))[definitionFile]
                     val expectedResult = patchExpectedResult(
                             File(projectsDir.parentFile, "bundler-expected-output-lockfile.yml"),
                             url = normalizeVcsUrl(vcsUrl),
@@ -63,7 +65,8 @@ class BundlerTest : WordSpec() {
             "show error if no lockfile is present" {
                 val definitionFile = File(projectsDir, "no-lockfile/Gemfile")
 
-                val actualResult = Bundler.create().resolveDependencies(listOf(definitionFile))[definitionFile]
+                val actualResult = Bundler.create()
+                        .resolveDependencies(ANALYZER_ROOT, listOf(definitionFile))[definitionFile]
 
                 actualResult shouldNotBe null
                 actualResult!!.project.id shouldBe Identifier
@@ -79,7 +82,8 @@ class BundlerTest : WordSpec() {
                 val definitionFile = File(projectsDir, "gemspec/Gemfile")
 
                 try {
-                    val actualResult = Bundler.create().resolveDependencies(listOf(definitionFile))[definitionFile]
+                    val actualResult = Bundler.create()
+                            .resolveDependencies(ANALYZER_ROOT, listOf(definitionFile))[definitionFile]
                     val expectedResult = patchExpectedResult(
                             File(projectsDir.parentFile, "bundler-expected-output-gemspec.yml"),
                             url = normalizeVcsUrl(vcsUrl),

--- a/analyzer/src/funTest/kotlin/GoDepTest.kt
+++ b/analyzer/src/funTest/kotlin/GoDepTest.kt
@@ -25,6 +25,7 @@ import com.here.ort.model.Identifier
 import com.here.ort.model.Project
 import com.here.ort.model.VcsInfo
 import com.here.ort.model.yamlMapper
+import com.here.ort.utils.test.ANALYZER_ROOT
 
 import io.kotlintest.matchers.startWith
 import io.kotlintest.shouldBe
@@ -42,7 +43,7 @@ class GoDepTest : WordSpec() {
                 val manifestFile = File(projectsDir, "external/qmstr/Gopkg.toml")
                 val godep = GoDep.create()
 
-                val result = godep.resolveDependencies(listOf(manifestFile))[manifestFile]
+                val result = godep.resolveDependencies(ANALYZER_ROOT, listOf(manifestFile))[manifestFile]
                 val expectedResult = File(projectsDir, "external/qmstr-expected-output.yml").readText()
 
                 yamlMapper.writeValueAsString(result) shouldBe expectedResult
@@ -52,7 +53,7 @@ class GoDepTest : WordSpec() {
                 val manifestFile = File(projectsDir, "synthetic/godep/no-lockfile/Gopkg.toml")
                 val godep = GoDep.create()
 
-                val result = godep.resolveDependencies(listOf(manifestFile))[manifestFile]
+                val result = godep.resolveDependencies(ANALYZER_ROOT, listOf(manifestFile))[manifestFile]
 
                 result shouldNotBe null
                 result!!.project.id shouldBe Identifier
@@ -70,7 +71,7 @@ class GoDepTest : WordSpec() {
 
                 val allowDynamicVersionsOriginal = Main.allowDynamicVersions
                 Main.allowDynamicVersions = true
-                val result = godep.resolveDependencies(listOf(manifestFile))[manifestFile]
+                val result = godep.resolveDependencies(ANALYZER_ROOT, listOf(manifestFile))[manifestFile]
                 Main.allowDynamicVersions = allowDynamicVersionsOriginal
 
                 result shouldNotBe null
@@ -83,7 +84,7 @@ class GoDepTest : WordSpec() {
                 val manifestFile = File(projectsDir, "external/sprig/glide.yaml")
                 val godep = GoDep.create()
 
-                val result = godep.resolveDependencies(listOf(manifestFile))[manifestFile]
+                val result = godep.resolveDependencies(ANALYZER_ROOT, listOf(manifestFile))[manifestFile]
                 val expectedResult = File(projectsDir, "external/sprig-expected-output.yml").readText()
 
                 yamlMapper.writeValueAsString(result) shouldBe expectedResult
@@ -93,7 +94,7 @@ class GoDepTest : WordSpec() {
                 val manifestFile = File(projectsDir, "external/godep/Godeps/Godeps.json")
                 val godep = GoDep.create()
 
-                val result = godep.resolveDependencies(listOf(manifestFile))[manifestFile]
+                val result = godep.resolveDependencies(ANALYZER_ROOT, listOf(manifestFile))[manifestFile]
                 val expectedResult = File(projectsDir, "external/godep-expected-output.yml").readText()
 
                 yamlMapper.writeValueAsString(result) shouldBe expectedResult

--- a/analyzer/src/funTest/kotlin/GradleLibraryTest.kt
+++ b/analyzer/src/funTest/kotlin/GradleLibraryTest.kt
@@ -23,6 +23,7 @@ import com.here.ort.analyzer.managers.Gradle
 import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
+import com.here.ort.utils.test.ANALYZER_ROOT
 import com.here.ort.utils.test.patchExpectedResult
 
 import io.kotlintest.shouldBe
@@ -46,7 +47,7 @@ class GradleLibraryTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle.create().resolveDependencies(listOf(packageFile))[packageFile]
+            val result = Gradle.create().resolveDependencies(ANALYZER_ROOT, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -61,7 +62,7 @@ class GradleLibraryTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle.create().resolveDependencies(listOf(packageFile))[packageFile]
+            val result = Gradle.create().resolveDependencies(ANALYZER_ROOT, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -76,7 +77,7 @@ class GradleLibraryTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle.create().resolveDependencies(listOf(packageFile))[packageFile]
+            val result = Gradle.create().resolveDependencies(ANALYZER_ROOT, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()

--- a/analyzer/src/funTest/kotlin/GradleTest.kt
+++ b/analyzer/src/funTest/kotlin/GradleTest.kt
@@ -25,6 +25,7 @@ import com.here.ort.downloader.vcs.Git
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.ProcessCapture
 import com.here.ort.utils.normalizeVcsUrl
+import com.here.ort.utils.test.ANALYZER_ROOT
 import com.here.ort.utils.test.ExpensiveTag
 import com.here.ort.utils.test.patchExpectedResult
 
@@ -62,7 +63,7 @@ class GradleTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle.create().resolveDependencies(listOf(packageFile))[packageFile]
+            val result = Gradle.create().resolveDependencies(ANALYZER_ROOT, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -77,7 +78,7 @@ class GradleTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle.create().resolveDependencies(listOf(packageFile))[packageFile]
+            val result = Gradle.create().resolveDependencies(ANALYZER_ROOT, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -92,7 +93,7 @@ class GradleTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle.create().resolveDependencies(listOf(packageFile))[packageFile]
+            val result = Gradle.create().resolveDependencies(ANALYZER_ROOT, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -107,7 +108,7 @@ class GradleTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle.create().resolveDependencies(listOf(packageFile))[packageFile]
+            val result = Gradle.create().resolveDependencies(ANALYZER_ROOT, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -122,7 +123,7 @@ class GradleTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle.create().resolveDependencies(listOf(packageFile))[packageFile]
+            val result = Gradle.create().resolveDependencies(ANALYZER_ROOT, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
@@ -178,7 +179,7 @@ class GradleTest : StringSpec() {
                         revision = vcsRevision
                 )
 
-                val result = Gradle.create().resolveDependencies(listOf(packageFile))[packageFile]
+                val result = Gradle.create().resolveDependencies(ANALYZER_ROOT, listOf(packageFile))[packageFile]
 
                 result shouldNotBe null
                 result!!.errors shouldBe emptyList()

--- a/analyzer/src/funTest/kotlin/MavenTest.kt
+++ b/analyzer/src/funTest/kotlin/MavenTest.kt
@@ -24,6 +24,7 @@ import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
 import com.here.ort.utils.safeDeleteRecursively
+import com.here.ort.utils.test.ANALYZER_ROOT
 import com.here.ort.utils.test.patchExpectedResult
 
 import io.kotlintest.shouldBe
@@ -43,7 +44,7 @@ class MavenTest : StringSpec() {
             val pomFile = File(projectDir, "pom.xml")
             val expectedResult = File(projectDir.parentFile, "jgnash-expected-output.yml").readText()
 
-            val result = Maven.create().resolveDependencies(listOf(pomFile))[pomFile]
+            val result = Maven.create().resolveDependencies(ANALYZER_ROOT, listOf(pomFile))[pomFile]
 
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
@@ -60,7 +61,7 @@ class MavenTest : StringSpec() {
             // resolveDependencies so that it is available in the Maven.projectsByIdentifier cache. Otherwise resolution
             // of transitive dependencies would not work.
             val result = Maven.create()
-                    .resolveDependencies(listOf(pomFileCore, pomFileResources))[pomFileCore]
+                    .resolveDependencies(ANALYZER_ROOT, listOf(pomFileCore, pomFileResources))[pomFileCore]
 
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
@@ -73,7 +74,7 @@ class MavenTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Maven.create().resolveDependencies(listOf(pomFile))[pomFile]
+            val result = Maven.create().resolveDependencies(ANALYZER_ROOT, listOf(pomFile))[pomFile]
 
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
@@ -91,7 +92,7 @@ class MavenTest : StringSpec() {
             // available in the Maven.projectsByIdentifier cache. Otherwise resolution of transitive dependencies would
             // not work.
             val result = Maven.create()
-                    .resolveDependencies(listOf(pomFileApp, pomFileLib))[pomFileApp]
+                    .resolveDependencies(ANALYZER_ROOT, listOf(pomFileApp, pomFileLib))[pomFileApp]
 
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
@@ -104,7 +105,7 @@ class MavenTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Maven.create().resolveDependencies(listOf(pomFile))[pomFile]
+            val result = Maven.create().resolveDependencies(ANALYZER_ROOT, listOf(pomFile))[pomFile]
 
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
@@ -123,7 +124,7 @@ class MavenTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Maven.create().resolveDependencies(listOf(pomFile))[pomFile]
+            val result = Maven.create().resolveDependencies(ANALYZER_ROOT, listOf(pomFile))[pomFile]
 
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }

--- a/analyzer/src/funTest/kotlin/NpmTest.kt
+++ b/analyzer/src/funTest/kotlin/NpmTest.kt
@@ -24,6 +24,7 @@ import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
 import com.here.ort.utils.safeDeleteRecursively
+import com.here.ort.utils.test.ANALYZER_ROOT
 import com.here.ort.utils.test.patchExpectedResult
 
 import io.kotlintest.Description
@@ -60,7 +61,7 @@ class NpmTest : WordSpec() {
                 val packageFile = File(workingDir, "package.json")
                 val npm = NPM.create()
 
-                val result = npm.resolveDependencies(listOf(packageFile))[packageFile]
+                val result = npm.resolveDependencies(ANALYZER_ROOT, listOf(packageFile))[packageFile]
                 val vcsPath = vcsDir.getPathToRoot(workingDir)
                 val expectedResult = patchExpectedResult(
                         File(projectsDir.parentFile, "npm-expected-output.yml"),
@@ -80,7 +81,7 @@ class NpmTest : WordSpec() {
                 val packageFile = File(workingDir, "package.json")
                 val npm = NPM.create()
 
-                val result = npm.resolveDependencies(listOf(packageFile))[packageFile]
+                val result = npm.resolveDependencies(ANALYZER_ROOT, listOf(packageFile))[packageFile]
                 val vcsPath = vcsDir.getPathToRoot(workingDir)
                 val expectedResult = patchExpectedResult(
                         File(projectsDir.parentFile, "npm-expected-output.yml"),
@@ -99,7 +100,7 @@ class NpmTest : WordSpec() {
                 val workingDir = File(projectsDir, "no-lockfile")
                 val packageFile = File(workingDir, "package.json")
 
-                val result = NPM.create().resolveDependencies(listOf(packageFile))[packageFile]
+                val result = NPM.create().resolveDependencies(ANALYZER_ROOT, listOf(packageFile))[packageFile]
                 val vcsPath = vcsDir.getPathToRoot(workingDir)
                 val expectedResult = patchExpectedResult(
                         File(projectsDir.parentFile, "npm-expected-output-no-lockfile.yml"),
@@ -117,7 +118,7 @@ class NpmTest : WordSpec() {
                 val workingDir = File(projectsDir, "multiple-lockfiles")
                 val packageFile = File(workingDir, "package.json")
 
-                val result = NPM.create().resolveDependencies(listOf(packageFile))[packageFile]
+                val result = NPM.create().resolveDependencies(ANALYZER_ROOT, listOf(packageFile))[packageFile]
                 val vcsPath = vcsDir.getPathToRoot(workingDir)
                 val expectedResult = patchExpectedResult(
                         File(projectsDir.parentFile, "npm-expected-output-multiple-lockfiles.yml"),
@@ -136,7 +137,7 @@ class NpmTest : WordSpec() {
                 val packageFile = File(workingDir, "package.json")
                 val npm = NPM.create()
 
-                val result = npm.resolveDependencies(listOf(packageFile))[packageFile]
+                val result = npm.resolveDependencies(ANALYZER_ROOT, listOf(packageFile))[packageFile]
                 val vcsPath = vcsDir.getPathToRoot(workingDir)
                 val expectedResult = patchExpectedResult(
                         File(projectsDir.parentFile, "npm-expected-output.yml"),
@@ -158,7 +159,7 @@ class NpmTest : WordSpec() {
                 val packageFile = File(workingDir, "package.json")
                 val npm = NPM.create()
 
-                val result = npm.resolveDependencies(listOf(packageFile))[packageFile]
+                val result = npm.resolveDependencies(ANALYZER_ROOT, listOf(packageFile))[packageFile]
                 val vcsPath = vcsDir.getPathToRoot(workingDir)
                 val expectedResult = patchExpectedResult(
                         File(projectsDir.parentFile, "npm-expected-output.yml"),

--- a/analyzer/src/funTest/kotlin/PhpComposerTest.kt
+++ b/analyzer/src/funTest/kotlin/PhpComposerTest.kt
@@ -24,6 +24,7 @@ import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.Identifier
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
+import com.here.ort.utils.test.ANALYZER_ROOT
 import com.here.ort.utils.test.patchExpectedResult
 
 import io.kotlintest.matchers.startWith
@@ -44,7 +45,7 @@ class PhpComposerTest : StringSpec() {
         "Project dependencies are detected correctly" {
             val definitionFile = File(projectsDir, "lockfile/composer.json")
 
-            val result = PhpComposer.create().resolveDependencies(listOf(definitionFile))[definitionFile]
+            val result = PhpComposer.create().resolveDependencies(ANALYZER_ROOT, listOf(definitionFile))[definitionFile]
             val expectedResults = patchExpectedResult(
                     File(projectsDir.parentFile, "php-composer-expected-output.yml"),
                     url = normalizeVcsUrl(vcsUrl),
@@ -58,7 +59,7 @@ class PhpComposerTest : StringSpec() {
         "Error is shown when no lock file is present" {
             val definitionFile = File(projectsDir, "no-lockfile/composer.json")
 
-            val result = PhpComposer.create().resolveDependencies(listOf(definitionFile))[definitionFile]
+            val result = PhpComposer.create().resolveDependencies(ANALYZER_ROOT, listOf(definitionFile))[definitionFile]
 
             result shouldNotBe null
             result!!.project.id shouldBe Identifier.fromString("PhpComposer::src/funTest/assets/projects/synthetic/" +

--- a/analyzer/src/funTest/kotlin/PipTest.kt
+++ b/analyzer/src/funTest/kotlin/PipTest.kt
@@ -23,6 +23,7 @@ import com.here.ort.analyzer.managers.PIP
 import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
+import com.here.ort.utils.test.ANALYZER_ROOT
 
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.StringSpec
@@ -35,7 +36,7 @@ class PipTest : StringSpec({
     "setup.py dependencies should be resolved correctly for spdx-tools-python" {
         val definitionFile = File(projectsDir, "external/spdx-tools-python/setup.py")
 
-        val result = PIP.create().resolveDependencies(listOf(definitionFile))[definitionFile]
+        val result = PIP.create().resolveDependencies(ANALYZER_ROOT, listOf(definitionFile))[definitionFile]
         val expectedResult = File(projectsDir, "external/spdx-tools-python-expected-output.yml").readText()
 
         yamlMapper.writeValueAsString(result) shouldBe expectedResult
@@ -44,7 +45,7 @@ class PipTest : StringSpec({
     "requirements.txt dependencies should be resolved correctly for example-python-flask" {
         val definitionFile = File(projectsDir, "external/example-python-flask/requirements.txt")
 
-        val result = PIP.create().resolveDependencies(listOf(definitionFile))[definitionFile]
+        val result = PIP.create().resolveDependencies(ANALYZER_ROOT, listOf(definitionFile))[definitionFile]
         val expectedResult = File(projectsDir, "external/example-python-flask-expected-output.yml").readText()
 
         yamlMapper.writeValueAsString(result) shouldBe expectedResult
@@ -63,7 +64,7 @@ class PipTest : StringSpec({
                 .replaceFirst("<REPLACE_REVISION>", vcsRevision)
                 .replaceFirst("<REPLACE_PATH>", vcsPath)
 
-        val result = PIP.create().resolveDependencies(listOf(definitionFile))[definitionFile]
+        val result = PIP.create().resolveDependencies(ANALYZER_ROOT, listOf(definitionFile))[definitionFile]
 
         yamlMapper.writeValueAsString(result) shouldBe expectedResult
     }

--- a/analyzer/src/funTest/kotlin/SbtTest.kt
+++ b/analyzer/src/funTest/kotlin/SbtTest.kt
@@ -22,6 +22,7 @@ package com.here.ort.analyzer
 import com.here.ort.analyzer.managers.SBT
 import com.here.ort.downloader.vcs.Git
 import com.here.ort.model.yamlMapper
+import com.here.ort.utils.test.ANALYZER_ROOT
 
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.StringSpec
@@ -46,7 +47,7 @@ class SbtTest : StringSpec({
         definitionFile.isFile shouldBe true
         expectedOutputFile.isFile shouldBe true
 
-        val resolutionResult = sbt.resolveDependencies(listOf(definitionFile))
+        val resolutionResult = sbt.resolveDependencies(ANALYZER_ROOT, listOf(definitionFile))
 
         // Because of the mapping from SBT to POM files we cannot use definitionFile as the key, so just ensure
         // there is exactly one entry to take.

--- a/analyzer/src/funTest/kotlin/integration/AbstractIntegrationSpec.kt
+++ b/analyzer/src/funTest/kotlin/integration/AbstractIntegrationSpec.kt
@@ -25,6 +25,7 @@ import com.here.ort.downloader.Main
 import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.Package
 import com.here.ort.utils.safeDeleteRecursively
+import com.here.ort.utils.test.ANALYZER_ROOT
 import com.here.ort.utils.test.ExpensiveTag
 
 import io.kotlintest.Description
@@ -101,7 +102,7 @@ abstract class AbstractIntegrationSpec : StringSpec() {
         "Analyzer creates one non-empty result per definition file".config(tags = setOf(ExpensiveTag)) {
             definitionFilesForTest.forEach { manager, files ->
                 println("Resolving $manager dependencies in $files.")
-                val results = manager.create().resolveDependencies(files)
+                val results = manager.create().resolveDependencies(ANALYZER_ROOT, files)
 
                 results.size shouldBe files.size
                 results.values.forEach { result ->

--- a/analyzer/src/main/kotlin/Main.kt
+++ b/analyzer/src/main/kotlin/Main.kt
@@ -207,7 +207,7 @@ object Main {
         // Resolve dependencies per package manager.
         managedDefinitionFiles.forEach { manager, files ->
             // Print the list of dependencies.
-            val results = manager.create().resolveDependencies(files)
+            val results = manager.create().resolveDependencies(inputDir.toPath(), files)
 
             val curatedResults = packageCurationsFile?.let {
                 val provider = YamlFilePackageCurationProvider(it)

--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -183,7 +183,7 @@ abstract class PackageManager {
      * Return a tree of resolved dependencies (not necessarily declared dependencies, in case conflicts were resolved)
      * for each provided path.
      */
-    open fun resolveDependencies(definitionFiles: List<File>): ResolutionResult {
+    open fun resolveDependencies(analyzerRoot: Path, definitionFiles: List<File>): ResolutionResult {
         val result = mutableMapOf<File, ProjectAnalyzerResult>()
 
         prepareResolution(definitionFiles).forEach { definitionFile ->
@@ -197,11 +197,13 @@ abstract class PackageManager {
                 } catch (e: Exception) {
                     e.showStackTrace()
 
+                    val relativePath = analyzerRoot.relativize(definitionFile.toPath())
+
                     val errorProject = Project.EMPTY.copy(
                             id = Identifier(
                                     provider = toString(),
                                     namespace = "",
-                                    name = definitionFile.invariantSeparatorsPath,
+                                    name = relativePath.toString(),
                                     version = ""
                             ),
                             definitionFilePath = VersionControlSystem.getPathToRoot(definitionFile) ?: "",

--- a/analyzer/src/main/kotlin/managers/SBT.kt
+++ b/analyzer/src/main/kotlin/managers/SBT.kt
@@ -34,6 +34,7 @@ import com.vdurmont.semver4j.Semver
 
 import java.io.File
 import java.io.IOException
+import java.nio.file.Path
 
 class SBT : PackageManager() {
     companion object : PackageManagerFactory<SBT>(
@@ -159,7 +160,7 @@ class SBT : PackageManager() {
         return pomFiles.toList()
     }
 
-    override fun resolveDependencies(definitionFiles: List<File>) =
+    override fun resolveDependencies(analyzerRoot: Path, definitionFiles: List<File>) =
             // Simply pass on the list of POM files to Maven, ignoring the SBT build files here.
-            Maven.create().enableSbtMode().resolveDependencies(prepareResolution(definitionFiles))
+            Maven.create().enableSbtMode().resolveDependencies(analyzerRoot, prepareResolution(definitionFiles))
 }

--- a/utils-test/src/main/kotlin/Utils.kt
+++ b/utils-test/src/main/kotlin/Utils.kt
@@ -21,6 +21,8 @@ package com.here.ort.utils.test
 
 import java.io.File
 
+val ANALYZER_ROOT = File("").toPath()
+
 fun patchExpectedResult(result: File, custom: Pair<String, String>? = null, definitionFilePath: String? = null,
                         url: String? = null, revision: String? = null, path: String? = null,
                         urlProcessed: String? = null): String {


### PR DESCRIPTION
The name used for failed projects is taken from the path of the definition
file. Make sure it is used relative to the input directory of the analyzer
to avoid unneccessarily long paths if the analyzer is executed from another
directory.