### PR TITLE
DrupalIntegrationTest: Add "yarn.lock" as an expected definition file

### DIFF
--- a/analyzer/src/funTest/kotlin/integration/DrupalIntegrationTest.kt
+++ b/analyzer/src/funTest/kotlin/integration/DrupalIntegrationTest.kt
@@ -23,6 +23,7 @@ import com.here.ort.analyzer.PackageManager
 import com.here.ort.analyzer.PackageManagerFactory
 import com.here.ort.analyzer.managers.NPM
 import com.here.ort.analyzer.managers.PhpComposer
+import com.here.ort.analyzer.managers.Yarn
 import com.here.ort.model.Identifier
 import com.here.ort.model.Package
 import com.here.ort.model.RemoteArtifact
@@ -85,6 +86,9 @@ class DrupalIntegrationTest : AbstractIntegrationSpec() {
                 NPM to listOf(
                         File(downloadDir, "core/package.json"),
                         File(downloadDir, "core/assets/vendor/jquery.ui/package.json")
+                ),
+                Yarn to listOf(
+                        File(downloadDir, "core/yarn.lock")
                 )
         )
     }


### PR DESCRIPTION
This is a fixup for a391d9e.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/598)
<!-- Reviewable:end -->
