### PR TITLE
Update README to link to project roadmap

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,7 @@ The toolkit is envisioned to consist of the following libraries:
 * *Documenter* * - Generates the outcome of the review, e.g. Open Source notices and annotated [SPDX](https://spdx.org/)
   files that can be included into your distribution.
 
-\* Libraries to be completed by Q3 2018.
+\* Libraries to be be implemented, see our [roadmap](https://github.com/heremaps/oss-review-toolkit/projects/1) for details. 
 
 ## Installation
 


### PR DESCRIPTION
Updating README.md to point to our roadmap on GitHub instead of communicating a release date that by now has been moved

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/775)
<!-- Reviewable:end -->
