### PR TITLE
analyzer: Fix reporting duplicate project identifiers

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
@@ -28,7 +28,7 @@ project:
       - id: "PyPI::Werkzeug:0.14.1"
         dependencies: []
         errors: []
-      - id: "PyPI::click:6.7"
+      - id: "PyPI::click:7.0"
         dependencies: []
         errors: []
       - id: "PyPI::itsdangerous:0.24"
@@ -141,18 +141,18 @@ packages:
       path: ""
   curations: []
 - package:
-    id: "PyPI::click:6.7"
+    id: "PyPI::click:7.0"
     declared_licenses:
     - "BSD"
-    description: "A simple wrapper around optparse for powerful command line utilities."
-    homepage_url: "http://github.com/mitsuhiko/click"
+    description: "Composable command line interface toolkit"
+    homepage_url: "https://palletsprojects.com/p/click/"
     binary_artifact:
-      url: "https://files.pythonhosted.org/packages/34/c1/8806f99713ddb993c5366c362b2f908f18269f8d792aff1abfd700775a77/click-6.7-py2.py3-none-any.whl"
-      hash: "5e7a4e296b3212da2ff11017675d7a4d"
+      url: "https://files.pythonhosted.org/packages/fa/37/45185cb5abbc30d7257104c434fe0b07e5a195a6847506c074527aa599ec/Click-7.0-py2.py3-none-any.whl"
+      hash: "4de489e31c57834a21b8be7111dab613"
       hash_algorithm: "MD5"
     source_artifact:
-      url: "https://files.pythonhosted.org/packages/95/d9/c3336b6b5711c3ab9d1d3a80f1a3e2afeb9d8c02a7166462f6cc96570897/click-6.7.tar.gz"
-      hash: "fc4cc00c4863833230d3af92af48abd4"
+      url: "https://files.pythonhosted.org/packages/f8/5c/f60e9d8a1e77005f664b76ff8aeaee5bc05d0a91798afd7f53fc998dbc47/Click-7.0.tar.gz"
+      hash: "7f53d50f7b7373ebc7963f9ff697450a"
       hash_algorithm: "MD5"
     vcs:
       type: ""
@@ -160,8 +160,8 @@ packages:
       revision: ""
       path: ""
     vcs_processed:
-      type: "git"
-      url: "https://github.com/mitsuhiko/click.git"
+      type: ""
+      url: ""
       revision: ""
       path: ""
   curations: []

--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -86,7 +86,7 @@ class Analyzer(private val config: AnalyzerConfiguration) {
         }
 
         val vcs = VersionControlSystem.getCloneInfo(absoluteProjectPath)
-        val analyzerResultBuilder = AnalyzerResultBuilder()
+        val analyzerResultBuilder = AnalyzerResultBuilder(absoluteProjectPath)
 
         // Resolve dependencies per package manager.
         managedFiles.forEach { manager, files ->

--- a/model/src/main/kotlin/AnalyzerResult.kt
+++ b/model/src/main/kotlin/AnalyzerResult.kt
@@ -67,7 +67,12 @@ data class AnalyzerResult(
     }
 }
 
-class AnalyzerResultBuilder {
+class AnalyzerResultBuilder(
+        /**
+         * The root directory of the analyzer run this builder is used for.
+         */
+        private val rootDir: File
+) {
     private val projects = sortedSetOf<Project>()
     private val packages = sortedSetOf<CuratedPackage>()
     private val errors = sortedMapOf<Identifier, List<Error>>()
@@ -82,15 +87,15 @@ class AnalyzerResultBuilder {
         val existingProject = projects.find { it.id == projectAnalyzerResult.project.id }
 
         if (existingProject != null) {
-            val existingFile = File(existingProject.definitionFilePath)
-            val incomingFile = File(projectAnalyzerResult.project.definitionFilePath)
+            val existingFile = File(rootDir, existingProject.definitionFilePath)
+            val incomingFile = File(rootDir, projectAnalyzerResult.project.definitionFilePath)
 
             val error = Error(
                     source = "analyzer",
                     message = "Multiple projects with the same id '${existingProject.id}' found. Not adding the " +
-                            "project defined in '$incomingFile' (SHA-1: ${incomingFile.hash()}) to the " +
-                            "analyzer results as it duplicates the project defined in " +
-                            "'$existingFile' (SHA-1: ${existingFile.hash()})."
+                            "project defined in '${incomingFile.relativeTo(rootDir)}' (SHA-1: " +
+                            "${incomingFile.hash()}) to the analyzer results as it duplicates the project defined in " +
+                            "'${existingFile.relativeTo(rootDir)}' (SHA-1: ${existingFile.hash()})."
             )
 
             log.error { error.message }

--- a/model/src/test/kotlin/AnalyzerResultTest.kt
+++ b/model/src/test/kotlin/AnalyzerResultTest.kt
@@ -22,6 +22,8 @@ package com.here.ort.model
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.WordSpec
 
+import java.io.File
+
 class AnalyzerResultTest : WordSpec() {
     private val package1 = Package.EMPTY.copy(id = Identifier("provider-1", "namespace-1", "package-1", "version-1"))
     private val package2 = Package.EMPTY.copy(id = Identifier("provider-2", "namespace-2", "package-2", "version-2"))
@@ -54,7 +56,7 @@ class AnalyzerResultTest : WordSpec() {
     init {
         "AnalyzerResult" should {
             "be serialized and deserialized correctly" {
-                val mergedResults = AnalyzerResultBuilder()
+                val mergedResults = AnalyzerResultBuilder(File(""))
                         .addResult(analyzerResult1)
                         .addResult(analyzerResult2)
                         .build()
@@ -69,7 +71,7 @@ class AnalyzerResultTest : WordSpec() {
 
         "AnalyzerResultBuilder" should {
             "merge results from all files" {
-                val mergedResults = AnalyzerResultBuilder()
+                val mergedResults = AnalyzerResultBuilder(File(""))
                         .addResult(analyzerResult1)
                         .addResult(analyzerResult2)
                         .build()


### PR DESCRIPTION
The `AnalyzerResultBuilder` requires the root path of the analyzed
project to be able to calculate the file hashes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/910)
<!-- Reviewable:end -->
