### PR TITLE
Licensee: Fix getting the SPDX ID for a license match

### DIFF
--- a/scanner/src/main/kotlin/scanners/Licensee.kt
+++ b/scanner/src/main/kotlin/scanners/Licensee.kt
@@ -120,19 +120,11 @@ object Licensee : LocalScanner() {
     }
 
     override fun generateSummary(startTime: Instant, endTime: Instant, result: JsonNode): ScanSummary {
-        val licenses = sortedSetOf<String>()
-
-        val licenseSummary = result["licenses"]
         val matchedFiles = result["matched_files"]
 
-        matchedFiles.forEach {
-            val licenseKey = it["matched_license"].textValue()
-            licenseSummary.find {
-                it["key"].textValue() == licenseKey
-            }?.let {
-                licenses += it["spdx_id"].textValue()
-            }
-        }
+        val licenses = matchedFiles.map {
+            it["matched_license"].textValue()
+        }.toSortedSet()
 
         return ScanSummary(startTime, endTime, matchedFiles.count(), licenses, errors = sortedSetOf())
     }


### PR DESCRIPTION
As of [1] the "matched_license" already is the SPDX ID instead of an
internal key name. This is a fixup for 924eb69.

[1] https://github.com/benbalter/licensee/pull/283

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/646)
<!-- Reviewable:end -->
