### PR TITLE
reporter-web-app: Fix incorrect summarization of package errors

### DIFF
--- a/reporter-web-app/src/components/SummaryView.js
+++ b/reporter-web-app/src/components/SummaryView.js
@@ -75,15 +75,13 @@ class SummaryView extends React.Component {
                 && data.errors.total) {
                 if (data.errors.data.open
                     && Number.isInteger(data.errors.total.open)) {
-                    viewData.errors.open = this.convertErrorsToTableFormat(data.errors.data.open);
+                    viewData.errors.open = data.errors.data.open;
                     viewData.errors.totalOpen = data.errors.total.open;
                 }
 
                 if (data.errors.data.addressed
                     && Number.isInteger(data.errors.total.addressed)) {
-                    viewData.errors.addressed = this.convertErrorsToTableFormat(
-                        data.errors.data.addressed
-                    );
+                        viewData.errors.addressed = data.errors.data.addressed;
                     viewData.errors.totalAddressed = data.errors.total.addressed;
                 }
             }
@@ -93,10 +91,6 @@ class SummaryView extends React.Component {
             ...this.state,
             viewData
         };
-    }
-
-    convertErrorsToTableFormat(errors) {
-        return Object.values(errors).reduce((accumulator, error) => [...accumulator, ...error], []);
     }
 
     convertLicensesToChartFormat(licenses) {


### PR DESCRIPTION
Refactored code to fix a bug in the code that creates a list
of errors from walking package tree. Previous code did not
collect all package errors as the code had not been updated
to align with a recent report data format change e.g.
scanResult.errors => scanResult.summary.errors

This bug resulted in some reviews to be displayed as
'Completed scan successfully' whilst in reality there
were errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/808)
<!-- Reviewable:end -->
