### PR TITLE
NPM:fix uncaught IOException

### DIFF
--- a/analyzer/src/main/kotlin/managers/NPM.kt
+++ b/analyzer/src/main/kotlin/managers/NPM.kt
@@ -149,7 +149,13 @@ open class NPM(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConf
             definitionFiles.first().parentFile
         }
 
-        val rootPackageJson = projectRoot.resolve("package.json").readValue<ObjectNode>()
+        val rootDefinitionFile = projectRoot.resolve("package.json")
+        if (!rootDefinitionFile.exists()) {
+            workspaceMatchers = emptyList()
+            return definitionFiles
+        }
+
+        val rootPackageJson = rootDefinitionFile.readValue<ObjectNode>()
         workspaceMatchers = rootPackageJson["workspaces"]?.map {
             FileSystems.getDefault().getPathMatcher("glob:$projectRoot/${it.textValue()}")
         }.orEmpty()


### PR DESCRIPTION
Given a list of definition files 'mapDefinitionFiles' needs to decide which
of those files shall be handled by this package manager. In case of NPM all
definition files that are not handled by a Yarn workspace need to be filtered
out as of the recent introduction of basic Yarn workspace support, see dcf44b7.

The implemented logic which is based on computing a common file prefix does not
work in all possible cases. In context of this bug the computed project root
path does not have any child file called 'package.json'. This is the typical
case for Git Repo based projects resulting in an IOException.

Checking whether that file exists fixes this issue quickly. This change
intentionally doesn't fix the Yarn workspace detection for all possible cases
since this requires more effort and is left for a following change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/973)
<!-- Reviewable:end -->
