### PR TITLE
Add link to ort-talk Slack to README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,12 +5,18 @@
 | [![Linux build status][1]][2]  | [![Windows build status][3]][4] |
 | [![Linux code coverage][5]][6] |                                 |
 
+| Interact with us!              |
+| :----------------------------- |
+| [![ort-talk][7]][8]            |
+
 [1]: https://travis-ci.com/heremaps/oss-review-toolkit.svg?branch=master
 [2]: https://travis-ci.com/heremaps/oss-review-toolkit
 [3]: https://ci.appveyor.com/api/projects/status/hbc1mn5hpo9a4hcq/branch/master?svg=true
 [4]: https://ci.appveyor.com/project/heremaps/oss-review-toolkit/branch/master
 [5]: https://codecov.io/gh/heremaps/oss-review-toolkit/branch/master/graph/badge.svg
 [6]: https://codecov.io/gh/heremaps/oss-review-toolkit/
+[7]: https://img.shields.io/badge/slack-ort--talk-blue.svg?longCache=true&logo=slack
+[8]: https://join.slack.com/t/ort-talk/shared_invite/enQtMzk3MDU5Njk0Njc1LWQwMDU3NDBjYmEzNGJkM2JiYTE2MmI0MzdhZDRiZjI0MWM3YjZlZGU2ODFhNjgwOTAyZTc5ZGRhZGEyNjMwYTc
 
 # Introduction
 


### PR DESCRIPTION
Added a link to our Slack to README.md. If someone has a suggestion for a pretty Slack badge I'm happy to take it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/814)
<!-- Reviewable:end -->
