### PR TITLE
scanner: Print declared / detected licenses only in debug mode

### DIFF
--- a/scanner/src/main/kotlin/Main.kt
+++ b/scanner/src/main/kotlin/Main.kt
@@ -230,8 +230,8 @@ object Main {
                 yamlMapper.writeValue(it, ScanResultContainer(pkg.id, result))
             }
 
-            println("Declared licenses for '${pkg.id}': ${pkg.declaredLicenses.joinToString()}")
-            println("Detected licenses for '${pkg.id}': ${result.flatMap { it.summary.licenses }.joinToString()}")
+            log.debug { "Declared licenses for '${pkg.id}': ${pkg.declaredLicenses.joinToString()}" }
+            log.debug { "Detected licenses for '${pkg.id}': ${result.flatMap { it.summary.licenses }.joinToString()}" }
         }
 
         val resultContainers = results.map { (pkg, results) ->


### PR DESCRIPTION
These can get long and clutter regular output, so only show them in debug
mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/628)
<!-- Reviewable:end -->
