### PR TITLE
PIP: Fix the logic to determine the project name from requirements.txt

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/pip-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pip-expected-output.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "PIP::Example-App:2.4.0"
+  id: "PIP::Example-App-requirements:2.4.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/pip/requirements.txt"
   declared_licenses:
   - "MIT"


### PR DESCRIPTION
In case a "setup.py" was present in addition to multiple
"requirements*.txt" files the project name was only constructed from
"setup.py" for all "requirements*.txt" files, leading to duplicate
project names. Fix this by always considering "setup.py" and
"requirements*.txt", if any, to get project meta-data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/922)
<!-- Reviewable:end -->
