### PR TITLE
Gradle: Upgrade Kotlin to version 1.2.50

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     // We need to hard-code the version here because of
     // https://github.com/gradle/gradle/issues/1697
-    id 'org.jetbrains.kotlin.jvm' version '1.2.41' apply false
+    id 'org.jetbrains.kotlin.jvm' version '1.2.50' apply false
     id 'org.jetbrains.dokka' version '0.9.16' apply false
 
     // Note that the detekt Gradle plugin version does not necessarily
@@ -60,7 +60,7 @@ subprojects {
     }
 
     dependencies {
-        compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.41'
+        compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 
         testCompile "io.kotlintest:kotlintest-core:$kotlintestVersion"
         testCompile "io.kotlintest:kotlintest-assertions:$kotlintestVersion"
@@ -81,7 +81,7 @@ subprojects {
     // TODO: Remove this once jackson-module-kotlin and kotlintest are updated.
     configurations.all {
         resolutionStrategy {
-            force 'org.jetbrains.kotlin:kotlin-reflect:1.2.41'
+            force 'org.jetbrains.kotlin:kotlin-reflect:1.2.50'
         }
     }
 


### PR DESCRIPTION
See https://blog.jetbrains.com/kotlin/2018/06/kotlin-1-2-50-is-out/.

The stdlib by default resolves to the version of the plugin, so simply
omit that version number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/624)
<!-- Reviewable:end -->
