### PR TITLE
Decouple PackageManagers from the Main class

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "SBT:io.github.soc:directories:6"
   definition_file_path: "target/directories-6.pom"

--- a/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "PIP::example-python-flask:0773991e36a4c69b121cdb05146d6140347d4065"
   definition_file_path: "requirements.txt"

--- a/analyzer/src/funTest/assets/projects/external/godep-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/godep-expected-output.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "GoDep::godep:ce0bfadeb516ab23c845a85c4b0eae421ec9614b"
   definition_file_path: "Godeps/Godeps.json"

--- a/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "Maven:jgnash:jgnash-core:2.30.0"
   definition_file_path: "jgnash-core/pom.xml"

--- a/analyzer/src/funTest/assets/projects/external/jgnash-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/jgnash-expected-output.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "Maven:jgnash:jgnash2:2.30.0"
   definition_file_path: "pom.xml"

--- a/analyzer/src/funTest/assets/projects/external/qmstr-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/qmstr-expected-output.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "GoDep::qmstr:0cd17d10b931c9108450ca5a68d4f85b6e4953ef"
   definition_file_path: "Gopkg.toml"

--- a/analyzer/src/funTest/assets/projects/external/quickcheck-state-machine-expected-output-win32.yml
+++ b/analyzer/src/funTest/assets/projects/external/quickcheck-state-machine-expected-output-win32.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "Stack:Testing:quickcheck-state-machine:0.3.1"
   definition_file_path: "stack.yaml"

--- a/analyzer/src/funTest/assets/projects/external/quickcheck-state-machine-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/quickcheck-state-machine-expected-output.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "Stack:Testing:quickcheck-state-machine:0.3.1"
   definition_file_path: "stack.yaml"

--- a/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "PIP::spdx-tools:0.5.4"
   definition_file_path: "setup.py"

--- a/analyzer/src/funTest/assets/projects/external/sprig-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/sprig-expected-output.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "GoDep::sprig:9d9aa1f74c86fd9d36ecfe3f2a44a3093c3d4c15"
   definition_file_path: "glide.yaml"

--- a/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-gemspec.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-gemspec.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "Bundler::test-project:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/bundler/gemspec/Gemfile"

--- a/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-lockfile.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-lockfile.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "Bundler::lockfile:"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/bundler/lockfile/Gemfile"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 vcs:
   type: "Git"
   url: "<REPLACE_URL>"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 vcs:
   type: "Git"
   url: "<REPLACE_URL>"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-app.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "Gradle:com.here.ort.gradle.example:app:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-android/app/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-lib.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "Gradle:com.here.ort.gradle.example:lib:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-android/lib/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-root.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "Gradle:com.here.ort.gradle.example:Gradle-Android-Example:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-android/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-2.14.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-2.14.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "Gradle:com.here.ort.gradle.example:app:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-3.4.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-3.4.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "Gradle:com.here.ort.gradle.example:app:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "Gradle:com.here.ort.gradle.example:app:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "Gradle:com.here.ort.gradle.example:lib-without-repo:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "Gradle:com.here.ort.gradle.example:lib:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-root.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "Gradle::Gradle-Example:"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-unsupported-version.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-unsupported-version.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "Gradle:com.here.ort.gradle.example:gradle-unsupported-version:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-unsupported-version/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-app.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "Gradle:com.here.ort.gradle.example:app:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-library/app/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-lib.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "Gradle:com.here.ort.gradle.example:lib:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-library/lib/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-root.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "Gradle::Gradle-Example:"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-library/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-app.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "Maven:com.here.ort.maven:maven-app:1.0-SNAPSHOT"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/maven/app/pom.xml"

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-lib.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "Maven:com.here.ort.maven:maven-lib:1.0-SNAPSHOT"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/maven/lib/pom.xml"

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-root.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "Maven:com.here.ort.maven:maven-project:1.0-SNAPSHOT"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/maven/pom.xml"

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-parent-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-parent-expected-output-root.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "Maven:com.here.ort.maven:maven-parent-project:1.0-SNAPSHOT"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/maven-parent/pom.xml"

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "NPM::npm-project-that-depends-on-babel:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/npm-babel/package.json"

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output-no-lockfile.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output-no-lockfile.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "NPM::src/funTest/assets/projects/synthetic/npm/no-lockfile/package.json:"
   definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "NPM::npm-project:2.0.0"
   definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"

--- a/analyzer/src/funTest/assets/projects/synthetic/php-composer-expected-output-no-deps.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/php-composer-expected-output-no-deps.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "PhpComposer:ort:composer-test-project:0.1.0"
   definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"

--- a/analyzer/src/funTest/assets/projects/synthetic/php-composer-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/php-composer-expected-output.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "PhpComposer:ort:composer-test-project:0.1.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/php-composer/lockfile/composer.json"

--- a/analyzer/src/funTest/assets/projects/synthetic/pip-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pip-expected-output.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "PIP::Example-App:2.4.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/pip/requirements.txt"

--- a/analyzer/src/funTest/assets/projects/synthetic/yarn-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/yarn-expected-output.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 project:
   id: "Yarn::npm-yarn:2.0.0"
   definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"

--- a/analyzer/src/funTest/kotlin/BabelTest.kt
+++ b/analyzer/src/funTest/kotlin/BabelTest.kt
@@ -21,6 +21,7 @@ package com.here.ort.analyzer
 
 import com.here.ort.analyzer.managers.NPM
 import com.here.ort.downloader.VersionControlSystem
+import com.here.ort.model.AnalyzerConfiguration
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
 import com.here.ort.utils.safeDeleteRecursively
@@ -57,7 +58,8 @@ class BabelTest : WordSpec() {
     init {
         "Babel dependencies" should {
             "be correctly analyzed" {
-                val npm = NPM.create()
+                val config = AnalyzerConfiguration(false, false)
+                val npm = NPM.create(config)
                 val packageFile = File(projectDir, "package.json")
 
                 val expectedResult = patchExpectedResult(

--- a/analyzer/src/funTest/kotlin/BundlerTest.kt
+++ b/analyzer/src/funTest/kotlin/BundlerTest.kt
@@ -21,6 +21,7 @@ package com.here.ort.analyzer
 
 import com.here.ort.analyzer.managers.Bundler
 import com.here.ort.downloader.VersionControlSystem
+import com.here.ort.model.AnalyzerConfiguration
 import com.here.ort.model.Identifier
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
@@ -47,7 +48,8 @@ class BundlerTest : WordSpec() {
                 val definitionFile = File(projectsDir, "lockfile/Gemfile")
 
                 try {
-                    val actualResult = Bundler.create()
+                    val config = AnalyzerConfiguration(false, false)
+                    val actualResult = Bundler.create(config)
                             .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
                     val expectedResult = patchExpectedResult(
                             File(projectsDir.parentFile, "bundler-expected-output-lockfile.yml"),
@@ -65,7 +67,8 @@ class BundlerTest : WordSpec() {
             "show error if no lockfile is present" {
                 val definitionFile = File(projectsDir, "no-lockfile/Gemfile")
 
-                val actualResult = Bundler.create()
+                val config = AnalyzerConfiguration(false, false)
+                val actualResult = Bundler.create(config)
                         .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
 
                 actualResult shouldNotBe null
@@ -82,7 +85,8 @@ class BundlerTest : WordSpec() {
                 val definitionFile = File(projectsDir, "gemspec/Gemfile")
 
                 try {
-                    val actualResult = Bundler.create()
+                    val config = AnalyzerConfiguration(false, false)
+                    val actualResult = Bundler.create(config)
                             .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
                     val expectedResult = patchExpectedResult(
                             File(projectsDir.parentFile, "bundler-expected-output-gemspec.yml"),

--- a/analyzer/src/funTest/kotlin/GoDepTest.kt
+++ b/analyzer/src/funTest/kotlin/GoDepTest.kt
@@ -21,6 +21,7 @@ package com.here.ort.analyzer
 
 import com.here.ort.analyzer.managers.GoDep
 import com.here.ort.downloader.VersionControlSystem
+import com.here.ort.model.AnalyzerConfiguration
 import com.here.ort.model.Identifier
 import com.here.ort.model.Project
 import com.here.ort.model.VcsInfo
@@ -41,7 +42,8 @@ class GoDepTest : WordSpec() {
         "GoDep" should {
             "resolve dependencies from a lockfile correctly" {
                 val manifestFile = File(projectsDir, "external/qmstr/Gopkg.toml")
-                val godep = GoDep.create()
+                val config = AnalyzerConfiguration(false, false)
+                val godep = GoDep.create(config)
 
                 val result = godep.resolveDependencies(USER_DIR, listOf(manifestFile))[manifestFile]
                 val expectedResult = File(projectsDir, "external/qmstr-expected-output.yml").readText()
@@ -51,7 +53,8 @@ class GoDepTest : WordSpec() {
 
             "show error if no lockfile is present" {
                 val manifestFile = File(projectsDir, "synthetic/godep/no-lockfile/Gopkg.toml")
-                val godep = GoDep.create()
+                val config = AnalyzerConfiguration(false, false)
+                val godep = GoDep.create(config)
 
                 val result = godep.resolveDependencies(USER_DIR, listOf(manifestFile))[manifestFile]
 
@@ -67,12 +70,10 @@ class GoDepTest : WordSpec() {
 
             "invoke the dependency solver if no lockfile is present and allowDynamicVersions is set" {
                 val manifestFile = File(projectsDir, "synthetic/godep/no-lockfile/Gopkg.toml")
-                val godep = GoDep.create()
+                val config = AnalyzerConfiguration(false, true)
+                val godep = GoDep.create(config)
 
-                val allowDynamicVersionsOriginal = Main.allowDynamicVersions
-                Main.allowDynamicVersions = true
                 val result = godep.resolveDependencies(USER_DIR, listOf(manifestFile))[manifestFile]
-                Main.allowDynamicVersions = allowDynamicVersionsOriginal
 
                 result shouldNotBe null
                 result!!.project shouldNotBe Project.EMPTY
@@ -82,7 +83,8 @@ class GoDepTest : WordSpec() {
 
             "import dependencies from Glide" {
                 val manifestFile = File(projectsDir, "external/sprig/glide.yaml")
-                val godep = GoDep.create()
+                val config = AnalyzerConfiguration(false, false)
+                val godep = GoDep.create(config)
 
                 val result = godep.resolveDependencies(USER_DIR, listOf(manifestFile))[manifestFile]
                 val expectedResult = File(projectsDir, "external/sprig-expected-output.yml").readText()
@@ -92,7 +94,8 @@ class GoDepTest : WordSpec() {
 
             "import dependencies from godeps" {
                 val manifestFile = File(projectsDir, "external/godep/Godeps/Godeps.json")
-                val godep = GoDep.create()
+                val config = AnalyzerConfiguration(false, false)
+                val godep = GoDep.create(config)
 
                 val result = godep.resolveDependencies(USER_DIR, listOf(manifestFile))[manifestFile]
                 val expectedResult = File(projectsDir, "external/godep-expected-output.yml").readText()
@@ -101,7 +104,8 @@ class GoDepTest : WordSpec() {
             }
 
             "construct an import path from VCS info" {
-                val godep = GoDep.create()
+                val config = AnalyzerConfiguration(false, false)
+                val godep = GoDep.create(config)
                 val gopath = File("/tmp/gopath")
                 val projectDir = File(projectsDir, "external/qmstr")
                 val vcs = VersionControlSystem.forDirectory(projectDir)!!.getInfo()
@@ -112,7 +116,8 @@ class GoDepTest : WordSpec() {
             }
 
             "construct an import path for directories that are not repositories" {
-                val godep = GoDep.create()
+                val config = AnalyzerConfiguration(false, false)
+                val godep = GoDep.create(config)
                 val gopath = File("/tmp/gopath")
                 val projectDir = File(projectsDir, "synthetic/godep/no-lockfile")
                 val vcs = VcsInfo.EMPTY

--- a/analyzer/src/funTest/kotlin/GradleAndroidTest.kt
+++ b/analyzer/src/funTest/kotlin/GradleAndroidTest.kt
@@ -21,6 +21,7 @@ package com.here.ort.analyzer
 
 import com.here.ort.analyzer.managers.Gradle
 import com.here.ort.downloader.VersionControlSystem
+import com.here.ort.model.AnalyzerConfiguration
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
 import com.here.ort.utils.test.AndroidTag
@@ -48,7 +49,8 @@ class GradleAndroidTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle.create().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val config = AnalyzerConfiguration(false, false)
+            val result = Gradle.create(config).resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -63,7 +65,8 @@ class GradleAndroidTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle.create().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val config = AnalyzerConfiguration(false, false)
+            val result = Gradle.create(config).resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -78,7 +81,8 @@ class GradleAndroidTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle.create().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val config = AnalyzerConfiguration(false, false)
+            val result = Gradle.create(config).resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()

--- a/analyzer/src/funTest/kotlin/GradleLibraryTest.kt
+++ b/analyzer/src/funTest/kotlin/GradleLibraryTest.kt
@@ -21,6 +21,7 @@ package com.here.ort.analyzer
 
 import com.here.ort.analyzer.managers.Gradle
 import com.here.ort.downloader.VersionControlSystem
+import com.here.ort.model.AnalyzerConfiguration
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
 import com.here.ort.utils.test.USER_DIR
@@ -47,7 +48,8 @@ class GradleLibraryTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle.create().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val config = AnalyzerConfiguration(false, false)
+            val result = Gradle.create(config).resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -62,7 +64,8 @@ class GradleLibraryTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle.create().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val config = AnalyzerConfiguration(false, false)
+            val result = Gradle.create(config).resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -77,7 +80,8 @@ class GradleLibraryTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle.create().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val config = AnalyzerConfiguration(false, false)
+            val result = Gradle.create(config).resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()

--- a/analyzer/src/funTest/kotlin/GradleTest.kt
+++ b/analyzer/src/funTest/kotlin/GradleTest.kt
@@ -22,6 +22,7 @@ package com.here.ort.analyzer
 import com.here.ort.analyzer.managers.Gradle
 import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.downloader.vcs.Git
+import com.here.ort.model.AnalyzerConfiguration
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.ProcessCapture
 import com.here.ort.utils.normalizeVcsUrl
@@ -63,7 +64,8 @@ class GradleTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle.create().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val config = AnalyzerConfiguration(false, false)
+            val result = Gradle.create(config).resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -78,7 +80,8 @@ class GradleTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle.create().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val config = AnalyzerConfiguration(false, false)
+            val result = Gradle.create(config).resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -93,7 +96,8 @@ class GradleTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle.create().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val config = AnalyzerConfiguration(false, false)
+            val result = Gradle.create(config).resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -108,7 +112,8 @@ class GradleTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle.create().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val config = AnalyzerConfiguration(false, false)
+            val result = Gradle.create(config).resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -123,7 +128,8 @@ class GradleTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle.create().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val config = AnalyzerConfiguration(false, false)
+            val result = Gradle.create(config).resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
@@ -179,7 +185,8 @@ class GradleTest : StringSpec() {
                         revision = vcsRevision
                 )
 
-                val result = Gradle.create().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+                val config = AnalyzerConfiguration(false, false)
+                val result = Gradle.create(config).resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
                 result shouldNotBe null
                 result!!.errors shouldBe emptyList()

--- a/analyzer/src/funTest/kotlin/MavenTest.kt
+++ b/analyzer/src/funTest/kotlin/MavenTest.kt
@@ -21,6 +21,7 @@ package com.here.ort.analyzer
 
 import com.here.ort.analyzer.managers.Maven
 import com.here.ort.downloader.VersionControlSystem
+import com.here.ort.model.AnalyzerConfiguration
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
 import com.here.ort.utils.safeDeleteRecursively
@@ -44,7 +45,8 @@ class MavenTest : StringSpec() {
             val pomFile = File(projectDir, "pom.xml")
             val expectedResult = File(projectDir.parentFile, "jgnash-expected-output.yml").readText()
 
-            val result = Maven.create().resolveDependencies(USER_DIR, listOf(pomFile))[pomFile]
+            val config = AnalyzerConfiguration(false, false)
+            val result = Maven.create(config).resolveDependencies(USER_DIR, listOf(pomFile))[pomFile]
 
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
@@ -60,7 +62,8 @@ class MavenTest : StringSpec() {
             // jgnash-core depends on jgnash-resources, so we also have to pass the pom.xml of jgnash-resources to
             // resolveDependencies so that it is available in the Maven.projectsByIdentifier cache. Otherwise resolution
             // of transitive dependencies would not work.
-            val result = Maven.create()
+            val config = AnalyzerConfiguration(false, false)
+            val result = Maven.create(config)
                     .resolveDependencies(USER_DIR, listOf(pomFileCore, pomFileResources))[pomFileCore]
 
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
@@ -74,7 +77,8 @@ class MavenTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Maven.create().resolveDependencies(USER_DIR, listOf(pomFile))[pomFile]
+            val config = AnalyzerConfiguration(false, false)
+            val result = Maven.create(config).resolveDependencies(USER_DIR, listOf(pomFile))[pomFile]
 
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
@@ -91,7 +95,8 @@ class MavenTest : StringSpec() {
             // app depends on lib, so we also have to pass the pom.xml of lib to resolveDependencies so that it is
             // available in the Maven.projectsByIdentifier cache. Otherwise resolution of transitive dependencies would
             // not work.
-            val result = Maven.create()
+            val config = AnalyzerConfiguration(false, false)
+            val result = Maven.create(config)
                     .resolveDependencies(USER_DIR, listOf(pomFileApp, pomFileLib))[pomFileApp]
 
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
@@ -105,7 +110,8 @@ class MavenTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Maven.create().resolveDependencies(USER_DIR, listOf(pomFile))[pomFile]
+            val config = AnalyzerConfiguration(false, false)
+            val result = Maven.create(config).resolveDependencies(USER_DIR, listOf(pomFile))[pomFile]
 
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
@@ -124,7 +130,8 @@ class MavenTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Maven.create().resolveDependencies(USER_DIR, listOf(pomFile))[pomFile]
+            val config = AnalyzerConfiguration(false, false)
+            val result = Maven.create(config).resolveDependencies(USER_DIR, listOf(pomFile))[pomFile]
 
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }

--- a/analyzer/src/funTest/kotlin/NpmTest.kt
+++ b/analyzer/src/funTest/kotlin/NpmTest.kt
@@ -21,6 +21,7 @@ package com.here.ort.analyzer
 
 import com.here.ort.analyzer.managers.NPM
 import com.here.ort.downloader.VersionControlSystem
+import com.here.ort.model.AnalyzerConfiguration
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
 import com.here.ort.utils.safeDeleteRecursively
@@ -59,9 +60,9 @@ class NpmTest : WordSpec() {
             "resolve shrinkwrap dependencies correctly" {
                 val workingDir = File(projectsDir, "shrinkwrap")
                 val packageFile = File(workingDir, "package.json")
-                val npm = NPM.create()
 
-                val result = npm.resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+                val config = AnalyzerConfiguration(false, false)
+                val result = NPM.create(config).resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
                 val vcsPath = vcsDir.getPathToRoot(workingDir)
                 val expectedResult = patchExpectedResult(
                         File(projectsDir.parentFile, "npm-expected-output.yml"),
@@ -78,9 +79,9 @@ class NpmTest : WordSpec() {
             "resolve package-lock dependencies correctly" {
                 val workingDir = File(projectsDir, "package-lock")
                 val packageFile = File(workingDir, "package.json")
-                val npm = NPM.create()
 
-                val result = npm.resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+                val config = AnalyzerConfiguration(false, false)
+                val result = NPM.create(config).resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
                 val vcsPath = vcsDir.getPathToRoot(workingDir)
                 val expectedResult = patchExpectedResult(
                         File(projectsDir.parentFile, "npm-expected-output.yml"),
@@ -98,7 +99,8 @@ class NpmTest : WordSpec() {
                 val workingDir = File(projectsDir, "no-lockfile")
                 val packageFile = File(workingDir, "package.json")
 
-                val result = NPM.create().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+                val config = AnalyzerConfiguration(false, false)
+                val result = NPM.create(config).resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
                 val vcsPath = vcsDir.getPathToRoot(workingDir)
                 val expectedResult = patchExpectedResult(
                         File(projectsDir.parentFile, "npm-expected-output-no-lockfile.yml"),
@@ -115,9 +117,9 @@ class NpmTest : WordSpec() {
             "resolve dependencies even if the node_modules directory already exists" {
                 val workingDir = File(projectsDir, "node-modules")
                 val packageFile = File(workingDir, "package.json")
-                val npm = NPM.create()
 
-                val result = npm.resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+                val config = AnalyzerConfiguration(false, false)
+                val result = NPM.create(config).resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
                 val vcsPath = vcsDir.getPathToRoot(workingDir)
                 val expectedResult = patchExpectedResult(
                         File(projectsDir.parentFile, "npm-expected-output.yml"),

--- a/analyzer/src/funTest/kotlin/PhpComposerTest.kt
+++ b/analyzer/src/funTest/kotlin/PhpComposerTest.kt
@@ -21,6 +21,7 @@ package com.here.ort.analyzer
 
 import com.here.ort.analyzer.managers.PhpComposer
 import com.here.ort.downloader.VersionControlSystem
+import com.here.ort.model.AnalyzerConfiguration
 import com.here.ort.model.Identifier
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
@@ -45,7 +46,9 @@ class PhpComposerTest : StringSpec() {
         "Project dependencies are detected correctly" {
             val definitionFile = File(projectsDir, "lockfile/composer.json")
 
-            val result = PhpComposer.create().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+            val config = AnalyzerConfiguration(false, false)
+            val result = PhpComposer.create(config)
+                    .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
             val expectedResults = patchExpectedResult(
                     File(projectsDir.parentFile, "php-composer-expected-output.yml"),
                     url = normalizeVcsUrl(vcsUrl),
@@ -59,7 +62,9 @@ class PhpComposerTest : StringSpec() {
         "Error is shown when no lock file is present" {
             val definitionFile = File(projectsDir, "no-lockfile/composer.json")
 
-            val result = PhpComposer.create().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+            val config = AnalyzerConfiguration(false, false)
+            val result = PhpComposer.create(config)
+                    .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
 
             result shouldNotBe null
             result!!.project.id shouldBe Identifier.fromString("PhpComposer::src/funTest/assets/projects/synthetic/" +
@@ -74,7 +79,9 @@ class PhpComposerTest : StringSpec() {
         "No composer.lock is required for projects without dependencies" {
             val definitionFile = File(projectsDir, "no-deps/composer.json")
 
-            val result = PhpComposer.create().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+            val config = AnalyzerConfiguration(false, false)
+            val result = PhpComposer.create(config)
+                    .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
             val expectedResults = patchExpectedResult(
                     File(projectsDir.parentFile, "php-composer-expected-output-no-deps.yml"),
                     definitionFilePath = VersionControlSystem.getPathToRoot(definitionFile),
@@ -89,7 +96,9 @@ class PhpComposerTest : StringSpec() {
         "No composer.lock is required for projects with empty dependencies" {
             val definitionFile = File(projectsDir, "empty-deps/composer.json")
 
-            val result = PhpComposer.create().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+            val config = AnalyzerConfiguration(false, false)
+            val result = PhpComposer.create(config)
+                    .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
             val expectedResults = patchExpectedResult(
                     File(projectsDir.parentFile, "php-composer-expected-output-no-deps.yml"),
                     definitionFilePath = VersionControlSystem.getPathToRoot(definitionFile),

--- a/analyzer/src/funTest/kotlin/PipTest.kt
+++ b/analyzer/src/funTest/kotlin/PipTest.kt
@@ -21,6 +21,7 @@ package com.here.ort.analyzer
 
 import com.here.ort.analyzer.managers.PIP
 import com.here.ort.downloader.VersionControlSystem
+import com.here.ort.model.AnalyzerConfiguration
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
 import com.here.ort.utils.test.USER_DIR
@@ -36,7 +37,8 @@ class PipTest : StringSpec({
     "setup.py dependencies should be resolved correctly for spdx-tools-python" {
         val definitionFile = File(projectsDir, "external/spdx-tools-python/setup.py")
 
-        val result = PIP.create().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+        val config = AnalyzerConfiguration(false, false)
+        val result = PIP.create(config).resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
         val expectedResult = File(projectsDir, "external/spdx-tools-python-expected-output.yml").readText()
 
         yamlMapper.writeValueAsString(result) shouldBe expectedResult
@@ -45,7 +47,8 @@ class PipTest : StringSpec({
     "requirements.txt dependencies should be resolved correctly for example-python-flask" {
         val definitionFile = File(projectsDir, "external/example-python-flask/requirements.txt")
 
-        val result = PIP.create().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+        val config = AnalyzerConfiguration(false, false)
+        val result = PIP.create(config).resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
         val expectedResult = File(projectsDir, "external/example-python-flask-expected-output.yml").readText()
 
         yamlMapper.writeValueAsString(result) shouldBe expectedResult
@@ -64,7 +67,8 @@ class PipTest : StringSpec({
                 .replaceFirst("<REPLACE_REVISION>", vcsRevision)
                 .replaceFirst("<REPLACE_PATH>", vcsPath)
 
-        val result = PIP.create().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+        val config = AnalyzerConfiguration(false, false)
+        val result = PIP.create(config).resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
 
         yamlMapper.writeValueAsString(result) shouldBe expectedResult
     }

--- a/analyzer/src/funTest/kotlin/SbtTest.kt
+++ b/analyzer/src/funTest/kotlin/SbtTest.kt
@@ -21,6 +21,7 @@ package com.here.ort.analyzer
 
 import com.here.ort.analyzer.managers.SBT
 import com.here.ort.downloader.vcs.Git
+import com.here.ort.model.AnalyzerConfiguration
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.test.USER_DIR
 
@@ -30,8 +31,6 @@ import io.kotlintest.specs.StringSpec
 import java.io.File
 
 class SbtTest : StringSpec({
-    val sbt = SBT.create()
-
     "Dependencies of the external 'directories' project should be detected correctly" {
         val projectName = "directories"
         val projectDir = File("src/funTest/assets/projects/external/$projectName")
@@ -47,7 +46,8 @@ class SbtTest : StringSpec({
         definitionFile.isFile shouldBe true
         expectedOutputFile.isFile shouldBe true
 
-        val resolutionResult = sbt.resolveDependencies(USER_DIR, listOf(definitionFile))
+        val config = AnalyzerConfiguration(false, false)
+        val resolutionResult = SBT.create(config).resolveDependencies(USER_DIR, listOf(definitionFile))
 
         // Because of the mapping from SBT to POM files we cannot use definitionFile as the key, so just ensure
         // there is exactly one entry to take.

--- a/analyzer/src/funTest/kotlin/StackTest.kt
+++ b/analyzer/src/funTest/kotlin/StackTest.kt
@@ -20,6 +20,7 @@
 package com.here.ort.analyzer
 
 import com.here.ort.analyzer.managers.Stack
+import com.here.ort.model.AnalyzerConfiguration
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.OS
 import com.here.ort.utils.test.USER_DIR
@@ -35,7 +36,8 @@ class StackTest : StringSpec({
     "Dependencies should be resolved correctly for quickcheck-state-machine" {
         val definitionFile = File(projectsDir, "external/quickcheck-state-machine/stack.yaml")
 
-        val result = Stack.create().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+        val config = AnalyzerConfiguration(false, false)
+        val result = Stack.create(config).resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
         val expectedOutput = if (OS.isWindows) {
             "external/quickcheck-state-machine-expected-output-win32.yml"
         } else {
@@ -50,7 +52,8 @@ class StackTest : StringSpec({
     "Dependencies should be resolved correctly for quickcheck-state-machine-example" {
         val definitionFile = File(projectsDir, "external/quickcheck-state-machine/example/stack.yaml")
 
-        val result = Stack.create().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+        val config = AnalyzerConfiguration(false, false)
+        val result = Stack.create(config).resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
         val expectedOutput = if (OS.isWindows) {
             "external/quickcheck-state-machine-example-expected-output-win32.yml"
         } else {

--- a/analyzer/src/funTest/kotlin/YarnTest.kt
+++ b/analyzer/src/funTest/kotlin/YarnTest.kt
@@ -21,6 +21,7 @@ package com.here.ort.analyzer
 
 import com.here.ort.analyzer.managers.Yarn
 import com.here.ort.downloader.VersionControlSystem
+import com.here.ort.model.AnalyzerConfiguration
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
 import com.here.ort.utils.safeDeleteRecursively
@@ -58,9 +59,8 @@ class YarnTest : WordSpec() {
         "yarn" should {
             "resolve dependencies correctly" {
                 val packageFile = File(projectDir, "package.json")
-                val yarn = Yarn.create()
-
-                val result = yarn.resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+                val config = AnalyzerConfiguration(false, false)
+                val result = Yarn.create(config).resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
                 val vcsPath = vcsDir.getPathToRoot(projectDir)
                 val expectedResult = patchExpectedResult(
                         File(projectDir.parentFile, "yarn-expected-output.yml"),

--- a/analyzer/src/funTest/kotlin/integration/AbstractIntegrationSpec.kt
+++ b/analyzer/src/funTest/kotlin/integration/AbstractIntegrationSpec.kt
@@ -23,6 +23,7 @@ import com.here.ort.analyzer.ManagedProjectFiles
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.downloader.Main
 import com.here.ort.downloader.VersionControlSystem
+import com.here.ort.model.AnalyzerConfiguration
 import com.here.ort.model.Identifier
 import com.here.ort.model.Package
 import com.here.ort.utils.safeDeleteRecursively
@@ -110,7 +111,8 @@ abstract class AbstractIntegrationSpec : StringSpec() {
         "Analyzer creates one non-empty result per definition file".config(tags = setOf(ExpensiveTag)) {
             definitionFilesForTest.forEach { manager, files ->
                 println("Resolving $manager dependencies in $files.")
-                val results = manager.create().resolveDependencies(USER_DIR, files)
+                val config = AnalyzerConfiguration(false, false)
+                val results = manager.create(config).resolveDependencies(USER_DIR, files)
 
                 results.size shouldBe files.size
                 results.values.forEach { result ->

--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -23,6 +23,7 @@ import ch.frankel.slf4k.*
 
 import com.here.ort.analyzer.managers.*
 import com.here.ort.downloader.VersionControlSystem
+import com.here.ort.model.AnalyzerConfiguration
 import com.here.ort.model.Identifier
 import com.here.ort.model.Project
 import com.here.ort.model.ProjectAnalyzerResult
@@ -48,7 +49,7 @@ typealias ResolutionResult = MutableMap<File, ProjectAnalyzerResult>
 /**
  * A class representing a package manager that handles software dependencies.
  */
-abstract class PackageManager {
+abstract class PackageManager(protected val config: AnalyzerConfiguration) {
     companion object {
         /**
          * The prioritized list of all available package managers. This needs to be initialized lazily to ensure the
@@ -212,8 +213,8 @@ abstract class PackageManager {
                             vcsProcessed = processProjectVcs(definitionFile.parentFile)
                     )
 
-                    result[definitionFile] = ProjectAnalyzerResult(Main.allowDynamicVersions, errorProject,
-                            sortedSetOf(), e.collectMessages())
+                    result[definitionFile] = ProjectAnalyzerResult(config, errorProject, sortedSetOf(),
+                            e.collectMessages())
 
                     log.error { "Resolving dependencies for '${definitionFile.name}' failed with: ${e.message}" }
                 }

--- a/analyzer/src/main/kotlin/PackageManagerFactory.kt
+++ b/analyzer/src/main/kotlin/PackageManagerFactory.kt
@@ -19,6 +19,8 @@
 
 package com.here.ort.analyzer
 
+import com.here.ort.model.AnalyzerConfiguration
+
 import java.nio.file.FileSystems
 
 /**
@@ -38,7 +40,7 @@ abstract class PackageManagerFactory<out T : PackageManager>(
     /**
      * Create a new instance of the [PackageManager].
      */
-    abstract fun create(): T
+    abstract fun create(config: AnalyzerConfiguration): T
 
     /**
      * Return the Java class name to make JCommander display a proper name in list parameters of this custom type.

--- a/analyzer/src/main/kotlin/managers/Bower.kt
+++ b/analyzer/src/main/kotlin/managers/Bower.kt
@@ -21,16 +21,17 @@ package com.here.ort.analyzer.managers
 
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.analyzer.PackageManagerFactory
+import com.here.ort.model.AnalyzerConfiguration
 
 import java.io.File
 
-class Bower : PackageManager() {
+class Bower(config: AnalyzerConfiguration) : PackageManager(config) {
     companion object : PackageManagerFactory<Bower>(
             "https://bower.io/",
             "JavaScript",
             listOf("bower.json")
     ) {
-        override fun create() = Bower()
+        override fun create(config: AnalyzerConfiguration) = Bower(config)
     }
 
     override fun command(workingDir: File) = "bower"

--- a/analyzer/src/main/kotlin/managers/Bundler.kt
+++ b/analyzer/src/main/kotlin/managers/Bundler.kt
@@ -27,6 +27,7 @@ import com.here.ort.analyzer.Main
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.analyzer.PackageManagerFactory
 import com.here.ort.downloader.VersionControlSystem
+import com.here.ort.model.AnalyzerConfiguration
 import com.here.ort.model.HashAlgorithm
 import com.here.ort.model.Identifier
 import com.here.ort.model.Package
@@ -58,14 +59,14 @@ import java.util.SortedSet
 
 import okhttp3.Request
 
-class Bundler : PackageManager() {
+class Bundler(config: AnalyzerConfiguration) : PackageManager(config) {
     companion object : PackageManagerFactory<Bundler>(
             "http://bundler.io/",
             "Ruby",
             // See http://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/.
             listOf("Gemfile")
     ) {
-        override fun create() = Bundler()
+        override fun create(config: AnalyzerConfiguration) = Bundler(config)
 
         val bundle = if (OS.isWindows) "bundle.bat" else "bundle"
     }
@@ -82,7 +83,7 @@ class Bundler : PackageManager() {
         checkCommandVersion(
                 bundle,
                 Requirement.buildIvy("1.16.+"),
-                ignoreActualVersion = Main.ignoreVersions,
+                ignoreActualVersion = config.ignoreToolVersions,
                 transform = { it.substringAfter("Bundler version ") }
         )
 
@@ -126,12 +127,7 @@ class Bundler : PackageManager() {
                     scopes = scopes.toSortedSet()
             )
 
-            return ProjectAnalyzerResult(
-                    Main.allowDynamicVersions,
-                    project,
-                    packages.map { it.toCuratedPackage() }.toSortedSet(),
-                    errors
-            )
+            return ProjectAnalyzerResult(config, project, packages.map { it.toCuratedPackage() }.toSortedSet(), errors)
         } finally {
             // Delete vendor folder to not pollute the scan.
             log.info { "Deleting temporary directory '$vendorDir'..." }
@@ -246,7 +242,7 @@ class Bundler : PackageManager() {
             workingDir.listFiles { _, name -> name.endsWith(".gemspec") }.firstOrNull()
 
     private fun installDependencies(workingDir: File) {
-        require(Main.allowDynamicVersions || File(workingDir, "Gemfile.lock").isFile) {
+        require(config.allowDynamicVersions || File(workingDir, "Gemfile.lock").isFile) {
             "No lockfile found in ${workingDir.invariantSeparatorsPath}, dependency versions are unstable."
         }
 

--- a/analyzer/src/main/kotlin/managers/CocoaPods.kt
+++ b/analyzer/src/main/kotlin/managers/CocoaPods.kt
@@ -21,16 +21,17 @@ package com.here.ort.analyzer.managers
 
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.analyzer.PackageManagerFactory
+import com.here.ort.model.AnalyzerConfiguration
 
 import java.io.File
 
-class CocoaPods : PackageManager() {
+class CocoaPods(config: AnalyzerConfiguration) : PackageManager(config) {
     companion object : PackageManagerFactory<CocoaPods>(
             "https://cocoapods.org/",
             "Objective-C",
             listOf("Podfile.lock", "Podfile")
     ) {
-        override fun create() = CocoaPods()
+        override fun create(config: AnalyzerConfiguration) = CocoaPods(config)
     }
 
     override fun command(workingDir: File) = "pod"

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -24,12 +24,12 @@ import DependencyTreeModel
 
 import ch.frankel.slf4k.*
 
-import com.here.ort.analyzer.Main
 import com.here.ort.analyzer.MavenSupport
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.analyzer.PackageManagerFactory
 import com.here.ort.analyzer.identifier
 import com.here.ort.downloader.VersionControlSystem
+import com.here.ort.model.AnalyzerConfiguration
 import com.here.ort.model.Identifier
 import com.here.ort.model.Package
 import com.here.ort.model.PackageReference
@@ -63,13 +63,13 @@ import org.eclipse.aether.repository.RemoteRepository
 
 import org.gradle.tooling.GradleConnector
 
-class Gradle : PackageManager() {
+class Gradle(config: AnalyzerConfiguration) : PackageManager(config) {
     companion object : PackageManagerFactory<Gradle>(
             "https://gradle.org/",
             "Java",
             listOf("build.gradle", "settings.gradle")
     ) {
-        override fun create() = Gradle()
+        override fun create(config: AnalyzerConfiguration) = Gradle(config)
 
         val gradle = if (OS.isWindows) "gradle.bat" else "gradle"
         val wrapper = if (OS.isWindows) "gradlew.bat" else "gradlew"
@@ -135,8 +135,8 @@ class Gradle : PackageManager() {
                     scopes = scopes.toSortedSet()
             )
 
-            return ProjectAnalyzerResult(Main.allowDynamicVersions, project,
-                    packages.values.map { it.toCuratedPackage() }.toSortedSet(), dependencyTreeModel.errors)
+            return ProjectAnalyzerResult(config, project, packages.values.map { it.toCuratedPackage() }.toSortedSet(),
+                    dependencyTreeModel.errors)
         } finally {
             connection.close()
         }

--- a/analyzer/src/main/kotlin/managers/Maven.kt
+++ b/analyzer/src/main/kotlin/managers/Maven.kt
@@ -21,12 +21,12 @@ package com.here.ort.analyzer.managers
 
 import ch.frankel.slf4k.*
 
-import com.here.ort.analyzer.Main
 import com.here.ort.analyzer.MavenSupport
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.analyzer.PackageManagerFactory
 import com.here.ort.analyzer.identifier
 import com.here.ort.downloader.VersionControlSystem
+import com.here.ort.model.AnalyzerConfiguration
 import com.here.ort.model.Identifier
 import com.here.ort.model.Package
 import com.here.ort.model.PackageReference
@@ -58,13 +58,13 @@ import org.eclipse.aether.repository.LocalRepository
 import org.eclipse.aether.repository.LocalRepositoryManager
 import org.eclipse.aether.repository.RemoteRepository
 
-class Maven : PackageManager() {
+class Maven(config: AnalyzerConfiguration) : PackageManager(config) {
     companion object : PackageManagerFactory<Maven>(
             "https://maven.apache.org/",
             "Java",
             listOf("pom.xml")
     ) {
-        override fun create() = Maven()
+        override fun create(config: AnalyzerConfiguration) = Maven(config)
     }
 
     /**
@@ -163,8 +163,7 @@ class Maven : PackageManager() {
                 scopes = scopes.values.toSortedSet()
         )
 
-        return ProjectAnalyzerResult(Main.allowDynamicVersions, project,
-                packages.values.map { it.toCuratedPackage() }.toSortedSet())
+        return ProjectAnalyzerResult(config, project, packages.values.map { it.toCuratedPackage() }.toSortedSet())
     }
 
     private fun parseDependency(node: DependencyNode, packages: MutableMap<String, Package>): PackageReference {

--- a/analyzer/src/main/kotlin/managers/SBT.kt
+++ b/analyzer/src/main/kotlin/managers/SBT.kt
@@ -21,9 +21,9 @@ package com.here.ort.analyzer.managers
 
 import ch.frankel.slf4k.*
 
-import com.here.ort.analyzer.Main
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.analyzer.PackageManagerFactory
+import com.here.ort.model.AnalyzerConfiguration
 import com.here.ort.utils.OS
 import com.here.ort.utils.ProcessCapture
 import com.here.ort.utils.checkCommandVersion
@@ -35,7 +35,7 @@ import com.vdurmont.semver4j.Semver
 import java.io.File
 import java.io.IOException
 
-class SBT : PackageManager() {
+class SBT(config: AnalyzerConfiguration) : PackageManager(config) {
     companion object : PackageManagerFactory<SBT>(
             "http://www.scala-sbt.org/",
             "Scala",
@@ -57,7 +57,7 @@ class SBT : PackageManager() {
             }
         }
 
-        override fun create() = SBT()
+        override fun create(config: AnalyzerConfiguration) = SBT(config)
     }
 
     override fun command(workingDir: File) = if (OS.isWindows) "sbt.bat" else "sbt"
@@ -92,7 +92,7 @@ class SBT : PackageManager() {
                 Requirement.buildIvy("[0.13.0,)"),
                 versionArguments = "$SBT_BATCH_MODE $SBT_LOG_NO_FORMAT sbtVersion",
                 workingDir = workingDir,
-                ignoreActualVersion = Main.ignoreVersions,
+                ignoreActualVersion = config.ignoreToolVersions,
                 transform = this::extractLowestSbtVersion
         )
 
@@ -161,5 +161,5 @@ class SBT : PackageManager() {
 
     override fun resolveDependencies(analyzerRoot: File, definitionFiles: List<File>) =
             // Simply pass on the list of POM files to Maven, ignoring the SBT build files here.
-            Maven.create().enableSbtMode().resolveDependencies(analyzerRoot, prepareResolution(definitionFiles))
+            Maven.create(config).enableSbtMode().resolveDependencies(analyzerRoot, prepareResolution(definitionFiles))
 }

--- a/analyzer/src/main/kotlin/managers/Stack.kt
+++ b/analyzer/src/main/kotlin/managers/Stack.kt
@@ -25,6 +25,7 @@ import com.here.ort.analyzer.Main
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.analyzer.PackageManagerFactory
 import com.here.ort.downloader.VersionControlSystem
+import com.here.ort.model.AnalyzerConfiguration
 import com.here.ort.model.HashAlgorithm
 import com.here.ort.model.Identifier
 import com.here.ort.model.Package
@@ -50,13 +51,13 @@ import java.net.HttpURLConnection
 import java.nio.file.FileSystems
 import java.util.SortedSet
 
-class Stack : PackageManager() {
+class Stack(config: AnalyzerConfiguration) : PackageManager(config) {
     companion object : PackageManagerFactory<Stack>(
             "http://haskellstack.org/",
             "Haskell",
             listOf("stack.yaml")
     ) {
-        override fun create() = Stack()
+        override fun create(config: AnalyzerConfiguration) = Stack(config)
     }
 
     override fun command(workingDir: File) = "stack"
@@ -152,8 +153,7 @@ class Stack : PackageManager() {
                 scopes = scopes
         )
 
-        return ProjectAnalyzerResult(Main.allowDynamicVersions, project,
-                allPackages.values.map { it.toCuratedPackage() }.toSortedSet())
+        return ProjectAnalyzerResult(config, project, allPackages.values.map { it.toCuratedPackage() }.toSortedSet())
     }
 
     private fun buildDependencyTree(parentName: String, allPackages: MutableMap<Package, Package>,

--- a/analyzer/src/main/kotlin/managers/Unmanaged.kt
+++ b/analyzer/src/main/kotlin/managers/Unmanaged.kt
@@ -19,10 +19,10 @@
 
 package com.here.ort.analyzer.managers
 
-import com.here.ort.analyzer.Main
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.analyzer.PackageManagerFactory
 import com.here.ort.downloader.VersionControlSystem
+import com.here.ort.model.AnalyzerConfiguration
 import com.here.ort.model.Identifier
 import com.here.ort.model.Project
 import com.here.ort.model.ProjectAnalyzerResult
@@ -33,9 +33,9 @@ import java.io.File
 /**
  * A fake [PackageManager] for projects that do not use any of the known package managers.
  */
-class Unmanaged : PackageManager() {
+class Unmanaged(config: AnalyzerConfiguration) : PackageManager(config) {
     companion object : PackageManagerFactory<Unmanaged>("", "", emptyList()) {
-        override fun create() = Unmanaged()
+        override fun create(config: AnalyzerConfiguration) = Unmanaged(config)
     }
 
     override fun command(workingDir: File) = throw NotImplementedError()
@@ -64,6 +64,6 @@ class Unmanaged : PackageManager() {
                 scopes = sortedSetOf()
         )
 
-        return ProjectAnalyzerResult(Main.allowDynamicVersions, project, sortedSetOf())
+        return ProjectAnalyzerResult(config, project, sortedSetOf())
     }
 }

--- a/analyzer/src/main/kotlin/managers/Yarn.kt
+++ b/analyzer/src/main/kotlin/managers/Yarn.kt
@@ -19,8 +19,8 @@
 
 package com.here.ort.analyzer.managers
 
-import com.here.ort.analyzer.Main
 import com.here.ort.analyzer.PackageManagerFactory
+import com.here.ort.model.AnalyzerConfiguration
 import com.here.ort.utils.OS
 import com.here.ort.utils.checkCommandVersion
 
@@ -28,13 +28,13 @@ import com.vdurmont.semver4j.Requirement
 
 import java.io.File
 
-class Yarn : NPM() {
+class Yarn(config: AnalyzerConfiguration) : NPM(config) {
     companion object : PackageManagerFactory<Yarn>(
             "https://www.yarnpkg.com/",
             "JavaScript",
             listOf("yarn.lock")
     ) {
-        override fun create() = Yarn()
+        override fun create(config: AnalyzerConfiguration) = Yarn(config)
     }
 
     override val recognizedLockFiles = listOf("yarn.lock")
@@ -49,7 +49,7 @@ class Yarn : NPM() {
         // We do not actually depend on any features specific to a Yarn version, but we still want to stick to a fixed
         // minor version to be sure to get consistent results.
         checkCommandVersion(command(workingDir), Requirement.buildIvy("1.3.+"),
-                ignoreActualVersion = Main.ignoreVersions)
+                ignoreActualVersion = config.ignoreToolVersions)
 
         return definitionFiles
     }

--- a/model/src/main/kotlin/AnalyzerConfiguration.kt
+++ b/model/src/main/kotlin/AnalyzerConfiguration.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2017-2018 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.model
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+
+data class AnalyzerConfiguration(
+        /**
+         * If set to true, ignore the versions of used command line tools. Note that this might lead to erroneous
+         * results if the tools have changed in usage or behavior. If set to false, check the versions to match the
+         * expected versions and fail the analysis on a mismatch.
+         */
+        val ignoreToolVersions: Boolean,
+
+        /**
+         * Enable the analysis of projects that use version ranges to declare their dependencies. If set to true,
+         * dependencies of exactly the same project might change with another scan done at a later time if any of the
+         * (transitive) dependencies are declared using version ranges and a new version of such a dependency was
+         * published in the meantime. If set to false, analysis of projects that use version ranges will fail.
+         */
+        val allowDynamicVersions: Boolean
+)
+
+class AnalyzerConfigurationDeserializer : StdDeserializer<AnalyzerConfiguration>(AnalyzerConfiguration::class.java) {
+    override fun deserialize(p: JsonParser, ctxt: DeserializationContext): AnalyzerConfiguration {
+        val node = p.codec.readTree<JsonNode>(p)
+        return if (node.isBoolean) {
+            // For backward-compatibility if only "allowDynamicVersions" / "allow_dynamic_versions" is specified.
+            AnalyzerConfiguration(false, node.booleanValue())
+        } else {
+            AnalyzerConfiguration(node.get("ignore_tool_versions").booleanValue(),
+                    node.get("allow_dynamic_versions").booleanValue())
+        }
+    }
+}

--- a/model/src/main/kotlin/Mappers.kt
+++ b/model/src/main/kotlin/Mappers.kt
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 
 val ortModelModule = SimpleModule("OrtModelModule").apply {
+    addDeserializer(AnalyzerConfiguration::class.java, AnalyzerConfigurationDeserializer())
     addDeserializer(Identifier::class.java, IdentifierFromStringDeserializer())
     addDeserializer(VcsInfo::class.java, VcsInfoDeserializer())
 

--- a/model/src/main/kotlin/ProjectAnalyzerResult.kt
+++ b/model/src/main/kotlin/ProjectAnalyzerResult.kt
@@ -28,13 +28,10 @@ import java.util.SortedSet
  */
 data class ProjectAnalyzerResult(
         /**
-         * If dynamic versions were allowed during the dependency resolution. If true it means that the dependency tree
-         * might change with another scan if any of the (transitive) dependencies is declared with a version range and
-         * a new version of this dependency was released in the meantime. It is always true for package managers that do
-         * not support lock files, but do support version ranges.
+         * The [AnalyzerConfiguration] that was used to generate the result.
          */
-        @JsonAlias("allowDynamicVersions")
-        val allowDynamicVersions: Boolean,
+        @JsonAlias("allowDynamicVersions", "allow_dynamic_versions")
+        val config: AnalyzerConfiguration,
 
         /**
          * The project that was analyzed. The tree of dependencies is implicitly contained in the scopes in the form

--- a/model/src/test/kotlin/AnalyzerResultTest.kt
+++ b/model/src/test/kotlin/AnalyzerResultTest.kt
@@ -44,16 +44,18 @@ class AnalyzerResultTest : WordSpec() {
             scopes = sortedSetOf(scope1, scope2)
     )
 
-    private val analyzerResult1 = ProjectAnalyzerResult(true, project1, sortedSetOf(package1.toCuratedPackage()),
+    private val config = AnalyzerConfiguration(false, true)
+    private val analyzerResult1 = ProjectAnalyzerResult(config, project1, sortedSetOf(package1.toCuratedPackage()),
             listOf("error-1", "error-2"))
-    private val analyzerResult2 = ProjectAnalyzerResult(true, project2,
+    private val analyzerResult2 = ProjectAnalyzerResult(config, project2,
             sortedSetOf(package1.toCuratedPackage(), package2.toCuratedPackage(), package3.toCuratedPackage()),
             listOf("error-2"))
 
     init {
         "AnalyzerResult" should {
             "create the correct ProjectAnalyzerResults" {
-                val mergedResults = AnalyzerResultBuilder(true, vcs)
+                val config = AnalyzerConfiguration(false, true)
+                val mergedResults = AnalyzerResultBuilder(config, vcs)
                         .addResult(analyzerResult1)
                         .addResult(analyzerResult2)
                         .build()
@@ -62,7 +64,8 @@ class AnalyzerResultTest : WordSpec() {
             }
 
             "be serialized and deserialized correctly" {
-                val mergedResults = AnalyzerResultBuilder(true, vcs)
+                val config = AnalyzerConfiguration(false, true)
+                val mergedResults = AnalyzerResultBuilder(config, vcs)
                         .addResult(analyzerResult1)
                         .addResult(analyzerResult2)
                         .build()
@@ -77,12 +80,13 @@ class AnalyzerResultTest : WordSpec() {
 
         "AnalyzerResultBuilder" should {
             "merge results from all files" {
-                val mergedResults = AnalyzerResultBuilder(true, vcs)
+                val config = AnalyzerConfiguration(false, true)
+                val mergedResults = AnalyzerResultBuilder(config, vcs)
                         .addResult(analyzerResult1)
                         .addResult(analyzerResult2)
                         .build()
 
-                mergedResults.allowDynamicVersions shouldBe true
+                mergedResults.config.allowDynamicVersions shouldBe true
                 mergedResults.vcs shouldBe vcs
                 mergedResults.vcsProcessed shouldBe vcs.normalize()
                 mergedResults.projects shouldBe sortedSetOf(project1, project2)

--- a/model/src/test/kotlin/ProjectAnalyzerResultTest.kt
+++ b/model/src/test/kotlin/ProjectAnalyzerResultTest.kt
@@ -25,7 +25,7 @@ import io.kotlintest.specs.StringSpec
 class ProjectAnalyzerResultTest : StringSpec({
     "collectErrors should find all errors" {
         val result = ProjectAnalyzerResult(
-                allowDynamicVersions = true,
+                config = AnalyzerConfiguration(false, true),
                 project = Project(
                         id = Identifier("provider", "namespace", "name", "version"),
                         definitionFilePath = "definitionFilePath",

--- a/scanner/src/funTest/assets/analyzer-result.yml
+++ b/scanner/src/funTest/assets/analyzer-result.yml
@@ -1,5 +1,7 @@
 ---
-allow_dynamic_versions: false
+config:
+  ignore_tool_versions: false
+  allow_dynamic_versions: false
 vcs:
   type: ""
   url: ""

--- a/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
@@ -1,6 +1,8 @@
 ---
 analyzer_result:
-  allow_dynamic_versions: false
+  config:
+    ignore_tool_versions: false
+    allow_dynamic_versions: false
   vcs:
     type: ""
     url: ""

--- a/scanner/src/main/kotlin/Main.kt
+++ b/scanner/src/main/kotlin/Main.kt
@@ -27,6 +27,7 @@ import com.beust.jcommander.Parameter
 import com.beust.jcommander.ParameterException
 
 import com.here.ort.downloader.VersionControlSystem
+import com.here.ort.model.AnalyzerConfiguration
 import com.here.ort.model.AnalyzerResult
 import com.here.ort.model.AnalyzerResultBuilder
 import com.here.ort.model.Identifier
@@ -272,7 +273,8 @@ object Main {
 
         val vcsInfo = VersionControlSystem.forDirectory(inputPath.takeIf { it.isDirectory }
                 ?: inputPath.parentFile)?.getInfo(inputPath) ?: VcsInfo.EMPTY
-        val analyzerResult = AnalyzerResultBuilder(true, vcsInfo).build()
+        val config = AnalyzerConfiguration(false, true)
+        val analyzerResult = AnalyzerResultBuilder(config, vcsInfo).build()
 
         val scanResultContainer = ScanResultContainer(Identifier("", "", inputPath.absolutePath, ""), listOf(result))
 


### PR DESCRIPTION
As we aim for the ORT modules to be usable as independent libraries,
PackageManagers should not depend on the Main entry point for command
line usage. As a step into the right direction, avoid PackageManagers to
directly access Main's command line parameters by introducing a
AnalyzerConfiguration class that instead holds all relevant options.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/693)
<!-- Reviewable:end -->
