### PR TITLE
analyzer: Pass an absolute path to resolveDependencies()

### DIFF
--- a/analyzer/src/main/kotlin/Main.kt
+++ b/analyzer/src/main/kotlin/Main.kt
@@ -206,7 +206,7 @@ object Main {
         // Resolve dependencies per package manager.
         managedDefinitionFiles.forEach { manager, files ->
             // Print the list of dependencies.
-            val results = manager.create().resolveDependencies(inputDir, files)
+            val results = manager.create().resolveDependencies(absoluteProjectPath, files)
 
             val curatedResults = packageCurationsFile?.let {
                 val provider = YamlFilePackageCurationProvider(it)


### PR DESCRIPTION
Otherwise passing "." as the inputDir would make resolving a path relative to it fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/639)
<!-- Reviewable:end -->
