### PR TITLE
model: Fix AnalyzerResult.hasErrors()

### DIFF
--- a/model/src/main/kotlin/AnalyzerResult.kt
+++ b/model/src/main/kotlin/AnalyzerResult.kt
@@ -70,7 +70,8 @@ data class AnalyzerResult(
         fun hasErrors(pkgReference: PackageReference): Boolean =
                 pkgReference.errors.isNotEmpty() || pkgReference.dependencies.any { hasErrors(it) }
 
-        return errors.isNotEmpty() || projects.any { it.scopes.any { it.dependencies.any { hasErrors(it) } } }
+        return errors.any { it.value.isNotEmpty() }
+                || projects.any { it.scopes.any { it.dependencies.any { hasErrors(it) } } }
     }
 }
 


### PR DESCRIPTION
The function checked if the errors map is not empty instead of checking if
any of the lists contained in the map is not empty. This always returned
true, because the map contains one entry for each project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/745)
<!-- Reviewable:end -->
