### PR TITLE
model: Introduce a CustomData typealias

### DIFF
--- a/model/src/main/kotlin/AnalyzerResult.kt
+++ b/model/src/main/kotlin/AnalyzerResult.kt
@@ -53,7 +53,7 @@ data class AnalyzerResult(
          * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.
          */
         @JsonInclude(JsonInclude.Include.NON_EMPTY)
-        val data: Map<String, Any> = emptyMap()
+        val data: CustomData = emptyMap()
 ) {
     /**
      * True if there were any errors during the analysis, false otherwise.

--- a/model/src/main/kotlin/Model.kt
+++ b/model/src/main/kotlin/Model.kt
@@ -19,25 +19,4 @@
 
 package com.here.ort.model
 
-import com.fasterxml.jackson.annotation.JsonInclude
-
-/**
- * This class contains information about which values were changed when applying a curation.
- */
-data class PackageCurationResult(
-        /**
-         * Contains the values from before applying the [curation]. Values which were not changed are null.
-         */
-        val base: PackageCurationData,
-
-        /**
-         * The curation that was applied.
-         */
-        val curation: PackageCurationData,
-
-        /**
-         * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.
-         */
-        @JsonInclude(JsonInclude.Include.NON_EMPTY)
-        val data: CustomData = emptyMap()
-)
+typealias CustomData = Map<String, Any>

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -47,5 +47,5 @@ data class OrtResult(
          * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.
          */
         @JsonInclude(JsonInclude.Include.NON_EMPTY)
-        val data: Map<String, Any> = emptyMap()
+        val data: CustomData = emptyMap()
 )

--- a/model/src/main/kotlin/Package.kt
+++ b/model/src/main/kotlin/Package.kt
@@ -78,7 +78,7 @@ data class Package(
          * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.
          */
         @JsonInclude(JsonInclude.Include.NON_EMPTY)
-        val data: Map<String, Any> = emptyMap()
+        val data: CustomData = emptyMap()
 ) : Comparable<Package> {
     /**
      * A comparison function to sort packages by their identifier.

--- a/model/src/main/kotlin/PackageCurationData.kt
+++ b/model/src/main/kotlin/PackageCurationData.kt
@@ -77,7 +77,7 @@ data class PackageCurationData(
          * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.
          */
         @JsonInclude(JsonInclude.Include.NON_EMPTY)
-        val data: Map<String, Any> = emptyMap()
+        val data: CustomData = emptyMap()
 ) {
     /**
      * Apply the curation data to the provided package, by overriding all values of the original package with non-null

--- a/model/src/main/kotlin/PackageReference.kt
+++ b/model/src/main/kotlin/PackageReference.kt
@@ -55,7 +55,7 @@ data class PackageReference(
          * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.
          */
         @JsonInclude(JsonInclude.Include.NON_EMPTY)
-        val data: Map<String, Any> = emptyMap()
+        val data: CustomData = emptyMap()
 ) : Comparable<PackageReference> {
     /**
      * Return the set of identifiers for all packages references this package reference depends on.

--- a/model/src/main/kotlin/Project.kt
+++ b/model/src/main/kotlin/Project.kt
@@ -79,7 +79,7 @@ data class Project(
          * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.
          */
         @JsonInclude(JsonInclude.Include.NON_EMPTY)
-        val data: Map<String, Any> = emptyMap()
+        val data: CustomData = emptyMap()
 ) : Comparable<Project> {
     fun collectDependencyIds(includeErroneous: Boolean = true) = scopes.fold(sortedSetOf<Identifier>()) { ids, scope ->
         ids.also { it += scope.collectDependencyIds(includeErroneous) }

--- a/model/src/main/kotlin/Provenance.kt
+++ b/model/src/main/kotlin/Provenance.kt
@@ -64,7 +64,7 @@ data class Provenance(
          * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.
          */
         @JsonInclude(JsonInclude.Include.NON_EMPTY)
-        val data: Map<String, Any> = emptyMap()
+        val data: CustomData = emptyMap()
 ) {
     init {
         require(sourceArtifact == null || vcsInfo == null) {

--- a/model/src/main/kotlin/RemoteArtifact.kt
+++ b/model/src/main/kotlin/RemoteArtifact.kt
@@ -44,7 +44,7 @@ data class RemoteArtifact(
          * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.
          */
         @JsonInclude(JsonInclude.Include.NON_EMPTY)
-        val data: Map<String, Any> = emptyMap()
+        val data: CustomData = emptyMap()
 ) {
     companion object {
         /**

--- a/model/src/main/kotlin/ScanRecord.kt
+++ b/model/src/main/kotlin/ScanRecord.kt
@@ -48,7 +48,7 @@ data class ScanRecord(
          * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.
          */
         @JsonInclude(JsonInclude.Include.NON_EMPTY)
-        val data: Map<String, Any> = emptyMap()
+        val data: CustomData = emptyMap()
 ) {
     /**
      * True if any of the [scanResults] contain errors.

--- a/model/src/main/kotlin/ScanResult.kt
+++ b/model/src/main/kotlin/ScanResult.kt
@@ -54,5 +54,5 @@ data class ScanResult(
          * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.
          */
         @JsonInclude(JsonInclude.Include.NON_EMPTY)
-        val data: Map<String, Any> = emptyMap()
+        val data: CustomData = emptyMap()
 )

--- a/model/src/main/kotlin/ScanResultContainer.kt
+++ b/model/src/main/kotlin/ScanResultContainer.kt
@@ -39,7 +39,7 @@ data class ScanResultContainer(
          * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.
          */
         @JsonInclude(JsonInclude.Include.NON_EMPTY)
-        val data: Map<String, Any> = emptyMap()
+        val data: CustomData = emptyMap()
 ) : Comparable<ScanResultContainer> {
     /**
      * A comparison function to sort scan result containers by their identifier.

--- a/model/src/main/kotlin/ScannerDetails.kt
+++ b/model/src/main/kotlin/ScannerDetails.kt
@@ -48,7 +48,7 @@ data class ScannerDetails(
          * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.
          */
         @JsonInclude(JsonInclude.Include.NON_EMPTY)
-        val data: Map<String, Any> = emptyMap()
+        val data: CustomData = emptyMap()
 ) {
     private val MAJOR_MINOR = EnumSet.of(Semver.VersionDiff.MAJOR, Semver.VersionDiff.MINOR)
 

--- a/model/src/main/kotlin/Scope.kt
+++ b/model/src/main/kotlin/Scope.kt
@@ -56,7 +56,7 @@ data class Scope(
          * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.
          */
         @JsonInclude(JsonInclude.Include.NON_EMPTY)
-        val data: Map<String, Any> = emptyMap()
+        val data: CustomData = emptyMap()
 ) : Comparable<Scope> {
     fun collectDependencyIds(includeErroneous: Boolean = true, includeExcluded: Boolean = true) =
             dependencies.fold(sortedSetOf<Identifier>()) { ids, ref ->

--- a/model/src/main/kotlin/VcsInfo.kt
+++ b/model/src/main/kotlin/VcsInfo.kt
@@ -65,7 +65,7 @@ data class VcsInfo(
          * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.
          */
         @JsonInclude(JsonInclude.Include.NON_EMPTY)
-        val data: Map<String, Any> = emptyMap()
+        val data: CustomData = emptyMap()
 ) {
     companion object {
         /**


### PR DESCRIPTION
Introduce a typealias for the data maps. This ensures that all data maps
use the same data type, and allows for changing it in a central place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/839)
<!-- Reviewable:end -->
