### PR TITLE
Git: Throw an error if a requested VCS path does not exist

### DIFF
--- a/downloader/src/main/kotlin/vcs/Git.kt
+++ b/downloader/src/main/kotlin/vcs/Git.kt
@@ -52,6 +52,13 @@ class Git : GitBase() {
                 if (recursive && File(targetDir, ".gitmodules").isFile) {
                     run(targetDir, "submodule", "update", "--init", "--recursive")
                 }
+
+                pkg.vcsProcessed.path.let {
+                    if (it.isNotEmpty() && !targetDir.resolve(it).isDirectory) {
+                        throw DownloadException("The $type working directory at '$targetDir' does not contain the " +
+                                "requested path '$it'.")
+                    }
+                }
             }
         } catch (e: IOException) {
             throw DownloadException("$type failed to download from URL '${pkg.vcsProcessed.url}'.", e)


### PR DESCRIPTION
This ensures our sparse checkout actually matches the path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/969)
<!-- Reviewable:end -->
