### PR TITLE
Work around a regression to call tools with absolute paths

### DIFF
--- a/downloader/src/main/kotlin/DownloadException.kt
+++ b/downloader/src/main/kotlin/DownloadException.kt
@@ -20,7 +20,7 @@
 package com.here.ort.downloader
 
 class DownloadException : Exception {
-    constructor(cause: Exception): super(cause)
-    constructor(message: String): super(message)
-    constructor(message: String, cause: Exception?): super(message, cause)
+    constructor(cause: Exception?): super(cause)
+    constructor(message: String?): super(message)
+    constructor(message: String?, cause: Exception?): super(message, cause)
 }

--- a/scanner/src/main/kotlin/ScanException.kt
+++ b/scanner/src/main/kotlin/ScanException.kt
@@ -20,7 +20,7 @@
 package com.here.ort.scanner
 
 class ScanException : Exception {
-    constructor(cause: Exception): super(cause)
-    constructor(message: String): super(message)
-    constructor(message: String, cause: Exception?): super(message, cause)
+    constructor(cause: Exception?): super(cause)
+    constructor(message: String?): super(message)
+    constructor(message: String?, cause: Exception?): super(message, cause)
 }

--- a/scanner/src/main/kotlin/scanners/Askalono.kt
+++ b/scanner/src/main/kotlin/scanners/Askalono.kt
@@ -35,6 +35,7 @@ import com.here.ort.scanner.LocalScanner
 import com.here.ort.scanner.ScanException
 import com.here.ort.scanner.AbstractScannerFactory
 import com.here.ort.scanner.HTTP_CACHE_PATH
+import com.here.ort.utils.CommandLineTool
 import com.here.ort.utils.OkHttpClientHelper
 import com.here.ort.utils.OS
 import com.here.ort.utils.ProcessCapture
@@ -68,11 +69,17 @@ class Askalono(config: ScannerConfiguration) : LocalScanner(config) {
         return "askalono.$extension"
     }
 
-    override fun getVersion(dir: File) =
-            getVersion(workingDir = dir, transform = {
-                // "askalono --version" returns a string like "askalono 0.2.0-beta.1", so simply remove the prefix.
-                it.substringAfter("askalono ")
-            })
+    override fun getVersion(dir: File): String {
+        val cmd = command()
+        val tool = object : CommandLineTool {
+            override fun command(workingDir: File?) = dir.resolve(cmd).absolutePath
+        }
+
+        return tool.getVersion(transform = {
+            // "askalono --version" returns a string like "askalono 0.2.0-beta.1", so simply remove the prefix.
+            it.substringAfter("askalono ")
+        })
+    }
 
     override fun bootstrap(): File {
         val scannerExe = command()

--- a/scanner/src/main/kotlin/scanners/BoyterLc.kt
+++ b/scanner/src/main/kotlin/scanners/BoyterLc.kt
@@ -35,6 +35,7 @@ import com.here.ort.scanner.LocalScanner
 import com.here.ort.scanner.ScanException
 import com.here.ort.scanner.AbstractScannerFactory
 import com.here.ort.scanner.HTTP_CACHE_PATH
+import com.here.ort.utils.CommandLineTool
 import com.here.ort.utils.OkHttpClientHelper
 import com.here.ort.utils.OS
 import com.here.ort.utils.ProcessCapture
@@ -65,11 +66,17 @@ class BoyterLc(config: ScannerConfiguration) : LocalScanner(config) {
 
     override fun command(workingDir: File?) = if (OS.isWindows) "lc.exe" else "lc"
 
-    override fun getVersion(dir: File) =
-            getVersion(workingDir = dir, transform = {
-                // "lc --version" returns a string like "licensechecker version 1.1.1", so simply remove the prefix.
-                it.substringAfter("licensechecker version ")
-            })
+    override fun getVersion(dir: File): String {
+        val cmd = command()
+        val tool = object : CommandLineTool {
+            override fun command(workingDir: File?) = dir.resolve(cmd).absolutePath
+        }
+
+        return tool.getVersion(transform = {
+            // "lc --version" returns a string like "licensechecker version 1.1.1", so simply remove the prefix.
+            it.substringAfter("licensechecker version ")
+        })
+    }
 
     override fun bootstrap(): File {
         val platform = when {

--- a/scanner/src/main/kotlin/scanners/Licensee.kt
+++ b/scanner/src/main/kotlin/scanners/Licensee.kt
@@ -34,6 +34,7 @@ import com.here.ort.model.jsonMapper
 import com.here.ort.scanner.LocalScanner
 import com.here.ort.scanner.ScanException
 import com.here.ort.scanner.AbstractScannerFactory
+import com.here.ort.utils.CommandLineTool
 import com.here.ort.utils.OS
 import com.here.ort.utils.ProcessCapture
 import com.here.ort.utils.getPathFromEnvironment
@@ -55,7 +56,14 @@ class Licensee(config: ScannerConfiguration) : LocalScanner(config) {
 
     override fun command(workingDir: File?) = if (OS.isWindows) "licensee.bat" else "licensee"
 
-    override fun getVersion(dir: File) = getVersion("version", workingDir = dir)
+    override fun getVersion(dir: File): String {
+        val cmd = command()
+        val tool = object : CommandLineTool {
+            override fun command(workingDir: File?) = dir.resolve(cmd).absolutePath
+        }
+
+        return tool.getVersion("version")
+    }
 
     override fun bootstrap(): File {
         val gem = if (OS.isWindows) "gem.cmd" else "gem"

--- a/scanner/src/main/kotlin/scanners/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/ScanCode.kt
@@ -36,6 +36,7 @@ import com.here.ort.model.jsonMapper
 import com.here.ort.scanner.LocalScanner
 import com.here.ort.scanner.ScanException
 import com.here.ort.scanner.AbstractScannerFactory
+import com.here.ort.utils.CommandLineTool
 import com.here.ort.utils.OS
 import com.here.ort.utils.ProcessCapture
 import com.here.ort.utils.log
@@ -111,12 +112,18 @@ class ScanCode(config: ScannerConfiguration) : LocalScanner(config) {
 
     override fun command(workingDir: File?) = if (OS.isWindows) "scancode.bat" else "scancode"
 
-    override fun getVersion(dir: File) =
-            getVersion(workingDir = dir, transform = {
-                // "scancode --version" returns a string like "ScanCode version 2.0.1.post1.fb67a181", so simply remove
-                // the prefix.
-                it.substringAfter("ScanCode version ")
-            })
+    override fun getVersion(dir: File): String {
+        val cmd = command()
+        val tool = object : CommandLineTool {
+            override fun command(workingDir: File?) = dir.resolve(cmd).absolutePath
+        }
+
+        return tool.getVersion(transform = {
+            // "scancode --version" returns a string like "ScanCode version 2.0.1.post1.fb67a181", so simply remove
+            // the prefix.
+            it.substringAfter("ScanCode version ")
+        })
+    }
 
     override fun bootstrap(): File {
         val gitRoot = File(".").searchUpwardsForSubdirectory(".git")

--- a/utils/src/main/kotlin/CommandLineTool.kt
+++ b/utils/src/main/kotlin/CommandLineTool.kt
@@ -60,7 +60,7 @@ interface CommandLineTool {
      */
     fun getVersion(versionArguments: String = "--version", workingDir: File? = null,
                    transform: (String) -> String = { it }): String {
-        val version = run(*versionArguments.split(' ').toTypedArray())
+        val version = run(workingDir, *versionArguments.split(' ').toTypedArray())
 
         // Some tools actually report the version to stderr, so try that as a fallback.
         val versionString = sequenceOf(version.stdout, version.stderr).map {


### PR DESCRIPTION
Please have a look at the individual commit messages for the details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/856)
<!-- Reviewable:end -->
