### PR TITLE
cli: Handle exceptions thrown in report generation

### DIFF
--- a/cli/src/main/kotlin/Main.kt
+++ b/cli/src/main/kotlin/Main.kt
@@ -400,7 +400,13 @@ object Main {
             }
 
             reportFormats.distinct().forEach {
-                it.generateReport(ortResult, outputDir)
+                try {
+                    it.generateReport(ortResult, outputDir)
+                } catch (e: Exception) {
+                    e.showStackTrace()
+
+                    log.error { "Could not create '$it' report: ${e.message}" }
+                }
             }
         }
     }


### PR DESCRIPTION
If generating a report fails with an exception, catch it and continue
creating the other reports, instead of aborting the program.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/817)
<!-- Reviewable:end -->
