### PR TITLE
VersionControlSystem: Limit the output of matching tags

### DIFF
--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -259,8 +259,11 @@ abstract class VersionControlSystem {
             return when {
                 versionNames.isEmpty() ->
                     throw IOException("No matching tag found for version '$version'.")
-                versionNames.size > 1 ->
-                    throw IOException("Multiple matching tags found for version '$version': $versionNames")
+                versionNames.size > 1 -> {
+                    val limit = 20
+                    throw IOException("Multiple matching tags found for version '$version' (output limited to $limit " +
+                            "matches): ${versionNames.take(limit)}")
+                }
                 else -> versionNames.first()
             }
         }


### PR DESCRIPTION
There are projects with a lot of matching tags, so limit the output to
not spam the error report.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/677)
<!-- Reviewable:end -->
