### PR TITLE
model: Make the scan error summary a list

### DIFF
--- a/model/src/main/kotlin/ScanSummary.kt
+++ b/model/src/main/kotlin/ScanSummary.kt
@@ -52,7 +52,7 @@ data class ScanSummary(
         val licenses: SortedSet<String>,
 
         /**
-         * A list of errors that occured during the scan.
+         * The list of errors that occurred during the scan.
          */
-        val errors: SortedSet<String>
+        val errors: MutableList<String>
 )

--- a/model/src/test/kotlin/ScanResultContainerTest.kt
+++ b/model/src/test/kotlin/ScanResultContainerTest.kt
@@ -54,14 +54,14 @@ class ScanResultContainerTest : WordSpec() {
             scannerEndTime1,
             1,
             sortedSetOf("license 1.1", "license 1.2"),
-            sortedSetOf("error 1.1", "error 1.2")
+            mutableListOf("error 1.1", "error 1.2")
     )
     private val scanSummary2 = ScanSummary(
             scannerStartTime2,
             scannerEndTime2,
             2,
             sortedSetOf("license 2.1", "license 2.2"),
-            sortedSetOf("error 2.1", "error 2.2")
+            mutableListOf("error 2.1", "error 2.2")
     )
 
     private val rawResult1 = jsonMapper.readTree("\"key 1\": \"value 1\"")

--- a/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
@@ -181,9 +181,7 @@ scan_results:
       file_count: 0
       licenses: []
       errors:
-      - "Package 'Gradle:com.here.ort.gradle.example:lib:1.0.0' could not be scanned\
-        \ because no source code could be downloaded: No source artifact URL provided\
-        \ for 'Gradle:com.here.ort.gradle.example:lib:1.0.0'."
+      - "DownloadException: No source artifact URL provided for 'Gradle:com.here.ort.gradle.example:lib:1.0.0'."
 - id: "Maven:junit:junit:4.12"
   results:
   - provenance:

--- a/scanner/src/funTest/kotlin/HttpCacheTest.kt
+++ b/scanner/src/funTest/kotlin/HttpCacheTest.kt
@@ -136,14 +136,14 @@ class HttpCacheTest : StringSpec() {
             scannerEndTime1,
             1,
             sortedSetOf("license 1.1", "license 1.2"),
-            sortedSetOf("error 1.1", "error 1.2")
+            mutableListOf("error 1.1", "error 1.2")
     )
     private val scanSummaryWithoutFiles = ScanSummary(
             scannerStartTime2,
             scannerEndTime2,
             0,
             sortedSetOf(),
-            sortedSetOf()
+            mutableListOf()
     )
 
     private val rawResultWithContent = jsonMapper.readTree("\"key 1\": \"value 1\"")

--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -131,7 +131,7 @@ abstract class LocalScanner : Scanner() {
                                 endTime = now,
                                 fileCount = 0,
                                 licenses = sortedSetOf(),
-                                errors = e.collectMessages().toSortedSet()
+                                errors = e.collectMessages().toMutableList()
                         ),
                         rawResult = EMPTY_JSON_NODE)
                 )
@@ -185,8 +185,7 @@ abstract class LocalScanner : Scanner() {
                             endTime = now,
                             fileCount = 0,
                             licenses = sortedSetOf(),
-                            errors = sortedSetOf("Package '${pkg.id}' could not be scanned because no source code " +
-                                    "could be downloaded: ${e.message}")
+                            errors = e.collectMessages().toMutableList()
                     ),
                     EMPTY_JSON_NODE
             )

--- a/scanner/src/main/kotlin/Main.kt
+++ b/scanner/src/main/kotlin/Main.kt
@@ -266,7 +266,7 @@ object Main {
             log.error { "Could not scan path '${inputPath.absolutePath}': ${e.message}" }
 
             val now = Instant.now()
-            val summary = ScanSummary(now, now, 0, sortedSetOf(), e.collectMessages().toSortedSet())
+            val summary = ScanSummary(now, now, 0, sortedSetOf(), e.collectMessages().toMutableList())
             ScanResult(Provenance(now), localScanner.getDetails(), summary)
         }
 

--- a/scanner/src/main/kotlin/scanners/Askalono.kt
+++ b/scanner/src/main/kotlin/scanners/Askalono.kt
@@ -141,6 +141,6 @@ object Askalono : LocalScanner() {
 
     override fun generateSummary(startTime: Instant, endTime: Instant, result: JsonNode): ScanSummary {
         val licenses = result.map { it["License"].textValue() }
-        return ScanSummary(startTime, endTime, result.size(), licenses.toSortedSet(), errors = sortedSetOf())
+        return ScanSummary(startTime, endTime, result.size(), licenses.toSortedSet(), errors = mutableListOf())
     }
 }

--- a/scanner/src/main/kotlin/scanners/BoyterLc.kt
+++ b/scanner/src/main/kotlin/scanners/BoyterLc.kt
@@ -155,6 +155,6 @@ object BoyterLc : LocalScanner() {
             }
         }
 
-        return ScanSummary(startTime, endTime, result.size(), licenses, errors = sortedSetOf())
+        return ScanSummary(startTime, endTime, result.size(), licenses, errors = mutableListOf())
     }
 }

--- a/scanner/src/main/kotlin/scanners/FileCounter.kt
+++ b/scanner/src/main/kotlin/scanners/FileCounter.kt
@@ -73,6 +73,6 @@ object FileCounter : LocalScanner() {
 
     override fun generateSummary(startTime: Instant, endTime: Instant, result: JsonNode): ScanSummary {
         val fileCount = result["file_count"].intValue()
-        return ScanSummary(startTime, endTime, fileCount, licenses = sortedSetOf(), errors = sortedSetOf())
+        return ScanSummary(startTime, endTime, fileCount, licenses = sortedSetOf(), errors = mutableListOf())
     }
 }

--- a/scanner/src/main/kotlin/scanners/Licensee.kt
+++ b/scanner/src/main/kotlin/scanners/Licensee.kt
@@ -126,6 +126,6 @@ object Licensee : LocalScanner() {
             it["matched_license"].textValue()
         }.toSortedSet()
 
-        return ScanSummary(startTime, endTime, matchedFiles.count(), licenses, errors = sortedSetOf())
+        return ScanSummary(startTime, endTime, matchedFiles.count(), licenses, errors = mutableListOf())
     }
 }

--- a/scanner/src/main/kotlin/scanners/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/ScanCode.kt
@@ -42,7 +42,6 @@ import java.io.File
 import java.io.IOException
 import java.time.Instant
 import java.util.regex.Pattern
-import java.util.SortedSet
 
 object ScanCode : LocalScanner() {
     private const val OUTPUT_FORMAT = "json-pp"
@@ -180,7 +179,7 @@ object ScanCode : LocalScanner() {
     override fun generateSummary(startTime: Instant, endTime: Instant, result: JsonNode): ScanSummary {
         val fileCount = result["files_count"].intValue()
         val licenses = sortedSetOf<String>()
-        val errors = sortedSetOf<String>()
+        val errors = mutableListOf<String>()
 
         result["files"]?.forEach { file ->
             file["licenses"]?.forEach { license ->
@@ -203,7 +202,7 @@ object ScanCode : LocalScanner() {
      * Map messages about unknown errors to a more compact form. Return true if solely memory errors occurred, return
      * false otherwise.
      */
-    internal fun mapUnknownErrors(errors: SortedSet<String>): Boolean {
+    internal fun mapUnknownErrors(errors: MutableList<String>): Boolean {
         if (errors.isEmpty()) {
             return false
         }
@@ -230,7 +229,7 @@ object ScanCode : LocalScanner() {
         }
 
         errors.clear()
-        errors += mappedErrors
+        errors += mappedErrors.distinct()
 
         return onlyMemoryErrors
     }
@@ -239,7 +238,7 @@ object ScanCode : LocalScanner() {
      * Map messages about timeout errors to a more compact form. Return true if solely timeout errors occurred, return
      * false otherwise.
      */
-    internal fun mapTimeoutErrors(errors: SortedSet<String>): Boolean {
+    internal fun mapTimeoutErrors(errors: MutableList<String>): Boolean {
         if (errors.isEmpty()) {
             return false
         }
@@ -259,7 +258,7 @@ object ScanCode : LocalScanner() {
         }
 
         errors.clear()
-        errors += mappedErrors
+        errors += mappedErrors.distinct()
 
         return onlyTimeoutErrors
     }

--- a/scanner/src/test/kotlin/ScanCodeTest.kt
+++ b/scanner/src/test/kotlin/ScanCodeTest.kt
@@ -34,31 +34,32 @@ class ScanCodeTest : WordSpec({
             val result = ScanCode.getResult(resultFile)
             val summary = ScanCode.generateSummary(Instant.now(), Instant.now(), result)
             ScanCode.mapTimeoutErrors(summary.errors) shouldBe true
-            summary.errors.joinToString("\n") shouldBe sortedSetOf(
-                    "ERROR: Timeout after 300 seconds while scanning file " +
-                            "'test/3rdparty/syntax/angular-1.2.5.json'.",
+            summary.errors.joinToString("\n") shouldBe listOf(
                     "ERROR: Timeout after 300 seconds while scanning file " +
                             "'test/3rdparty/syntax/angular-1.2.5.tokens'.",
                     "ERROR: Timeout after 300 seconds while scanning file " +
-                            "'test/3rdparty/syntax/jquery-1.9.1.json'.",
-                    "ERROR: Timeout after 300 seconds while scanning file " +
                             "'test/3rdparty/syntax/jquery-1.9.1.tokens'.",
-                    "ERROR: Timeout after 300 seconds while scanning file " +
-                            "'test/3rdparty/syntax/jquery.mobile-1.4.2.json'.",
                     "ERROR: Timeout after 300 seconds while scanning file " +
                             "'test/3rdparty/syntax/jquery.mobile-1.4.2.tokens'.",
                     "ERROR: Timeout after 300 seconds while scanning file " +
-                            "'test/3rdparty/syntax/mootools-1.4.5.json'.",
-                    "ERROR: Timeout after 300 seconds while scanning file " +
                             "'test/3rdparty/syntax/mootools-1.4.5.tokens'.",
-                    "ERROR: Timeout after 300 seconds while scanning file " +
-                            "'test/3rdparty/syntax/underscore-1.5.2.json'.",
                     "ERROR: Timeout after 300 seconds while scanning file " +
                             "'test/3rdparty/syntax/underscore-1.5.2.tokens'.",
                     "ERROR: Timeout after 300 seconds while scanning file " +
-                            "'test/3rdparty/syntax/yui-3.12.0.json'.",
+                            "'test/3rdparty/syntax/yui-3.12.0.tokens'.",
+
                     "ERROR: Timeout after 300 seconds while scanning file " +
-                            "'test/3rdparty/syntax/yui-3.12.0.tokens'."
+                            "'test/3rdparty/syntax/angular-1.2.5.json'.",
+                    "ERROR: Timeout after 300 seconds while scanning file " +
+                            "'test/3rdparty/syntax/jquery-1.9.1.json'.",
+                    "ERROR: Timeout after 300 seconds while scanning file " +
+                            "'test/3rdparty/syntax/jquery.mobile-1.4.2.json'.",
+                    "ERROR: Timeout after 300 seconds while scanning file " +
+                            "'test/3rdparty/syntax/mootools-1.4.5.json'.",
+                    "ERROR: Timeout after 300 seconds while scanning file " +
+                            "'test/3rdparty/syntax/underscore-1.5.2.json'.",
+                    "ERROR: Timeout after 300 seconds while scanning file " +
+                            "'test/3rdparty/syntax/yui-3.12.0.json'."
             ).joinToString("\n")
         }
 
@@ -76,7 +77,7 @@ class ScanCodeTest : WordSpec({
             val result = ScanCode.getResult(resultFile)
             val summary = ScanCode.generateSummary(Instant.now(), Instant.now(), result)
             ScanCode.mapUnknownErrors(summary.errors) shouldBe true
-            summary.errors.joinToString("\n") shouldBe sortedSetOf(
+            summary.errors.joinToString("\n") shouldBe listOf(
                     "ERROR: MemoryError while scanning file 'data.json'."
             ).joinToString("\n")
         }
@@ -86,7 +87,7 @@ class ScanCodeTest : WordSpec({
             val result = ScanCode.getResult(resultFile)
             val summary = ScanCode.generateSummary(Instant.now(), Instant.now(), result)
             ScanCode.mapUnknownErrors(summary.errors) shouldBe false
-            summary.errors.joinToString("\n") shouldBe sortedSetOf(
+            summary.errors.joinToString("\n") shouldBe listOf(
                     "ERROR: AttributeError while scanning file 'compiler/testData/cli/js-dce/withSourceMap.js.map' " +
                             "('NoneType' object has no attribute 'splitlines')."
             ).joinToString("\n")


### PR DESCRIPTION
The order of errors, like the messages from a chain of exceptions, is
important. So make this a list instead of a set of errors, like we also
already have it in other places. The original idea was to, in case of
multiple separate errors, to not show duplicates in the summary. But in
reality we do not use this field to store multiple errors, but multiple
messages for the same root error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/672)
<!-- Reviewable:end -->
