### PR TITLE
Do not use the Gradle daemon in CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -49,21 +49,20 @@ install:
 
 # Do something useful here to override the default MSBuild (which would fail otherwise).
 build_script:
+  - echo org.gradle.daemon=false>>%HOME%\.gradle\gradle.properties
   - echo org.gradle.java.home=C:/Program Files/Java/jdk9>>%HOME%\.gradle\gradle.properties
-  - gradlew dokkaJar
+
+test_script:
+  - if "%APPVEYOR_SCHEDULED_BUILD%"=="True" (
+      gradlew --stacktrace dokkaJar check
+    ) else (
+      gradlew -Dkotlintest.tags.exclude=ExpensiveTag --stacktrace dokkaJar check
+    )
 
 artifacts:
   - path: '**\build\libs\*-dokka.jar'
 
-test_script:
-  - if "%APPVEYOR_SCHEDULED_BUILD%"=="True" (
-      gradlew --stacktrace check
-    ) else (
-      gradlew -Dkotlintest.tags.exclude=ExpensiveTag --stacktrace check
-    )
-
 on_finish:
-  - gradlew --stop # Fix "fileHashes.bin" being used by another process.
   - ps: |
       $url = "https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)"
       $pattern = '**\build\test-results\**\TEST-*.xml'

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,9 +51,9 @@ script:
     fi
   - set -o pipefail
   - if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
-      ./gradlew -Dkotlintest.tags.exclude=ScanCodeTag --stacktrace check jacocoReport | tee log.txt;
+      ./gradlew --no-daemon -Dkotlintest.tags.exclude=ScanCodeTag --stacktrace check jacocoReport | tee log.txt;
     else
-      ./gradlew -Dkotlintest.tags.exclude=ExpensiveTag --stacktrace check jacocoReport | tee log.txt;
+      ./gradlew --no-daemon -Dkotlintest.tags.exclude=ExpensiveTag --stacktrace check jacocoReport | tee log.txt;
     fi
   - if grep -A1 ".+Test.+STARTED$" log.txt | grep -q "^:"; then
       echo "Some tests seemingly have been aborted.";


### PR DESCRIPTION
This avoids potential file locking issues on Windows. Using the daemon
does not pay off anyway as we only launch Gradle once now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/869)
<!-- Reviewable:end -->
