### PR TITLE
Maven: Add an empty lifecycle mapping for "hpi" packaging

### DIFF
--- a/analyzer/src/main/resources/META-INF/plexus/components.xml
+++ b/analyzer/src/main/resources/META-INF/plexus/components.xml
@@ -66,6 +66,24 @@
         </component>
 
         <!--
+         | Jenkins Plugin (https://jenkins.io/doc/book/managing/plugins/)
+         |-->
+        <component>
+            <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
+            <role-hint>hpi</role-hint>
+            <implementation>org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping</implementation>
+            <configuration>
+                <lifecycles>
+                    <lifecycle>
+                        <id>default</id>
+                        <phases>
+                        </phases>
+                    </lifecycle>
+                </lifecycles>
+            </configuration>
+        </component>
+
+        <!--
          | ZIP
          |-->
         <component>


### PR DESCRIPTION
This enables parsing of POM files that use "hpi" packaging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/632)
<!-- Reviewable:end -->
