### PR TITLE
PackageManager: Ignore intermediate build system directories

### DIFF
--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -67,6 +67,9 @@ abstract class PackageManager(
         val ALL by lazy { LOADER.iterator().asSequence().toList() }
 
         private val IGNORED_DIRECTORY_MATCHERS = listOf(
+                // Ignore intermediate build system directories.
+                ".gradle",
+                "node_modules",
                 // Ignore resources in a standard Maven / Gradle project layout.
                 "src/main/resources",
                 "src/test/resources",


### PR DESCRIPTION
This came up when analyzing our own reporter-web-app. While we temporarily
move away any existing "node_modules" directory before resolving NPM
dependencies, it is confusing to list found definition files in there in
the first place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/875)
<!-- Reviewable:end -->
