### PR TITLE
downloader: Fix chosing the "root" project with the empty path

### DIFF
--- a/scanner/src/main/kotlin/Main.kt
+++ b/scanner/src/main/kotlin/Main.kt
@@ -26,6 +26,7 @@ import com.beust.jcommander.JCommander
 import com.beust.jcommander.Parameter
 import com.beust.jcommander.ParameterException
 
+import com.here.ort.downloader.consolidateProjectPackagesByVcs
 import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.AnalyzerConfiguration
 import com.here.ort.model.AnalyzerResult
@@ -197,7 +198,7 @@ object Main {
         val analyzerResult = dependenciesFile.mapper().readValue(dependenciesFile, AnalyzerResult::class.java)
 
         // Add the projects as packages to scan.
-        val projectPackages = analyzerResult.projects.map { it.toPackage().toCuratedPackage() }
+        val projectPackages = consolidateProjectPackagesByVcs(analyzerResult.projects).map { it.toCuratedPackage() }
 
         val projectScanScopes = if (scopesToScan.isNotEmpty()) {
             println("Limiting scan to scopes: $scopesToScan")


### PR DESCRIPTION
For GitRepo we must not de-duplicate based on VcsInfo without taking the
path into account. Also, the first entry in projectsWithSameVcs is not
necessarily the one which origtinally had the empty path, if any, so
actually search for it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/719)
<!-- Reviewable:end -->
