### PR TITLE
analyzer: Do not run NPM and Yarn for the same project

### DIFF
--- a/analyzer/src/main/kotlin/managers/Yarn.kt
+++ b/analyzer/src/main/kotlin/managers/Yarn.kt
@@ -27,6 +27,9 @@ import com.here.ort.utils.OS
 import com.vdurmont.semver4j.Requirement
 
 import java.io.File
+import java.io.IOException
+
+val YARN_LOCK_FILES = listOf("yarn.lock")
 
 /**
  * The Yarn package manager for JavaScript, see https://www.yarnpkg.com/.
@@ -34,23 +37,56 @@ import java.io.File
 class Yarn(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
         NPM(analyzerConfig, repoConfig) {
     class Factory : AbstractPackageManagerFactory<Yarn>() {
-        override val globsForDefinitionFiles = listOf("yarn.lock")
+        override val globsForDefinitionFiles = listOf("package.json")
 
         override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
                 Yarn(analyzerConfig, repoConfig)
     }
 
-    override val recognizedLockFiles = listOf("yarn.lock")
+    override val recognizedLockFiles = YARN_LOCK_FILES
 
     override fun command(workingDir: File?) = if (OS.isWindows) "yarn.cmd" else "yarn"
 
     override fun prepareResolution(definitionFiles: List<File>): List<File> {
-        // We do not actually depend on any features specific to a Yarn version, but we still want to stick to a fixed
-        // minor version to be sure to get consistent results.
-        checkVersion(Requirement.buildNPM("1.3.* - 1.9.*"), ignoreActualVersion = analyzerConfig.ignoreToolVersions)
+        val conflictingLockFiles = mutableMapOf<File, Pair<List<File>, List<File>>>()
 
-        // Map "yarn.lock" files to existing "package.json" files for use by the NPM class (which in this case calls
-        // "yarn" to install the dependencies).
-        return definitionFiles.mapNotNull { File(it.parentFile, "package.json").takeIf { it.isFile } }
+        // Only keep those definition files that are accompanied by a Yarn lock file.
+        val yarnDefinitionFiles = definitionFiles.filter { definitionFile ->
+            val existingYarnLockFiles = recognizedLockFiles.mapNotNull { lockFileName ->
+                definitionFile.resolveSibling(lockFileName).takeIf { it.isFile }
+            }
+
+            val existingNpmLockFiles = super.recognizedLockFiles.mapNotNull { lockFileName ->
+                definitionFile.resolveSibling(lockFileName).takeIf { it.isFile }
+            }
+
+            existingYarnLockFiles.isNotEmpty().also {
+                if (it && existingNpmLockFiles.isNotEmpty()) {
+                    conflictingLockFiles.put(definitionFile, Pair(existingYarnLockFiles, existingNpmLockFiles))
+                }
+            }
+        }
+
+        if (conflictingLockFiles.isNotEmpty()) {
+            val message = buildString {
+                appendln("Found the following conflicting lock files:")
+
+                conflictingLockFiles.forEach { definitionfile, (yarnLockFiles, npmLockFiles) ->
+                    val yarnLockFileNames = yarnLockFiles.map { it.name }
+                    val npmLockFileNames = npmLockFiles.map { it.name }
+                    appendln("For '$definitionfile', $yarnLockFileNames vs. $npmLockFileNames.")
+                }
+            }
+
+            throw IOException(message)
+        }
+
+        if (yarnDefinitionFiles.isNotEmpty()) {
+            // We do not actually depend on any features specific to a Yarn version, but we still want to stick to a
+            // fixed minor version to be sure to get consistent results.
+            checkVersion(Requirement.buildNPM("1.3.* - 1.9.*"), ignoreActualVersion = analyzerConfig.ignoreToolVersions)
+        }
+
+        return yarnDefinitionFiles
     }
 }

--- a/analyzer/src/test/kotlin/PackageManagerTest.kt
+++ b/analyzer/src/test/kotlin/PackageManagerTest.kt
@@ -55,7 +55,7 @@ class PackageManagerTest : WordSpec({
             managedFilesByName["PIP"] shouldBe listOf(File(projectDir, "setup.py"))
             managedFilesByName["SBT"] shouldBe listOf(File(projectDir, "build.sbt"))
             managedFilesByName["Stack"] shouldBe listOf(File(projectDir, "stack.yaml"))
-            managedFilesByName["Yarn"] shouldBe listOf(File(projectDir, "yarn.lock"))
+            managedFilesByName["Yarn"] shouldBe listOf(File(projectDir, "package.json"))
         }
 
         "find only files for active package managers" {


### PR DESCRIPTION
Previously, NPM was run in addition to Yarn in case only "yarn.lock"
(besides a "package.json", of course) was present, as it could be
interpreted as an NPM project without a lock file, *and* as a Yarn project
with a lock file. However, running both NPM and Yarn was a source of
confusion, esp. for projects that intend to be used with Yarn only, as a
single project appeared twice in the results.

Therefore, change the behavior so that always either NPM or Yarn is
used depending on the presence of "yarn.lock": If no "yarn.lock" is
present, use NPM, and if it is, use Yarn. If both "yarn.lock" and
"package-lock.json" are present an IOException is thrown.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/887)
<!-- Reviewable:end -->
