### PR TITLE
scanner: Inline the writeResult() function

### DIFF
--- a/scanner/src/main/kotlin/Main.kt
+++ b/scanner/src/main/kotlin/Main.kt
@@ -200,7 +200,11 @@ object Main {
         val ortResult = dependenciesFile?.let { scanDependenciesFile(it, config) }
                 ?: scanInputPath(inputPath!!, config)
 
-        writeResult(outputDir, ortResult)
+        outputFormats.forEach { format ->
+            val scanRecordFile = File(outputDir, "scan-result.${format.fileExtension}")
+            println("Writing scan record to '${scanRecordFile.absolutePath}'.")
+            format.mapper.writerWithDefaultPrettyPrinter().writeValue(scanRecordFile, ortResult)
+        }
     }
 
     private fun scanDependenciesFile(dependenciesFile: File, config: ScannerConfiguration): OrtResult {
@@ -316,13 +320,5 @@ object Main {
         val repository = Repository(vcs, vcs.normalize(), RepositoryConfiguration(null))
 
         return OrtResult(repository, scanner = scannerRun)
-    }
-
-    private fun writeResult(outputDirectory: File, ortResult: OrtResult) {
-        outputFormats.forEach { format ->
-            val scanRecordFile = File(outputDirectory, "scan-result.${format.fileExtension}")
-            println("Writing scan record to '${scanRecordFile.absolutePath}'.")
-            format.mapper.writerWithDefaultPrettyPrinter().writeValue(scanRecordFile, ortResult)
-        }
     }
 }


### PR DESCRIPTION
If at all a function, it should probably be part of OrtResult or an
extension function for File. Neither is really fitting here, also
because of the println(). So just inline this small function which is
only called once. This also helps for the upcoming CLI refactoring.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/771)
<!-- Reviewable:end -->
