### PR TITLE
scanner: Use a real timestamp in the file counter test

### DIFF
--- a/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
@@ -171,14 +171,14 @@ scan_results:
 - id: "Gradle:com.here.ort.gradle.example:lib:1.0.0"
   results:
   - provenance:
-      downloadTime: "<TIMESTAMP>"
+      downloadTime: "1970-01-01T00:00:00Z"
     scanner:
       name: "filecounter"
       version: "1.0"
       configuration: ""
     summary:
-      startTime: "<TIMESTAMP>"
-      endTime: "<TIMESTAMP>"
+      startTime: "1970-01-01T00:00:00Z"
+      endTime: "1970-01-01T00:00:00Z"
       fileCount: 0
       licenses: []
       errors:
@@ -188,7 +188,7 @@ scan_results:
 - id: "Maven:junit:junit:4.12"
   results:
   - provenance:
-      downloadTime: "<TIMESTAMP>"
+      downloadTime: "1970-01-01T00:00:00Z"
       sourceArtifact:
         url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
         hash: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
@@ -198,15 +198,15 @@ scan_results:
       version: "1.0"
       configuration: ""
     summary:
-      startTime: "<TIMESTAMP>"
-      endTime: "<TIMESTAMP>"
+      startTime: "1970-01-01T00:00:00Z"
+      endTime: "1970-01-01T00:00:00Z"
       fileCount: 234
       licenses: []
       errors: []
 - id: "Maven:org.apache.commons:commons-lang3:3.5"
   results:
   - provenance:
-      downloadTime: "<TIMESTAMP>"
+      downloadTime: "1970-01-01T00:00:00Z"
       sourceArtifact:
         url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
         hash: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
@@ -216,15 +216,15 @@ scan_results:
       version: "1.0"
       configuration: ""
     summary:
-      startTime: "<TIMESTAMP>"
-      endTime: "<TIMESTAMP>"
+      startTime: "1970-01-01T00:00:00Z"
+      endTime: "1970-01-01T00:00:00Z"
       fileCount: 168
       licenses: []
       errors: []
 - id: "Maven:org.apache.commons:commons-text:1.1"
   results:
   - provenance:
-      downloadTime: "<TIMESTAMP>"
+      downloadTime: "1970-01-01T00:00:00Z"
       sourceArtifact:
         url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
         hash: "f0770f7f0472bf120ada47beecadce4056fbd20a"
@@ -234,15 +234,15 @@ scan_results:
       version: "1.0"
       configuration: ""
     summary:
-      startTime: "<TIMESTAMP>"
-      endTime: "<TIMESTAMP>"
+      startTime: "1970-01-01T00:00:00Z"
+      endTime: "1970-01-01T00:00:00Z"
       fileCount: 80
       licenses: []
       errors: []
 - id: "Maven:org.hamcrest:hamcrest-core:1.3"
   results:
   - provenance:
-      downloadTime: "<TIMESTAMP>"
+      downloadTime: "1970-01-01T00:00:00Z"
       sourceArtifact:
         url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
         hash: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
@@ -252,8 +252,8 @@ scan_results:
       version: "1.0"
       configuration: ""
     summary:
-      startTime: "<TIMESTAMP>"
-      endTime: "<TIMESTAMP>"
+      startTime: "1970-01-01T00:00:00Z"
+      endTime: "1970-01-01T00:00:00Z"
       fileCount: 47
       licenses: []
       errors: []

--- a/scanner/src/funTest/kotlin/scanners/FileCounterTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/FileCounterTest.kt
@@ -30,6 +30,7 @@ import io.kotlintest.shouldBe
 import io.kotlintest.specs.StringSpec
 
 import java.io.File
+import java.time.Instant
 
 class FileCounterTest : StringSpec() {
     private val assetsDir = File("src/funTest/assets")
@@ -50,7 +51,7 @@ class FileCounterTest : StringSpec() {
     private val timeRegex = Regex("(download|end|start)Time: \".*\"")
 
     private fun patchActualResult(result: String) = result
-            .replace(timeRegex) { "${it.groupValues[1]}Time: \"<TIMESTAMP>\"" }
+            .replace(timeRegex) { "${it.groupValues[1]}Time: \"${Instant.EPOCH}\"" }
 
     init {
         "Gradle project scan results from analyzer result file are correct" {


### PR DESCRIPTION
This way the expected output file can actually be parsed e.g. by the
reporter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/616)
<!-- Reviewable:end -->
