### PR TITLE
Fix undefined detected licenses error if no scan was made

### DIFF
--- a/reporter-web-app/src/utils.js
+++ b/reporter-web-app/src/utils.js
@@ -149,9 +149,10 @@ export function convertToRenderFormat(reportData) {
             pkgObj.license_findings = packageFromScanner.reduce((accumulator, scanResult) =>
                 accumulator.concat(scanResult.summary.license_findings), []);
 
-            pkgObj.detected_licenses = removeDuplicatesInArray(
-                pkgObj.license_findings.map(finding => finding.license)
-            );
+            pkgObj.detected_licenses = pkgObj.license_findings.reduce((accumulator, finding) => {
+                accumulator.push(finding.license);
+                return accumulator;
+            }, []);
 
             addPackageLicensesToProject(
                 projectIndex,
@@ -166,6 +167,9 @@ export function convertToRenderFormat(reportData) {
                 pkgObj.detected_licenses
             );
         } else {
+            pkgObj.results = [];
+            pkgObj.license_findings = [];
+            pkgObj.detected_licenses = [];
             console.error('Package ' + pkgObj.id + ' was detected by Analyzer but not scanned');
         }
 


### PR DESCRIPTION
Undefined error was thrown as no default values were set for
several package attributes related to detected package licenses
Had asssumed that each package found by the Analyzer
would be scanned by the Scanner

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/796)
<!-- Reviewable:end -->
