### PR TITLE
scanner: Use Konf to parse the configuration file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,10 +78,14 @@ subprojects {
         funTestCompile project(':utils-test')
     }
 
-    // TODO: Remove this once jackson-module-kotlin and kotlintest are updated.
     configurations.all {
         resolutionStrategy {
+            // TODO: Remove this once jackson-module-kotlin and kotlintest are updated.
             force 'org.jetbrains.kotlin:kotlin-reflect:1.2.51'
+
+            // Required because Konf dependens on version 1.21 which is incompatible with Jackson 2.9.x:
+            // https://github.com/FasterXML/jackson-dataformats-text/issues/67#issuecomment-384400676
+            force 'org.yaml:snakeyaml:1.18'
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ digraphVersion = 1.0
 disklrucacheVersion = 2.0.2
 jacksonVersion = 2.9.6
 jcommanderVersion = 1.74
+konfVersion = 0.11
 kotlintestVersion = 3.1.8
 mavenVersion = 3.5.4
 mavenResolverVersion = 1.1.1

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -9,4 +9,6 @@ dependencies {
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
     compile "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+
+    compile "com.uchuhimo:konf:$konfVersion"
 }

--- a/model/src/main/kotlin/config/ScannerConfiguration.kt
+++ b/model/src/main/kotlin/config/ScannerConfiguration.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2017-2018 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.model.config
+
+import com.uchuhimo.konf.ConfigSpec
+
+object ScannerConfiguration : ConfigSpec("scanner") {
+    val cache by optional<CacheConfiguration?>(null)
+}
+
+data class CacheConfiguration(
+        val type: String,
+        val url: String,
+        val apiToken: String
+)

--- a/scanner/src/main/kotlin/Main.kt
+++ b/scanner/src/main/kotlin/Main.kt
@@ -38,6 +38,7 @@ import com.here.ort.model.ScanRecord
 import com.here.ort.model.ScanResult
 import com.here.ort.model.ScanResultContainer
 import com.here.ort.model.ScanSummary
+import com.here.ort.model.config.ScannerConfiguration
 import com.here.ort.model.mapper
 import com.here.ort.scanner.scanners.ScanCode
 import com.here.ort.utils.PARAMETER_ORDER_HELP
@@ -48,6 +49,8 @@ import com.here.ort.utils.collectMessages
 import com.here.ort.utils.log
 import com.here.ort.utils.printStackTrace
 import com.here.ort.utils.showStackTrace
+
+import com.uchuhimo.konf.Config
 
 import java.io.File
 import java.time.Instant
@@ -179,7 +182,10 @@ object Main {
         }
 
         configFile?.let {
-            ScanResultsCache.configure(it.mapper().readTree(it))
+            val config = Config { addSpec(ScannerConfiguration) }.from.yaml.file(it)
+            config[ScannerConfiguration.cache]?.let {
+                ScanResultsCache.configure(it)
+            }
         }
 
         println("Using scanner '$scanner'.")

--- a/scanner/src/main/kotlin/ScanResultsCache.kt
+++ b/scanner/src/main/kotlin/ScanResultsCache.kt
@@ -21,14 +21,13 @@ package com.here.ort.scanner
 
 import ch.frankel.slf4k.*
 
-import com.fasterxml.jackson.databind.JsonNode
-
 import com.here.ort.model.CacheStatistics
 import com.here.ort.model.Identifier
 import com.here.ort.model.Package
 import com.here.ort.model.ScanResult
 import com.here.ort.model.ScanResultContainer
 import com.here.ort.model.ScannerDetails
+import com.here.ort.model.config.CacheConfiguration
 import com.here.ort.utils.log
 
 interface ScanResultsCache {
@@ -76,24 +75,13 @@ interface ScanResultsCache {
 
         var stats = CacheStatistics()
 
-        fun configure(config: JsonNode?) {
-            // Return early if there is no cache configuration.
-            val cacheNode = config?.get(Main.TOOL_NAME)?.get("cache") ?: return
-
-            val type = cacheNode["type"]?.textValue() ?: throw IllegalArgumentException("Cache type is missing.")
-
-            when (type.toLowerCase()) {
+        fun configure(config: CacheConfiguration) {
+            when (config.type.toLowerCase()) {
                 "artifactory" -> {
-                    val apiToken = cacheNode["apiToken"]?.textValue()
-                            ?: throw IllegalArgumentException("API token for Artifactory cache is missing.")
-
-                    val url = cacheNode["url"]?.textValue()
-                            ?: throw IllegalArgumentException("URL for Artifactory cache is missing.")
-
-                    cache = ArtifactoryCache(url, apiToken)
-                    log.info { "Using Artifactory cache '$url'." }
+                    cache = ArtifactoryCache(config.url, config.apiToken)
+                    log.info { "Using Artifactory cache '${config.url}'." }
                 }
-                else -> throw IllegalArgumentException("Cache type '$type' unknown.")
+                else -> throw IllegalArgumentException("Cache type '${config.type}' unknown.")
             }
         }
 

--- a/scanner/src/test/kotlin/ScanResultsCacheTest.kt
+++ b/scanner/src/test/kotlin/ScanResultsCacheTest.kt
@@ -19,7 +19,7 @@
 
 package com.here.ort.scanner
 
-import com.here.ort.model.yamlMapper
+import com.here.ort.model.config.CacheConfiguration
 
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldNotBe
@@ -41,63 +41,18 @@ class ScanResultsCacheTest : WordSpec() {
 
     init {
         "ScanResultsCache.configure" should {
-            "fail if the cache type is missing" {
-                val exception = shouldThrow<IllegalArgumentException> {
-                    val config = yamlMapper.readTree("""
-                        scanner:
-                          cache:
-                    """)
-                    ScanResultsCache.configure(config)
-                }
-                exception.message shouldBe "Cache type is missing."
-            }
-
             "fail if the cache type is unknown" {
                 val exception = shouldThrow<IllegalArgumentException> {
-                    val config = yamlMapper.readTree("""
-                        scanner:
-                          cache:
-                            type: abcd
-                    """)
+                    val config = CacheConfiguration("abcd", "", "")
+
                     ScanResultsCache.configure(config)
                 }
                 exception.message shouldBe "Cache type 'abcd' unknown."
             }
 
-            "fail if the Artifactory URL is missing" {
-                val exception = shouldThrow<IllegalArgumentException> {
-                    val config = yamlMapper.readTree("""
-                        scanner:
-                          cache:
-                            type: Artifactory
-                            apiToken: someApiToken
-                    """)
-                    ScanResultsCache.configure(config)
-                }
-                exception.message shouldBe "URL for Artifactory cache is missing."
-            }
-
-            "fail if the Artifactory apiToken is missing" {
-                val exception = shouldThrow<IllegalArgumentException> {
-                    val config = yamlMapper.readTree("""
-                        scanner:
-                          cache:
-                            type: Artifactory
-                            url: someUrl
-                    """)
-                    ScanResultsCache.configure(config)
-                }
-                exception.message shouldBe "API token for Artifactory cache is missing."
-            }
-
             "configure the Artifactory cache correctly" {
-                val config = yamlMapper.readTree("""
-                        scanner:
-                          cache:
-                            type: Artifactory
-                            apiToken: someApiToken
-                            url: someUrl
-                    """)
+                val config = CacheConfiguration(type = "Artifactory", url = "someUrl", apiToken = "someApiToken")
+
                 ScanResultsCache.configure(config)
 
                 ScanResultsCache.cache shouldNotBe null


### PR DESCRIPTION
Use Konf [1] to parse the configuration file. Put the ScannerConfiguration
class in the model module because there will a unified configuration file
in future which needs to be parseable by all tools.

[1] https://github.com/uchuhimo/konf

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/707)
<!-- Reviewable:end -->
