### PR TITLE
analyzer: Minor renaming of variables

### DIFF
--- a/analyzer/src/funTest/kotlin/integration/AbstractIntegrationSpec.kt
+++ b/analyzer/src/funTest/kotlin/integration/AbstractIntegrationSpec.kt
@@ -52,13 +52,13 @@ abstract class AbstractIntegrationSpec : StringSpec() {
     /**
      * The definition files that are expected to be found by the [PackageManager].
      */
-    protected abstract val expectedDefinitionFiles: ManagedProjectFiles
+    protected abstract val expectedManagedFiles: ManagedProjectFiles
 
     /**
-     * The definition files that shall be used for dependency resolution. Defaults to [expectedDefinitionFiles], but
-     * can be reduced for large projects that have a lot of definition files to speed up the test.
+     * The definition files by package manager that are to be used for testing dependency resolution. Defaults to
+     * [expectedManagedFiles], but can be e.g. limited to a subset of files in big projects to speed up the test.
      */
-    protected open val definitionFilesForTest by lazy { expectedDefinitionFiles }
+    protected open val managedFilesForTest by lazy { expectedManagedFiles }
 
     /**
      * The list of package identifiers for which errors are expected.
@@ -96,13 +96,13 @@ abstract class AbstractIntegrationSpec : StringSpec() {
         }
 
         "All package manager definition files are found".config(tags = setOf(ExpensiveTag)) {
-            val definitionFiles = PackageManager.findManagedFiles(downloadResult.downloadDirectory)
+            val managedFiles = PackageManager.findManagedFiles(downloadResult.downloadDirectory)
 
-            definitionFiles.size shouldBe expectedDefinitionFiles.size
-            definitionFiles.forEach { manager, files ->
+            managedFiles.size shouldBe expectedManagedFiles.size
+            managedFiles.forEach { manager, files ->
                 println("Verifying definition files for $manager.")
 
-                val expectedFiles = expectedDefinitionFiles[manager]
+                val expectedFiles = expectedManagedFiles[manager]
 
                 expectedFiles shouldNotBe null
                 files.sorted().joinToString("\n") shouldBe expectedFiles!!.sorted().joinToString("\n")
@@ -110,7 +110,7 @@ abstract class AbstractIntegrationSpec : StringSpec() {
         }
 
         "Analyzer creates one non-empty result per definition file".config(tags = setOf(ExpensiveTag)) {
-            definitionFilesForTest.forEach { manager, files ->
+            managedFilesForTest.forEach { manager, files ->
                 println("Resolving $manager dependencies in $files.")
                 val results = manager.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                         .resolveDependencies(USER_DIR, files)

--- a/analyzer/src/funTest/kotlin/integration/DrupalIntegrationTest.kt
+++ b/analyzer/src/funTest/kotlin/integration/DrupalIntegrationTest.kt
@@ -52,7 +52,7 @@ class DrupalIntegrationTest : AbstractIntegrationSpec() {
             )
     )
 
-    override val expectedDefinitionFiles by lazy {
+    override val expectedManagedFiles by lazy {
         val downloadDir = downloadResult.downloadDirectory
 
         mapOf(
@@ -93,7 +93,7 @@ class DrupalIntegrationTest : AbstractIntegrationSpec() {
         )
     }
 
-    override val definitionFilesForTest by lazy {
+    override val managedFilesForTest by lazy {
         mapOf(PhpComposer as PackageManagerFactory<PackageManager> to
                 // Limit to definition files that come long with a lock file.
                 listOf(File(downloadResult.downloadDirectory, "composer.json")))

--- a/analyzer/src/funTest/kotlin/integration/GradleIntegrationTest.kt
+++ b/analyzer/src/funTest/kotlin/integration/GradleIntegrationTest.kt
@@ -50,7 +50,7 @@ class GradleIntegrationTest : AbstractIntegrationSpec() {
             )
     )
 
-    override val expectedDefinitionFiles by lazy {
+    override val expectedManagedFiles by lazy {
         // The Gradle project contains far too many definition files to list them all here. Use this tests to double
         // check that all of them are found, and that they are assigned to the correct package manager.
         val gradleFilenames = listOf("build.gradle", "settings.gradle")
@@ -68,7 +68,7 @@ class GradleIntegrationTest : AbstractIntegrationSpec() {
         )
     }
 
-    override val definitionFilesForTest by lazy {
+    override val managedFilesForTest by lazy {
         mapOf(Gradle as PackageManagerFactory<PackageManager> to
                 listOf(File(downloadResult.downloadDirectory, "buildSrc/build.gradle")))
     }

--- a/analyzer/src/funTest/kotlin/integration/SimpleFormIntegrationTest.kt
+++ b/analyzer/src/funTest/kotlin/integration/SimpleFormIntegrationTest.kt
@@ -50,7 +50,7 @@ class SimpleFormIntegrationTest : AbstractIntegrationSpec() {
             )
     )
 
-    override val expectedDefinitionFiles by lazy {
+    override val expectedManagedFiles by lazy {
         val downloadDir = downloadResult.downloadDirectory
         mapOf(
                 Bundler as PackageManagerFactory<PackageManager> to listOf(

--- a/analyzer/src/funTest/kotlin/integration/VueJsIntegrationTest.kt
+++ b/analyzer/src/funTest/kotlin/integration/VueJsIntegrationTest.kt
@@ -49,7 +49,7 @@ class VueJsIntegrationTest : AbstractIntegrationSpec() {
             )
     )
 
-    override val expectedDefinitionFiles by lazy {
+    override val expectedManagedFiles by lazy {
         val downloadDir = downloadResult.downloadDirectory
         mapOf(
                 NPM as PackageManagerFactory<PackageManager> to listOf(
@@ -62,7 +62,7 @@ class VueJsIntegrationTest : AbstractIntegrationSpec() {
         )
     }
 
-    override val definitionFilesForTest by lazy {
+    override val managedFilesForTest by lazy {
         mapOf(NPM as PackageManagerFactory<PackageManager> to
                 listOf(File(downloadResult.downloadDirectory, "package.json")))
     }

--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -52,7 +52,7 @@ class Analyzer(private val config: AnalyzerConfiguration) {
         }
 
         // Map of files managed by the respective package manager.
-        var managedDefinitionFiles = if (packageManagers.size == 1 && absoluteProjectPath.isFile) {
+        var managedFiles = if (packageManagers.size == 1 && absoluteProjectPath.isFile) {
             // If only one package manager is activated, treat the given path as definition file for that package
             // manager despite its name.
             mutableMapOf(packageManagers.first() to listOf(absoluteProjectPath))
@@ -61,20 +61,20 @@ class Analyzer(private val config: AnalyzerConfiguration) {
         }
 
         if (config.removeExcludesFromResult) {
-            managedDefinitionFiles = filterExcludedProjects(managedDefinitionFiles, repositoryConfiguration)
+            managedFiles = filterExcludedProjects(managedFiles, repositoryConfiguration)
         }
 
-        val hasDefinitionFileInRootDirectory = managedDefinitionFiles.values.flatten().any {
+        val hasDefinitionFileInRootDirectory = managedFiles.values.flatten().any {
             it.parentFile.absoluteFile == absoluteProjectPath
         }
 
-        if (managedDefinitionFiles.isEmpty() || !hasDefinitionFileInRootDirectory) {
-            managedDefinitionFiles[Unmanaged] = listOf(absoluteProjectPath)
+        if (managedFiles.isEmpty() || !hasDefinitionFileInRootDirectory) {
+            managedFiles[Unmanaged] = listOf(absoluteProjectPath)
         }
 
         if (log.isInfoEnabled) {
             // Log the summary of projects found per package manager.
-            managedDefinitionFiles.forEach { manager, files ->
+            managedFiles.forEach { manager, files ->
                 // No need to use curly-braces-syntax for logging here as the log level check is already done above.
                 log.info("$manager projects found in:")
                 log.info(files.joinToString("\n") {
@@ -87,7 +87,7 @@ class Analyzer(private val config: AnalyzerConfiguration) {
         val analyzerResultBuilder = AnalyzerResultBuilder()
 
         // Resolve dependencies per package manager.
-        managedDefinitionFiles.forEach { manager, files ->
+        managedFiles.forEach { manager, files ->
             val results = manager.create(config, repositoryConfiguration)
                     .resolveDependencies(absoluteProjectPath, files)
 


### PR DESCRIPTION
Call maps of managers to definiton files "managed files" to distinguish
from lists of definition files and to align with function names like e.g.
findManagedFiles(). Also improve a related code comment along the way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/792)
<!-- Reviewable:end -->
