### PR TITLE
cli: Add missing space in description of `--repository-configuration-file`

### DIFF
--- a/cli/src/main/kotlin/Main.kt
+++ b/cli/src/main/kotlin/Main.kt
@@ -167,7 +167,7 @@ object Main : CommandWithHelp() {
                 order = PARAMETER_ORDER_OPTIONAL)
         private var packageCurationsFile: File? = null
 
-        @Parameter(description = "A file containing the repository configuration. If set the .ort.yml file from the" +
+        @Parameter(description = "A file containing the repository configuration. If set the .ort.yml file from the " +
                 "repository will be ignored.",
                 names = ["--repository-configuration-file"],
                 order = PARAMETER_ORDER_OPTIONAL)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/892)
<!-- Reviewable:end -->
