### PR TITLE
Revert "Use sets where lists are supposed to contain unordered entries only once"

### DIFF
--- a/analyzer/src/main/kotlin/Main.kt
+++ b/analyzer/src/main/kotlin/Main.kt
@@ -79,10 +79,10 @@ object Main {
     @Suppress("LateinitUsage")
     private lateinit var outputDir: File
 
-    @Parameter(description = "The set of output formats used for the result file(s).",
+    @Parameter(description = "The list of output formats used for the result file(s).",
             names = ["--output-formats", "-f"],
             order = PARAMETER_ORDER_OPTIONAL)
-    private var outputFormats = setOf(OutputFormat.YAML)
+    private var outputFormats = listOf(OutputFormat.YAML)
 
     @Parameter(description = "Ignore versions of required tools. NOTE: This may lead to erroneous results.",
             names = ["--ignore-tool-versions"],

--- a/downloader/src/main/kotlin/Main.kt
+++ b/downloader/src/main/kotlin/Main.kt
@@ -52,7 +52,6 @@ import com.here.ort.utils.unpack
 import java.io.File
 import java.io.IOException
 import java.time.Instant
-import java.util.EnumSet
 import java.util.SortedSet
 
 import kotlin.system.exitProcess
@@ -177,7 +176,7 @@ object Main {
     @Parameter(description = "The data entities from the dependencies analysis file to download.",
             names = ["--entities", "-e"],
             order = PARAMETER_ORDER_OPTIONAL)
-    private var entities = EnumSet.allOf(DataEntity::class.java)
+    private var entities = enumValues<DataEntity>().asList()
 
     @Parameter(description = "Allow the download of moving revisions (like e.g. HEAD or master in Git). By default " +
             "these revision are forbidden because they are not pointing to a stable revision of the source code.",

--- a/reporter/src/main/kotlin/Main.kt
+++ b/reporter/src/main/kotlin/Main.kt
@@ -64,11 +64,11 @@ object Main {
     @Suppress("LateinitUsage")
     private lateinit var outputDir: File
 
-    @Parameter(description = "The set of report formats that will be generated.",
+    @Parameter(description = "The list of report formats that will be generated.",
             names = ["--report-formats", "-f"],
             required = true,
             order = PARAMETER_ORDER_MANDATORY)
-    private lateinit var reportFormats: Set<ReportFormat>
+    private lateinit var reportFormats: List<ReportFormat>
 
     @Parameter(description = "Enable info logging.",
             names = ["--info"],

--- a/scanner/src/main/kotlin/Main.kt
+++ b/scanner/src/main/kotlin/Main.kt
@@ -86,11 +86,11 @@ object Main {
             order = PARAMETER_ORDER_OPTIONAL)
     private var inputPath: File? = null
 
-    @Parameter(description = "The set of scopes that shall be scanned. Works only with the " +
+    @Parameter(description = "The list of scopes that shall be scanned. Works only with the " +
             "--dependencies-file parameter. If empty, all scopes are scanned.",
             names = ["--scopes"],
             order = PARAMETER_ORDER_OPTIONAL)
-    private var scopesToScan = setOf<String>()
+    private var scopesToScan = listOf<String>()
 
     @Parameter(description = "The output directory to store the scan results in.",
             names = ["--output-dir", "-o"],
@@ -116,10 +116,10 @@ object Main {
     @Suppress("LateinitUsage")
     private var configFile: File? = null
 
-    @Parameter(description = "The set of output formats used for the result file(s).",
+    @Parameter(description = "The list of output formats used for the result file(s).",
             names = ["--output-formats", "-f"],
             order = PARAMETER_ORDER_OPTIONAL)
-    private var outputFormats = setOf(OutputFormat.YAML)
+    private var outputFormats = listOf(OutputFormat.YAML)
 
     @Parameter(description = "Enable info logging.",
             names = ["--info"],


### PR DESCRIPTION
This reverts commit 7ee6438c3d1d0db6a73e57988d778539cffe36e2.

JCommander does not support sets by default. It only has a
DefaultListConverter. As a result it fails to parse the set parameters with
the correct type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/776)
<!-- Reviewable:end -->
