### PR TITLE
ScanCode: Fix passing the raw scan result

### DIFF
--- a/scanner/src/main/kotlin/scanners/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/ScanCode.kt
@@ -158,7 +158,7 @@ object ScanCode : LocalScanner() {
 
         with(process) {
             if (isSuccess() || hasOnlyMemoryErrors || hasOnlyTimeoutErrors) {
-                return ScanResult(provenance, scannerDetails, summary)
+                return ScanResult(provenance, scannerDetails, summary, result)
             } else {
                 throw ScanException(errorMessage)
             }


### PR DESCRIPTION
This is a fixup for 6dba67c that enables caching of scan results again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/607)
<!-- Reviewable:end -->
