### PR TITLE
analyzer: Pass config from .ort.yml to package managers

### DIFF
--- a/analyzer/src/funTest/kotlin/BabelTest.kt
+++ b/analyzer/src/funTest/kotlin/BabelTest.kt
@@ -25,9 +25,10 @@ import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
 import com.here.ort.utils.safeDeleteRecursively
 import com.here.ort.utils.test.DEFAULT_ANALYZER_CONFIGURATION
-import com.here.ort.utils.test.USER_DIR
+import com.here.ort.utils.test.DEFAULT_REPOSITORY_CONFIGURATION
 import com.here.ort.utils.test.patchActualResult
 import com.here.ort.utils.test.patchExpectedResult
+import com.here.ort.utils.test.USER_DIR
 
 import io.kotlintest.Description
 import io.kotlintest.TestResult
@@ -59,7 +60,7 @@ class BabelTest : WordSpec() {
     init {
         "Babel dependencies" should {
             "be correctly analyzed" {
-                val npm = NPM.create(DEFAULT_ANALYZER_CONFIGURATION)
+                val npm = NPM.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                 val packageFile = File(projectDir, "package.json")
 
                 val expectedResult = patchExpectedResult(

--- a/analyzer/src/funTest/kotlin/BundlerTest.kt
+++ b/analyzer/src/funTest/kotlin/BundlerTest.kt
@@ -26,6 +26,7 @@ import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
 import com.here.ort.utils.safeDeleteRecursively
 import com.here.ort.utils.test.DEFAULT_ANALYZER_CONFIGURATION
+import com.here.ort.utils.test.DEFAULT_REPOSITORY_CONFIGURATION
 import com.here.ort.utils.test.USER_DIR
 import com.here.ort.utils.test.patchExpectedResult
 
@@ -48,7 +49,7 @@ class BundlerTest : WordSpec() {
                 val definitionFile = File(projectsDir, "lockfile/Gemfile")
 
                 try {
-                    val actualResult = Bundler.create(DEFAULT_ANALYZER_CONFIGURATION)
+                    val actualResult = Bundler.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                             .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
                     val expectedResult = patchExpectedResult(
                             File(projectsDir.parentFile, "bundler-expected-output-lockfile.yml"),
@@ -66,7 +67,7 @@ class BundlerTest : WordSpec() {
             "show error if no lockfile is present" {
                 val definitionFile = File(projectsDir, "no-lockfile/Gemfile")
 
-                val actualResult = Bundler.create(DEFAULT_ANALYZER_CONFIGURATION)
+                val actualResult = Bundler.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                         .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
 
                 actualResult shouldNotBe null
@@ -83,7 +84,7 @@ class BundlerTest : WordSpec() {
                 val definitionFile = File(projectsDir, "gemspec/Gemfile")
 
                 try {
-                    val actualResult = Bundler.create(DEFAULT_ANALYZER_CONFIGURATION)
+                    val actualResult = Bundler.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                             .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
                     val expectedResult = patchExpectedResult(
                             File(projectsDir.parentFile, "bundler-expected-output-gemspec.yml"),

--- a/analyzer/src/funTest/kotlin/GoDepTest.kt
+++ b/analyzer/src/funTest/kotlin/GoDepTest.kt
@@ -27,6 +27,7 @@ import com.here.ort.model.VcsInfo
 import com.here.ort.model.config.AnalyzerConfiguration
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.test.DEFAULT_ANALYZER_CONFIGURATION
+import com.here.ort.utils.test.DEFAULT_REPOSITORY_CONFIGURATION
 import com.here.ort.utils.test.USER_DIR
 
 import io.kotlintest.matchers.startWith
@@ -43,7 +44,7 @@ class GoDepTest : WordSpec() {
         "GoDep" should {
             "resolve dependencies from a lockfile correctly" {
                 val manifestFile = File(projectsDir, "external/qmstr/Gopkg.toml")
-                val godep = GoDep.create(DEFAULT_ANALYZER_CONFIGURATION)
+                val godep = GoDep.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 
                 val result = godep.resolveDependencies(USER_DIR, listOf(manifestFile))[manifestFile]
                 val expectedResult = File(projectsDir, "external/qmstr-expected-output.yml").readText()
@@ -53,7 +54,7 @@ class GoDepTest : WordSpec() {
 
             "show error if no lockfile is present" {
                 val manifestFile = File(projectsDir, "synthetic/godep/no-lockfile/Gopkg.toml")
-                val godep = GoDep.create(DEFAULT_ANALYZER_CONFIGURATION)
+                val godep = GoDep.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 
                 val result = godep.resolveDependencies(USER_DIR, listOf(manifestFile))[manifestFile]
 
@@ -70,7 +71,7 @@ class GoDepTest : WordSpec() {
             "invoke the dependency solver if no lockfile is present and allowDynamicVersions is set" {
                 val manifestFile = File(projectsDir, "synthetic/godep/no-lockfile/Gopkg.toml")
                 val config = AnalyzerConfiguration(false, true, false)
-                val godep = GoDep.create(config)
+                val godep = GoDep.create(config, DEFAULT_REPOSITORY_CONFIGURATION)
 
                 val result = godep.resolveDependencies(USER_DIR, listOf(manifestFile))[manifestFile]
 
@@ -82,7 +83,7 @@ class GoDepTest : WordSpec() {
 
             "import dependencies from Glide" {
                 val manifestFile = File(projectsDir, "external/sprig/glide.yaml")
-                val godep = GoDep.create(DEFAULT_ANALYZER_CONFIGURATION)
+                val godep = GoDep.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 
                 val result = godep.resolveDependencies(USER_DIR, listOf(manifestFile))[manifestFile]
                 val expectedResult = File(projectsDir, "external/sprig-expected-output.yml").readText()
@@ -92,7 +93,7 @@ class GoDepTest : WordSpec() {
 
             "import dependencies from godeps" {
                 val manifestFile = File(projectsDir, "external/godep/Godeps/Godeps.json")
-                val godep = GoDep.create(DEFAULT_ANALYZER_CONFIGURATION)
+                val godep = GoDep.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 
                 val result = godep.resolveDependencies(USER_DIR, listOf(manifestFile))[manifestFile]
                 val expectedResult = File(projectsDir, "external/godep-expected-output.yml").readText()
@@ -101,7 +102,7 @@ class GoDepTest : WordSpec() {
             }
 
             "construct an import path from VCS info" {
-                val godep = GoDep.create(DEFAULT_ANALYZER_CONFIGURATION)
+                val godep = GoDep.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                 val gopath = File("/tmp/gopath")
                 val projectDir = File(projectsDir, "external/qmstr")
                 val vcs = VersionControlSystem.forDirectory(projectDir)!!.getInfo()
@@ -112,7 +113,7 @@ class GoDepTest : WordSpec() {
             }
 
             "construct an import path for directories that are not repositories" {
-                val godep = GoDep.create(DEFAULT_ANALYZER_CONFIGURATION)
+                val godep = GoDep.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                 val gopath = File("/tmp/gopath")
                 val projectDir = File(projectsDir, "synthetic/godep/no-lockfile")
                 val vcs = VcsInfo.EMPTY

--- a/analyzer/src/funTest/kotlin/GradleAndroidTest.kt
+++ b/analyzer/src/funTest/kotlin/GradleAndroidTest.kt
@@ -25,8 +25,9 @@ import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
 import com.here.ort.utils.test.AndroidTag
 import com.here.ort.utils.test.DEFAULT_ANALYZER_CONFIGURATION
-import com.here.ort.utils.test.USER_DIR
+import com.here.ort.utils.test.DEFAULT_REPOSITORY_CONFIGURATION
 import com.here.ort.utils.test.patchExpectedResult
+import com.here.ort.utils.test.USER_DIR
 
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldNotBe
@@ -49,7 +50,7 @@ class GradleAndroidTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle.create(DEFAULT_ANALYZER_CONFIGURATION)
+            val result = Gradle.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                     .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
@@ -65,7 +66,7 @@ class GradleAndroidTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle.create(DEFAULT_ANALYZER_CONFIGURATION)
+            val result = Gradle.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                     .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
@@ -81,7 +82,7 @@ class GradleAndroidTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle.create(DEFAULT_ANALYZER_CONFIGURATION)
+            val result = Gradle.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                     .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null

--- a/analyzer/src/funTest/kotlin/GradleLibraryTest.kt
+++ b/analyzer/src/funTest/kotlin/GradleLibraryTest.kt
@@ -24,6 +24,7 @@ import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
 import com.here.ort.utils.test.DEFAULT_ANALYZER_CONFIGURATION
+import com.here.ort.utils.test.DEFAULT_REPOSITORY_CONFIGURATION
 import com.here.ort.utils.test.USER_DIR
 import com.here.ort.utils.test.patchExpectedResult
 
@@ -48,7 +49,7 @@ class GradleLibraryTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle.create(DEFAULT_ANALYZER_CONFIGURATION)
+            val result = Gradle.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                     .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
@@ -64,7 +65,7 @@ class GradleLibraryTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle.create(DEFAULT_ANALYZER_CONFIGURATION)
+            val result = Gradle.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                     .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
@@ -80,7 +81,7 @@ class GradleLibraryTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle.create(DEFAULT_ANALYZER_CONFIGURATION)
+            val result = Gradle.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                     .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null

--- a/analyzer/src/funTest/kotlin/GradleTest.kt
+++ b/analyzer/src/funTest/kotlin/GradleTest.kt
@@ -26,10 +26,11 @@ import com.here.ort.model.yamlMapper
 import com.here.ort.utils.ProcessCapture
 import com.here.ort.utils.normalizeVcsUrl
 import com.here.ort.utils.test.DEFAULT_ANALYZER_CONFIGURATION
+import com.here.ort.utils.test.DEFAULT_REPOSITORY_CONFIGURATION
 import com.here.ort.utils.test.ExpensiveTag
-import com.here.ort.utils.test.USER_DIR
 import com.here.ort.utils.test.patchActualResult
 import com.here.ort.utils.test.patchExpectedResult
+import com.here.ort.utils.test.USER_DIR
 
 import io.kotlintest.Description
 import io.kotlintest.Spec
@@ -65,7 +66,7 @@ class GradleTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle.create(DEFAULT_ANALYZER_CONFIGURATION)
+            val result = Gradle.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                     .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
@@ -81,7 +82,7 @@ class GradleTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle.create(DEFAULT_ANALYZER_CONFIGURATION)
+            val result = Gradle.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                     .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
@@ -97,7 +98,7 @@ class GradleTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle.create(DEFAULT_ANALYZER_CONFIGURATION)
+            val result = Gradle.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                     .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
@@ -113,7 +114,7 @@ class GradleTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle.create(DEFAULT_ANALYZER_CONFIGURATION)
+            val result = Gradle.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                     .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
@@ -129,7 +130,7 @@ class GradleTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle.create(DEFAULT_ANALYZER_CONFIGURATION)
+            val result = Gradle.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                     .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
@@ -186,7 +187,7 @@ class GradleTest : StringSpec() {
                         revision = vcsRevision
                 )
 
-                val result = Gradle.create(DEFAULT_ANALYZER_CONFIGURATION)
+                val result = Gradle.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                         .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
                 result shouldNotBe null

--- a/analyzer/src/funTest/kotlin/MavenTest.kt
+++ b/analyzer/src/funTest/kotlin/MavenTest.kt
@@ -25,6 +25,7 @@ import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
 import com.here.ort.utils.safeDeleteRecursively
 import com.here.ort.utils.test.DEFAULT_ANALYZER_CONFIGURATION
+import com.here.ort.utils.test.DEFAULT_REPOSITORY_CONFIGURATION
 import com.here.ort.utils.test.USER_DIR
 import com.here.ort.utils.test.patchExpectedResult
 
@@ -45,7 +46,7 @@ class MavenTest : StringSpec() {
             val pomFile = File(projectDir, "pom.xml")
             val expectedResult = File(projectDir.parentFile, "jgnash-expected-output.yml").readText()
 
-            val result = Maven.create(DEFAULT_ANALYZER_CONFIGURATION)
+            val result = Maven.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                     .resolveDependencies(USER_DIR, listOf(pomFile))[pomFile]
 
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
@@ -62,7 +63,7 @@ class MavenTest : StringSpec() {
             // jgnash-core depends on jgnash-resources, so we also have to pass the pom.xml of jgnash-resources to
             // resolveDependencies so that it is available in the Maven.projectsByIdentifier cache. Otherwise resolution
             // of transitive dependencies would not work.
-            val result = Maven.create(DEFAULT_ANALYZER_CONFIGURATION)
+            val result = Maven.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                     .resolveDependencies(USER_DIR, listOf(pomFileCore, pomFileResources))[pomFileCore]
 
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
@@ -76,7 +77,7 @@ class MavenTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Maven.create(DEFAULT_ANALYZER_CONFIGURATION)
+            val result = Maven.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                     .resolveDependencies(USER_DIR, listOf(pomFile))[pomFile]
 
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
@@ -94,7 +95,7 @@ class MavenTest : StringSpec() {
             // app depends on lib, so we also have to pass the pom.xml of lib to resolveDependencies so that it is
             // available in the Maven.projectsByIdentifier cache. Otherwise resolution of transitive dependencies would
             // not work.
-            val result = Maven.create(DEFAULT_ANALYZER_CONFIGURATION)
+            val result = Maven.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                     .resolveDependencies(USER_DIR, listOf(pomFileApp, pomFileLib))[pomFileApp]
 
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
@@ -108,7 +109,7 @@ class MavenTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Maven.create(DEFAULT_ANALYZER_CONFIGURATION)
+            val result = Maven.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                     .resolveDependencies(USER_DIR, listOf(pomFile))[pomFile]
 
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
@@ -128,7 +129,7 @@ class MavenTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Maven.create(DEFAULT_ANALYZER_CONFIGURATION)
+            val result = Maven.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                     .resolveDependencies(USER_DIR, listOf(pomFile))[pomFile]
 
             yamlMapper.writeValueAsString(result) shouldBe expectedResult

--- a/analyzer/src/funTest/kotlin/NpmTest.kt
+++ b/analyzer/src/funTest/kotlin/NpmTest.kt
@@ -25,9 +25,10 @@ import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
 import com.here.ort.utils.safeDeleteRecursively
 import com.here.ort.utils.test.DEFAULT_ANALYZER_CONFIGURATION
-import com.here.ort.utils.test.USER_DIR
+import com.here.ort.utils.test.DEFAULT_REPOSITORY_CONFIGURATION
 import com.here.ort.utils.test.patchActualResult
 import com.here.ort.utils.test.patchExpectedResult
+import com.here.ort.utils.test.USER_DIR
 
 import io.kotlintest.Description
 import io.kotlintest.TestResult
@@ -62,7 +63,7 @@ class NpmTest : WordSpec() {
                 val workingDir = File(projectsDir, "shrinkwrap")
                 val packageFile = File(workingDir, "package.json")
 
-                val result = NPM.create(DEFAULT_ANALYZER_CONFIGURATION)
+                val result = NPM.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                         .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
                 val vcsPath = vcsDir.getPathToRoot(workingDir)
                 val expectedResult = patchExpectedResult(
@@ -81,7 +82,7 @@ class NpmTest : WordSpec() {
                 val workingDir = File(projectsDir, "package-lock")
                 val packageFile = File(workingDir, "package.json")
 
-                val result = NPM.create(DEFAULT_ANALYZER_CONFIGURATION)
+                val result = NPM.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                         .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
                 val vcsPath = vcsDir.getPathToRoot(workingDir)
                 val expectedResult = patchExpectedResult(
@@ -100,7 +101,7 @@ class NpmTest : WordSpec() {
                 val workingDir = File(projectsDir, "no-lockfile")
                 val packageFile = File(workingDir, "package.json")
 
-                val result = NPM.create(DEFAULT_ANALYZER_CONFIGURATION)
+                val result = NPM.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                         .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
                 val vcsPath = vcsDir.getPathToRoot(workingDir)
                 val expectedResult = patchExpectedResult(
@@ -119,7 +120,7 @@ class NpmTest : WordSpec() {
                 val workingDir = File(projectsDir, "node-modules")
                 val packageFile = File(workingDir, "package.json")
 
-                val result = NPM.create(DEFAULT_ANALYZER_CONFIGURATION)
+                val result = NPM.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                         .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
                 val vcsPath = vcsDir.getPathToRoot(workingDir)
                 val expectedResult = patchExpectedResult(

--- a/analyzer/src/funTest/kotlin/PhpComposerTest.kt
+++ b/analyzer/src/funTest/kotlin/PhpComposerTest.kt
@@ -25,6 +25,7 @@ import com.here.ort.model.Identifier
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
 import com.here.ort.utils.test.DEFAULT_ANALYZER_CONFIGURATION
+import com.here.ort.utils.test.DEFAULT_REPOSITORY_CONFIGURATION
 import com.here.ort.utils.test.USER_DIR
 import com.here.ort.utils.test.patchExpectedResult
 
@@ -46,7 +47,7 @@ class PhpComposerTest : StringSpec() {
         "Project dependencies are detected correctly" {
             val definitionFile = File(projectsDir, "lockfile/composer.json")
 
-            val result = PhpComposer.create(DEFAULT_ANALYZER_CONFIGURATION)
+            val result = PhpComposer.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                     .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
             val expectedResults = patchExpectedResult(
                     File(projectsDir.parentFile, "php-composer-expected-output.yml"),
@@ -61,7 +62,7 @@ class PhpComposerTest : StringSpec() {
         "Error is shown when no lock file is present" {
             val definitionFile = File(projectsDir, "no-lockfile/composer.json")
 
-            val result = PhpComposer.create(DEFAULT_ANALYZER_CONFIGURATION)
+            val result = PhpComposer.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                     .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
 
             result shouldNotBe null
@@ -77,7 +78,7 @@ class PhpComposerTest : StringSpec() {
         "No composer.lock is required for projects without dependencies" {
             val definitionFile = File(projectsDir, "no-deps/composer.json")
 
-            val result = PhpComposer.create(DEFAULT_ANALYZER_CONFIGURATION)
+            val result = PhpComposer.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                     .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
             val expectedResults = patchExpectedResult(
                     File(projectsDir.parentFile, "php-composer-expected-output-no-deps.yml"),
@@ -93,7 +94,7 @@ class PhpComposerTest : StringSpec() {
         "No composer.lock is required for projects with empty dependencies" {
             val definitionFile = File(projectsDir, "empty-deps/composer.json")
 
-            val result = PhpComposer.create(DEFAULT_ANALYZER_CONFIGURATION)
+            val result = PhpComposer.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                     .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
             val expectedResults = patchExpectedResult(
                     File(projectsDir.parentFile, "php-composer-expected-output-no-deps.yml"),

--- a/analyzer/src/funTest/kotlin/PipTest.kt
+++ b/analyzer/src/funTest/kotlin/PipTest.kt
@@ -24,6 +24,7 @@ import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
 import com.here.ort.utils.test.DEFAULT_ANALYZER_CONFIGURATION
+import com.here.ort.utils.test.DEFAULT_REPOSITORY_CONFIGURATION
 import com.here.ort.utils.test.USER_DIR
 import com.here.ort.utils.test.patchExpectedResult
 
@@ -38,7 +39,7 @@ class PipTest : StringSpec({
     "setup.py dependencies should be resolved correctly for spdx-tools-python" {
         val definitionFile = File(projectsDir, "external/spdx-tools-python/setup.py")
 
-        val result = PIP.create(DEFAULT_ANALYZER_CONFIGURATION)
+        val result = PIP.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                 .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
         val expectedResult = File(projectsDir, "external/spdx-tools-python-expected-output.yml").readText()
 
@@ -48,7 +49,7 @@ class PipTest : StringSpec({
     "requirements.txt dependencies should be resolved correctly for example-python-flask" {
         val definitionFile = File(projectsDir, "external/example-python-flask/requirements.txt")
 
-        val result = PIP.create(DEFAULT_ANALYZER_CONFIGURATION)
+        val result = PIP.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                 .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
         val expectedResult = File(projectsDir, "external/example-python-flask-expected-output.yml").readText()
 
@@ -67,7 +68,7 @@ class PipTest : StringSpec({
                 revision = vcsRevision,
                 path = vcsPath)
 
-        val result = PIP.create(DEFAULT_ANALYZER_CONFIGURATION)
+        val result = PIP.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                 .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
 
         yamlMapper.writeValueAsString(result) shouldBe expectedResult

--- a/analyzer/src/funTest/kotlin/StackTest.kt
+++ b/analyzer/src/funTest/kotlin/StackTest.kt
@@ -23,6 +23,7 @@ import com.here.ort.analyzer.managers.Stack
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.OS
 import com.here.ort.utils.test.DEFAULT_ANALYZER_CONFIGURATION
+import com.here.ort.utils.test.DEFAULT_REPOSITORY_CONFIGURATION
 import com.here.ort.utils.test.USER_DIR
 
 import io.kotlintest.shouldBe
@@ -36,7 +37,7 @@ class StackTest : StringSpec({
     "Dependencies should be resolved correctly for quickcheck-state-machine" {
         val definitionFile = File(projectsDir, "external/quickcheck-state-machine/stack.yaml")
 
-        val result = Stack.create(DEFAULT_ANALYZER_CONFIGURATION)
+        val result = Stack.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                 .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
         val expectedOutput = if (OS.isWindows) {
             "external/quickcheck-state-machine-expected-output-win32.yml"
@@ -52,7 +53,7 @@ class StackTest : StringSpec({
     "Dependencies should be resolved correctly for quickcheck-state-machine-example" {
         val definitionFile = File(projectsDir, "external/quickcheck-state-machine/example/stack.yaml")
 
-        val result = Stack.create(DEFAULT_ANALYZER_CONFIGURATION)
+        val result = Stack.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                 .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
         val expectedOutput = if (OS.isWindows) {
             "external/quickcheck-state-machine-example-expected-output-win32.yml"

--- a/analyzer/src/funTest/kotlin/YarnTest.kt
+++ b/analyzer/src/funTest/kotlin/YarnTest.kt
@@ -25,6 +25,7 @@ import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
 import com.here.ort.utils.safeDeleteRecursively
 import com.here.ort.utils.test.DEFAULT_ANALYZER_CONFIGURATION
+import com.here.ort.utils.test.DEFAULT_REPOSITORY_CONFIGURATION
 import com.here.ort.utils.test.USER_DIR
 import com.here.ort.utils.test.patchExpectedResult
 
@@ -59,7 +60,7 @@ class YarnTest : WordSpec() {
         "yarn" should {
             "resolve dependencies correctly" {
                 val packageFile = File(projectDir, "package.json")
-                val result = Yarn.create(DEFAULT_ANALYZER_CONFIGURATION)
+                val result = Yarn.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                         .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
                 val vcsPath = vcsDir.getPathToRoot(projectDir)
                 val expectedResult = patchExpectedResult(

--- a/analyzer/src/funTest/kotlin/integration/AbstractIntegrationSpec.kt
+++ b/analyzer/src/funTest/kotlin/integration/AbstractIntegrationSpec.kt
@@ -27,6 +27,7 @@ import com.here.ort.model.Identifier
 import com.here.ort.model.Package
 import com.here.ort.utils.safeDeleteRecursively
 import com.here.ort.utils.test.DEFAULT_ANALYZER_CONFIGURATION
+import com.here.ort.utils.test.DEFAULT_REPOSITORY_CONFIGURATION
 import com.here.ort.utils.test.ExpensiveTag
 import com.here.ort.utils.test.USER_DIR
 
@@ -111,7 +112,8 @@ abstract class AbstractIntegrationSpec : StringSpec() {
         "Analyzer creates one non-empty result per definition file".config(tags = setOf(ExpensiveTag)) {
             definitionFilesForTest.forEach { manager, files ->
                 println("Resolving $manager dependencies in $files.")
-                val results = manager.create(DEFAULT_ANALYZER_CONFIGURATION).resolveDependencies(USER_DIR, files)
+                val results = manager.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
+                        .resolveDependencies(USER_DIR, files)
 
                 results.size shouldBe files.size
                 results.values.forEach { result ->

--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -29,6 +29,7 @@ import com.here.ort.model.Project
 import com.here.ort.model.ProjectAnalyzerResult
 import com.here.ort.model.VcsInfo
 import com.here.ort.model.config.AnalyzerConfiguration
+import com.here.ort.model.config.RepositoryConfiguration
 import com.here.ort.utils.collectMessages
 import com.here.ort.utils.log
 import com.here.ort.utils.normalizeVcsUrl
@@ -50,7 +51,8 @@ typealias ResolutionResult = MutableMap<File, ProjectAnalyzerResult>
 /**
  * A class representing a package manager that handles software dependencies.
  */
-abstract class PackageManager(protected val config: AnalyzerConfiguration) {
+abstract class PackageManager(protected val analyzerConfig: AnalyzerConfiguration,
+                              protected val repoConfig: RepositoryConfiguration) {
     companion object {
         /**
          * The prioritized list of all available package managers. This needs to be initialized lazily to ensure the

--- a/analyzer/src/main/kotlin/PackageManagerFactory.kt
+++ b/analyzer/src/main/kotlin/PackageManagerFactory.kt
@@ -20,6 +20,7 @@
 package com.here.ort.analyzer
 
 import com.here.ort.model.config.AnalyzerConfiguration
+import com.here.ort.model.config.RepositoryConfiguration
 
 import java.nio.file.FileSystems
 
@@ -40,7 +41,7 @@ abstract class PackageManagerFactory<out T : PackageManager>(
     /**
      * Create a new instance of the [PackageManager].
      */
-    abstract fun create(config: AnalyzerConfiguration): T
+    abstract fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration): T
 
     /**
      * Return the Java class name to make JCommander display a proper name in list parameters of this custom type.

--- a/analyzer/src/main/kotlin/managers/Bower.kt
+++ b/analyzer/src/main/kotlin/managers/Bower.kt
@@ -22,16 +22,19 @@ package com.here.ort.analyzer.managers
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.analyzer.PackageManagerFactory
 import com.here.ort.model.config.AnalyzerConfiguration
+import com.here.ort.model.config.RepositoryConfiguration
 
 import java.io.File
 
-class Bower(config: AnalyzerConfiguration) : PackageManager(config) {
+class Bower(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
+        PackageManager(analyzerConfig, repoConfig) {
     companion object : PackageManagerFactory<Bower>(
             "https://bower.io/",
             "JavaScript",
             listOf("bower.json")
     ) {
-        override fun create(config: AnalyzerConfiguration) = Bower(config)
+        override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
+                Bower(analyzerConfig, repoConfig)
     }
 
     override fun command(workingDir: File) = "bower"

--- a/analyzer/src/main/kotlin/managers/CocoaPods.kt
+++ b/analyzer/src/main/kotlin/managers/CocoaPods.kt
@@ -22,16 +22,19 @@ package com.here.ort.analyzer.managers
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.analyzer.PackageManagerFactory
 import com.here.ort.model.config.AnalyzerConfiguration
+import com.here.ort.model.config.RepositoryConfiguration
 
 import java.io.File
 
-class CocoaPods(config: AnalyzerConfiguration) : PackageManager(config) {
+class CocoaPods(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
+        PackageManager(analyzerConfig, repoConfig) {
     companion object : PackageManagerFactory<CocoaPods>(
             "https://cocoapods.org/",
             "Objective-C",
             listOf("Podfile.lock", "Podfile")
     ) {
-        override fun create(config: AnalyzerConfiguration) = CocoaPods(config)
+        override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
+                CocoaPods(analyzerConfig, repoConfig)
     }
 
     override fun command(workingDir: File) = "pod"

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -39,6 +39,7 @@ import com.here.ort.model.RemoteArtifact
 import com.here.ort.model.Scope
 import com.here.ort.model.VcsInfo
 import com.here.ort.model.config.AnalyzerConfiguration
+import com.here.ort.model.config.RepositoryConfiguration
 import com.here.ort.utils.OS
 import com.here.ort.utils.collectMessages
 import com.here.ort.utils.log
@@ -64,13 +65,15 @@ import org.eclipse.aether.repository.RemoteRepository
 
 import org.gradle.tooling.GradleConnector
 
-class Gradle(config: AnalyzerConfiguration) : PackageManager(config) {
+class Gradle(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
+        PackageManager(analyzerConfig, repoConfig) {
     companion object : PackageManagerFactory<Gradle>(
             "https://gradle.org/",
             "Java",
             listOf("build.gradle", "settings.gradle")
     ) {
-        override fun create(config: AnalyzerConfiguration) = Gradle(config)
+        override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
+                Gradle(analyzerConfig, repoConfig)
 
         val gradle = if (OS.isWindows) "gradle.bat" else "gradle"
         val wrapper = if (OS.isWindows) "gradlew.bat" else "gradlew"

--- a/analyzer/src/main/kotlin/managers/Maven.kt
+++ b/analyzer/src/main/kotlin/managers/Maven.kt
@@ -34,6 +34,7 @@ import com.here.ort.model.Project
 import com.here.ort.model.ProjectAnalyzerResult
 import com.here.ort.model.Scope
 import com.here.ort.model.config.AnalyzerConfiguration
+import com.here.ort.model.config.RepositoryConfiguration
 import com.here.ort.utils.collectMessages
 import com.here.ort.utils.log
 import com.here.ort.utils.searchUpwardsForSubdirectory
@@ -59,13 +60,15 @@ import org.eclipse.aether.repository.LocalRepository
 import org.eclipse.aether.repository.LocalRepositoryManager
 import org.eclipse.aether.repository.RemoteRepository
 
-class Maven(config: AnalyzerConfiguration) : PackageManager(config) {
+class Maven(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
+        PackageManager(analyzerConfig, repoConfig) {
     companion object : PackageManagerFactory<Maven>(
             "https://maven.apache.org/",
             "Java",
             listOf("pom.xml")
     ) {
-        override fun create(config: AnalyzerConfiguration) = Maven(config)
+        override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
+                Maven(analyzerConfig, repoConfig)
     }
 
     private val maven = MavenSupport { localRepositoryManager ->

--- a/analyzer/src/main/kotlin/managers/NPM.kt
+++ b/analyzer/src/main/kotlin/managers/NPM.kt
@@ -39,6 +39,7 @@ import com.here.ort.model.RemoteArtifact
 import com.here.ort.model.Scope
 import com.here.ort.model.VcsInfo
 import com.here.ort.model.config.AnalyzerConfiguration
+import com.here.ort.model.config.RepositoryConfiguration
 import com.here.ort.model.jsonMapper
 import com.here.ort.utils.OS
 import com.here.ort.utils.OkHttpClientHelper
@@ -66,13 +67,15 @@ import org.apache.commons.codec.binary.Base64
 import org.apache.commons.codec.binary.Hex
 
 @Suppress("LargeClass", "TooManyFunctions")
-open class NPM(config: AnalyzerConfiguration) : PackageManager(config) {
+open class NPM(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
+        PackageManager(analyzerConfig, repoConfig) {
     companion object : PackageManagerFactory<NPM>(
             "https://www.npmjs.com/",
             "JavaScript",
             listOf("package.json")
     ) {
-        override fun create(config: AnalyzerConfiguration) = NPM(config)
+        override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
+                NPM(analyzerConfig, repoConfig)
 
         /**
          * Expand NPM shortcuts for URLs to hosting sites to full URLs so that they can be used in a regular way.
@@ -123,7 +126,7 @@ open class NPM(config: AnalyzerConfiguration) : PackageManager(config) {
         // We do not actually depend on any features specific to an NPM version, but we still want to stick to a fixed
         // minor version to be sure to get consistent results.
         checkCommandVersion(command(workingDir), Requirement.buildIvy("5.5.+"),
-                ignoreActualVersion = config.ignoreToolVersions)
+                ignoreActualVersion = analyzerConfig.ignoreToolVersions)
 
         return definitionFiles
     }
@@ -475,7 +478,7 @@ open class NPM(config: AnalyzerConfiguration) : PackageManager(config) {
      * Install dependencies using the given package manager command.
      */
     private fun installDependencies(workingDir: File) {
-        if (!config.allowDynamicVersions) {
+        if (!analyzerConfig.allowDynamicVersions) {
             val lockFiles = recognizedLockFiles.filter {
                 File(workingDir, it).isFile
             }

--- a/analyzer/src/main/kotlin/managers/PIP.kt
+++ b/analyzer/src/main/kotlin/managers/PIP.kt
@@ -39,6 +39,7 @@ import com.here.ort.model.RemoteArtifact
 import com.here.ort.model.Scope
 import com.here.ort.model.VcsInfo
 import com.here.ort.model.config.AnalyzerConfiguration
+import com.here.ort.model.config.RepositoryConfiguration
 import com.here.ort.model.jsonMapper
 import com.here.ort.utils.OkHttpClientHelper
 import com.here.ort.utils.OS
@@ -57,7 +58,8 @@ import java.util.SortedSet
 
 import okhttp3.Request
 
-class PIP(config: AnalyzerConfiguration) : PackageManager(config) {
+class PIP(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
+        PackageManager(analyzerConfig, repoConfig) {
     companion object : PackageManagerFactory<PIP>(
             "https://pip.pypa.io/",
             "Python",
@@ -65,7 +67,8 @@ class PIP(config: AnalyzerConfiguration) : PackageManager(config) {
             // https://caremad.io/posts/2013/07/setup-vs-requirement/.
             listOf("requirements*.txt", "setup.py")
     ) {
-        override fun create(config: AnalyzerConfiguration) = PIP(config)
+        override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
+                PIP(analyzerConfig, repoConfig)
 
         private const val PIP_VERSION = "9.0.3"
 
@@ -113,7 +116,7 @@ class PIP(config: AnalyzerConfiguration) : PackageManager(config) {
         // virtualenv bundles pip. In order to get pip 9.0.1 inside a virtualenv, which is a version that supports
         // installing packages from a Git URL that include a commit SHA1, we need at least virtualenv 15.1.0.
         checkCommandVersion("virtualenv", Requirement.buildIvy("15.1.+"),
-                ignoreActualVersion = config.ignoreToolVersions)
+                ignoreActualVersion = analyzerConfig.ignoreToolVersions)
 
         return definitionFiles
     }

--- a/analyzer/src/main/kotlin/managers/PhpComposer.kt
+++ b/analyzer/src/main/kotlin/managers/PhpComposer.kt
@@ -39,6 +39,7 @@ import com.here.ort.model.RemoteArtifact
 import com.here.ort.model.Scope
 import com.here.ort.model.VcsInfo
 import com.here.ort.model.config.AnalyzerConfiguration
+import com.here.ort.model.config.RepositoryConfiguration
 import com.here.ort.model.jsonMapper
 import com.here.ort.utils.OS
 import com.here.ort.utils.ProcessCapture
@@ -57,13 +58,15 @@ import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 import java.util.SortedSet
 
-class PhpComposer(config: AnalyzerConfiguration) : PackageManager(config) {
+class PhpComposer(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
+        PackageManager(analyzerConfig, repoConfig) {
     companion object : PackageManagerFactory<PhpComposer>(
             "https://getcomposer.org/",
             "PHP",
             listOf("composer.json")
     ) {
-        override fun create(config: AnalyzerConfiguration) = PhpComposer(config)
+        override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
+                PhpComposer(analyzerConfig, repoConfig)
 
         private const val PHAR_BINARY = "composer.phar"
         private const val LOCK_FILE = "composer.lock"
@@ -99,7 +102,7 @@ class PhpComposer(config: AnalyzerConfiguration) : PackageManager(config) {
                 command(workingDir),
                 Requirement.buildIvy("[1.5,)"),
                 "--no-ansi --version",
-                ignoreActualVersion = config.ignoreToolVersions,
+                ignoreActualVersion = analyzerConfig.ignoreToolVersions,
                 transform = { it.split(" ").dropLast(2).last().removeSurrounding("(", ")") }
         )
 
@@ -287,7 +290,7 @@ class PhpComposer(config: AnalyzerConfiguration) : PackageManager(config) {
     }
 
     private fun installDependencies(workingDir: File) {
-        require(config.allowDynamicVersions || File(workingDir, LOCK_FILE).isFile) {
+        require(analyzerConfig.allowDynamicVersions || File(workingDir, LOCK_FILE).isFile) {
             "No lock file found in $workingDir, dependency versions are unstable."
         }
 

--- a/analyzer/src/main/kotlin/managers/SBT.kt
+++ b/analyzer/src/main/kotlin/managers/SBT.kt
@@ -24,6 +24,7 @@ import ch.frankel.slf4k.*
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.analyzer.PackageManagerFactory
 import com.here.ort.model.config.AnalyzerConfiguration
+import com.here.ort.model.config.RepositoryConfiguration
 import com.here.ort.utils.OS
 import com.here.ort.utils.ProcessCapture
 import com.here.ort.utils.checkCommandVersion
@@ -36,7 +37,8 @@ import java.io.File
 import java.io.IOException
 import java.util.Properties
 
-class SBT(config: AnalyzerConfiguration) : PackageManager(config) {
+class SBT(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
+        PackageManager(analyzerConfig, repoConfig) {
     companion object : PackageManagerFactory<SBT>(
             "http://www.scala-sbt.org/",
             "Scala",
@@ -59,7 +61,8 @@ class SBT(config: AnalyzerConfiguration) : PackageManager(config) {
             }
         }
 
-        override fun create(config: AnalyzerConfiguration) = SBT(config)
+        override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
+                SBT(analyzerConfig, repoConfig)
     }
 
     override fun command(workingDir: File) = if (OS.isWindows) "sbt.bat" else "sbt"
@@ -120,7 +123,7 @@ class SBT(config: AnalyzerConfiguration) : PackageManager(config) {
                     sbtVersionRequirement,
                     versionArguments = "$SBT_BATCH_MODE $SBT_LOG_NO_FORMAT sbtVersion",
                     workingDir = workingDir,
-                    ignoreActualVersion = config.ignoreToolVersions,
+                    ignoreActualVersion = analyzerConfig.ignoreToolVersions,
                     transform = this::extractLowestSbtVersion
             )
         } else {
@@ -160,5 +163,6 @@ class SBT(config: AnalyzerConfiguration) : PackageManager(config) {
 
     override fun resolveDependencies(analyzerRoot: File, definitionFiles: List<File>) =
             // Simply pass on the list of POM files to Maven, ignoring the SBT build files here.
-            Maven.create(config).enableSbtMode().resolveDependencies(analyzerRoot, prepareResolution(definitionFiles))
+            Maven.create(analyzerConfig, repoConfig).enableSbtMode()
+                    .resolveDependencies(analyzerRoot, prepareResolution(definitionFiles))
 }

--- a/analyzer/src/main/kotlin/managers/Stack.kt
+++ b/analyzer/src/main/kotlin/managers/Stack.kt
@@ -35,6 +35,7 @@ import com.here.ort.model.RemoteArtifact
 import com.here.ort.model.Scope
 import com.here.ort.model.VcsInfo
 import com.here.ort.model.config.AnalyzerConfiguration
+import com.here.ort.model.config.RepositoryConfiguration
 import com.here.ort.utils.OkHttpClientHelper
 import com.here.ort.utils.ProcessCapture
 import com.here.ort.utils.log
@@ -51,13 +52,15 @@ import java.net.HttpURLConnection
 import java.nio.file.FileSystems
 import java.util.SortedSet
 
-class Stack(config: AnalyzerConfiguration) : PackageManager(config) {
+class Stack(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
+        PackageManager(analyzerConfig, repoConfig) {
     companion object : PackageManagerFactory<Stack>(
             "http://haskellstack.org/",
             "Haskell",
             listOf("stack.yaml")
     ) {
-        override fun create(config: AnalyzerConfiguration) = Stack(config)
+        override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
+                Stack(analyzerConfig, repoConfig)
     }
 
     override fun command(workingDir: File) = "stack"

--- a/analyzer/src/main/kotlin/managers/Unmanaged.kt
+++ b/analyzer/src/main/kotlin/managers/Unmanaged.kt
@@ -27,15 +27,18 @@ import com.here.ort.model.Project
 import com.here.ort.model.ProjectAnalyzerResult
 import com.here.ort.model.VcsInfo
 import com.here.ort.model.config.AnalyzerConfiguration
+import com.here.ort.model.config.RepositoryConfiguration
 
 import java.io.File
 
 /**
  * A fake [PackageManager] for projects that do not use any of the known package managers.
  */
-class Unmanaged(config: AnalyzerConfiguration) : PackageManager(config) {
+class Unmanaged(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
+        PackageManager(analyzerConfig, repoConfig) {
     companion object : PackageManagerFactory<Unmanaged>("", "", emptyList()) {
-        override fun create(config: AnalyzerConfiguration) = Unmanaged(config)
+        override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
+                Unmanaged(analyzerConfig, repoConfig)
     }
 
     override fun command(workingDir: File) = throw NotImplementedError()

--- a/analyzer/src/main/kotlin/managers/Yarn.kt
+++ b/analyzer/src/main/kotlin/managers/Yarn.kt
@@ -21,6 +21,7 @@ package com.here.ort.analyzer.managers
 
 import com.here.ort.analyzer.PackageManagerFactory
 import com.here.ort.model.config.AnalyzerConfiguration
+import com.here.ort.model.config.RepositoryConfiguration
 import com.here.ort.utils.OS
 import com.here.ort.utils.checkCommandVersion
 
@@ -28,13 +29,15 @@ import com.vdurmont.semver4j.Requirement
 
 import java.io.File
 
-class Yarn(config: AnalyzerConfiguration) : NPM(config) {
+class Yarn(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
+        NPM(analyzerConfig, repoConfig) {
     companion object : PackageManagerFactory<Yarn>(
             "https://www.yarnpkg.com/",
             "JavaScript",
             listOf("yarn.lock")
     ) {
-        override fun create(config: AnalyzerConfiguration) = Yarn(config)
+        override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
+                Yarn(analyzerConfig, repoConfig)
     }
 
     override val recognizedLockFiles = listOf("yarn.lock")
@@ -49,7 +52,7 @@ class Yarn(config: AnalyzerConfiguration) : NPM(config) {
         // We do not actually depend on any features specific to a Yarn version, but we still want to stick to a fixed
         // minor version to be sure to get consistent results.
         checkCommandVersion(command(workingDir), Requirement.buildIvy("1.3.+"),
-                ignoreActualVersion = config.ignoreToolVersions)
+                ignoreActualVersion = analyzerConfig.ignoreToolVersions)
 
         // Map "yarn.lock" files to existing "package.json" files for use by the NPM class (which in this case calls
         // "yarn" to install the dependencies).

--- a/utils-test/src/main/kotlin/Utils.kt
+++ b/utils-test/src/main/kotlin/Utils.kt
@@ -20,10 +20,12 @@
 package com.here.ort.utils.test
 
 import com.here.ort.model.config.AnalyzerConfiguration
+import com.here.ort.model.config.RepositoryConfiguration
 import java.io.File
 import java.time.Instant
 
 val DEFAULT_ANALYZER_CONFIGURATION = AnalyzerConfiguration(false, false, false)
+val DEFAULT_REPOSITORY_CONFIGURATION = RepositoryConfiguration(null)
 
 val TIMESTAMP_REGEX = Regex("(timestamp): \".*\"")
 val USER_DIR = File(System.getProperty("user.dir"))


### PR DESCRIPTION
This is done in preparation of implementing BitBake support (#722), which requires a mechanism to pass a list of recipes to analyze.

Since this list is specific to the repository being analyzed, it makes sense to add this information to .ort.yml and give package manager instances access to it, analogous to the command line parameters via AnalyzerConfiguration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/777)
<!-- Reviewable:end -->
