### PR TITLE
analyzer: Update expected results for spdx-tools-python in `PipTest`

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
@@ -30,7 +30,7 @@ project:
           dependencies: []
           errors: []
         errors: []
-      - id: "PyPI::pyparsing:2.2.0"
+      - id: "PyPI::pyparsing:2.2.1"
         dependencies: []
         errors: []
       errors: []
@@ -89,18 +89,18 @@ packages:
       path: ""
   curations: []
 - package:
-    id: "PyPI::pyparsing:2.2.0"
+    id: "PyPI::pyparsing:2.2.1"
     declared_licenses:
     - "MIT"
     description: "Python parsing module"
-    homepage_url: "http://pyparsing.wikispaces.com/"
+    homepage_url: "https://github.com/pyparsing/pyparsing/"
     binary_artifact:
-      url: "https://files.pythonhosted.org/packages/6a/8a/718fd7d3458f9fab8e67186b00abdd345b639976bc7fb3ae722e1b026a50/pyparsing-2.2.0-py2.py3-none-any.whl"
-      hash: "7247e7896688eff4bc8c7fc5d0cdd2b0"
+      url: "https://files.pythonhosted.org/packages/42/47/e6d51aef3d0393f7d343592d63a73beee2a8d3d69c22b053e252c6cfacd5/pyparsing-2.2.1-py2.py3-none-any.whl"
+      hash: "8e12977085a06601c1117a4f57f29ac3"
       hash_algorithm: "MD5"
     source_artifact:
-      url: "https://files.pythonhosted.org/packages/3c/ec/a94f8cf7274ea60b5413df054f82a8980523efd712ec55a59e7c3357cf7c/pyparsing-2.2.0.tar.gz"
-      hash: "0214e42d63af850256962b6744c948d9"
+      url: "https://files.pythonhosted.org/packages/cc/24/f185147523a3299a0dfbe21937d621060b3a7e98dfc672298641984769b3/pyparsing-2.2.1.tar.gz"
+      hash: "c3b5a3bba8dd57aa88baf70658f1449b"
       hash_algorithm: "MD5"
     vcs:
       type: ""
@@ -108,8 +108,8 @@ packages:
       revision: ""
       path: ""
     vcs_processed:
-      type: ""
-      url: ""
+      type: "git"
+      url: "https://github.com/pyparsing/pyparsing.git"
       revision: ""
       path: ""
   curations: []


### PR DESCRIPTION
The dependency on "pyparsing" was updated from 2.2.0 to 2.2.1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/878)
<!-- Reviewable:end -->
