### PR TITLE
init.gradle: Add the exact same error only once per project

### DIFF
--- a/analyzer/src/main/resources/init.gradle
+++ b/analyzer/src/main/resources/init.gradle
@@ -206,7 +206,7 @@ class AbstractDependencyTreePlugin<T> implements Plugin<T> {
 
             def version = project.version == 'unspecified' ? '' : project.version
             return new DependencyTreeModelImpl(project.group ?: '', project.name, version ?: '', configurations,
-                    repositories, errors)
+                    repositories, errors.unique())
         }
 
         Dependency parseDependency(DependencyResult dependencyResult, Project project,


### PR DESCRIPTION
This avoids e.g. multiple "Project uses an Ivy repository which is not
supported by the analyzer" errors per project.