### PR TITLE
Utils: Return early from filterVersionNames() for full matches

### DIFF
--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -114,6 +114,9 @@ object OkHttpClientHelper {
 fun filterVersionNames(version: String, names: List<String>, project: String? = null): List<String> {
     if (version.isBlank() || names.isEmpty()) return emptyList()
 
+    // If there is a full match, return it right away.
+    names.find { it == version }?.let { return listOf(it) }
+
     val normalizedSeparator = '_'
     val normalizedVersion = version.replace(Regex("([.-])"), normalizedSeparator.toString()).toLowerCase()
 

--- a/utils/src/test/kotlin/UtilsTest.kt
+++ b/utils/src/test/kotlin/UtilsTest.kt
@@ -218,6 +218,15 @@ class UtilsTest : WordSpec({
             filterVersionNames("6.9.0", names, "babel-plugin-transform-simplify-comparison-operators")
                     .joinToString("\n") shouldBe "babel-plugin-transform-simplify-comparison-operators@6.9.0"
         }
+
+        "find names when others with trailing digits are present" {
+            val names = listOf(
+                    "1.11.6", "1.11.60", "1.11.61", "1.11.62", "1.11.63", "1.11.64", "1.11.65", "1.11.66", "1.11.67",
+                    "1.11.68", "1.11.69"
+            )
+
+            filterVersionNames("1.11.6", names).joinToString("\n") shouldBe "1.11.6"
+        }
     }
 
     "getLicenseText" should {


### PR DESCRIPTION
This fixes the issue that e.g. "1.11.6" was regarded to be ambigious to
"1.11.60" etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/686)
<!-- Reviewable:end -->
