### PR TITLE
Teach splitUrl() to split paths from a URL to a Git repository

### DIFF
--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -208,7 +208,7 @@ abstract class VersionControlSystem {
                         }
                     }
 
-                    VcsInfo("git", url, revision, path = path)
+                    VcsInfo("Git", url, revision, path = path)
                 }
 
                 else -> {

--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -211,7 +211,14 @@ abstract class VersionControlSystem {
                     VcsInfo("git", url, revision, path = path)
                 }
 
-                else -> VcsInfo("", vcsUrl, "")
+                else -> {
+                    val gitUrlParts = vcsUrl.split(".git/")
+                    if (gitUrlParts.count() == 2) {
+                        VcsInfo("Git", "${gitUrlParts[0]}.git", "", null, gitUrlParts[1])
+                    } else {
+                        VcsInfo("", vcsUrl, "")
+                    }
+                }
             }
         }
     }

--- a/downloader/src/test/kotlin/VersionControlSystemTest.kt
+++ b/downloader/src/test/kotlin/VersionControlSystemTest.kt
@@ -64,6 +64,21 @@ class VersionControlSystemTest : WordSpec({
         }
     }
 
+    "splitUrl" should {
+        "split paths from a URL to a Git repository" {
+            val actual = VersionControlSystem.splitUrl(
+                    "https://git-wip-us.apache.org/repos/asf/zeppelin.git/zeppelin-interpreter"
+            )
+            val expected = VcsInfo(
+                    type = "Git",
+                    url = "https://git-wip-us.apache.org/repos/asf/zeppelin.git",
+                    revision = "",
+                    path = "zeppelin-interpreter"
+            )
+            actual shouldBe expected
+        }
+    }
+
     "splitUrl for Bitbucket" should {
         "not modify URLs without a path".config(enabled = Mercurial().isInPath()) {
             val actual = VersionControlSystem.splitUrl(

--- a/downloader/src/test/kotlin/VersionControlSystemTest.kt
+++ b/downloader/src/test/kotlin/VersionControlSystemTest.kt
@@ -125,7 +125,7 @@ class VersionControlSystemTest : WordSpec({
                     "https://github.com/heremaps/oss-review-toolkit.git"
             )
             val expected = VcsInfo(
-                    type = "git",
+                    type = "Git",
                     url = "https://github.com/heremaps/oss-review-toolkit.git",
                     revision = ""
             )
@@ -137,7 +137,7 @@ class VersionControlSystemTest : WordSpec({
                     "https://github.com/blob/tree.git"
             )
             val expected = VcsInfo(
-                    type = "git",
+                    type = "Git",
                     url = "https://github.com/blob/tree.git",
                     revision = ""
             )
@@ -149,7 +149,7 @@ class VersionControlSystemTest : WordSpec({
                     "https://github.com/babel/babel/tree/master/packages/babel-code-frame.git"
             )
             val expected = VcsInfo(
-                    type = "git",
+                    type = "Git",
                     url = "https://github.com/babel/babel.git",
                     revision = "master",
                     path = "packages/babel-code-frame"
@@ -162,7 +162,7 @@ class VersionControlSystemTest : WordSpec({
                     "https://github.com/crypto-browserify/crypto-browserify/blob/6aebafa/test/create-hmac.js"
             )
             val expected = VcsInfo(
-                    type = "git",
+                    type = "Git",
                     url = "https://github.com/crypto-browserify/crypto-browserify.git",
                     revision = "6aebafa",
                     path = "test/create-hmac.js"
@@ -175,7 +175,7 @@ class VersionControlSystemTest : WordSpec({
                     "ssh://git@github.com/EsotericSoftware/kryo.git/kryo-shaded"
             )
             val expected = VcsInfo(
-                    type = "git",
+                    type = "Git",
                     url = "ssh://git@github.com/EsotericSoftware/kryo.git",
                     revision = "",
                     path = "kryo-shaded"
@@ -190,7 +190,7 @@ class VersionControlSystemTest : WordSpec({
                     "https://gitlab.com/rich-harris/rollup-plugin-buble.git"
             )
             val expected = VcsInfo(
-                    type = "git",
+                    type = "Git",
                     url = "https://gitlab.com/rich-harris/rollup-plugin-buble.git",
                     revision = ""
             )
@@ -202,7 +202,7 @@ class VersionControlSystemTest : WordSpec({
                     "https://gitlab.com/Rich-Harris/rollup-plugin-buble/tree/master/src"
             )
             val expected = VcsInfo(
-                    type = "git",
+                    type = "Git",
                     url = "https://gitlab.com/Rich-Harris/rollup-plugin-buble.git",
                     revision = "master",
                     path = "src"
@@ -215,7 +215,7 @@ class VersionControlSystemTest : WordSpec({
                     "https://gitlab.com/Rich-Harris/rollup-plugin-buble/blob/v0.15.0/README.md"
             )
             val expected = VcsInfo(
-                    type = "git",
+                    type = "Git",
                     url = "https://gitlab.com/Rich-Harris/rollup-plugin-buble.git",
                     revision = "v0.15.0",
                     path = "README.md"


### PR DESCRIPTION
Please have a look at the individual commit messages for the details.