### PR TITLE
PIP: Do not require "url" or "download_url" to be present in setup.py

### DIFF
--- a/analyzer/src/main/kotlin/managers/PIP.kt
+++ b/analyzer/src/main/kotlin/managers/PIP.kt
@@ -45,6 +45,7 @@ import com.here.ort.utils.ProcessCapture
 import com.here.ort.utils.checkCommandVersion
 import com.here.ort.utils.log
 import com.here.ort.utils.safeDeleteRecursively
+import com.here.ort.utils.textValueOrEmpty
 
 import com.vdurmont.semver4j.Requirement
 
@@ -160,7 +161,7 @@ class PIP : PackageManager() {
             // So the best we can do is to map this the project's homepage URL.
             jsonMapper.readTree(pydep.stdout()).let {
                 declaredLicenses = getDeclaredLicenses(it)
-                listOf(it["project_name"].textValue(), it["version"].textValue(), it["repo_url"].textValue())
+                listOf(it["project_name"].textValue(), it["version"].textValue(), it["repo_url"].textValueOrEmpty())
             }
         } else {
             // In case of "requirements*.txt" there is no meta-data at all available, so use the parent directory name


### PR DESCRIPTION
For example, this one does not have these:

https://github.com/syoyo/tinyobjloader/blob/f750f3faebb688a0c7f3d918fb29a96c2ec652e4/python/setup.py

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/684)
<!-- Reviewable:end -->
