### PR TITLE
analyzer: Use all system properties and environment variables in Maven

### DIFF
--- a/analyzer/src/main/kotlin/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/MavenSupport.kt
@@ -52,6 +52,7 @@ import org.apache.maven.project.ProjectBuilder
 import org.apache.maven.project.ProjectBuildingException
 import org.apache.maven.project.ProjectBuildingRequest
 import org.apache.maven.project.ProjectBuildingResult
+import org.apache.maven.properties.internal.EnvironmentUtils
 import org.apache.maven.session.scope.internal.SessionScope
 
 import org.codehaus.plexus.DefaultContainerConfiguration
@@ -117,8 +118,9 @@ class MavenSupport(localRepositoryManagerConverter: (LocalRepositoryManager) -> 
     private fun createMavenExecutionRequest(): MavenExecutionRequest {
         val request = DefaultMavenExecutionRequest()
 
-        request.systemProperties["java.home"] = System.getProperty("java.home")
-        request.systemProperties["java.version"] = System.getProperty("java.version")
+        val props = System.getProperties()
+        EnvironmentUtils.addEnvVars(props)
+        request.systemProperties = props
 
         val populator = container.lookup(MavenExecutionRequestPopulator::class.java, "default")
 


### PR DESCRIPTION
This is important because system properties and environment variables can
be used to activate Maven profiles.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/664)
<!-- Reviewable:end -->
