### PR TITLE
Travis: Stop uploading of test artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,11 +58,3 @@ script:
 
 after_success:
   - bash <(curl -s https://codecov.io/bash) -X gcov -f '!*/src/*/assets/*'
-
-addons:
-  artifacts:
-    paths:
-      - ./analyzer/build/reports/tests
-      - ./downloader/build/reports/tests
-      - ./scanner/build/reports/tests
-      - ./utils/build/reports/tests


### PR DESCRIPTION
This never really worked as expected due to [1] and would again require
rotating of S3 credentials, so simply disable it for now.

[1] https://github.com/travis-ci/travis-ci/issues/9025

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/947)
<!-- Reviewable:end -->
