### PR TITLE
Stash dir utility

### DIFF
--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -609,7 +609,7 @@ private class StashDirectory(directories: Set<File>) : Closeable {
         val tempDir = stashedDirectories[originalDir]
         tempDir ?: return
 
-        log.info { "Moving back directory from: '${tempDir.absolutePath}' to '${originalDir.absolutePath}'." }
+        log.info { "Moving back directory from '${tempDir.absolutePath}' to '${originalDir.absolutePath}'." }
 
         Files.move(tempDir.toPath(), originalDir.toPath(), StandardCopyOption.ATOMIC_MOVE)
         stashedDirectories.remove(originalDir)

--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -19,6 +19,8 @@
 
 package com.here.ort.utils
 
+import ch.frankel.slf4k.*
+
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.util.ClassUtil
 
@@ -36,6 +38,7 @@ import okhttp3.Request
 import okhttp3.RequestBody
 import okhttp3.Response
 
+import java.io.Closeable
 import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.io.PrintStream
@@ -45,6 +48,7 @@ import java.nio.file.FileVisitResult
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.SimpleFileVisitor
+import java.nio.file.StandardCopyOption
 import java.nio.file.attribute.BasicFileAttributes
 import java.security.Permission
 
@@ -566,4 +570,48 @@ fun Throwable.showStackTrace() {
     // We cannot use a function expression for a single "if"-statement, see
     // https://discuss.kotlinlang.org/t/if-operator-in-function-expression/7227.
     if (printStackTrace) printStackTrace()
+}
+
+/**
+ * Return a Closable which moves the given directories to temporary directories on initialization. On close, it deletes
+ * any conflicting existing directories in the original location and then moves the original directories back.
+ */
+fun stashDirectories(vararg directories: File): Closeable = StashDirectory(setOf(*directories))
+
+private class StashDirectory(directories: Set<File>) : Closeable {
+    private val stashedDirectories = mutableMapOf<File, File>()
+
+    init {
+        directories.forEach {
+            stashDir(it)
+        }
+    }
+
+    override fun close() {
+        HashMap(stashedDirectories).forEach {
+            unstashDir(it.key)
+        }
+    }
+
+    private fun stashDir(originalDir: File) {
+        if (!originalDir.isDirectory) return
+
+        val tempDir = createTempDir(originalDir.name, ".tmp", originalDir.parentFile)
+        log.info { "Temporarily moving directory from '${originalDir.absolutePath}' to '${tempDir.absolutePath}'." }
+
+        Files.move(originalDir.toPath(), tempDir.toPath(), StandardCopyOption.ATOMIC_MOVE)
+        stashedDirectories[originalDir] = tempDir
+    }
+
+    private fun unstashDir(originalDir: File) {
+        originalDir.safeDeleteRecursively()
+
+        val tempDir = stashedDirectories[originalDir]
+        tempDir ?: return
+
+        log.info { "Moving back directory from: '${tempDir.absolutePath}' to '${originalDir.absolutePath}'." }
+
+        Files.move(tempDir.toPath(), originalDir.toPath(), StandardCopyOption.ATOMIC_MOVE)
+        stashedDirectories.remove(originalDir)
+    }
 }


### PR DESCRIPTION
The logic for moving directories to temporary directories and back was redundantly implement accross several package managers. That redundancy is eliminated by extracting the logic from Bower and re-using it all over the place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/882)
<!-- Reviewable:end -->
