### PR TITLE
analyzer: Fix getting provenance information for analysis of GitRepos

### DIFF
--- a/analyzer/src/funTest/kotlin/PhpComposerTest.kt
+++ b/analyzer/src/funTest/kotlin/PhpComposerTest.kt
@@ -84,7 +84,7 @@ class PhpComposerTest : StringSpec() {
                     .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
             val expectedResults = patchExpectedResult(
                     File(projectsDir.parentFile, "php-composer-expected-output-no-deps.yml"),
-                    definitionFilePath = VersionControlSystem.getInfo(definitionFile).path,
+                    definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
                     url = normalizeVcsUrl(vcsUrl),
                     revision = vcsRevision,
                     path = vcsDir.getPathToRoot(definitionFile.parentFile)
@@ -101,7 +101,7 @@ class PhpComposerTest : StringSpec() {
                     .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
             val expectedResults = patchExpectedResult(
                     File(projectsDir.parentFile, "php-composer-expected-output-no-deps.yml"),
-                    definitionFilePath = VersionControlSystem.getInfo(definitionFile).path,
+                    definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
                     url = normalizeVcsUrl(vcsUrl),
                     revision = vcsRevision,
                     path = vcsDir.getPathToRoot(definitionFile.parentFile)

--- a/analyzer/src/funTest/kotlin/vcs/GitRepoTest.kt
+++ b/analyzer/src/funTest/kotlin/vcs/GitRepoTest.kt
@@ -27,7 +27,6 @@ import com.here.ort.model.Package
 import com.here.ort.model.VcsInfo
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.safeDeleteRecursively
-import com.here.ort.utils.test.ExpensiveTag
 import com.here.ort.utils.test.patchExpectedResult
 
 import io.kotlintest.Description
@@ -53,7 +52,7 @@ class GitRepoTest : StringSpec() {
     }
 
     init {
-        "Analyzer correctly reports GitRepo VcsInfo for Bundler projects".config(tags = setOf(ExpensiveTag)) {
+        "Analyzer correctly reports GitRepo VcsInfo for Bundler projects" {
             val vcs = VcsInfo("GitRepo", REPO_URL, REPO_REV, path = REPO_MANIFEST)
             val pkg = Package.EMPTY.copy(vcsProcessed = vcs)
 

--- a/analyzer/src/main/kotlin/Main.kt
+++ b/analyzer/src/main/kotlin/Main.kt
@@ -32,7 +32,6 @@ import com.here.ort.model.AnalyzerConfiguration
 import com.here.ort.model.AnalyzerResultBuilder
 import com.here.ort.model.OutputFormat
 import com.here.ort.model.ProjectAnalyzerResult
-import com.here.ort.model.VcsInfo
 import com.here.ort.utils.PARAMETER_ORDER_HELP
 import com.here.ort.utils.PARAMETER_ORDER_LOGGING
 import com.here.ort.utils.PARAMETER_ORDER_MANDATORY
@@ -77,7 +76,7 @@ fun analyze(config: AnalyzerConfiguration, absoluteProjectPath: File,
         }
     }
 
-    val vcs = VersionControlSystem.forDirectory(absoluteProjectPath)?.getInfo() ?: VcsInfo.EMPTY
+    val vcs = VersionControlSystem.getCloneInfo(absoluteProjectPath)
     val analyzerResultBuilder = AnalyzerResultBuilder(config, vcs)
 
     // Resolve dependencies per package manager.

--- a/analyzer/src/main/kotlin/Main.kt
+++ b/analyzer/src/main/kotlin/Main.kt
@@ -32,6 +32,7 @@ import com.here.ort.model.AnalyzerConfiguration
 import com.here.ort.model.AnalyzerResultBuilder
 import com.here.ort.model.OutputFormat
 import com.here.ort.model.ProjectAnalyzerResult
+import com.here.ort.model.VcsInfo
 import com.here.ort.utils.PARAMETER_ORDER_HELP
 import com.here.ort.utils.PARAMETER_ORDER_LOGGING
 import com.here.ort.utils.PARAMETER_ORDER_MANDATORY
@@ -76,7 +77,8 @@ fun analyze(config: AnalyzerConfiguration, absoluteProjectPath: File,
         }
     }
 
-    val analyzerResultBuilder = AnalyzerResultBuilder(config, VersionControlSystem.getInfo(absoluteProjectPath))
+    val vcs = VersionControlSystem.forDirectory(absoluteProjectPath)?.getInfo() ?: VcsInfo.EMPTY
+    val analyzerResultBuilder = AnalyzerResultBuilder(config, vcs)
 
     // Resolve dependencies per package manager.
     managedDefinitionFiles.forEach { manager, files ->

--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -169,7 +169,7 @@ abstract class PackageManager(protected val config: AnalyzerConfiguration) {
          */
         fun processProjectVcs(projectDir: File, vcsFromProject: VcsInfo = VcsInfo.EMPTY,
                               homepageUrl: String = ""): VcsInfo {
-            val vcsFromWorkingTree = VersionControlSystem.getInfo(projectDir).normalize()
+            val vcsFromWorkingTree = VersionControlSystem.getPathInfo(projectDir).normalize()
             return vcsFromWorkingTree.merge(processPackageVcs(vcsFromProject, homepageUrl))
         }
     }
@@ -207,7 +207,7 @@ abstract class PackageManager(protected val config: AnalyzerConfiguration) {
                                     name = relativePath,
                                     version = ""
                             ),
-                            definitionFilePath = VersionControlSystem.getInfo(definitionFile).path,
+                            definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
                             vcsProcessed = processProjectVcs(definitionFile.parentFile)
                     )
 

--- a/analyzer/src/main/kotlin/managers/Bundler.kt
+++ b/analyzer/src/main/kotlin/managers/Bundler.kt
@@ -119,7 +119,7 @@ class Bundler(config: AnalyzerConfiguration) : PackageManager(config) {
 
             val project = Project(
                     id = projectId,
-                    definitionFilePath = VersionControlSystem.getInfo(definitionFile).path,
+                    definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
                     declaredLicenses = declaredLicenses.toSortedSet(),
                     vcs = VcsInfo.EMPTY,
                     vcsProcessed = processProjectVcs(workingDir, homepageUrl = homepageUrl),

--- a/analyzer/src/main/kotlin/managers/GoDep.kt
+++ b/analyzer/src/main/kotlin/managers/GoDep.kt
@@ -125,7 +125,7 @@ class GoDep(config: AnalyzerConfiguration) : PackageManager(config) {
                 config = config,
                 project = Project(
                         id = Identifier(provider, "", projectDir.name, projectVcs.revision),
-                        definitionFilePath = VersionControlSystem.getInfo(definitionFile).path,
+                        definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
                         declaredLicenses = sortedSetOf(),
                         vcs = VcsInfo.EMPTY,
                         vcsProcessed = projectVcs,

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -127,7 +127,7 @@ class Gradle(config: AnalyzerConfiguration) : PackageManager(config) {
                             name = dependencyTreeModel.name,
                             version = dependencyTreeModel.version
                     ),
-                    definitionFilePath = VersionControlSystem.getInfo(definitionFile).path,
+                    definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
                     declaredLicenses = sortedSetOf(),
                     vcs = VcsInfo.EMPTY,
                     vcsProcessed = processProjectVcs(definitionFile.parentFile),

--- a/analyzer/src/main/kotlin/managers/Maven.kt
+++ b/analyzer/src/main/kotlin/managers/Maven.kt
@@ -155,7 +155,7 @@ class Maven(config: AnalyzerConfiguration) : PackageManager(config) {
                         name = mavenProject.artifactId,
                         version = mavenProject.version
                 ),
-                definitionFilePath = VersionControlSystem.getInfo(definitionFile).path,
+                definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
                 declaredLicenses = maven.parseLicenses(mavenProject),
                 vcs = vcsFromPackage,
                 vcsProcessed = processProjectVcs(projectDir, vcsFromPackage, mavenProject.url ?: ""),

--- a/analyzer/src/main/kotlin/managers/NPM.kt
+++ b/analyzer/src/main/kotlin/managers/NPM.kt
@@ -446,7 +446,7 @@ open class NPM(config: AnalyzerConfiguration) : PackageManager(config) {
                         name = name,
                         version = version
                 ),
-                definitionFilePath = VersionControlSystem.getInfo(packageJson).path,
+                definitionFilePath = VersionControlSystem.getPathInfo(packageJson).path,
                 declaredLicenses = declaredLicenses,
                 vcs = vcsFromPackage,
                 vcsProcessed = processProjectVcs(projectDir, vcsFromPackage, homepageUrl),

--- a/analyzer/src/main/kotlin/managers/PIP.kt
+++ b/analyzer/src/main/kotlin/managers/PIP.kt
@@ -290,7 +290,7 @@ class PIP(config: AnalyzerConfiguration) : PackageManager(config) {
                         name = projectName,
                         version = projectVersion
                 ),
-                definitionFilePath = VersionControlSystem.getInfo(definitionFile).path,
+                definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
                 declaredLicenses = declaredLicenses,
                 vcs = VcsInfo.EMPTY,
                 vcsProcessed = processProjectVcs(workingDir, homepageUrl = projectHomepage),

--- a/analyzer/src/main/kotlin/managers/PIP.kt
+++ b/analyzer/src/main/kotlin/managers/PIP.kt
@@ -170,7 +170,7 @@ class PIP(config: AnalyzerConfiguration) : PackageManager(config) {
             // plus what "*" expands to as the project name and the VCS revision, if any, as the project version.
             val name = definitionFile.parentFile.name +
                     definitionFile.name.removePrefix("requirements").removeSuffix(".txt")
-            val version = VersionControlSystem.forDirectory(workingDir)?.getRevision() ?: ""
+            val version = VersionControlSystem.getCloneInfo(workingDir).revision
 
             val pythonVersionLines = definitionFile.readLines().filter { it.contains("python_version") }
             if (pythonVersionLines.isNotEmpty()) {

--- a/analyzer/src/main/kotlin/managers/PhpComposer.kt
+++ b/analyzer/src/main/kotlin/managers/PhpComposer.kt
@@ -204,7 +204,7 @@ class PhpComposer(config: AnalyzerConfiguration) : PackageManager(config) {
                         name = rawName.substringAfter("/"),
                         version = json["version"].textValueOrEmpty()
                 ),
-                definitionFilePath = VersionControlSystem.getInfo(definitionFile).path,
+                definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
                 declaredLicenses = parseDeclaredLicenses(json),
                 vcs = vcs,
                 vcsProcessed = processProjectVcs(definitionFile.parentFile, vcs, homepageUrl),

--- a/analyzer/src/main/kotlin/managers/Stack.kt
+++ b/analyzer/src/main/kotlin/managers/Stack.kt
@@ -145,7 +145,7 @@ class Stack(config: AnalyzerConfiguration) : PackageManager(config) {
 
         val project = Project(
                 id = projectId,
-                definitionFilePath = VersionControlSystem.getInfo(definitionFile).path,
+                definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
                 declaredLicenses = projectPackage.declaredLicenses,
                 vcs = projectPackage.vcs,
                 vcsProcessed = processProjectVcs(workingDir, projectPackage.vcs, projectPackage.homepageUrl),

--- a/analyzer/src/main/kotlin/managers/Unmanaged.kt
+++ b/analyzer/src/main/kotlin/managers/Unmanaged.kt
@@ -59,7 +59,7 @@ class Unmanaged(config: AnalyzerConfiguration) : PackageManager(config) {
                 definitionFilePath = "",
                 declaredLicenses = sortedSetOf(),
                 vcs = VcsInfo.EMPTY,
-                vcsProcessed = VersionControlSystem.getInfo(definitionFile),
+                vcsProcessed = VersionControlSystem.forDirectory(definitionFile)?.getInfo() ?: VcsInfo.EMPTY,
                 homepageUrl = "",
                 scopes = sortedSetOf()
         )

--- a/analyzer/src/main/kotlin/managers/Unmanaged.kt
+++ b/analyzer/src/main/kotlin/managers/Unmanaged.kt
@@ -59,7 +59,7 @@ class Unmanaged(config: AnalyzerConfiguration) : PackageManager(config) {
                 definitionFilePath = "",
                 declaredLicenses = sortedSetOf(),
                 vcs = VcsInfo.EMPTY,
-                vcsProcessed = VersionControlSystem.forDirectory(definitionFile)?.getInfo() ?: VcsInfo.EMPTY,
+                vcsProcessed = VersionControlSystem.getCloneInfo(definitionFile),
                 homepageUrl = "",
                 scopes = sortedSetOf()
         )

--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -93,10 +93,10 @@ abstract class VersionControlSystem {
                 }
 
         /**
-         * Conveniently return all VCS information for a specific [path]. If [path] points to a nested VCS (like an
-         * individual Git working tree of GitRepo), information for the nested VCS is returned.
+         * Return all VCS information about a specific [path]. If [path] points to a nested VCS (like an individual Git
+         * working tree of GitRepo), information for the nested VCS is returned.
          */
-        fun getInfo(path: File): VcsInfo {
+        fun getPathInfo(path: File): VcsInfo {
             val dir = path.takeIf { it.isDirectory } ?: path.parentFile
             return VersionControlSystem.forDirectory(dir)?.let { workingTree ->
                 // Always return the relative path to the (nested) VCS root.

--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -99,6 +99,7 @@ abstract class VersionControlSystem {
         fun getInfo(path: File): VcsInfo {
             val dir = path.takeIf { it.isDirectory } ?: path.parentFile
             return VersionControlSystem.forDirectory(dir)?.let { workingTree ->
+                // Always return the relative path to the (nested) VCS root.
                 workingTree.getInfo().copy(path = workingTree.getPathToRoot(path))
             } ?: VcsInfo.EMPTY
         }
@@ -209,7 +210,7 @@ abstract class VersionControlSystem {
          * Conveniently return all VCS information about how this working tree was created, so it could be easily
          * recreated from that information.
          */
-        open fun getInfo() = VcsInfo(getType(), getRemoteUrl(), getRevision())
+        open fun getInfo() = VcsInfo(getType(), getRemoteUrl(), getRevision(), path = getPathToRoot(workingDir))
 
         /**
          * Return true if the [workingDir] is managed by this VCS, false otherwise.

--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -93,6 +93,11 @@ abstract class VersionControlSystem {
                 }
 
         /**
+         * Return all VCS information about a [workingDir]. This is a convenience wrapper around [WorkingTree.getInfo].
+         */
+        fun getCloneInfo(workingDir: File) = VersionControlSystem.forDirectory(workingDir)?.getInfo() ?: VcsInfo.EMPTY
+
+        /**
          * Return all VCS information about a specific [path]. If [path] points to a nested VCS (like an individual Git
          * working tree of GitRepo), information for the nested VCS is returned.
          */

--- a/scanner/src/main/kotlin/Main.kt
+++ b/scanner/src/main/kotlin/Main.kt
@@ -270,7 +270,7 @@ object Main {
             ScanResult(Provenance(now), localScanner.getDetails(), summary)
         }
 
-        val vcsInfo = VersionControlSystem.getInfo(inputPath)
+        val vcsInfo = VersionControlSystem.getPathInfo(inputPath)
         val config = AnalyzerConfiguration(false, true)
         val analyzerResult = AnalyzerResultBuilder(config, vcsInfo).build()
 


### PR DESCRIPTION
We must not use "getInfo(path)" in these cases as that call resolves the
path relative to the VCS root, but in case of GitRepo we need the path to
the manifest.

This is a fixup for f492022.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/701)
<!-- Reviewable:end -->
