### PR TITLE
analyzer: Disable dependency resolution in MavenSupport.parsePackage()

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,12 +22,9 @@ clone_depth: 50
 
 install:
   - git submodule update --init --recursive
-  # Install VCS tools.
-  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Sy cvs"
-  - set PATH=%PATH%;C:\msys64\usr\bin # For CVS.
-  # Install package managers.
-  - set PATH=C:\Ruby25\bin;%PATH% # For Bundler.
   - npm install -g npm@5.5.1 yarn@1.3.2
+  - pip install virtualenv==15.1.0
+  - cinst sbt --version 1.0.2 -y
   - cinst php --version 7.2.0 -y
   - cd c:\tools\php72 # For some reason pushd / popd does not work.
   - copy php.ini-production php.ini
@@ -35,13 +32,15 @@ install:
   - echo extension=php_mbstring.dll>>php.ini
   - echo extension=php_openssl.dll>>php.ini
   - cd %APPVEYOR_BUILD_FOLDER%
-  - pip install virtualenv==15.1.0
-  - cinst sbt --version 1.0.2 -y
-  # Install the Go toolchain and dep.
+  - refreshenv
+  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Sy cvs"
+  - set PATH=%PATH%;C:\msys64\usr\bin # For CVS.
+  - set PATH=C:\Ruby25\bin;%PATH% # For licensee.
+  # Install Go toolchain and dep.
   - rmdir c:\go /s /q
   - ps: Start-FileDownload 'https://storage.googleapis.com/golang/go1.10.windows-amd64.msi'
   - msiexec /i go1.10.windows-amd64.msi /q
-  - set PATH=c:\go\bin;%PATH%
+  - set Path=c:\go\bin;%Path%
   - go version
   - go env
   - mkdir c:\gopath
@@ -53,7 +52,6 @@ install:
   - ps: Start-FileDownload 'https://dl.google.com/android/repository/sdk-tools-windows-3859397.zip'
   - 7z x sdk-tools-windows-3859397.zip -o%ANDROID_HOME% > nul
   - yes | %ANDROID_HOME%\tools\bin\sdkmanager.bat platform-tools
-  - refreshenv
 
 # Do something useful here to override the default MSBuild (which would fail otherwise).
 build_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,16 +25,13 @@ env:
     - DEP_RELEASE_TAG="v0.4.1"
 
 install:
-  # Install VCS tools.
   - sudo apt install -y cvs
-  - curl https://storage.googleapis.com/git-repo-downloads/repo > ~/bin/repo
-  - chmod a+x ~/bin/repo
-  # Install package managers.
   - eval "$(gimme)"
   - curl https://raw.githubusercontent.com/golang/dep/7d5cd199ce454707f81c63b7ea4299151b8b981d/install.sh | sh
   - npm install -g npm@5.5.1 yarn@1.3.2
   - phpenv global 7.1
-  # Install SDKs.
+  - curl https://storage.googleapis.com/git-repo-downloads/repo > ~/bin/repo
+  - chmod a+x ~/bin/repo
   - wget -q https://dl.google.com/android/repository/sdk-tools-linux-3859397.zip
   - unzip -q sdk-tools-linux-3859397.zip -d $ANDROID_HOME
   - yes | $ANDROID_HOME/tools/bin/sdkmanager --verbose "platform-tools"

--- a/analyzer/src/main/kotlin/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/MavenSupport.kt
@@ -328,7 +328,7 @@ class MavenSupport(localRepositoryManagerConverter: (LocalRepositoryManager) -> 
                      localProjects: Map<String, MavenProject> = emptyMap(), sbtMode: Boolean = false): Package {
         val mavenRepositorySystem = container.lookup(MavenRepositorySystem::class.java, "default")
         val projectBuilder = container.lookup(ProjectBuilder::class.java, "default")
-        val projectBuildingRequest = createProjectBuildingRequest(true)
+        val projectBuildingRequest = createProjectBuildingRequest(false)
 
         projectBuildingRequest.remoteRepositories = repositories.map { repo ->
             // As the ID might be used as the key when generating a metadata file name, avoid the URL being used as the


### PR DESCRIPTION
The function only determines information about the package itself, not
about the dependencies, so it makes no sense to resolve the dependencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/648)
<!-- Reviewable:end -->
