### PR TITLE
analyzer: Never hard-code the value of allowDynamicVersions

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
@@ -1,5 +1,5 @@
 ---
-allow_dynamic_versions: true
+allow_dynamic_versions: false
 project:
   id: "SBT:io.github.soc:directories:6"
   definition_file_path: "target/directories-6.pom"

--- a/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
@@ -1,5 +1,5 @@
 ---
-allow_dynamic_versions: true
+allow_dynamic_versions: false
 project:
   id: "PIP::example-python-flask:0773991e36a4c69b121cdb05146d6140347d4065"
   definition_file_path: "requirements.txt"

--- a/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
@@ -1,5 +1,5 @@
 ---
-allow_dynamic_versions: true
+allow_dynamic_versions: false
 project:
   id: "Maven:jgnash:jgnash-core:2.30.0"
   definition_file_path: "jgnash-core/pom.xml"

--- a/analyzer/src/funTest/assets/projects/external/jgnash-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/jgnash-expected-output.yml
@@ -1,5 +1,5 @@
 ---
-allow_dynamic_versions: true
+allow_dynamic_versions: false
 project:
   id: "Maven:jgnash:jgnash2:2.30.0"
   definition_file_path: "pom.xml"

--- a/analyzer/src/funTest/assets/projects/external/quickcheck-state-machine-expected-output-win32.yml
+++ b/analyzer/src/funTest/assets/projects/external/quickcheck-state-machine-expected-output-win32.yml
@@ -1,5 +1,5 @@
 ---
-allow_dynamic_versions: true
+allow_dynamic_versions: false
 project:
   id: "Stack:Testing:quickcheck-state-machine:0.3.1"
   definition_file_path: "stack.yaml"

--- a/analyzer/src/funTest/assets/projects/external/quickcheck-state-machine-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/quickcheck-state-machine-expected-output.yml
@@ -1,5 +1,5 @@
 ---
-allow_dynamic_versions: true
+allow_dynamic_versions: false
 project:
   id: "Stack:Testing:quickcheck-state-machine:0.3.1"
   definition_file_path: "stack.yaml"

--- a/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
@@ -1,5 +1,5 @@
 ---
-allow_dynamic_versions: true
+allow_dynamic_versions: false
 project:
   id: "PIP::spdx-tools:0.5.4"
   definition_file_path: "setup.py"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-app.yml
@@ -1,5 +1,5 @@
 ---
-allow_dynamic_versions: true
+allow_dynamic_versions: false
 project:
   id: "Gradle:com.here.ort.gradle.example:app:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-android/app/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-lib.yml
@@ -1,5 +1,5 @@
 ---
-allow_dynamic_versions: true
+allow_dynamic_versions: false
 project:
   id: "Gradle:com.here.ort.gradle.example:lib:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-android/lib/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-root.yml
@@ -1,5 +1,5 @@
 ---
-allow_dynamic_versions: true
+allow_dynamic_versions: false
 project:
   id: "Gradle:com.here.ort.gradle.example:Gradle-Android-Example:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-android/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-2.14.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-2.14.yml
@@ -1,5 +1,5 @@
 ---
-allow_dynamic_versions: true
+allow_dynamic_versions: false
 project:
   id: "Gradle:com.here.ort.gradle.example:app:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-3.4.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-3.4.yml
@@ -1,5 +1,5 @@
 ---
-allow_dynamic_versions: true
+allow_dynamic_versions: false
 project:
   id: "Gradle:com.here.ort.gradle.example:app:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
@@ -1,5 +1,5 @@
 ---
-allow_dynamic_versions: true
+allow_dynamic_versions: false
 project:
   id: "Gradle:com.here.ort.gradle.example:app:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
@@ -1,5 +1,5 @@
 ---
-allow_dynamic_versions: true
+allow_dynamic_versions: false
 project:
   id: "Gradle:com.here.ort.gradle.example:lib-without-repo:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
@@ -1,5 +1,5 @@
 ---
-allow_dynamic_versions: true
+allow_dynamic_versions: false
 project:
   id: "Gradle:com.here.ort.gradle.example:lib:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-root.yml
@@ -1,5 +1,5 @@
 ---
-allow_dynamic_versions: true
+allow_dynamic_versions: false
 project:
   id: "Gradle::Gradle-Example:"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-unsupported-version.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-unsupported-version.yml
@@ -1,5 +1,5 @@
 ---
-allow_dynamic_versions: true
+allow_dynamic_versions: false
 project:
   id: "Gradle:com.here.ort.gradle.example:gradle-unsupported-version:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-unsupported-version/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-app.yml
@@ -1,5 +1,5 @@
 ---
-allow_dynamic_versions: true
+allow_dynamic_versions: false
 project:
   id: "Gradle:com.here.ort.gradle.example:app:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-library/app/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-lib.yml
@@ -1,5 +1,5 @@
 ---
-allow_dynamic_versions: true
+allow_dynamic_versions: false
 project:
   id: "Gradle:com.here.ort.gradle.example:lib:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-library/lib/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-root.yml
@@ -1,5 +1,5 @@
 ---
-allow_dynamic_versions: true
+allow_dynamic_versions: false
 project:
   id: "Gradle::Gradle-Example:"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-library/build.gradle"

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-app.yml
@@ -1,5 +1,5 @@
 ---
-allow_dynamic_versions: true
+allow_dynamic_versions: false
 project:
   id: "Maven:com.here.ort.maven:maven-app:1.0-SNAPSHOT"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/maven/app/pom.xml"

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-lib.yml
@@ -1,5 +1,5 @@
 ---
-allow_dynamic_versions: true
+allow_dynamic_versions: false
 project:
   id: "Maven:com.here.ort.maven:maven-lib:1.0-SNAPSHOT"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/maven/lib/pom.xml"

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-root.yml
@@ -1,5 +1,5 @@
 ---
-allow_dynamic_versions: true
+allow_dynamic_versions: false
 project:
   id: "Maven:com.here.ort.maven:maven-project:1.0-SNAPSHOT"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/maven/pom.xml"

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-parent-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-parent-expected-output-root.yml
@@ -1,5 +1,5 @@
 ---
-allow_dynamic_versions: true
+allow_dynamic_versions: false
 project:
   id: "Maven:com.here.ort.maven:maven-parent-project:1.0-SNAPSHOT"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/maven-parent/pom.xml"

--- a/analyzer/src/funTest/assets/projects/synthetic/pip-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pip-expected-output.yml
@@ -1,5 +1,5 @@
 ---
-allow_dynamic_versions: true
+allow_dynamic_versions: false
 project:
   id: "PIP::Example-App:2.4.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/pip/requirements.txt"

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -24,6 +24,7 @@ import DependencyTreeModel
 
 import ch.frankel.slf4k.*
 
+import com.here.ort.analyzer.Main
 import com.here.ort.analyzer.MavenSupport
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.analyzer.PackageManagerFactory
@@ -134,8 +135,7 @@ class Gradle : PackageManager() {
                     scopes = scopes.toSortedSet()
             )
 
-            // Gradle < 4.8 does not support lock files, so hard-code "allowDynamicVersions" to "true".
-            return ProjectAnalyzerResult(true, project,
+            return ProjectAnalyzerResult(Main.allowDynamicVersions, project,
                     packages.values.map { it.toCuratedPackage() }.toSortedSet(), dependencyTreeModel.errors)
         } finally {
             connection.close()

--- a/analyzer/src/main/kotlin/managers/Maven.kt
+++ b/analyzer/src/main/kotlin/managers/Maven.kt
@@ -21,6 +21,7 @@ package com.here.ort.analyzer.managers
 
 import ch.frankel.slf4k.*
 
+import com.here.ort.analyzer.Main
 import com.here.ort.analyzer.MavenSupport
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.analyzer.PackageManagerFactory
@@ -162,8 +163,8 @@ class Maven : PackageManager() {
                 scopes = scopes.values.toSortedSet()
         )
 
-        // Maven does not support lock files, so hard-code "allowDynamicVersions" to "true".
-        return ProjectAnalyzerResult(true, project, packages.values.map { it.toCuratedPackage() }.toSortedSet())
+        return ProjectAnalyzerResult(Main.allowDynamicVersions, project,
+                packages.values.map { it.toCuratedPackage() }.toSortedSet())
     }
 
     private fun parseDependency(node: DependencyNode, packages: MutableMap<String, Package>): PackageReference {

--- a/analyzer/src/main/kotlin/managers/PIP.kt
+++ b/analyzer/src/main/kotlin/managers/PIP.kt
@@ -291,8 +291,8 @@ class PIP : PackageManager() {
         // Remove the virtualenv by simply deleting the directory.
         virtualEnvDir.safeDeleteRecursively()
 
-        // PIP does not support lock files, so hard-code "allowDynamicVersions" to "true".
-        return ProjectAnalyzerResult(true, project, packages.map { it.toCuratedPackage() }.toSortedSet())
+        return ProjectAnalyzerResult(Main.allowDynamicVersions, project,
+                packages.map { it.toCuratedPackage() }.toSortedSet())
     }
 
     private fun getBinaryArtifact(pkg: Package, pkgReleases: ArrayNode): RemoteArtifact {

--- a/analyzer/src/main/kotlin/managers/Stack.kt
+++ b/analyzer/src/main/kotlin/managers/Stack.kt
@@ -152,8 +152,7 @@ class Stack : PackageManager() {
                 scopes = scopes
         )
 
-        // Stack does not support lock files, so hard-code "allowDynamicVersions" to "true".
-        return ProjectAnalyzerResult(true, project,
+        return ProjectAnalyzerResult(Main.allowDynamicVersions, project,
                 allPackages.values.map { it.toCuratedPackage() }.toSortedSet())
     }
 

--- a/reporter/src/test/assets/NPM-is-windows-1.0.2-scan-record.json
+++ b/reporter/src/test/assets/NPM-is-windows-1.0.2-scan-record.json
@@ -1,6 +1,6 @@
 {
   "analyzer_result" : {
-    "allow_dynamic_versions" : true,
+    "allow_dynamic_versions" : false,
     "vcs" : {
       "type" : "Git",
       "url" : "https://github.com/jonschlinkert/is-windows.git",

--- a/scanner/src/funTest/assets/analyzer-result.yml
+++ b/scanner/src/funTest/assets/analyzer-result.yml
@@ -1,5 +1,5 @@
 ---
-allow_dynamic_versions: true
+allow_dynamic_versions: false
 vcs:
   type: ""
   url: ""

--- a/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
@@ -1,6 +1,6 @@
 ---
 analyzer_result:
-  allow_dynamic_versions: true
+  allow_dynamic_versions: false
   vcs:
     type: ""
     url: ""


### PR DESCRIPTION
This value is not supposed to indicate whether the respective
PackageManager supports dynamic versions / version ranges or not, but
whether the user has chosen to allow them. It is supposed to document with
which configuration the analyzer was run. As a result, we should never
hard-code the value, but always use what the user specified.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/694)
<!-- Reviewable:end -->
