### PR TITLE
ProcessCapture: Fix docs to say "standard error stream"

### DIFF
--- a/utils/src/main/kotlin/ProcessCapture.kt
+++ b/utils/src/main/kotlin/ProcessCapture.kt
@@ -64,7 +64,7 @@ class ProcessCapture(vararg command: String, workingDir: File? = null, environme
         get() = stdoutFile.readText()
 
     /**
-     * Get the standard errors stream of the terminated process as a string.
+     * Get the standard error stream of the terminated process as a string.
      */
     val stderr
         get() = stderrFile.readText()


### PR DESCRIPTION
Singular, not plural.