### PR TITLE
analyzer: Update expected results with http URLs

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
@@ -2245,7 +2245,7 @@ packages:
       hash: ""
       hash_algorithm: ""
     source_artifact:
-      url: "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+      url: "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
       hash: "a8115c55e4a702fe4d150abd3872822a7e09fc98"
       hash_algorithm: "SHA-1"
     vcs:
@@ -3642,7 +3642,7 @@ packages:
       hash: ""
       hash_algorithm: ""
     source_artifact:
-      url: "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+      url: "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
       hash: "30057438eac6cf7f8c4767f38648d6697d75c903"
       hash_algorithm: "SHA-1"
     vcs:

--- a/analyzer/src/funTest/assets/projects/synthetic/yarn-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/yarn-expected-output.yml
@@ -753,7 +753,7 @@ packages:
       hash: ""
       hash_algorithm: ""
     source_artifact:
-      url: "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+      url: "http://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
       hash: "78203a4d1c328ae1d86dca6460e369b57f4055ae"
       hash_algorithm: "SHA-1"
     vcs:


### PR DESCRIPTION
For some reason the NPM registry started to return non-https URLs for
these.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/821)
<!-- Reviewable:end -->
