### PR TITLE
Gradle: Upgrade to Kotlin 1.2.70

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
@@ -4074,7 +4074,7 @@ packages:
       hash: ""
       hash_algorithm: ""
     source_artifact:
-      url: "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz"
+      url: "http://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz"
       hash: "4ed0ad060df3073300c48440373f72d1cc642d78"
       hash_algorithm: "SHA-1"
     vcs:

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     // We need to hard-code the version here because of
     // https://github.com/gradle/gradle/issues/1697
-    id 'org.jetbrains.kotlin.jvm' version '1.2.61' apply false
+    id 'org.jetbrains.kotlin.jvm' version '1.2.70' apply false
     id 'org.jetbrains.dokka' version '0.9.16' apply false
 
     // Note that the detekt Gradle plugin version does not necessarily
@@ -96,7 +96,7 @@ subprojects {
     // TODO: Remove this once jackson-module-kotlin and kotlintest are updated.
     configurations.all {
         resolutionStrategy {
-            force 'org.jetbrains.kotlin:kotlin-reflect:1.2.61'
+            force 'org.jetbrains.kotlin:kotlin-reflect:1.2.70'
         }
     }
 


### PR DESCRIPTION
See https://blog.jetbrains.com/kotlin/2018/09/kotlin-1-2-70-is-out/.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/865)
<!-- Reviewable:end -->
