### PR TITLE
scanner: Do not keep all raw results in memory

### DIFF
--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -138,7 +138,10 @@ abstract class LocalScanner(config: ScannerConfiguration) : Scanner(config) {
             val result = try {
                 log.info { "Starting scan of '${pkg.id}' (${index + 1}/${packages.size})." }
 
-                scanPackage(scannerDetails, pkg, outputDirectory, downloadDirectory)
+                scanPackage(scannerDetails, pkg, outputDirectory, downloadDirectory).map {
+                    // Remove the now unneeded reference to rawResult here to allow garbage collection to clean it up.
+                    it.copy(rawResult = null)
+                }
             } catch (e: ScanException) {
                 val now = Instant.now()
                 listOf(ScanResult(

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -117,9 +117,7 @@ abstract class Scanner(protected val config: ScannerConfiguration) {
 
         val results = scan(packagesToScan.map { it.pkg }, outputDirectory, downloadDirectory)
         val resultContainers = results.map { (pkg, results) ->
-            // Remove the raw results from the scan results to reduce the size of the scan result.
-            // TODO: Consider adding an option to keep the raw results.
-            ScanResultContainer(pkg.id, results.map { it.copy(rawResult = null) })
+            ScanResultContainer(pkg.id, results)
         }.toSortedSet()
 
         // Add scan results from de-duplicated project packages to result.


### PR DESCRIPTION
Before the raw scan results for each package were kept in memory until the
scan of all packages finished. This could easily lead to OutOfMemoryErrors,
especially for scanners with large results files, like ScanCode.

To fix this remove the raw results from memory directly after the scan of a
package finished.

Note that raw results are still written to the scan results cache.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/818)
<!-- Reviewable:end -->
