### PR TITLE
model: Make the `path` in `ProjectExclude` a regular expression

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -43,6 +43,17 @@ excludes:
 This configuration will mark the whole project and all its dependencies as excluded in the generated reports. For
 example, if an error occurs during the scan of a dependency of this project, it will not appear in the error summary.
 
+The path is interpreted as a regular expression, so it is possible to exclude all Gradle projects in a repository using
+a single exclude:
+
+```yaml
+excludes:
+  projects:
+  - path: ".*build.gradle"
+    reason: "EXAMPLE_OF"
+    comment: "The project contains example code which is not distributed."
+```
+
 For the available exclude reasons for projects, see
 [ProjectExcludeReason.kt](../model/src/main/kotlin/config/ProjectExcludeReason.kt).
 

--- a/model/src/main/kotlin/config/Excludes.kt
+++ b/model/src/main/kotlin/config/Excludes.kt
@@ -45,7 +45,7 @@ data class Excludes(
     /**
      * Return the [ProjectExclude] for the provided [project], or null if there is none.
      */
-    fun findProjectExclude(project: Project) = projects.find { it.path == project.definitionFilePath }
+    fun findProjectExclude(project: Project) = projects.find { it.matches(project.definitionFilePath) }
 
     /**
      * Return the [ScopeExclude]s for the provided [scope]. This includes global excludes from [scopes] as well as
@@ -70,7 +70,7 @@ data class Excludes(
      * True if the [project] is excluded by this [Excludes] configuration.
      */
     fun isProjectExcluded(project: Project) = projects.any {
-        it.path == project.definitionFilePath && it.isWholeProjectExcluded
+        it.matches(project.definitionFilePath) && it.isWholeProjectExcluded
     }
 
     /**

--- a/model/src/main/kotlin/config/ProjectExclude.kt
+++ b/model/src/main/kotlin/config/ProjectExclude.kt
@@ -21,6 +21,8 @@ package com.here.ort.model.config
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer
 
 /**
  * Defines which parts of a project should be excluded. The project is defined by the definition file located at [path]
@@ -29,9 +31,11 @@ import com.fasterxml.jackson.annotation.JsonInclude
  */
 data class ProjectExclude(
         /**
-         * The path of the project definition file, relative to the root of the repository.
+         * A regular expression to match the path of the project definition file, relative to the root of the
+         * repository.
          */
-        val path: String,
+        @JsonSerialize(using = ToStringSerializer::class)
+        val path: Regex,
 
         /**
          * The reason why the project is excluded, out of a predefined choice.
@@ -51,6 +55,13 @@ data class ProjectExclude(
         @JsonInclude(JsonInclude.Include.NON_EMPTY)
         val scopes: List<ScopeExclude> = emptyList()
 ) {
+    constructor(
+            path: String,
+            reason: ProjectExcludeReason? = null,
+            comment: String? = null,
+            scopes: List<ScopeExclude> = emptyList()
+    ) : this(Regex(path), reason, comment, scopes)
+
     /**
      * True if the whole project will be excluded. This is the case if no specific scopes to exclude are defined.
      */
@@ -62,4 +73,9 @@ data class ProjectExclude(
         // See: https://github.com/FasterXML/jackson-module-kotlin/issues/80#issuecomment-423308227
         @JsonIgnore
         get() = scopes.isEmpty()
+
+    /**
+     * True if [path] matches [projectPath].
+     */
+    fun matches(projectPath: String) = path.matches(projectPath)
 }

--- a/model/src/test/kotlin/config/RepositoryConfigurationTest.kt
+++ b/model/src/test/kotlin/config/RepositoryConfigurationTest.kt
@@ -69,14 +69,14 @@ class RepositoryConfigurationTest : WordSpec() {
                 projects should haveSize(2)
 
                 val project1 = projects[0]
-                project1.path shouldBe "project1/path"
+                project1.path.pattern shouldBe "project1/path"
                 project1.reason shouldBe ProjectExcludeReason.BUILD_TOOL_OF
                 project1.comment shouldBe "project comment"
                 project1.isWholeProjectExcluded shouldBe true
                 project1.scopes should beEmpty()
 
                 val project2 = projects[1]
-                project2.path shouldBe "project2/path"
+                project2.path.pattern shouldBe "project2/path"
                 project2.reason shouldBe null
                 project2.comment shouldBe null
                 project2.isWholeProjectExcluded shouldBe false


### PR DESCRIPTION
This allows for excluding multiple projects with a single `ProjectExclude`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/897)
<!-- Reviewable:end -->
