### PR TITLE
downloader: Disable transparent gzip in OkHTTP

### DIFF
--- a/downloader/src/main/kotlin/Main.kt
+++ b/downloader/src/main/kotlin/Main.kt
@@ -388,7 +388,15 @@ object Main {
             "Trying to download source artifact for '${target.id}' from '${target.sourceArtifact.url}'..."
         }
 
-        val request = Request.Builder().get().url(target.sourceArtifact.url).build()
+        val request = Request.Builder()
+                // Disable transparent gzip, otherwise we might end up writing a tar file to disk and expecting to find
+                // a tar.gz file, thus failing to unpack the archive.
+                // See https://github.com/square/okhttp/blob/parent-3.10.0/okhttp/src/main/java/okhttp3/internal/ \
+                // http/BridgeInterceptor.java#L79
+                .addHeader("Accept-Encoding", "identity")
+                .get()
+                .url(target.sourceArtifact.url)
+                .build()
 
         val startTime = Instant.now()
         val response = try {


### PR DESCRIPTION
Without this change, depending on the configuration of the webserver from which
source artifacts are downloaded, OkHTTP will decompress gzip transparently.
That leads to problems when calculating hash digests and unpacking archives,
since the file extension still indicates that the archive is compressed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/687)
<!-- Reviewable:end -->
