### PR TITLE
ScanCode: Remove matched license text from native output

### DIFF
--- a/scanner/src/main/kotlin/scanners/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/ScanCode.kt
@@ -54,7 +54,6 @@ object ScanCode : LocalScanner() {
     private val DEFAULT_CONFIGURATION_OPTIONS = listOf(
             "--copyright",
             "--license",
-            "--license-text",
             "--info",
             "--strip-root",
             "--timeout", TIMEOUT.toString()


### PR DESCRIPTION
Until [1] is fully fixed the matched text included in the output is not
the full / unmodified license text, so drop it to avoid confusion.

Instead, the plan is to get the vanilla license text from the SPDX
license database [2] which also would work with all scanners.

[1] https://github.com/nexB/scancode-toolkit/issues/504
[2] https://github.com/spdx/license-list-data

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/592)
<!-- Reviewable:end -->
