### PR TITLE
cli: Reflect in the help that ScanCode actually is the default scanner

### DIFF
--- a/cli/src/main/kotlin/commands/ScannerCommand.kt
+++ b/cli/src/main/kotlin/commands/ScannerCommand.kt
@@ -83,7 +83,7 @@ object ScannerCommand : CommandWithHelp() {
             names = ["--scanner", "-s"],
             converter = ScannerConverter::class,
             order = PARAMETER_ORDER_OPTIONAL)
-    private var scannerFactory: ScannerFactory? = null
+    private var scannerFactory = ScanCode.Factory()
 
     @Parameter(description = "The path to the configuration file.",
             names = ["--config", "-c"],
@@ -122,13 +122,15 @@ object ScannerCommand : CommandWithHelp() {
             ScanResultsCache.configure(it)
         }
 
-        val scanner = scannerFactory?.create(config) ?: ScanCode(config)
+        val scanner = scannerFactory.create(config)
 
         println("Using scanner '$scanner'.")
 
         val ortResult = dependenciesFile?.let {
             scanner.scanDependenciesFile(it, outputDir, downloadDir, scopesToScan.toSet())
         } ?: run {
+            // The check is not useless as we do not know what scanners plugins might add.
+            @Suppress("USELESS_IS_CHECK")
             require(scanner is LocalScanner) {
                 "To scan local files the chosen scanner must be a local scanner."
             }


### PR DESCRIPTION
The check for LocalScanner needs to go now as the compiler otherwise
correctly warns that the check is superfluous as we only have
LocalScanners currently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/927)
<!-- Reviewable:end -->
