### PR TITLE
Revert "SBT: Be explicit about running SBT with "--info""

### DIFF
--- a/analyzer/src/main/kotlin/managers/SBT.kt
+++ b/analyzer/src/main/kotlin/managers/SBT.kt
@@ -140,7 +140,7 @@ class SBT(config: AnalyzerConfiguration) : PackageManager(config) {
         }
 
         fun runSBT(vararg command: String) =
-                ProcessCapture(workingDir, command(workingDir), "--info", SBT_BATCH_MODE, SBT_LOG_NO_FORMAT, *command)
+                ProcessCapture(workingDir, command(workingDir), SBT_BATCH_MODE, SBT_LOG_NO_FORMAT, *command)
                         .requireSuccess()
 
         // Get the list of project names.


### PR DESCRIPTION
This (semantically) reverts commit 4352907 (while keeping the introduced
runSBT function) as there are several issues with passing the log level to
various versions of sbt:

https://github.com/sbt/sbt/issues/4285
https://github.com/sbt/sbt/issues/4088

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/712)
<!-- Reviewable:end -->
