### PR TITLE
VersionControlSystem: Catch IOExceptions when listing remote branches

### DIFF
--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -280,7 +280,12 @@ abstract class VersionControlSystem {
      * Check whether the given [revision] is likely to name a fixed revision that does not move.
      */
     fun isFixedRevision(workingTree: WorkingTree, revision: String) =
-            revision.isNotBlank() && revision !in latestRevisionNames && revision !in workingTree.listRemoteBranches()
+            try {
+                revision.isNotBlank() && revision !in latestRevisionNames &&
+                        revision !in workingTree.listRemoteBranches()
+            } catch (e: IOException) {
+                false
+            }
 
     /**
      * Check whether the VCS tool is at least of the specified [expectedVersion], e.g. to check for features.


### PR DESCRIPTION
Esp. for Subversion with its varing directory layout for branches / tags
(globally or per project) it could be that we are guessing the wrong
layout. In such a case we should not fail completely, but just fail this
check to give a later curation the chance to succeed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/949)
<!-- Reviewable:end -->
