### PR TITLE
Remove "aliases" from the Project model

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
@@ -5,7 +5,6 @@ project:
   definition_file_path: "target/directories-6.pom"
   declared_licenses:
   - "Mozilla Public License 2.0"
-  aliases: []
   vcs:
     type: "git"
     url: "git@github.com:soc/directories.git"

--- a/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
@@ -4,7 +4,6 @@ project:
   id: "PIP::example-python-flask:0773991e36a4c69b121cdb05146d6140347d4065"
   definition_file_path: "requirements.txt"
   declared_licenses: []
-  aliases: []
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/external/godep-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/godep-expected-output.yml
@@ -4,7 +4,6 @@ project:
   id: "GoDep::godep:ce0bfadeb516ab23c845a85c4b0eae421ec9614b"
   definition_file_path: "Godeps/Godeps.json"
   declared_licenses: []
-  aliases: []
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
@@ -4,7 +4,6 @@ project:
   id: "Maven:jgnash:jgnash-core:2.30.0"
   definition_file_path: "jgnash-core/pom.xml"
   declared_licenses: []
-  aliases: []
   vcs:
     type: "git"
     url: "git://github.com:ccavanaugh/jgnash.git"

--- a/analyzer/src/funTest/assets/projects/external/jgnash-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/jgnash-expected-output.yml
@@ -4,7 +4,6 @@ project:
   id: "Maven:jgnash:jgnash2:2.30.0"
   definition_file_path: "pom.xml"
   declared_licenses: []
-  aliases: []
   vcs:
     type: "git"
     url: "git://github.com:ccavanaugh/jgnash.git"

--- a/analyzer/src/funTest/assets/projects/external/qmstr-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/qmstr-expected-output.yml
@@ -4,7 +4,6 @@ project:
   id: "GoDep::qmstr:0cd17d10b931c9108450ca5a68d4f85b6e4953ef"
   definition_file_path: "Gopkg.toml"
   declared_licenses: []
-  aliases: []
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
@@ -6,7 +6,6 @@ project:
   declared_licenses:
   - "Apache Software"
   - "Apache-2.0"
-  aliases: []
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/external/sprig-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/sprig-expected-output.yml
@@ -4,7 +4,6 @@ project:
   id: "GoDep::sprig:9d9aa1f74c86fd9d36ecfe3f2a44a3093c3d4c15"
   definition_file_path: "glide.yaml"
   declared_licenses: []
-  aliases: []
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-gemspec.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-gemspec.yml
@@ -4,7 +4,6 @@ project:
   id: "Bundler::test-project:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/bundler/gemspec/Gemfile"
   declared_licenses: []
-  aliases: []
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-lockfile.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-lockfile.yml
@@ -4,7 +4,6 @@ project:
   id: "Bundler::lockfile:"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/bundler/lockfile/Gemfile"
   declared_licenses: []
-  aliases: []
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
@@ -14,7 +14,6 @@ projects:
 - id: "Gradle::Gradle-Example:"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/build.gradle"
   declared_licenses: []
-  aliases: []
   vcs:
     type: ""
     url: ""
@@ -30,7 +29,6 @@ projects:
 - id: "Gradle:com.here.ort.gradle.example:app:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app/build.gradle"
   declared_licenses: []
-  aliases: []
   vcs:
     type: ""
     url: ""
@@ -196,7 +194,6 @@ projects:
 - id: "Gradle:com.here.ort.gradle.example:lib-without-repo:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo/build.gradle"
   declared_licenses: []
-  aliases: []
   vcs:
     type: ""
     url: ""
@@ -319,7 +316,6 @@ projects:
 - id: "Gradle:com.here.ort.gradle.example:lib:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
   declared_licenses: []
-  aliases: []
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
@@ -14,7 +14,6 @@ projects:
 - id: "Gradle::Gradle-Example:"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/build.gradle"
   declared_licenses: []
-  aliases: []
   vcs:
     type: ""
     url: ""
@@ -30,7 +29,6 @@ projects:
 - id: "Gradle:com.here.ort.gradle.example:app:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app/build.gradle"
   declared_licenses: []
-  aliases: []
   vcs:
     type: ""
     url: ""
@@ -196,7 +194,6 @@ projects:
 - id: "Gradle:com.here.ort.gradle.example:lib-without-repo:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo/build.gradle"
   declared_licenses: []
-  aliases: []
   vcs:
     type: ""
     url: ""
@@ -319,7 +316,6 @@ projects:
 - id: "Gradle:com.here.ort.gradle.example:lib:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
   declared_licenses: []
-  aliases: []
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-app.yml
@@ -4,7 +4,6 @@ project:
   id: "Gradle:com.here.ort.gradle.example:app:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-android/app/build.gradle"
   declared_licenses: []
-  aliases: []
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-lib.yml
@@ -4,7 +4,6 @@ project:
   id: "Gradle:com.here.ort.gradle.example:lib:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-android/lib/build.gradle"
   declared_licenses: []
-  aliases: []
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-root.yml
@@ -4,7 +4,6 @@ project:
   id: "Gradle:com.here.ort.gradle.example:Gradle-Android-Example:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-android/build.gradle"
   declared_licenses: []
-  aliases: []
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-2.14.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-2.14.yml
@@ -4,7 +4,6 @@ project:
   id: "Gradle:com.here.ort.gradle.example:app:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app/build.gradle"
   declared_licenses: []
-  aliases: []
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-3.4.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-3.4.yml
@@ -4,7 +4,6 @@ project:
   id: "Gradle:com.here.ort.gradle.example:app:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app/build.gradle"
   declared_licenses: []
-  aliases: []
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
@@ -4,7 +4,6 @@ project:
   id: "Gradle:com.here.ort.gradle.example:app:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app/build.gradle"
   declared_licenses: []
-  aliases: []
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
@@ -4,7 +4,6 @@ project:
   id: "Gradle:com.here.ort.gradle.example:lib-without-repo:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo/build.gradle"
   declared_licenses: []
-  aliases: []
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
@@ -4,7 +4,6 @@ project:
   id: "Gradle:com.here.ort.gradle.example:lib:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
   declared_licenses: []
-  aliases: []
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-root.yml
@@ -4,7 +4,6 @@ project:
   id: "Gradle::Gradle-Example:"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/build.gradle"
   declared_licenses: []
-  aliases: []
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-unsupported-version.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-unsupported-version.yml
@@ -4,7 +4,6 @@ project:
   id: "Gradle:com.here.ort.gradle.example:gradle-unsupported-version:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-unsupported-version/build.gradle"
   declared_licenses: []
-  aliases: []
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-app.yml
@@ -4,7 +4,6 @@ project:
   id: "Gradle:com.here.ort.gradle.example:app:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-library/app/build.gradle"
   declared_licenses: []
-  aliases: []
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-lib.yml
@@ -4,7 +4,6 @@ project:
   id: "Gradle:com.here.ort.gradle.example:lib:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-library/lib/build.gradle"
   declared_licenses: []
-  aliases: []
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-root.yml
@@ -4,7 +4,6 @@ project:
   id: "Gradle::Gradle-Example:"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-library/build.gradle"
   declared_licenses: []
-  aliases: []
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-app.yml
@@ -4,7 +4,6 @@ project:
   id: "Maven:com.here.ort.maven:maven-app:1.0-SNAPSHOT"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/maven/app/pom.xml"
   declared_licenses: []
-  aliases: []
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-lib.yml
@@ -4,7 +4,6 @@ project:
   id: "Maven:com.here.ort.maven:maven-lib:1.0-SNAPSHOT"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/maven/lib/pom.xml"
   declared_licenses: []
-  aliases: []
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-root.yml
@@ -4,7 +4,6 @@ project:
   id: "Maven:com.here.ort.maven:maven-project:1.0-SNAPSHOT"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/maven/pom.xml"
   declared_licenses: []
-  aliases: []
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-parent-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-parent-expected-output-root.yml
@@ -5,7 +5,6 @@ project:
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/maven-parent/pom.xml"
   declared_licenses:
   - "Apache License, Version 2.0"
-  aliases: []
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
@@ -5,7 +5,6 @@ project:
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/npm-babel/package.json"
   declared_licenses:
   - "Apache-2.0"
-  aliases: []
   vcs:
     type: "git"
     url: "https://github.com/heremaps/oss-review-toolkit.git"

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output-no-lockfile.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output-no-lockfile.yml
@@ -4,7 +4,6 @@ project:
   id: "NPM::src/funTest/assets/projects/synthetic/npm/no-lockfile/package.json:"
   definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
   declared_licenses: []
-  aliases: []
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output.yml
@@ -5,7 +5,6 @@ project:
   definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
   declared_licenses:
   - "Apache-2.0"
-  aliases: []
   vcs:
     type: "git"
     url: "https://github.com/heremaps/oss-review-toolkit.git"

--- a/analyzer/src/funTest/assets/projects/synthetic/php-composer-expected-output-no-deps.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/php-composer-expected-output-no-deps.yml
@@ -6,7 +6,6 @@ project:
   declared_licenses:
   - "Apache-2.0"
   - "MIT"
-  aliases: []
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/php-composer-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/php-composer-expected-output.yml
@@ -6,7 +6,6 @@ project:
   declared_licenses:
   - "Apache-2.0"
   - "MIT"
-  aliases: []
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/pip-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pip-expected-output.yml
@@ -5,7 +5,6 @@ project:
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/pip/requirements.txt"
   declared_licenses:
   - "MIT"
-  aliases: []
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/yarn-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/yarn-expected-output.yml
@@ -5,7 +5,6 @@ project:
   definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
   declared_licenses:
   - "Apache-2.0"
-  aliases: []
   vcs:
     type: "git"
     url: "https://github.com/heremaps/oss-review-toolkit.git"

--- a/analyzer/src/main/kotlin/managers/Bundler.kt
+++ b/analyzer/src/main/kotlin/managers/Bundler.kt
@@ -120,7 +120,6 @@ class Bundler : PackageManager() {
                     id = projectId,
                     definitionFilePath = VersionControlSystem.getPathToRoot(definitionFile) ?: "",
                     declaredLicenses = declaredLicenses.toSortedSet(),
-                    aliases = emptyList(),
                     vcs = VcsInfo.EMPTY,
                     vcsProcessed = processProjectVcs(workingDir, homepageUrl = homepageUrl),
                     homepageUrl = homepageUrl,

--- a/analyzer/src/main/kotlin/managers/GoDep.kt
+++ b/analyzer/src/main/kotlin/managers/GoDep.kt
@@ -127,7 +127,6 @@ class GoDep : PackageManager() {
                         id = Identifier(provider, "", projectDir.name, projectVcs.revision),
                         definitionFilePath = VersionControlSystem.getPathToRoot(definitionFile) ?: "",
                         declaredLicenses = sortedSetOf(),
-                        aliases = emptyList(),
                         vcs = VcsInfo.EMPTY,
                         vcsProcessed = projectVcs,
                         homepageUrl = "",

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -128,7 +128,6 @@ class Gradle : PackageManager() {
                     ),
                     definitionFilePath = VersionControlSystem.getPathToRoot(definitionFile) ?: "",
                     declaredLicenses = sortedSetOf(),
-                    aliases = emptyList(),
                     vcs = VcsInfo.EMPTY,
                     vcsProcessed = processProjectVcs(definitionFile.parentFile),
                     homepageUrl = "",

--- a/analyzer/src/main/kotlin/managers/Maven.kt
+++ b/analyzer/src/main/kotlin/managers/Maven.kt
@@ -156,7 +156,6 @@ class Maven : PackageManager() {
                 ),
                 definitionFilePath = VersionControlSystem.getPathToRoot(definitionFile) ?: "",
                 declaredLicenses = maven.parseLicenses(mavenProject),
-                aliases = emptyList(),
                 vcs = vcsFromPackage,
                 vcsProcessed = processProjectVcs(projectDir, vcsFromPackage, mavenProject.url ?: ""),
                 homepageUrl = mavenProject.url ?: "",

--- a/analyzer/src/main/kotlin/managers/NPM.kt
+++ b/analyzer/src/main/kotlin/managers/NPM.kt
@@ -459,9 +459,8 @@ open class NPM : PackageManager() {
                         name = name,
                         version = version
                 ),
-                declaredLicenses = declaredLicenses,
                 definitionFilePath = VersionControlSystem.getPathToRoot(packageJson) ?: "",
-                aliases = emptyList(),
+                declaredLicenses = declaredLicenses,
                 vcs = vcsFromPackage,
                 vcsProcessed = processProjectVcs(projectDir, vcsFromPackage, homepageUrl),
                 homepageUrl = homepageUrl,

--- a/analyzer/src/main/kotlin/managers/PIP.kt
+++ b/analyzer/src/main/kotlin/managers/PIP.kt
@@ -273,7 +273,6 @@ class PIP : PackageManager() {
                 ),
                 definitionFilePath = VersionControlSystem.getPathToRoot(definitionFile) ?: "",
                 declaredLicenses = declaredLicenses,
-                aliases = emptyList(),
                 vcs = VcsInfo.EMPTY,
                 vcsProcessed = processProjectVcs(workingDir, homepageUrl = projectHomepage),
                 homepageUrl = projectHomepage,

--- a/analyzer/src/main/kotlin/managers/PhpComposer.kt
+++ b/analyzer/src/main/kotlin/managers/PhpComposer.kt
@@ -205,9 +205,8 @@ class PhpComposer : PackageManager() {
                         name = rawName.substringAfter("/"),
                         version = json["version"].textValueOrEmpty()
                 ),
-                declaredLicenses = parseDeclaredLicenses(json),
                 definitionFilePath = VersionControlSystem.getPathToRoot(definitionFile) ?: "",
-                aliases = emptyList(),
+                declaredLicenses = parseDeclaredLicenses(json),
                 vcs = vcs,
                 vcsProcessed = processProjectVcs(definitionFile.parentFile, vcs, homepageUrl),
                 homepageUrl = homepageUrl,

--- a/analyzer/src/main/kotlin/managers/Unmanaged.kt
+++ b/analyzer/src/main/kotlin/managers/Unmanaged.kt
@@ -58,7 +58,6 @@ class Unmanaged : PackageManager() {
                 ),
                 definitionFilePath = "",
                 declaredLicenses = sortedSetOf(),
-                aliases = emptyList(),
                 vcs = VcsInfo.EMPTY,
                 vcsProcessed = VersionControlSystem.forDirectory(definitionFile)?.getInfo() ?: VcsInfo.EMPTY,
                 homepageUrl = "",

--- a/model/src/main/kotlin/Project.kt
+++ b/model/src/main/kotlin/Project.kt
@@ -45,11 +45,6 @@ data class Project(
         val declaredLicenses: SortedSet<String>,
 
         /**
-         * Alternate project names, like abbreviations or code names.
-         */
-        val aliases: List<String>,
-
-        /**
          * Original VCS-related information as defined in the [Project]'s meta-data.
          */
         val vcs: VcsInfo,
@@ -120,7 +115,6 @@ data class Project(
                 id = Identifier.EMPTY,
                 definitionFilePath = "",
                 declaredLicenses = sortedSetOf(),
-                aliases = emptyList(),
                 vcs = VcsInfo.EMPTY,
                 homepageUrl = "",
                 scopes = sortedSetOf()

--- a/model/src/test/kotlin/ProjectAnalyzerResultTest.kt
+++ b/model/src/test/kotlin/ProjectAnalyzerResultTest.kt
@@ -30,7 +30,6 @@ class ProjectAnalyzerResultTest : StringSpec({
                         id = Identifier("provider", "namespace", "name", "version"),
                         definitionFilePath = "definitionFilePath",
                         declaredLicenses = sortedSetOf(),
-                        aliases = listOf(),
                         vcs = VcsInfo.EMPTY,
                         vcsProcessed = VcsInfo.EMPTY,
                         homepageUrl = "",

--- a/scanner/src/funTest/assets/analyzer-result.yml
+++ b/scanner/src/funTest/assets/analyzer-result.yml
@@ -14,7 +14,6 @@ projects:
 - id: "Gradle:com.here.ort.gradle.example:lib:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
   declared_licenses: []
-  aliases: []
   vcs:
     type: ""
     url: ""

--- a/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
@@ -15,7 +15,6 @@ analyzer_result:
   - id: "Gradle:com.here.ort.gradle.example:lib:1.0.0"
     definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
     declared_licenses: []
-    aliases: []
     vcs:
       type: ""
       url: ""


### PR DESCRIPTION
This field was originally meant to hold internal code names etc. As none
of the currently supported package managers actually supports this
field, and the analyzer is supposed to only gather data that can be
automatically retrived (and not manually added), remove this unused
field.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/634)
<!-- Reviewable:end -->
