### PR TITLE
Initialize the list of all classes discovered by ServiceLoader lazily

### DIFF
--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -59,12 +59,12 @@ abstract class PackageManager(
         protected val repoConfig: RepositoryConfiguration
 ) {
     companion object {
-        private val LOADER by lazy { ServiceLoader.load(PackageManagerFactory::class.java)!! }
+        private val LOADER = ServiceLoader.load(PackageManagerFactory::class.java)!!
 
         /**
          * The (prioritized) list of all available package managers in the classpath.
          */
-        val ALL = LOADER.iterator().asSequence().toList()
+        val ALL by lazy { LOADER.iterator().asSequence().toList() }
 
         private val IGNORED_DIRECTORY_MATCHERS = listOf(
                 // Ignore resources in a standard Maven / Gradle project layout.

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -36,12 +36,12 @@ import java.util.ServiceLoader
 
 abstract class Scanner(protected val config: ScannerConfiguration) {
     companion object {
-        private val LOADER by lazy { ServiceLoader.load(ScannerFactory::class.java)!! }
+        private val LOADER = ServiceLoader.load(ScannerFactory::class.java)!!
 
         /**
          * The list of all available scanners in the classpath.
          */
-        val ALL = LOADER.iterator().asSequence().toList()
+        val ALL by lazy { LOADER.iterator().asSequence().toList() }
     }
 
     /**


### PR DESCRIPTION
Not the loader, but the list of discovered classes should be initialized
lazily.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/798)
<!-- Reviewable:end -->
