### PR TITLE
AnalyzerResultTest: Properly pass a "resolvedRevision"

### DIFF
--- a/model/src/test/kotlin/AnalyzerResultTest.kt
+++ b/model/src/test/kotlin/AnalyzerResultTest.kt
@@ -23,7 +23,7 @@ import io.kotlintest.shouldBe
 import io.kotlintest.specs.WordSpec
 
 class AnalyzerResultTest : WordSpec() {
-    private val vcs = VcsInfo("type", "url", "revision", "path")
+    private val vcs = VcsInfo("type", "url", "revision", "resolvedRevision", "path")
 
     private val package1 = Package.EMPTY.copy(id = Identifier("provider-1", "namespace-1", "package-1", "version-1"))
     private val package2 = Package.EMPTY.copy(id = Identifier("provider-2", "namespace-2", "package-2", "version-2"))

--- a/model/src/test/kotlin/AnalyzerResultTest.kt
+++ b/model/src/test/kotlin/AnalyzerResultTest.kt
@@ -61,7 +61,7 @@ class AnalyzerResultTest : WordSpec() {
                 mergedResults.createProjectAnalyzerResults() shouldBe listOf(analyzerResult1, analyzerResult2)
             }
 
-            "can be serialized and deserialized" {
+            "be serialized and deserialized correctly" {
                 val mergedResults = AnalyzerResultBuilder(true, vcs)
                         .addResult(analyzerResult1)
                         .addResult(analyzerResult2)

--- a/model/src/test/kotlin/ScanResultContainerTest.kt
+++ b/model/src/test/kotlin/ScanResultContainerTest.kt
@@ -76,7 +76,7 @@ class ScanResultContainerTest : WordSpec() {
 
     init {
         "ScanResults" should {
-            "be serializable and deserializable" {
+            "be serialized and deserialized correctly" {
                 val serializedScanResults = jsonMapper.writeValueAsString(scanResults)
                 val deserializedScanResults =
                         jsonMapper.readValue(serializedScanResults, ScanResultContainer::class.java)


### PR DESCRIPTION
Before, the resolvedRevision was assigned the value "path". That did not
make the test fail, but was confusing to read in the output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/621)
<!-- Reviewable:end -->
