### PR TITLE
analyzer: Use `npm ci` if a lock file exists

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output.yml
@@ -70,6 +70,9 @@ project:
         dependencies:
         - id: "NPM:@types:node:10.5.8"
     - id: "NPM::long:3.2.0"
+    - id: "NPM::promise:7.3.1"
+      dependencies:
+      - id: "NPM::asap:2.0.6"
   - name: "devDependencies"
     dependencies:
     - id: "NPM::cson:4.1.0"

--- a/analyzer/src/funTest/assets/projects/synthetic/yarn-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/yarn-expected-output.yml
@@ -70,6 +70,9 @@ project:
         dependencies:
         - id: "NPM:@types:node:6.0.79"
     - id: "NPM::long:3.2.0"
+    - id: "NPM::promise:7.3.1"
+      dependencies:
+      - id: "NPM::asap:2.0.5"
   - name: "devDependencies"
     dependencies:
     - id: "NPM::cson:4.1.0"

--- a/analyzer/src/main/kotlin/managers/NPM.kt
+++ b/analyzer/src/main/kotlin/managers/NPM.kt
@@ -123,7 +123,7 @@ open class NPM(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConf
 
     override fun command(workingDir: File?) = if (OS.isWindows) "npm.cmd" else "npm"
 
-    override fun getVersionRequirement(): Requirement = Requirement.buildNPM("5.5.* - 6.4.*")
+    override fun getVersionRequirement(): Requirement = Requirement.buildNPM("5.7.* - 6.4.*")
 
     override fun mapDefinitionFiles(definitionFiles: List<File>) =
             PackageJsonUtils.mapDefinitionFilesForNpm(definitionFiles).toList()
@@ -503,7 +503,11 @@ open class NPM(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConf
         }
 
         // Install all NPM dependencies to enable NPM to list dependencies.
-        run(workingDir, "install", "--ignore-scripts")
+        if (hasLockFile(workingDir) && this !is Yarn) {
+            run(workingDir, "ci")
+        } else {
+            run(workingDir, "install", "--ignore-scripts")
+        }
 
         // TODO: capture warnings from npm output, e.g. "Unsupported platform" which happens for fsevents on all
         // platforms except for Mac.


### PR DESCRIPTION
To prevent NPM from modifying existing lock files, use `npm ci` [1] if a
lock file is found.

[1] https://docs.npmjs.com/cli/ci

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/877)
<!-- Reviewable:end -->
