### PR TITLE
Utils: Use a temporary file for redirecting output

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,6 +26,7 @@ install:
   - pip install virtualenv==15.1.0
   - cinst haskell-stack --version 1.7.1 -y
   - stack setup > nul # This installs the whole GHC to an isolated location!
+  - cinst sbt --version 1.0.2 -y
   - cinst php --version 7.2.0 -y
   - cinst composer --version 4.8.0 -y # The version refers to the installer, not to Composer.
   - cd c:\tools\php72 # For some reason pushd / popd does not work.

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ install:
   - curl https://raw.githubusercontent.com/golang/dep/7d5cd199ce454707f81c63b7ea4299151b8b981d/install.sh | sh
   - npm install -g bower@1.8.4 npm@6.4.0 yarn@1.9.4
   - phpenv global 7.1
+  - curl -Ls https://git.io/sbt > ~/bin/sbt
+  - chmod a+x ~/bin/sbt
   - curl -sSL https://get.haskellstack.org/ | sh
   - stack setup > /dev/null # This installs the whole GHC to an isolated location!
   - curl https://storage.googleapis.com/git-repo-downloads/repo > ~/bin/repo

--- a/analyzer/build.gradle
+++ b/analyzer/build.gradle
@@ -29,6 +29,4 @@ dependencies {
     implementation "org.apache.maven.resolver:maven-resolver-transport-wagon:$mavenResolverVersion"
 
     implementation "org.gradle:gradle-tooling-api:${gradle.gradleVersion}"
-
-    implementation "org.scala-sbt:sbt-launch:$sbtLaunchVersion"
 }

--- a/analyzer/src/main/kotlin/managers/SBT.kt
+++ b/analyzer/src/main/kotlin/managers/SBT.kt
@@ -25,12 +25,9 @@ import com.here.ort.analyzer.PackageManager
 import com.here.ort.analyzer.AbstractPackageManagerFactory
 import com.here.ort.model.config.AnalyzerConfiguration
 import com.here.ort.model.config.RepositoryConfiguration
+import com.here.ort.utils.CommandLineTool
+import com.here.ort.utils.OS
 import com.here.ort.utils.log
-import com.here.ort.utils.redirectStderr
-import com.here.ort.utils.redirectStdout
-import com.here.ort.utils.suppressInput
-import com.here.ort.utils.temporaryProperties
-import com.here.ort.utils.trapSystemExitCall
 
 import com.vdurmont.semver4j.Requirement
 import com.vdurmont.semver4j.Semver
@@ -43,7 +40,7 @@ import java.util.Properties
  * The SBT package manager for Scala, see https://www.scala-sbt.org/.
  */
 class SBT(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
-        PackageManager(analyzerConfig, repoConfig) {
+        PackageManager(analyzerConfig, repoConfig), CommandLineTool {
     class Factory : AbstractPackageManagerFactory<SBT>() {
         override val globsForDefinitionFiles = listOf("build.sbt", "build.scala")
 
@@ -52,8 +49,32 @@ class SBT(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfigura
     }
 
     companion object {
+        private val VERSION_REGEX = Regex("\\[info]\\s+(\\d+\\.\\d+\\.[^\\s]+)")
         private val PROJECT_REGEX = Regex("\\[info] \t [ *] (.+)")
         private val POM_REGEX = Regex("\\[info] Wrote (.+\\.pom)")
+
+        // Batch mode (which suppresses interactive prompts) is only supported on non-Windows, see
+        // https://github.com/sbt/sbt-launcher-package/blob/d251388/src/universal/bin/sbt#L86.
+        private val BATCH_MODE = if (!OS.isWindows) "-batch" else ""
+
+        // See https://github.com/sbt/sbt/issues/2695.
+        private val LOG_NO_FORMAT = "-Dsbt.log.noformat=true".let {
+            if (OS.isWindows) {
+                "\"$it\""
+            } else {
+                it
+            }
+        }
+    }
+
+    override fun command(workingDir: File?) = if (OS.isWindows) "sbt.bat" else "sbt"
+
+    private fun extractLowestSbtVersion(stdout: String): String {
+        val versions = stdout.lines().mapNotNull { line ->
+            VERSION_REGEX.matchEntire(line)?.groupValues?.getOrNull(1)?.let { Semver(it) }
+        }
+
+        return checkForSameSbtVersion(versions)
     }
 
     private fun checkForSameSbtVersion(versions: List<Semver>): String {
@@ -94,7 +115,17 @@ class SBT(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfigura
         val rootPropertiesFile = workingDir.resolve("project").resolve("build.properties")
         val propertiesFiles = workingDir.walkBottomUp().filter { it.isFile && it.name == "build.properties" }.toList()
 
-        if (propertiesFiles.contains(rootPropertiesFile)) {
+        if (!propertiesFiles.contains(rootPropertiesFile)) {
+            // Note that "sbt sbtVersion" behaves differently when executed inside or outside an SBT project, see
+            // https://stackoverflow.com/a/20337575/1127485.
+            checkVersion(
+                    sbtVersionRequirement,
+                    versionArguments = "$BATCH_MODE $LOG_NO_FORMAT sbtVersion",
+                    workingDir = workingDir,
+                    ignoreActualVersion = analyzerConfig.ignoreToolVersions,
+                    transform = this::extractLowestSbtVersion
+            )
+        } else {
             val versions = mutableListOf<Semver>()
 
             propertiesFiles.forEach { file ->
@@ -110,27 +141,10 @@ class SBT(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfigura
             }
         }
 
-        fun runSBT(vararg command: String): Pair<String, String> {
-            var stderr = ""
-
-            val stdout = redirectStdout {
-                stderr = redirectStderr {
-                    suppressInput {
-                        temporaryProperties("sbt.log.noformat" to "true", "user.dir" to workingDir.absolutePath) {
-                            trapSystemExitCall {
-                                xsbt.boot.Boot.main(command)
-                            }
-                        }
-                    }
-                }
-            }
-
-            return Pair(stdout, stderr)
-        }
+        fun runSBT(vararg command: String) = run(workingDir, BATCH_MODE, LOG_NO_FORMAT, *command)
 
         // Get the list of project names.
-        val (stdoutProjects, stderrProjects) = runSBT("projects")
-        val internalProjectNames = stdoutProjects.lines().mapNotNull {
+        val internalProjectNames = runSBT("projects").stdout.lines().mapNotNull {
             PROJECT_REGEX.matchEntire(it)?.groupValues?.getOrNull(1)
         }
 
@@ -138,21 +152,16 @@ class SBT(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfigura
             log.warn { "No SBT projects found inside the '${workingDir.absolutePath}' directory." }
         }
 
-        log.debug { stderrProjects }
-
         // Generate the POM files. Note that a single run of makePom might create multiple POM files in case of
         // aggregate projects.
         val makePomCommand = internalProjectNames.joinToString("") { ";$it/makePom" }
-        val (stdoutMakePom, stderrMakePom) = runSBT(makePomCommand)
-        val pomFiles = stdoutMakePom.lines().mapNotNull { line ->
+        val pomFiles = runSBT(makePomCommand).stdout.lines().mapNotNull { line ->
             POM_REGEX.matchEntire(line)?.groupValues?.getOrNull(1)?.let { File(it) }
         }
 
         if (pomFiles.isEmpty()) {
             log.warn { "No generated POM files found inside the '${workingDir.absolutePath}' directory." }
         }
-
-        log.debug { stderrMakePom }
 
         return pomFiles.distinct()
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,6 @@ kotlintestVersion = 3.1.10
 mavenVersion = 3.5.4
 mavenResolverVersion = 1.1.1
 okhttpVersion = 3.11.0
-sbtLaunchVersion = 1.2.1
 semverVersion = 2.2.0
 toml4jVersion = 0.7.2
 xzVersion = 1.8


### PR DESCRIPTION
For the same reason as in ProcessCapture, see 839bcdb, use a temporary
file to redirect output to work around the 64k pipe buffer limit on Linux.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/871)
<!-- Reviewable:end -->
