### PR TITLE
reporter-web-app: Fix to always set value of declared license to avoi…

### DIFF
--- a/reporter-web-app/src/utils.js
+++ b/reporter-web-app/src/utils.js
@@ -128,6 +128,9 @@ export function convertToRenderFormat(reportData) {
             pkgObj.declared_licenses = projectsFromAnalyzer[projectIndex].declared_licenses;
         } else if (packageFromAnalyzer) {
             pkgObj.declared_licenses = packageFromAnalyzer.declared_licenses;
+        } else {
+            pkgObj.declared_licenses = [];
+            console.error('Package ' + pkgObj.id + ' can not be found in Analyzer results');
         }
 
         addPackageLicensesToProject(


### PR DESCRIPTION
…d render crash

In some edge cases declared license is not set which resulted in the React UI to crash
Changed code to set default value to avoid crash and then throw error in browser console
making debugging of issue easier

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/825)
<!-- Reviewable:end -->
