### PR TITLE
model: Globally set the JSON property naming strategy to snake-case

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: true
+allow_dynamic_versions: true
 project:
   id: "SBT:io.github.soc:directories:6"
   definition_file_path: "target/directories-6.pom"

--- a/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: true
+allow_dynamic_versions: true
 project:
   id: "PIP::example-python-flask:0773991e36a4c69b121cdb05146d6140347d4065"
   definition_file_path: "requirements.txt"

--- a/analyzer/src/funTest/assets/projects/external/godep-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/godep-expected-output.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: false
+allow_dynamic_versions: false
 project:
   id: "GoDep::godep:ce0bfadeb516ab23c845a85c4b0eae421ec9614b"
   definition_file_path: "Godeps/Godeps.json"

--- a/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: true
+allow_dynamic_versions: true
 project:
   id: "Maven:jgnash:jgnash-core:2.30.0"
   definition_file_path: "jgnash-core/pom.xml"

--- a/analyzer/src/funTest/assets/projects/external/jgnash-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/jgnash-expected-output.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: true
+allow_dynamic_versions: true
 project:
   id: "Maven:jgnash:jgnash2:2.30.0"
   definition_file_path: "pom.xml"

--- a/analyzer/src/funTest/assets/projects/external/qmstr-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/qmstr-expected-output.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: false
+allow_dynamic_versions: false
 project:
   id: "GoDep::qmstr:0cd17d10b931c9108450ca5a68d4f85b6e4953ef"
   definition_file_path: "Gopkg.toml"

--- a/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: true
+allow_dynamic_versions: true
 project:
   id: "PIP::spdx-tools:0.5.4"
   definition_file_path: "setup.py"

--- a/analyzer/src/funTest/assets/projects/external/sprig-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/sprig-expected-output.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: false
+allow_dynamic_versions: false
 project:
   id: "GoDep::sprig:9d9aa1f74c86fd9d36ecfe3f2a44a3093c3d4c15"
   definition_file_path: "glide.yaml"

--- a/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-gemspec.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-gemspec.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: false
+allow_dynamic_versions: false
 project:
   id: "Bundler::test-project:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/bundler/gemspec/Gemfile"
@@ -153,13 +153,13 @@ packages:
       type: "git"
       url: "https://github.com/lostisland/faraday.git"
       revision: ""
-      resolvedRevision: ""
+      resolved_revision: ""
       path: ""
     vcs_processed:
       type: "git"
       url: "https://github.com/lostisland/faraday.git"
       revision: ""
-      resolvedRevision: ""
+      resolved_revision: ""
       path: ""
   curations: []
 - package:
@@ -181,13 +181,13 @@ packages:
       type: "git"
       url: "http://github.com/jwt/ruby-jwt.git"
       revision: ""
-      resolvedRevision: ""
+      resolved_revision: ""
       path: ""
     vcs_processed:
       type: "git"
       url: "https://github.com/jwt/ruby-jwt.git"
       revision: ""
-      resolvedRevision: ""
+      resolved_revision: ""
       path: ""
   curations: []
 - package:
@@ -210,13 +210,13 @@ packages:
       type: "git"
       url: "http://github.com/intridea/multi_json.git"
       revision: ""
-      resolvedRevision: ""
+      resolved_revision: ""
       path: ""
     vcs_processed:
       type: "git"
       url: "https://github.com/intridea/multi_json.git"
       revision: ""
-      resolvedRevision: ""
+      resolved_revision: ""
       path: ""
   curations: []
 - package:
@@ -239,13 +239,13 @@ packages:
       type: "git"
       url: "https://github.com/nicksieger/multipart-post.git"
       revision: ""
-      resolvedRevision: ""
+      resolved_revision: ""
       path: ""
     vcs_processed:
       type: "git"
       url: "https://github.com/nicksieger/multipart-post.git"
       revision: ""
-      resolvedRevision: ""
+      resolved_revision: ""
       path: ""
   curations: []
 - package:
@@ -397,13 +397,13 @@ packages:
       type: "git"
       url: "https://github.com/rspec/rspec-support.git"
       revision: ""
-      resolvedRevision: ""
+      resolved_revision: ""
       path: ""
     vcs_processed:
       type: "git"
       url: "https://github.com/rspec/rspec-support.git"
       revision: ""
-      resolvedRevision: ""
+      resolved_revision: ""
       path: ""
   curations: []
 - package:

--- a/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-lockfile.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-lockfile.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: false
+allow_dynamic_versions: false
 project:
   id: "Bundler::lockfile:"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/bundler/lockfile/Gemfile"
@@ -113,13 +113,13 @@ packages:
       type: "git"
       url: "http://github.com/flavorjones/mini_portile.git"
       revision: ""
-      resolvedRevision: ""
+      resolved_revision: ""
       path: ""
     vcs_processed:
       type: "git"
       url: "https://github.com/flavorjones/mini_portile.git"
       revision: ""
-      resolvedRevision: ""
+      resolved_revision: ""
       path: ""
   curations: []
 - package:
@@ -271,13 +271,13 @@ packages:
       type: "git"
       url: "https://github.com/rspec/rspec-support.git"
       revision: ""
-      resolvedRevision: ""
+      resolved_revision: ""
       path: ""
     vcs_processed:
       type: "git"
       url: "https://github.com/rspec/rspec-support.git"
       revision: ""
-      resolvedRevision: ""
+      resolved_revision: ""
       path: ""
   curations: []
 - package:

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-app.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: true
+allow_dynamic_versions: true
 project:
   id: "Gradle:com.here.ort.gradle.example:app:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-android/app/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-lib.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: true
+allow_dynamic_versions: true
 project:
   id: "Gradle:com.here.ort.gradle.example:lib:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-android/lib/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-root.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: true
+allow_dynamic_versions: true
 project:
   id: "Gradle:com.here.ort.gradle.example:Gradle-Android-Example:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-android/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-2.14.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-2.14.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: true
+allow_dynamic_versions: true
 project:
   id: "Gradle:com.here.ort.gradle.example:app:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-3.4.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-3.4.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: true
+allow_dynamic_versions: true
 project:
   id: "Gradle:com.here.ort.gradle.example:app:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: true
+allow_dynamic_versions: true
 project:
   id: "Gradle:com.here.ort.gradle.example:app:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: true
+allow_dynamic_versions: true
 project:
   id: "Gradle:com.here.ort.gradle.example:lib-without-repo:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: true
+allow_dynamic_versions: true
 project:
   id: "Gradle:com.here.ort.gradle.example:lib:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-root.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: true
+allow_dynamic_versions: true
 project:
   id: "Gradle::Gradle-Example:"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-unsupported-version.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-unsupported-version.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: true
+allow_dynamic_versions: true
 project:
   id: "Gradle:com.here.ort.gradle.example:gradle-unsupported-version:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-unsupported-version/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-app.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: true
+allow_dynamic_versions: true
 project:
   id: "Gradle:com.here.ort.gradle.example:app:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-library/app/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-lib.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: true
+allow_dynamic_versions: true
 project:
   id: "Gradle:com.here.ort.gradle.example:lib:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-library/lib/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-root.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: true
+allow_dynamic_versions: true
 project:
   id: "Gradle::Gradle-Example:"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-library/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-app.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: true
+allow_dynamic_versions: true
 project:
   id: "Maven:com.here.ort.maven:maven-app:1.0-SNAPSHOT"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/maven/app/pom.xml"

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-lib.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: true
+allow_dynamic_versions: true
 project:
   id: "Maven:com.here.ort.maven:maven-lib:1.0-SNAPSHOT"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/maven/lib/pom.xml"

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-root.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: true
+allow_dynamic_versions: true
 project:
   id: "Maven:com.here.ort.maven:maven-project:1.0-SNAPSHOT"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/maven/pom.xml"

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-parent-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-parent-expected-output-root.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: true
+allow_dynamic_versions: true
 project:
   id: "Maven:com.here.ort.maven:maven-parent-project:1.0-SNAPSHOT"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/maven-parent/pom.xml"

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: false
+allow_dynamic_versions: false
 project:
   id: "NPM::npm-project-that-depends-on-babel:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/npm-babel/package.json"

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output-no-lockfile.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output-no-lockfile.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: false
+allow_dynamic_versions: false
 project:
   id: "NPM::src/funTest/assets/projects/synthetic/npm/no-lockfile/package.json:"
   definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: false
+allow_dynamic_versions: false
 project:
   id: "NPM::npm-project:2.0.0"
   definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"

--- a/analyzer/src/funTest/assets/projects/synthetic/php-composer-expected-output-no-deps.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/php-composer-expected-output-no-deps.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: false
+allow_dynamic_versions: false
 project:
   id: "PhpComposer:ort:composer-test-project:0.1.0"
   definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"

--- a/analyzer/src/funTest/assets/projects/synthetic/php-composer-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/php-composer-expected-output.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: false
+allow_dynamic_versions: false
 project:
   id: "PhpComposer:ort:composer-test-project:0.1.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/php-composer/lockfile/composer.json"

--- a/analyzer/src/funTest/assets/projects/synthetic/pip-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pip-expected-output.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: true
+allow_dynamic_versions: true
 project:
   id: "PIP::Example-App:2.4.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/pip/requirements.txt"

--- a/analyzer/src/funTest/assets/projects/synthetic/yarn-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/yarn-expected-output.yml
@@ -1,5 +1,5 @@
 ---
-allowDynamicVersions: false
+allow_dynamic_versions: false
 project:
   id: "Yarn::npm-yarn:2.0.0"
   definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"

--- a/model/src/main/kotlin/AnalyzerResult.kt
+++ b/model/src/main/kotlin/AnalyzerResult.kt
@@ -21,8 +21,6 @@ package com.here.ort.model
 
 import ch.frankel.slf4k.*
 
-import com.fasterxml.jackson.annotation.JsonProperty
-
 import com.here.ort.utils.log
 
 import java.util.SortedMap
@@ -38,7 +36,6 @@ data class AnalyzerResult(
          * a new version of this dependency was released in the meantime. It is always true for package managers that do
          * not support lock files, but do support version ranges.
          */
-        @JsonProperty("allow_dynamic_versions")
         val allowDynamicVersions: Boolean,
 
         /**
@@ -49,7 +46,6 @@ data class AnalyzerResult(
         /**
          * The normalized [VcsInfo] of the analyzed repository.
          */
-        @JsonProperty("vcs_processed")
         val vcsProcessed: VcsInfo,
 
         /**

--- a/model/src/main/kotlin/CacheStatistics.kt
+++ b/model/src/main/kotlin/CacheStatistics.kt
@@ -19,8 +19,6 @@
 
 package com.here.ort.model
 
-import com.fasterxml.jackson.annotation.JsonProperty
-
 /**
  * Statistics about reads and hits in a cache.
  */
@@ -28,12 +26,10 @@ data class CacheStatistics(
         /**
          * The number of read operations in the cache.
          */
-        @JsonProperty("num_reads")
         var numReads: Int = 0,
 
         /**
          * The number of read operations that returned an entry from the cache.
          */
-        @JsonProperty("num_hits")
         var numHits: Int = 0
 )

--- a/model/src/main/kotlin/Mappers.kt
+++ b/model/src/main/kotlin/Mappers.kt
@@ -21,6 +21,7 @@ package com.here.ort.model
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.dataformat.xml.XmlFactory
@@ -47,6 +48,8 @@ private val mapperConfig: ObjectMapper.() -> Unit = {
     disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
 
     registerModule(ortModelModule)
+
+    setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE)
 }
 
 val jsonMapper = ObjectMapper().apply(mapperConfig)

--- a/model/src/main/kotlin/Package.kt
+++ b/model/src/main/kotlin/Package.kt
@@ -19,8 +19,6 @@
 
 package com.here.ort.model
 
-import com.fasterxml.jackson.annotation.JsonProperty
-
 import java.util.SortedSet
 
 /**
@@ -42,7 +40,6 @@ data class Package(
          * The list of licenses the authors have declared for this package. This does not necessarily correspond to the
          * licenses as detected by a scanner. Both need to be taken into account for any conclusions.
          */
-        @JsonProperty("declared_licenses")
         val declaredLicenses: SortedSet<String>,
 
         /**
@@ -53,19 +50,16 @@ data class Package(
         /**
          * The homepage of the package.
          */
-        @JsonProperty("homepage_url")
         val homepageUrl: String,
 
         /**
          * The remote artifact where the binary package can be downloaded.
          */
-        @JsonProperty("binary_artifact")
         val binaryArtifact: RemoteArtifact,
 
         /**
          * The remote artifact where the source package can be downloaded.
          */
-        @JsonProperty("source_artifact")
         val sourceArtifact: RemoteArtifact,
 
         /**
@@ -76,7 +70,6 @@ data class Package(
         /**
          * Processed VCS-related information about the [Package] that has e.g. common mistakes corrected.
          */
-        @JsonProperty("vcs_processed")
         val vcsProcessed: VcsInfo = vcs.normalize()
 ) : CustomData(), Comparable<Package> {
     /**

--- a/model/src/main/kotlin/PackageCurationData.kt
+++ b/model/src/main/kotlin/PackageCurationData.kt
@@ -20,7 +20,6 @@
 package com.here.ort.model
 
 import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.annotation.JsonProperty
 
 import java.util.SortedSet
 
@@ -35,7 +34,6 @@ data class PackageCurationData(
          * licenses as detected by a scanner. Both need to be taken into account for any conclusions.
          */
         @JsonInclude(JsonInclude.Include.NON_NULL)
-        @JsonProperty("declared_licenses")
         val declaredLicenses: SortedSet<String>? = null,
 
         /**
@@ -48,21 +46,18 @@ data class PackageCurationData(
          * The homepage of the package.
          */
         @JsonInclude(JsonInclude.Include.NON_NULL)
-        @JsonProperty("homepage_url")
         val homepageUrl: String? = null,
 
         /**
          * The remote artifact where the binary package can be downloaded.
          */
         @JsonInclude(JsonInclude.Include.NON_NULL)
-        @JsonProperty("binary_artifact")
         val binaryArtifact: RemoteArtifact? = null,
 
         /**
          * The remote artifact where the source package can be downloaded.
          */
         @JsonInclude(JsonInclude.Include.NON_NULL)
-        @JsonProperty("source_artifact")
         val sourceArtifact: RemoteArtifact? = null,
 
         /**

--- a/model/src/main/kotlin/Project.kt
+++ b/model/src/main/kotlin/Project.kt
@@ -19,8 +19,6 @@
 
 package com.here.ort.model
 
-import com.fasterxml.jackson.annotation.JsonProperty
-
 import java.util.SortedSet
 
 /**
@@ -38,14 +36,12 @@ data class Project(
          * The path to the definition file of this project, relative to the root of the repository described in [vcs]
          * and [vcsProcessed].
          */
-        @JsonProperty("definition_file_path")
         val definitionFilePath: String,
 
         /**
          * The list of licenses the authors have declared for this package. This does not necessarily correspond to the
          * licenses as detected by a scanner. Both need to be taken into account for any conclusions.
          */
-        @JsonProperty("declared_licenses")
         val declaredLicenses: SortedSet<String>,
 
         /**
@@ -61,13 +57,11 @@ data class Project(
         /**
          * Processed VCS-related information about the [Project] that has e.g. common mistakes corrected.
          */
-        @JsonProperty("vcs_processed")
         val vcsProcessed: VcsInfo = vcs.normalize(),
 
         /**
          * The URL to the project's homepage.
          */
-        @JsonProperty("homepage_url")
         val homepageUrl: String,
 
         /**

--- a/model/src/main/kotlin/ProjectAnalyzerResult.kt
+++ b/model/src/main/kotlin/ProjectAnalyzerResult.kt
@@ -19,6 +19,8 @@
 
 package com.here.ort.model
 
+import com.fasterxml.jackson.annotation.JsonAlias
+
 import java.util.SortedSet
 
 /**
@@ -31,6 +33,7 @@ data class ProjectAnalyzerResult(
          * a new version of this dependency was released in the meantime. It is always true for package managers that do
          * not support lock files, but do support version ranges.
          */
+        @JsonAlias("allowDynamicVersions")
         val allowDynamicVersions: Boolean,
 
         /**

--- a/model/src/main/kotlin/ProjectScanScopes.kt
+++ b/model/src/main/kotlin/ProjectScanScopes.kt
@@ -19,8 +19,6 @@
 
 package com.here.ort.model
 
-import com.fasterxml.jackson.annotation.JsonProperty
-
 import java.util.SortedSet
 
 /**
@@ -35,14 +33,12 @@ data class ProjectScanScopes(
         /**
          * The dependencies from these [Scope]s of the [Project] were scanned.
          */
-        @JsonProperty("scanned_scopes")
         val scannedScopes: SortedSet<String>,
 
         /**
          * The dependencies from these [Scope]s of the [Project] were not scanned, except if they are also a dependency
          * of any of the [scannedScopes].
          */
-        @JsonProperty("ignored_scopes")
         val ignoredScopes: SortedSet<String>
 ) : Comparable<ProjectScanScopes> {
     /**

--- a/model/src/main/kotlin/Provenance.kt
+++ b/model/src/main/kotlin/Provenance.kt
@@ -19,6 +19,7 @@
 
 package com.here.ort.model
 
+import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonInclude
 
 import java.time.Instant
@@ -31,17 +32,20 @@ data class Provenance(
         /**
          * The time when the source code was downloaded.
          */
+        @JsonAlias("downloadTime")
         val downloadTime: Instant,
 
         /**
          * The source artifact that was downloaded, or null.
          */
+        @JsonAlias("sourceArtifact")
         @JsonInclude(JsonInclude.Include.NON_NULL)
         val sourceArtifact: RemoteArtifact? = null,
 
         /**
          * The VCS repository that was downloaded, or null.
          */
+        @JsonAlias("vcsInfo")
         @JsonInclude(JsonInclude.Include.NON_NULL)
         val vcsInfo: VcsInfo? = null,
 
@@ -52,6 +56,7 @@ data class Provenance(
          * would be no way to match the package to the [Provenance] without downloading the source code and searching
          * for the tag again.
          */
+        @JsonAlias("originalVcsInfo")
         @JsonInclude(JsonInclude.Include.NON_NULL)
         val originalVcsInfo: VcsInfo? = null
 ) : CustomData() {

--- a/model/src/main/kotlin/RemoteArtifact.kt
+++ b/model/src/main/kotlin/RemoteArtifact.kt
@@ -19,8 +19,6 @@
 
 package com.here.ort.model
 
-import com.fasterxml.jackson.annotation.JsonProperty
-
 /**
  * Bundles information about a remote artifact.
  */
@@ -38,7 +36,6 @@ data class RemoteArtifact(
         /**
          * The name of the algorithm used to calculate the [hash].
          */
-        @JsonProperty("hash_algorithm")
         val hashAlgorithm: HashAlgorithm
 ) : CustomData() {
     companion object {

--- a/model/src/main/kotlin/ScanRecord.kt
+++ b/model/src/main/kotlin/ScanRecord.kt
@@ -19,8 +19,6 @@
 
 package com.here.ort.model
 
-import com.fasterxml.jackson.annotation.JsonProperty
-
 import java.util.SortedSet
 
 /**
@@ -30,31 +28,26 @@ data class ScanRecord(
         /**
          * The [AnalyzerResult] that was used as input for the scanner.
          */
-        @JsonProperty("analyzer_result")
         val analyzerResult: AnalyzerResult,
 
         /**
          * The scanned and ignored [Scope]s for each scanned [Project] by id.
          */
-        @JsonProperty("scanned_scopes")
         val scannedScopes: SortedSet<ProjectScanScopes>,
 
         /**
          * The [ScanResult]s for all [Package]s.
          */
-        @JsonProperty("scan_results")
         val scanResults: SortedSet<ScanResultContainer>,
 
         /**
          * The [CacheStatistics] for the scan results cache.
          */
-        @JsonProperty("cache_stats")
         val cacheStats: CacheStatistics
 ) : CustomData() {
     /**
      * True if the [analyzerResult] or any of the [scanResults] contain errors.
      */
-    @JsonProperty("has_errors")
     val hasErrors = analyzerResult.createProjectAnalyzerResults().any { it.hasErrors() }
             || scanResults.any { it.results.any { it.summary.errors.isNotEmpty() } }
 }

--- a/model/src/main/kotlin/ScanResult.kt
+++ b/model/src/main/kotlin/ScanResult.kt
@@ -19,6 +19,7 @@
 
 package com.here.ort.model
 
+import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.JsonNode
 
@@ -45,6 +46,7 @@ data class ScanResult(
          * The raw output of the scanner. Can be null if the raw result shall not be included. If the raw result is
          * empty it must not be null but [EMPTY_JSON_NODE].
          */
+        @JsonAlias("rawResult")
         @JsonInclude(JsonInclude.Include.NON_NULL)
         val rawResult: JsonNode? = null
 ) : CustomData()

--- a/model/src/main/kotlin/ScanSummary.kt
+++ b/model/src/main/kotlin/ScanSummary.kt
@@ -19,6 +19,8 @@
 
 package com.here.ort.model
 
+import com.fasterxml.jackson.annotation.JsonAlias
+
 import java.time.Instant
 import java.util.SortedSet
 
@@ -29,16 +31,19 @@ data class ScanSummary(
         /**
          * The time when the scan started.
          */
+        @JsonAlias("startTime")
         val startTime: Instant,
 
         /**
          * The time when the scan finished.
          */
+        @JsonAlias("endTime")
         val endTime: Instant,
 
         /**
          * The number of scanned files.
          */
+        @JsonAlias("fileCount")
         val fileCount: Int,
 
         /**

--- a/model/src/main/kotlin/VcsInfo.kt
+++ b/model/src/main/kotlin/VcsInfo.kt
@@ -123,7 +123,7 @@ class VcsInfoDeserializer : StdDeserializer<VcsInfo>(VcsInfo::class.java) {
         val type = node["type"].asTextOrEmpty()
         val url = node["url"].asTextOrEmpty()
         val revision = node["revision"].asTextOrEmpty()
-        val resolvedRevision = node["resolvedRevision"]?.asText()
+        val resolvedRevision = (node["resolved_revision"] ?: node["resolvedRevision"])?.asText()
         val path = node["path"].asTextOrEmpty()
         return VcsInfo(type, url, revision, resolvedRevision, path)
     }

--- a/model/src/test/assets/expected-scan-results.yml
+++ b/model/src/test/assets/expected-scan-results.yml
@@ -2,8 +2,8 @@
 id: "provider:namespace:name:version"
 results:
 - provenance:
-    downloadTime: "1970-01-02T00:00:00Z"
-    sourceArtifact:
+    download_time: "1970-01-02T00:00:00Z"
+    source_artifact:
       url: "url"
       hash: "hash"
       hash_algorithm: "SHA-1"
@@ -12,36 +12,36 @@ results:
     version: "version 1"
     configuration: "config 1"
   summary:
-    startTime: "1970-01-02T00:01:00Z"
-    endTime: "1970-01-02T00:02:00Z"
-    fileCount: 1
+    start_time: "1970-01-02T00:01:00Z"
+    end_time: "1970-01-02T00:02:00Z"
+    file_count: 1
     licenses:
     - "license 1.1"
     - "license 1.2"
     errors:
     - "error 1.1"
     - "error 1.2"
-  rawResult: "key 1"
+  raw_result: "key 1"
 - provenance:
-    downloadTime: "1970-01-03T00:00:00Z"
-    vcsInfo:
+    download_time: "1970-01-03T00:00:00Z"
+    vcs_info:
       type: "type"
       url: "url"
       revision: "revision"
-      resolvedRevision: "resolvedRevision"
+      resolved_revision: "resolvedRevision"
       path: "path"
   scanner:
     name: "name 2"
     version: "version 2"
     configuration: "config 2"
   summary:
-    startTime: "1970-01-03T00:01:00Z"
-    endTime: "1970-01-03T00:02:00Z"
-    fileCount: 2
+    start_time: "1970-01-03T00:01:00Z"
+    end_time: "1970-01-03T00:02:00Z"
+    file_count: 2
     licenses:
     - "license 2.1"
     - "license 2.2"
     errors:
     - "error 2.1"
     - "error 2.2"
-  rawResult: "key 2"
+  raw_result: "key 2"

--- a/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
@@ -171,15 +171,15 @@ scan_results:
 - id: "Gradle:com.here.ort.gradle.example:lib:1.0.0"
   results:
   - provenance:
-      downloadTime: "1970-01-01T00:00:00Z"
+      download_time: "1970-01-01T00:00:00Z"
     scanner:
       name: "filecounter"
       version: "1.0"
       configuration: ""
     summary:
-      startTime: "1970-01-01T00:00:00Z"
-      endTime: "1970-01-01T00:00:00Z"
-      fileCount: 0
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      file_count: 0
       licenses: []
       errors:
       - "Package 'Gradle:com.here.ort.gradle.example:lib:1.0.0' could not be scanned\
@@ -188,8 +188,8 @@ scan_results:
 - id: "Maven:junit:junit:4.12"
   results:
   - provenance:
-      downloadTime: "1970-01-01T00:00:00Z"
-      sourceArtifact:
+      download_time: "1970-01-01T00:00:00Z"
+      source_artifact:
         url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
         hash: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
         hash_algorithm: "SHA-1"
@@ -198,16 +198,16 @@ scan_results:
       version: "1.0"
       configuration: ""
     summary:
-      startTime: "1970-01-01T00:00:00Z"
-      endTime: "1970-01-01T00:00:00Z"
-      fileCount: 234
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      file_count: 234
       licenses: []
       errors: []
 - id: "Maven:org.apache.commons:commons-lang3:3.5"
   results:
   - provenance:
-      downloadTime: "1970-01-01T00:00:00Z"
-      sourceArtifact:
+      download_time: "1970-01-01T00:00:00Z"
+      source_artifact:
         url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
         hash: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
         hash_algorithm: "SHA-1"
@@ -216,16 +216,16 @@ scan_results:
       version: "1.0"
       configuration: ""
     summary:
-      startTime: "1970-01-01T00:00:00Z"
-      endTime: "1970-01-01T00:00:00Z"
-      fileCount: 168
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      file_count: 168
       licenses: []
       errors: []
 - id: "Maven:org.apache.commons:commons-text:1.1"
   results:
   - provenance:
-      downloadTime: "1970-01-01T00:00:00Z"
-      sourceArtifact:
+      download_time: "1970-01-01T00:00:00Z"
+      source_artifact:
         url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
         hash: "f0770f7f0472bf120ada47beecadce4056fbd20a"
         hash_algorithm: "SHA-1"
@@ -234,16 +234,16 @@ scan_results:
       version: "1.0"
       configuration: ""
     summary:
-      startTime: "1970-01-01T00:00:00Z"
-      endTime: "1970-01-01T00:00:00Z"
-      fileCount: 80
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      file_count: 80
       licenses: []
       errors: []
 - id: "Maven:org.hamcrest:hamcrest-core:1.3"
   results:
   - provenance:
-      downloadTime: "1970-01-01T00:00:00Z"
-      sourceArtifact:
+      download_time: "1970-01-01T00:00:00Z"
+      source_artifact:
         url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
         hash: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
         hash_algorithm: "SHA-1"
@@ -252,9 +252,9 @@ scan_results:
       version: "1.0"
       configuration: ""
     summary:
-      startTime: "1970-01-01T00:00:00Z"
-      endTime: "1970-01-01T00:00:00Z"
-      fileCount: 47
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      file_count: 47
       licenses: []
       errors: []
 cache_stats:

--- a/scanner/src/funTest/kotlin/scanners/FileCounterTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/FileCounterTest.kt
@@ -48,10 +48,10 @@ class FileCounterTest : StringSpec() {
         ScanResultsCache.stats = CacheStatistics()
     }
 
-    private val timeRegex = Regex("(download|end|start)Time: \".*\"")
+    private val timeRegex = Regex("((download|end|start)_time): \".*\"")
 
     private fun patchActualResult(result: String) = result
-            .replace(timeRegex) { "${it.groupValues[1]}Time: \"${Instant.EPOCH}\"" }
+            .replace(timeRegex) { "${it.groupValues[1]}: \"${Instant.EPOCH}\"" }
 
     init {
         "Gradle project scan results from analyzer result file are correct" {

--- a/scanner/src/main/kotlin/scanners/FileCounter.kt
+++ b/scanner/src/main/kotlin/scanners/FileCounter.kt
@@ -72,7 +72,7 @@ object FileCounter : LocalScanner() {
     }
 
     override fun generateSummary(startTime: Instant, endTime: Instant, result: JsonNode): ScanSummary {
-        val fileCount = result["fileCount"].intValue()
+        val fileCount = result["file_count"].intValue()
         return ScanSummary(startTime, endTime, fileCount, licenses = sortedSetOf(), errors = sortedSetOf())
     }
 }


### PR DESCRIPTION
Remove individual JsonProperty annotations in turn as it is too easy to
forget them. For Kotlin properties where JsonProperty annotation indeed
had been forgotten, use a JsonAlias to accept camel-case names for
backwards-compatibility.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/620)
<!-- Reviewable:end -->
