### PR TITLE
Gradle: Upgrade to Kotlin 1.2.60

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     // We need to hard-code the version here because of
     // https://github.com/gradle/gradle/issues/1697
-    id 'org.jetbrains.kotlin.jvm' version '1.2.51' apply false
+    id 'org.jetbrains.kotlin.jvm' version '1.2.60' apply false
     id 'org.jetbrains.dokka' version '0.9.16' apply false
 
     // Note that the detekt Gradle plugin version does not necessarily
@@ -81,7 +81,7 @@ subprojects {
     // TODO: Remove this once jackson-module-kotlin and kotlintest are updated.
     configurations.all {
         resolutionStrategy {
-            force 'org.jetbrains.kotlin:kotlin-reflect:1.2.51'
+            force 'org.jetbrains.kotlin:kotlin-reflect:1.2.60'
         }
     }
 


### PR DESCRIPTION
See https://blog.jetbrains.com/kotlin/2018/08/kotlin-1-2-60-is-out/.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/742)
<!-- Reviewable:end -->
