### PR TITLE
Move all companion objects to the top of the class for consistency

### DIFF
--- a/analyzer/src/main/kotlin/managers/Bower.kt
+++ b/analyzer/src/main/kotlin/managers/Bower.kt
@@ -56,13 +56,6 @@ import java.util.Stack
  */
 class Bower(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
         PackageManager(analyzerConfig, repoConfig), CommandLineTool {
-    class Factory : AbstractPackageManagerFactory<Bower>() {
-        override val globsForDefinitionFiles = listOf("bower.json")
-
-        override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
-                Bower(analyzerConfig, repoConfig)
-    }
-
     companion object {
         // We do not actually depend on any features specific to this Bower version, but we still want to
         // stick to fixed versions to be sure to get consistent results.
@@ -204,6 +197,13 @@ class Bower(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfigu
 
             return result.toSortedSet()
         }
+    }
+
+    class Factory : AbstractPackageManagerFactory<Bower>() {
+        override val globsForDefinitionFiles = listOf("bower.json")
+
+        override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
+                Bower(analyzerConfig, repoConfig)
     }
 
     override fun toString() = PROVIDER_NAME

--- a/analyzer/src/main/kotlin/managers/NPM.kt
+++ b/analyzer/src/main/kotlin/managers/NPM.kt
@@ -73,13 +73,6 @@ val NPM_LOCK_FILES = listOf("npm-shrinkwrap.json", "package-lock.json")
  */
 open class NPM(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
         PackageManager(analyzerConfig, repoConfig), CommandLineTool {
-    class Factory : AbstractPackageManagerFactory<NPM>() {
-        override val globsForDefinitionFiles = listOf("package.json")
-
-        override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
-                NPM(analyzerConfig, repoConfig)
-    }
-
     companion object {
         /**
          * Expand NPM shortcuts for URLs to hosting sites to full URLs so that they can be used in a regular way.
@@ -116,6 +109,13 @@ open class NPM(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConf
                 url
             }
         }
+    }
+
+    class Factory : AbstractPackageManagerFactory<NPM>() {
+        override val globsForDefinitionFiles = listOf("package.json")
+
+        override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
+                NPM(analyzerConfig, repoConfig)
     }
 
     protected open val recognizedLockFiles = NPM_LOCK_FILES

--- a/analyzer/src/main/kotlin/managers/SBT.kt
+++ b/analyzer/src/main/kotlin/managers/SBT.kt
@@ -41,13 +41,6 @@ import java.util.Properties
  */
 class SBT(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
         PackageManager(analyzerConfig, repoConfig), CommandLineTool {
-    class Factory : AbstractPackageManagerFactory<SBT>() {
-        override val globsForDefinitionFiles = listOf("build.sbt", "build.scala")
-
-        override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
-                SBT(analyzerConfig, repoConfig)
-    }
-
     companion object {
         private val VERSION_REGEX = Regex("\\[info]\\s+(\\d+\\.\\d+\\.[^\\s]+)")
         private val PROJECT_REGEX = Regex("\\[info] \t [ *] (.+)")
@@ -65,6 +58,13 @@ class SBT(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfigura
                 it
             }
         }
+    }
+
+    class Factory : AbstractPackageManagerFactory<SBT>() {
+        override val globsForDefinitionFiles = listOf("build.sbt", "build.scala")
+
+        override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
+                SBT(analyzerConfig, repoConfig)
     }
 
     override fun command(workingDir: File?) = if (OS.isWindows) "sbt.bat" else "sbt"

--- a/model/src/main/kotlin/Package.kt
+++ b/model/src/main/kotlin/Package.kt
@@ -80,6 +80,22 @@ data class Package(
         @JsonInclude(JsonInclude.Include.NON_EMPTY)
         val data: CustomData = emptyMap()
 ) : Comparable<Package> {
+    companion object {
+        /**
+         * A constant for a [Package] where all properties are empty.
+         */
+        @JvmField
+        val EMPTY = Package(
+                id = Identifier.EMPTY,
+                declaredLicenses = sortedSetOf(),
+                description = "",
+                homepageUrl = "",
+                binaryArtifact = RemoteArtifact.EMPTY,
+                sourceArtifact = RemoteArtifact.EMPTY,
+                vcs = VcsInfo.EMPTY
+        )
+    }
+
     /**
      * A comparison function to sort packages by their identifier.
      */
@@ -113,20 +129,4 @@ data class Package(
      */
     fun toReference(dependencies: SortedSet<PackageReference> = sortedSetOf(), errors: List<Error> = emptyList()) =
             PackageReference(id, dependencies, errors)
-
-    companion object {
-        /**
-         * A constant for a [Package] where all properties are empty.
-         */
-        @JvmField
-        val EMPTY = Package(
-                id = Identifier.EMPTY,
-                declaredLicenses = sortedSetOf(),
-                description = "",
-                homepageUrl = "",
-                binaryArtifact = RemoteArtifact.EMPTY,
-                sourceArtifact = RemoteArtifact.EMPTY,
-                vcs = VcsInfo.EMPTY
-        )
-    }
 }

--- a/model/src/main/kotlin/Project.kt
+++ b/model/src/main/kotlin/Project.kt
@@ -74,6 +74,21 @@ data class Project(
         @JsonInclude(JsonInclude.Include.NON_EMPTY)
         val data: CustomData = emptyMap()
 ) : Comparable<Project> {
+    companion object {
+        /**
+         * A constant for a [Project] where all properties are empty.
+         */
+        @JvmField
+        val EMPTY = Project(
+                id = Identifier.EMPTY,
+                definitionFilePath = "",
+                declaredLicenses = sortedSetOf(),
+                vcs = VcsInfo.EMPTY,
+                homepageUrl = "",
+                scopes = sortedSetOf()
+        )
+    }
+
     fun collectDependencyIds(includeErroneous: Boolean = true) =
             scopes.fold(sortedSetOf<Identifier>()) { ids, scope ->
                 ids.also { it += scope.collectDependencyIds(includeErroneous) }
@@ -120,19 +135,4 @@ data class Project(
             vcs = vcs,
             vcsProcessed = vcsProcessed
     )
-
-    companion object {
-        /**
-         * A constant for a [Project] where all properties are empty.
-         */
-        @JvmField
-        val EMPTY = Project(
-                id = Identifier.EMPTY,
-                definitionFilePath = "",
-                declaredLicenses = sortedSetOf(),
-                vcs = VcsInfo.EMPTY,
-                homepageUrl = "",
-                scopes = sortedSetOf()
-        )
-    }
 }

--- a/scanner/src/main/kotlin/ScanResultsCache.kt
+++ b/scanner/src/main/kotlin/ScanResultsCache.kt
@@ -31,40 +31,6 @@ import com.here.ort.model.config.ArtifactoryCacheConfiguration
 import com.here.ort.utils.log
 
 interface ScanResultsCache {
-
-    /**
-     * Read all [ScanResult]s for this [id] from the cache.
-     *
-     * @param id The [Identifier] of the scanned [Package].
-     *
-     * @return The [ScanResultContainer] for this [id].
-     */
-    fun read(id: Identifier): ScanResultContainer
-
-    /**
-     * Read the [ScanResult]s matching the [id][Package.id] of [pkg] and the [scannerDetails] from the cache.
-     * [ScannerDetails.isCompatible] is used to check if the results are compatible with the provided [scannerDetails].
-     * Also [Package.sourceArtifact], [Package.vcs], and [Package.vcsProcessed] are used to check if the scan result
-     * matches the expected source code location. This is important to find the correct results when different revisions
-     * of a package using the same version name are used (e.g. multiple scans of 1.0-SNAPSHOT during development).
-     *
-     * @param pkg The [Package] to look up results for.
-     * @param scannerDetails Details about the scanner that was used to scan the [Package].
-     *
-     * @return The [ScanResultContainer] matching the [id][Package.id] of [pkg] and the [scannerDetails].
-     */
-    fun read(pkg: Package, scannerDetails: ScannerDetails): ScanResultContainer
-
-    /**
-     * Add a [ScanResult] to the [ScanResultContainer] for this [id] and write it to the cache.
-     *
-     * @param id The [Identifier] of the scanned [Package].
-     * @param scanResult The [ScanResult]. The [ScanResult.rawResult] must not be null.
-     *
-     * @return If the [ScanResult] could be written to the cache.
-     */
-    fun add(id: Identifier, scanResult: ScanResult): Boolean
-
     companion object : ScanResultsCache {
         var cache = object : ScanResultsCache {
             override fun read(id: Identifier) = ScanResultContainer(id, emptyList())
@@ -106,4 +72,37 @@ interface ScanResultsCache {
 
         override fun add(id: Identifier, scanResult: ScanResult) = cache.add(id, scanResult)
     }
+
+    /**
+     * Read all [ScanResult]s for this [id] from the cache.
+     *
+     * @param id The [Identifier] of the scanned [Package].
+     *
+     * @return The [ScanResultContainer] for this [id].
+     */
+    fun read(id: Identifier): ScanResultContainer
+
+    /**
+     * Read the [ScanResult]s matching the [id][Package.id] of [pkg] and the [scannerDetails] from the cache.
+     * [ScannerDetails.isCompatible] is used to check if the results are compatible with the provided [scannerDetails].
+     * Also [Package.sourceArtifact], [Package.vcs], and [Package.vcsProcessed] are used to check if the scan result
+     * matches the expected source code location. This is important to find the correct results when different revisions
+     * of a package using the same version name are used (e.g. multiple scans of 1.0-SNAPSHOT during development).
+     *
+     * @param pkg The [Package] to look up results for.
+     * @param scannerDetails Details about the scanner that was used to scan the [Package].
+     *
+     * @return The [ScanResultContainer] matching the [id][Package.id] of [pkg] and the [scannerDetails].
+     */
+    fun read(pkg: Package, scannerDetails: ScannerDetails): ScanResultContainer
+
+    /**
+     * Add a [ScanResult] to the [ScanResultContainer] for this [id] and write it to the cache.
+     *
+     * @param id The [Identifier] of the scanned [Package].
+     * @param scanResult The [ScanResult]. The [ScanResult.rawResult] must not be null.
+     *
+     * @return If the [ScanResult] could be written to the cache.
+     */
+    fun add(id: Identifier, scanResult: ScanResult): Boolean
 }


### PR DESCRIPTION
The only exception are constructors which should be close to the default
constructor, and enum constants which have to come before any other
content.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/937)
<!-- Reviewable:end -->
