### PR TITLE
GitRepo: Clone all groups by default

### DIFF
--- a/downloader/src/main/kotlin/vcs/GitRepo.kt
+++ b/downloader/src/main/kotlin/vcs/GitRepo.kt
@@ -95,21 +95,26 @@ class GitRepo : GitBase() {
     }
 
     private fun runRepoCommand(targetDir: File, vararg args: String) {
+        val patchedArgs = if (args.first() == "init") {
+            if (OS.isWindows) {
+                // The current "stable" release of "repo" still does not support Windows officially, so get the latest
+                // code from the "master" branch instead.
+                listOf(args.first(), "--groups=all", "--no-clone-bundle", "--no-repo-verify", "--repo-branch=master") +
+                        args.drop(1)
+            } else {
+                listOf(args.first(), "--groups=all") + args.drop(1)
+            }
+        } else {
+            args.toList()
+        }
+
         if (OS.isWindows) {
             val repo = getPathFromEnvironment("repo") ?: throw IOException("'repo' not found in PATH.")
 
-            val windowsArgs = if (args.first() == "init") {
-                // The current "stable" release of "repo" still does not support Windows officially, so get the latest
-                // code from the "master" branch instead.
-                listOf(args.first(), "--no-clone-bundle", "--no-repo-verify", "--repo-branch=master") + args.drop(1)
-            } else {
-                args.toList()
-            }
-
             // On Windows, the script itself is not executable, so we need to wrap the call by "python".
-            ProcessCapture(targetDir, "python", repo.absolutePath, *windowsArgs.toTypedArray()).requireSuccess()
+            ProcessCapture(targetDir, "python", repo.absolutePath, *patchedArgs.toTypedArray()).requireSuccess()
         } else {
-            ProcessCapture(targetDir, "repo", *args).requireSuccess()
+            ProcessCapture(targetDir, "repo", *patchedArgs.toTypedArray()).requireSuccess()
         }
     }
 }


### PR DESCRIPTION
The default group to clone is called "default", but if groups are in use
this likely only is a subset of all projects. Until we properly support
the groups feature, be conservative and clone all projects instead of only
projects in the default group.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/913)
<!-- Reviewable:end -->
