### PR TITLE
Travis: Explicitly state that sudo is required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: required
+
 language: java
 
 jdk:


### PR DESCRIPTION
sudo was implicitly required already as we use "sudo apt install -y cvs"
in the "install" section, but removing that line would make Travis
silently switch to "sudo: false", i.e. the container-based EC2
infrastructure. As we are planning to move to Docker-based builds which
also require sudo, make that requirement explicit already now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/649)
<!-- Reviewable:end -->
