### PR TITLE
ScanCode: Only use the error message to get distinct errors

### DIFF
--- a/scanner/src/main/kotlin/scanners/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/ScanCode.kt
@@ -233,7 +233,7 @@ object ScanCode : LocalScanner() {
         }
 
         errors.clear()
-        errors += mappedErrors.distinct()
+        errors += mappedErrors.distinctBy { it.message }
 
         return onlyMemoryErrors
     }
@@ -262,7 +262,7 @@ object ScanCode : LocalScanner() {
         }
 
         errors.clear()
-        errors += mappedErrors.distinct()
+        errors += mappedErrors.distinctBy { it.message }
 
         return onlyTimeoutErrors
     }


### PR DESCRIPTION
When mapping unknown errors only the error message is relevant, not the
other properties of the error object.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/769)
<!-- Reviewable:end -->
