### PR TITLE
utils: Double encode "%2F" in fileSystemEncode()

### DIFF
--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -395,6 +395,9 @@ fun String.fileSystemEncode() =
         java.net.URLEncoder.encode(this, "UTF-8")
                 .replace("*", "%2A")
                 .replace(Regex("(^\\.|\\.$)"), "%2E")
+                // Some setups have issues with "%2F" being part of an URL, e.g. when using Apache Redirect, so double
+                // encode it.
+                .replace("%2F", "%252F")
                 .take(255)
 
 /**

--- a/utils/src/test/kotlin/UtilsTest.kt
+++ b/utils/src/test/kotlin/UtilsTest.kt
@@ -490,6 +490,10 @@ class UtilsTest : WordSpec({
             ":".fileSystemEncode() shouldBe "%3A"
         }
 
+        "double encode '/'" {
+            "/".fileSystemEncode() shouldBe "%252F"
+        }
+
         "create a valid file name" {
             val tempDir = createTempDir()
             val fileFromStr = File(tempDir, str.fileSystemEncode()).apply { writeText("dummy") }


### PR DESCRIPTION
Some setups have issues when "%2F" as part of an URL, e.g. when using
Apache Redirect. Double encode "%2F" to "%252F" to work around this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/743)
<!-- Reviewable:end -->
