### PR TITLE
reporter-web-app: Revert changes to for-loops

### DIFF
--- a/reporter-web-app/src/utils.js
+++ b/reporter-web-app/src/utils.js
@@ -435,7 +435,7 @@ export function convertToRenderFormat(reportData) {
     };
     const calculateNrPackagesLicenses = projectsLicenses => Object.values(projectsLicenses)
         .reduce((accumulator, projectLicenses) => {
-            Object.values(projectLicenses).forEach((license) => {
+            for (const license in projectLicenses) {
                 const licenseMap = projectLicenses[license];
 
                 if (!accumulator[license]) {
@@ -443,16 +443,16 @@ export function convertToRenderFormat(reportData) {
                 }
 
                 accumulator[license] += licenseMap.size;
-            });
+            }
             return accumulator;
         }, {});
     const calculateReportDataTotalLicenses = (projectsLicenses) => {
         const licensesSet = new Set([]);
 
         return Object.values(projectsLicenses).reduce((accumulator, projectLicenses) => {
-            Object.values(projectLicenses).forEach((license) => {
+            for (const license in projectLicenses) {
                 accumulator.add(license);
-            });
+            }
             return accumulator;
         }, licensesSet).size || undefined;
     };


### PR DESCRIPTION
These changes from 1d3f2d9 broke the report. A difference to using
forEach is that it does not enumerates properties in the prototype
chain, which probably caused the breakage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/841)
<!-- Reviewable:end -->
