### PR TITLE
Introduce the concept of a CommandLineTool

### DIFF
--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -174,12 +174,6 @@ abstract class PackageManager(
     override fun toString(): String = javaClass.simpleName
 
     /**
-     * Return the name of the package manager's command line application. As the preferred command might depend on the
-     * working directory it needs to be provided.
-     */
-    abstract fun command(workingDir: File): String
-
-    /**
      * Return a tree of resolved dependencies (not necessarily declared dependencies, in case conflicts were resolved)
      * for each provided path.
      */

--- a/analyzer/src/main/kotlin/managers/Bower.kt
+++ b/analyzer/src/main/kotlin/managers/Bower.kt
@@ -24,8 +24,6 @@ import com.here.ort.analyzer.AbstractPackageManagerFactory
 import com.here.ort.model.config.AnalyzerConfiguration
 import com.here.ort.model.config.RepositoryConfiguration
 
-import java.io.File
-
 /**
  * The Bower package manager for JavaScript, see https://bower.io/.
  */
@@ -37,6 +35,4 @@ class Bower(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfigu
         override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
                 Bower(analyzerConfig, repoConfig)
     }
-
-    override fun command(workingDir: File) = "bower"
 }

--- a/analyzer/src/main/kotlin/managers/CocoaPods.kt
+++ b/analyzer/src/main/kotlin/managers/CocoaPods.kt
@@ -24,8 +24,6 @@ import com.here.ort.analyzer.AbstractPackageManagerFactory
 import com.here.ort.model.config.AnalyzerConfiguration
 import com.here.ort.model.config.RepositoryConfiguration
 
-import java.io.File
-
 /**
  * The CocoaPods package manager for Objective-C, see https://cocoapods.org/.
  */
@@ -37,6 +35,4 @@ class CocoaPods(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryCon
         override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
                 CocoaPods(analyzerConfig, repoConfig)
     }
-
-    override fun command(workingDir: File) = "pod"
 }

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -40,7 +40,6 @@ import com.here.ort.model.Scope
 import com.here.ort.model.VcsInfo
 import com.here.ort.model.config.AnalyzerConfiguration
 import com.here.ort.model.config.RepositoryConfiguration
-import com.here.ort.utils.OS
 import com.here.ort.utils.collectMessages
 import com.here.ort.utils.log
 import com.here.ort.utils.showStackTrace
@@ -102,16 +101,6 @@ class Gradle(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfig
     }
 
     private val maven = MavenSupport(GradleCacheReader())
-
-    override fun command(workingDir: File): String {
-        val (gradle, wrapper) = if (OS.isWindows) {
-            Pair("gradle.bat", "gradlew.bat")
-        } else {
-            Pair("gradle", "gradlew")
-        }
-
-        return if (File(workingDir, wrapper).isFile) wrapper else gradle
-    }
 
     override fun resolveDependencies(definitionFile: File): ProjectAnalyzerResult? {
         val gradleConnection = GradleConnector

--- a/analyzer/src/main/kotlin/managers/Maven.kt
+++ b/analyzer/src/main/kotlin/managers/Maven.kt
@@ -92,8 +92,6 @@ class Maven(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfigu
      */
     fun enableSbtMode() = this.apply { sbtMode = true }
 
-    override fun command(workingDir: File) = "mvn"
-
     override fun prepareResolution(definitionFiles: List<File>): List<File> {
         val projectBuilder = maven.container.lookup(ProjectBuilder::class.java, "default")
         val projectBuildingRequest = maven.createProjectBuildingRequest(false)

--- a/analyzer/src/main/kotlin/managers/Stack.kt
+++ b/analyzer/src/main/kotlin/managers/Stack.kt
@@ -36,6 +36,7 @@ import com.here.ort.model.Scope
 import com.here.ort.model.VcsInfo
 import com.here.ort.model.config.AnalyzerConfiguration
 import com.here.ort.model.config.RepositoryConfiguration
+import com.here.ort.utils.CommandLineTool
 import com.here.ort.utils.OkHttpClientHelper
 import com.here.ort.utils.ProcessCapture
 import com.here.ort.utils.log
@@ -56,7 +57,7 @@ import java.util.SortedSet
  * The Stack package manager for Haskell, see https://haskellstack.org/.
  */
 class Stack(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
-        PackageManager(analyzerConfig, repoConfig) {
+        PackageManager(analyzerConfig, repoConfig), CommandLineTool {
     class Factory : AbstractPackageManagerFactory<Stack>() {
         override val globsForDefinitionFiles = listOf("stack.yaml")
 
@@ -64,7 +65,7 @@ class Stack(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfigu
                 Stack(analyzerConfig, repoConfig)
     }
 
-    override fun command(workingDir: File) = "stack"
+    override fun command(workingDir: File?) = "stack"
 
     override fun resolveDependencies(definitionFile: File): ProjectAnalyzerResult? {
         val workingDir = definitionFile.parentFile
@@ -90,7 +91,7 @@ class Stack(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfigu
             // Delete any left-overs from interrupted stack runs.
             File(workingDir, ".stack-work").safeDeleteRecursively()
 
-            return ProcessCapture(workingDir, command(workingDir), *command).requireSuccess()
+            return run(workingDir, *command)
         }
 
         fun mapParentsToChildren(scope: String): Map<String, List<String>> {

--- a/analyzer/src/main/kotlin/managers/Unmanaged.kt
+++ b/analyzer/src/main/kotlin/managers/Unmanaged.kt
@@ -43,8 +43,6 @@ class Unmanaged(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryCon
                 Unmanaged(analyzerConfig, repoConfig)
     }
 
-    override fun command(workingDir: File) = throw NotImplementedError()
-
     /**
      * Return a [ProjectAnalyzerResult] for the [Project] contained in the [definitionFile] directory, but does not
      * perform any dependency resolution.

--- a/analyzer/src/main/kotlin/managers/Yarn.kt
+++ b/analyzer/src/main/kotlin/managers/Yarn.kt
@@ -23,7 +23,6 @@ import com.here.ort.analyzer.AbstractPackageManagerFactory
 import com.here.ort.model.config.AnalyzerConfiguration
 import com.here.ort.model.config.RepositoryConfiguration
 import com.here.ort.utils.OS
-import com.here.ort.utils.checkCommandVersion
 
 import com.vdurmont.semver4j.Requirement
 
@@ -43,15 +42,12 @@ class Yarn(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfigur
 
     override val recognizedLockFiles = listOf("yarn.lock")
 
-    override fun command(workingDir: File) = if (OS.isWindows) { "yarn.cmd" } else { "yarn" }
+    override fun command(workingDir: File?) = if (OS.isWindows) "yarn.cmd" else "yarn"
 
     override fun prepareResolution(definitionFiles: List<File>): List<File> {
-        val workingDir = definitionFiles.first().parentFile
-
         // We do not actually depend on any features specific to a Yarn version, but we still want to stick to a fixed
         // minor version to be sure to get consistent results.
-        checkCommandVersion(command(workingDir), Requirement.buildNPM("1.3.* - 1.9.*"),
-                ignoreActualVersion = analyzerConfig.ignoreToolVersions)
+        checkVersion(Requirement.buildNPM("1.3.* - 1.9.*"), ignoreActualVersion = analyzerConfig.ignoreToolVersions)
 
         // Map "yarn.lock" files to existing "package.json" files for use by the NPM class (which in this case calls
         // "yarn" to install the dependencies).

--- a/downloader/src/main/kotlin/vcs/Cvs.kt
+++ b/downloader/src/main/kotlin/vcs/Cvs.kt
@@ -24,8 +24,8 @@ import ch.frankel.slf4k.*
 import com.here.ort.downloader.DownloadException
 import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.Package
+import com.here.ort.utils.CommandLineTool
 import com.here.ort.utils.ProcessCapture
-import com.here.ort.utils.getCommandVersion
 import com.here.ort.utils.log
 import com.here.ort.utils.safeDeleteRecursively
 import com.here.ort.utils.searchUpwardsForSubdirectory
@@ -40,24 +40,24 @@ import org.apache.commons.codec.digest.DigestUtils
 
 typealias CvsFileRevisions = List<Pair<String, String>>
 
-class Cvs : VersionControlSystem() {
+class Cvs : VersionControlSystem(), CommandLineTool {
+    private val versionRegex = Pattern.compile("Concurrent Versions System \\(CVS\\) (?<version>[\\d.]+).+")
+
     override val aliases = listOf("cvs")
-    override val commandName = "cvs"
     override val latestRevisionNames = emptyList<String>()
 
-    override fun getVersion(): String {
-        val versionRegex = Pattern.compile("Concurrent Versions System \\(CVS\\) (?<version>[\\d.]+).+")
+    override fun command(workingDir: File?) = "cvs"
 
-        return getCommandVersion("cvs") { output ->
-            versionRegex.matcher(output.lineSequence().first()).let {
-                if (it.matches()) {
-                    it.group("version")
-                } else {
-                    ""
+    override fun getVersion() =
+            getVersion { output ->
+                versionRegex.matcher(output.lineSequence().first()).let {
+                    if (it.matches()) {
+                        it.group("version")
+                    } else {
+                        ""
+                    }
                 }
             }
-        }
-    }
 
     override fun getWorkingTree(vcsDirectory: File) =
             object : WorkingTree(vcsDirectory) {

--- a/downloader/src/main/kotlin/vcs/GitBase.kt
+++ b/downloader/src/main/kotlin/vcs/GitBase.kt
@@ -20,29 +20,29 @@
 package com.here.ort.downloader.vcs
 
 import com.here.ort.downloader.VersionControlSystem
+import com.here.ort.utils.CommandLineTool
 import com.here.ort.utils.ProcessCapture
-import com.here.ort.utils.getCommandVersion
 
 import java.io.File
 import java.util.regex.Pattern
 
-abstract class GitBase : VersionControlSystem() {
-    override val commandName = "git"
+abstract class GitBase : VersionControlSystem(), CommandLineTool {
+    private val versionRegex = Pattern.compile("[Gg]it [Vv]ersion (?<version>[\\d.a-z-]+)(\\s.+)?")
+
     override val latestRevisionNames = listOf("HEAD", "@")
 
-    override fun getVersion(): String {
-        val versionRegex = Pattern.compile("[Gg]it [Vv]ersion (?<version>[\\d.a-z-]+)(\\s.+)?")
+    override fun command(workingDir: File?) = "git"
 
-        return getCommandVersion("git") { output ->
-            versionRegex.matcher(output.lineSequence().first()).let {
-                if (it.matches()) {
-                    it.group("version")
-                } else {
-                    ""
+    override fun getVersion() =
+            getVersion { output ->
+                versionRegex.matcher(output.lineSequence().first()).let {
+                    if (it.matches()) {
+                        it.group("version")
+                    } else {
+                        ""
+                    }
                 }
             }
-        }
-    }
 
     open inner class GitWorkingTree(workingDir: File) : WorkingTree(workingDir) {
         override fun isValid(): Boolean {

--- a/downloader/src/main/kotlin/vcs/Mercurial.kt
+++ b/downloader/src/main/kotlin/vcs/Mercurial.kt
@@ -24,8 +24,8 @@ import ch.frankel.slf4k.*
 import com.here.ort.downloader.DownloadException
 import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.Package
+import com.here.ort.utils.CommandLineTool
 import com.here.ort.utils.ProcessCapture
-import com.here.ort.utils.getCommandVersion
 import com.here.ort.utils.log
 import com.here.ort.utils.showStackTrace
 import com.here.ort.utils.spdx.LICENSE_FILE_NAMES
@@ -37,24 +37,24 @@ import java.util.regex.Pattern
 const val MERCURIAL_LARGE_FILES_EXTENSION = "largefiles = "
 const val MERCURIAL_SPARSE_EXTENSION = "sparse = "
 
-class Mercurial : VersionControlSystem() {
+class Mercurial : VersionControlSystem(), CommandLineTool {
+    private val versionRegex = Pattern.compile("Mercurial .*\\([Vv]ersion (?<version>[\\d.]+)\\)")
+
     override val aliases = listOf("mercurial", "hg")
-    override val commandName = "hg"
     override val latestRevisionNames = listOf("tip")
 
-    override fun getVersion(): String {
-        val versionRegex = Pattern.compile("Mercurial .*\\([Vv]ersion (?<version>[\\d.]+)\\)")
+    override fun command(workingDir: File?) = "hg"
 
-        return getCommandVersion("hg") { output ->
-            versionRegex.matcher(output.lineSequence().first()).let {
-                if (it.matches()) {
-                    it.group("version")
-                } else {
-                    ""
+    override fun getVersion() =
+            getVersion { output ->
+                versionRegex.matcher(output.lineSequence().first()).let {
+                    if (it.matches()) {
+                        it.group("version")
+                    } else {
+                        ""
+                    }
                 }
             }
-        }
-    }
 
     override fun getWorkingTree(vcsDirectory: File) =
             object : WorkingTree(vcsDirectory) {

--- a/downloader/src/main/kotlin/vcs/Subversion.kt
+++ b/downloader/src/main/kotlin/vcs/Subversion.kt
@@ -30,8 +30,8 @@ import com.here.ort.downloader.DownloadException
 import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.Package
 import com.here.ort.model.xmlMapper
+import com.here.ort.utils.CommandLineTool
 import com.here.ort.utils.ProcessCapture
-import com.here.ort.utils.getCommandVersion
 import com.here.ort.utils.log
 import com.here.ort.utils.showStackTrace
 
@@ -89,24 +89,24 @@ data class SubversionPathEntry(
         val commit: SubversionInfoCommit,
         val lock: SubversionInfoLock?)
 
-class Subversion : VersionControlSystem() {
+class Subversion : VersionControlSystem(), CommandLineTool {
+    private val versionRegex = Pattern.compile("svn, [Vv]ersion (?<version>[\\d.]+) \\(r\\d+\\)")
+
     override val aliases = listOf("subversion", "svn")
-    override val commandName = "svn"
     override val latestRevisionNames = listOf("HEAD")
 
-    override fun getVersion(): String {
-        val versionRegex = Pattern.compile("svn, [Vv]ersion (?<version>[\\d.]+) \\(r\\d+\\)")
+    override fun command(workingDir: File?) = "svn"
 
-        return getCommandVersion("svn") { output ->
-            versionRegex.matcher(output.lineSequence().first()).let {
-                if (it.matches()) {
-                    it.group("version")
-                } else {
-                    ""
+    override fun getVersion() =
+            getVersion { output ->
+                versionRegex.matcher(output.lineSequence().first()).let {
+                    if (it.matches()) {
+                        it.group("version")
+                    } else {
+                        ""
+                    }
                 }
             }
-        }
-    }
 
     override fun getWorkingTree(vcsDirectory: File) =
             object : WorkingTree(vcsDirectory) {

--- a/scanner/src/main/kotlin/scanners/FileCounter.kt
+++ b/scanner/src/main/kotlin/scanners/FileCounter.kt
@@ -47,12 +47,13 @@ class FileCounter(config: ScannerConfiguration) : LocalScanner(config) {
     data class FileCountResult(val fileCount: Int)
 
     override val resultFileExt = "json"
-    override val scannerExe = ""
     override val scannerVersion = "1.0"
 
-    override fun getConfiguration() = ""
+    override fun command(workingDir: File?) = ""
 
     override fun getVersion(dir: File) = scannerVersion
+
+    override fun getConfiguration() = ""
 
     override fun scanPath(scannerDetails: ScannerDetails, path: File, provenance: Provenance, resultsFile: File)
             : ScanResult {

--- a/utils/src/main/kotlin/CommandLineTool.kt
+++ b/utils/src/main/kotlin/CommandLineTool.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2017-2018 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.utils
+
+import ch.frankel.slf4k.*
+
+import com.vdurmont.semver4j.Requirement
+import com.vdurmont.semver4j.Semver
+
+import java.io.File
+import java.io.IOException
+
+/**
+ * An interface to implement by classes that are backed by a command line tool.
+ */
+interface CommandLineTool {
+    /**
+     * Return the name of the executable command. As the preferred command might depend on the directory to operate in
+     * the [workingDir] can be provided.
+     */
+    fun command(workingDir: File? = null): String
+
+    /**
+     * Return whether the executable for this command is available in the system PATH.
+     */
+    fun isInPath() = getPathFromEnvironment(command()) != null
+
+    /**
+     * Run the command in the [workingDir] directory with arguments as specified by [args] and the given [environment].
+     */
+    fun run(vararg args: String, workingDir: File? = null, environment: Map<String, String> = emptyMap()) =
+            ProcessCapture(command(workingDir), *args, workingDir = workingDir, environment = environment)
+                    .requireSuccess()
+
+    /**
+     * Run the command in the [workingDir] directory with arguments as specified by [args].
+     */
+    fun run(workingDir: File?, vararg args: String) =
+            ProcessCapture(workingDir, command(workingDir), *args).requireSuccess()
+
+    /**
+     * Get the version of the command by parsing its output.
+     */
+    fun getVersion(versionArguments: String = "--version", workingDir: File? = null,
+                   transform: (String) -> String = { it }): String {
+        val version = run(*versionArguments.split(' ').toTypedArray())
+
+        // Some tools actually report the version to stderr, so try that as a fallback.
+        val versionString = sequenceOf(version.stdout, version.stderr).map {
+            transform(it.trim())
+        }.find {
+            it.isNotBlank()
+        }
+
+        return versionString ?: ""
+    }
+
+    /**
+     * Run a [command] to check its version against a [requirement].
+     */
+    fun checkVersion(
+            requirement: Requirement,
+            versionArguments: String = "--version",
+            ignoreActualVersion: Boolean = false,
+            workingDir: File? = null,
+            transform: (String) -> String = { it }
+    ) {
+        val toolVersionOutput = getVersion(versionArguments, workingDir, transform)
+        val actualVersion = Semver(toolVersionOutput, Semver.SemverType.LOOSE)
+
+        if (!requirement.isSatisfiedBy(actualVersion)) {
+            val message = "Unsupported ${command()} version $actualVersion does not fulfill $requirement."
+            if (ignoreActualVersion) {
+                log.warn { "$message Still continuing because you chose to ignore the actual version." }
+            } else {
+                throw IOException(message)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add an interface to implement by all classes that are backed by a command
line tool. This makes it easier to identify our external dependencies on
command line tools and reduces code duplication.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/848)
<!-- Reviewable:end -->
