### PR TITLE
reporter-web-app: Support bootstrapping NPM and Yarn

### DIFF
--- a/reporter-web-app/build.gradle
+++ b/reporter-web-app/build.gradle
@@ -5,7 +5,10 @@ plugins {
 node {
     version = '8.11.4'
     yarnVersion = '1.9.4'
-
+    // Installing NPM is needed for installing Yarn because the Gradle Node plugin installs Yarn via NPM.
+    npmVersion = '6.4.0'
+    // Setting download flag is required for bootstrapping NPM.
+    download = true
     nodeModulesDir = file("${project.projectDir}/node")
 }
 


### PR DESCRIPTION
NPM needs to be installed in order to bootstrap Yarn
since the Gradle Node plugin install Yarn via NPM. For
this installation to work the download flag needs to
be set.

Also for not nefatively affecting reproducibility of
build setting a fixed NPM version.

See also the related issue [2] and open pull request [1].

[1] srs/gradle-node-plugin#186
[2] srs/gradle-node-plugin#175

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/862)
<!-- Reviewable:end -->
