### PR TITLE
reporter: Re-implement exclusion of projects and scopes in notice reporter

### DIFF
--- a/model/src/main/kotlin/config/Excludes.kt
+++ b/model/src/main/kotlin/config/Excludes.kt
@@ -21,6 +21,11 @@ package com.here.ort.model.config
 
 import com.fasterxml.jackson.annotation.JsonInclude
 
+import com.here.ort.model.AnalyzerResult
+import com.here.ort.model.Identifier
+import com.here.ort.model.Project
+import com.here.ort.model.Scope
+
 /**
  * Defines which parts of a repository should be excluded.
  */
@@ -36,4 +41,32 @@ data class Excludes(
          */
         @JsonInclude(JsonInclude.Include.NON_EMPTY)
         val scopes: List<ScopeExclude> = emptyList()
-)
+) {
+    /**
+     * Return the [ProjectExclude] for the provided [project], or null if there is none.
+     */
+    fun findProjectExclude(project: Project) = projects.find { it.path == project.definitionFilePath }
+
+    /**
+     * True if all occurrences of the package identified by [id] in the [analyzerResult] are excluded by this [Excludes]
+     * configuration.
+     */
+    fun isPackageExcluded(id: Identifier, analyzerResult: AnalyzerResult) =
+            analyzerResult.projects.all { project ->
+                isProjectExcluded(project) || project.scopes.all { scope ->
+                    isScopeExcluded(scope, project) || !scope.contains(id)
+                }
+            }
+
+    /**
+     * True if the [project] is excluded by this [Excludes] configuration.
+     */
+    fun isProjectExcluded(project: Project) = projects.any { it.path == project.definitionFilePath && it.exclude }
+
+    /**
+     * True if the [scope] is excluded in [project] by this [Excludes] configuration.
+     */
+    fun isScopeExcluded(scope: Scope, project: Project) =
+            scopes.any { it.name == scope.name }
+                    || findProjectExclude(project)?.scopes?.any { it.name == scope.name } ?: false
+}

--- a/reporter/src/main/kotlin/reporters/NoticeReporter.kt
+++ b/reporter/src/main/kotlin/reporters/NoticeReporter.kt
@@ -37,6 +37,8 @@ class NoticeReporter : Reporter() {
             "The provided ORT result file does not contain a scan record."
         }
 
+        val excludes = ortResult.repository.config.excludes
+        val analyzerResult = ortResult.analyzer!!.result
         val scanRecord = ortResult.scanner!!.results
 
         val outputFile = File(outputDir, NOTICE_FILE_NAME)
@@ -46,9 +48,11 @@ class NoticeReporter : Reporter() {
         // TODO: Decide whether we want to merge the list of detected licenses with declared licenses (which do not come
         // with a copyright).
         scanRecord.scanResults.forEach { container ->
-            container.results.forEach { result ->
-                result.summary.licenseFindings.forEach { licenseFinding ->
-                    allFindings.getOrPut(licenseFinding.license) { sortedSetOf() } += licenseFinding.copyrights
+            if (excludes == null || !excludes.isPackageExcluded(container.id, analyzerResult)) {
+                container.results.forEach { result ->
+                    result.summary.licenseFindings.forEach { licenseFinding ->
+                        allFindings.getOrPut(licenseFinding.license) { sortedSetOf() } += licenseFinding.copyrights
+                    }
                 }
             }
         }

--- a/reporter/src/test/assets/npm-test-with-exclude-NOTICE
+++ b/reporter/src/test/assets/npm-test-with-exclude-NOTICE
@@ -24,3 +24,17 @@ Redistribution and use in source and binary forms, with or without modification,
 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+----
+
+Copyright (c) 2014
+
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/reporter/src/test/assets/npm-test-with-exclude-scan-results.yml
+++ b/reporter/src/test/assets/npm-test-with-exclude-scan-results.yml
@@ -14,12 +14,8 @@ repository:
     excludes:
       scopes:
       - name: "devDependencies"
-        reason: "OTHER"
+        reason: "TEST_CASE_OF"
         comment: "Test dependencies."
-      packages:
-      - id: "NPM::dom-serializer:0.1.0"
-        reason: "OTHER"
-        comment: "Not distributed."
 analyzer:
   environment:
     os: "Linux"
@@ -58,7 +54,6 @@ analyzer:
               dependencies: []
               errors: []
             errors: []
-            excluded: true
           - id: "NPM::domelementtype:1.3.0"
             dependencies: []
             errors: []
@@ -80,7 +75,6 @@ analyzer:
             dependencies: []
             errors: []
           errors: []
-        excluded: true
     packages:
     - package:
         id: "NPM::boolbase:1.0.0"

--- a/reporter/src/test/kotlin/reporters/NoticeReporterTest.kt
+++ b/reporter/src/test/kotlin/reporters/NoticeReporterTest.kt
@@ -57,8 +57,7 @@ class NoticeReporterTest : WordSpec({
             resultFile.readText() shouldBe expectedResultFile.readText()
         }
 
-        // The test will be enabled again after re-implementing the exclusion logic in NoticeReporter.
-        "not contain licenses of excluded packages".config(enabled = false) {
+        "not contain licenses of excluded packages" {
             val expectedResultFile = File("src/test/assets/npm-test-with-exclude-NOTICE")
             val scanRecordFile = File("src/test/assets/npm-test-with-exclude-scan-results.yml")
             val ortResult = scanRecordFile.readValue(OrtResult::class.java)


### PR DESCRIPTION
Do not add licenses and copyright for packages that only appear in excluded
projects or scopes to the generated LICENSE file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/852)
<!-- Reviewable:end -->
