### PR TITLE
Add license note generator for only declared licenses

### DIFF
--- a/model/build.gradle
+++ b/model/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 task generateSpdxLicenseList {
     doLast {
         println "Fetching SPDX license list..."
+
         def jsonSlurper = new groovy.json.JsonSlurper()
         def spdxUrl = "https://raw.githubusercontent.com/spdx/license-list-data/master/json/licenses.json".toURL()
         def json = jsonSlurper.parse(spdxUrl)
@@ -28,7 +29,7 @@ task generateSpdxLicenseList {
         println "Found ${spdxLicenseIds.size()} SPDX license identifiers."
 
         def licenseEnumFile = file('src/main/kotlin/config/SpdxLicense.kt')
-        licenseEnumFile.write("""
+        licenseEnumFile.write("""\
             /*
              * Copyright (C) 2017-2018 HERE Europe B.V.
              *
@@ -56,10 +57,12 @@ task generateSpdxLicenseList {
              */
             enum class SpdxLicense(val license: String) {
             """.stripIndent())
+
         licenseEnumFile.append(spdxLicenseIds.collect { "    ${licenseToEnumEntry(it.toString())}" }.sort().join(',\n'))
         licenseEnumFile.append("""
             }
             """.stripIndent())
+
         println("Generated SPDX license enum '$licenseEnumFile'.")
     }
 }

--- a/model/src/main/kotlin/config/LicenseMapping.kt
+++ b/model/src/main/kotlin/config/LicenseMapping.kt
@@ -393,7 +393,8 @@ object LicenseMapping {
             "zlib" to enumSetOf(SpdxLicense.ZLIB)
     )
 
-    fun map(license: String) = (mapping[license] ?: enumSetOf()).apply {
-        SpdxLicense.values().find { it.license == license }?.let { add(it) }
-    }
+    fun map(license: String) =
+            (mapping[license] ?: enumSetOf()).apply {
+                SpdxLicense.values().find { it.license == license }?.let { add(it) }
+            }
 }

--- a/model/src/main/kotlin/config/SpdxLicense.kt
+++ b/model/src/main/kotlin/config/SpdxLicense.kt
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2017-2018 HERE Europe B.V.
  *

--- a/reporter/src/main/kotlin/reporters/AbstractNoticeReporter.kt
+++ b/reporter/src/main/kotlin/reporters/AbstractNoticeReporter.kt
@@ -35,7 +35,7 @@ import java.util.SortedSet
 
 abstract class AbstractNoticeReporter : Reporter() {
     override fun generateReport(ortResult: OrtResult, resolutionProvider: ResolutionProvider, outputDir: File): File? {
-        require(ortResult.scanner != null) {
+        requireNotNull(ortResult.scanner) {
             "The provided ORT result file does not contain a scan result."
         }
 

--- a/reporter/src/main/kotlin/reporters/AbstractNoticeReporter.kt
+++ b/reporter/src/main/kotlin/reporters/AbstractNoticeReporter.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2017-2018 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.reporter.reporters
+
+import ch.frankel.slf4k.*
+
+import com.here.ort.model.OrtResult
+import com.here.ort.reporter.Reporter
+import com.here.ort.reporter.ResolutionProvider
+import com.here.ort.utils.log
+import com.here.ort.utils.spdx.getLicenseText
+
+import java.io.File
+import java.util.SortedMap
+import java.util.SortedSet
+
+abstract class AbstractNoticeReporter : Reporter() {
+    override fun generateReport(ortResult: OrtResult, resolutionProvider: ResolutionProvider, outputDir: File): File? {
+        require(ortResult.scanner != null) {
+            "The provided ORT result file does not contain a scan result."
+        }
+
+        val outputFile = File(outputDir, noticeFileName)
+
+        val licenseFindings = getLicenseFindings(ortResult)
+
+        val findingsIterator = licenseFindings.filterNot { (license, _) ->
+            // For now, just skip license references for which SPDX has no license text.
+            license.startsWith("LicenseRef-")
+        }.iterator()
+
+        if (!findingsIterator.hasNext()) {
+            log.info { "Not writing a $noticeFileName file as it would be empty." }
+            return null
+        } else {
+            log.info { "Writing $noticeFileName file to '${outputFile.absolutePath}'." }
+        }
+
+        // Note: Do not use appendln() here as that would write out platform-native line endings, but we want to
+        // normalize on Unix-style line endings for consistency.
+        while (findingsIterator.hasNext()) {
+            val (license, copyrights) = findingsIterator.next()
+
+            var noticeBuilder = StringBuilder()
+
+            copyrights.forEach { copyright ->
+                noticeBuilder.append("$copyright\n")
+            }
+
+            if (copyrights.isNotEmpty()) noticeBuilder.append("\n")
+
+            noticeBuilder.append("${getLicenseText(license, true)}\n")
+
+            // Trim lines and remove consecutive blank lines as the license text formatting in SPDX JSON files is
+            // broken, see https://github.com/spdx/LicenseListPublisher/issues/30.
+            var previousLine = ""
+            val trimmedNoticeLines = noticeBuilder.lines().mapNotNull { line ->
+                val trimmedLine = line.trim()
+                trimmedLine.takeIf { it.isNotBlank() || previousLine.isNotBlank() }
+                        .also { previousLine = trimmedLine }
+            }
+
+            noticeBuilder = StringBuilder(trimmedNoticeLines.joinToString("\n"))
+
+            // Separate notice rows.
+            if (findingsIterator.hasNext()) noticeBuilder.append("\n----\n\n")
+
+            outputFile.appendText(noticeBuilder.toString())
+        }
+
+        return outputFile
+    }
+
+    abstract val noticeFileName: String
+
+    abstract fun getLicenseFindings(ortResult: OrtResult): SortedMap<String, SortedSet<String>>
+}

--- a/reporter/src/main/kotlin/reporters/NoticeOnlyDeclaredReporter.kt
+++ b/reporter/src/main/kotlin/reporters/NoticeOnlyDeclaredReporter.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2017-2018 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.reporter.reporters
+
+import com.here.ort.model.OrtResult
+import com.here.ort.model.config.LicenseMapping
+
+import java.util.SortedMap
+import java.util.SortedSet
+
+class NoticeOnlyDeclaredReporter : AbstractNoticeReporter() {
+    override val noticeFileName = "NOTICE_ONLY_DECLARED"
+
+    override fun getLicenseFindings(ortResult: OrtResult): SortedMap<String, SortedSet<String>> {
+        val excludes = ortResult.repository.config.excludes
+        val analyzerResult = ortResult.analyzer!!.result
+        val scanRecord = ortResult.scanner!!.results
+
+        val licenseFindings = sortedMapOf<String, SortedSet<String>>()
+
+        // TODO: Decide whether we want to merge the list of detected licenses with declared licenses (which do not come
+        // with a copyright).
+        scanRecord.scanResults.forEach { container ->
+            if (excludes == null || !excludes.isPackageExcluded(container.id, analyzerResult)) {
+                container.results.forEach { result ->
+                    result.summary.licenseFindings.forEach { licenseFinding ->
+                        licenseFindings.getOrPut(licenseFinding.license) { sortedSetOf() } += licenseFinding.copyrights
+                    }
+                }
+            }
+        }
+
+        val allDeclaredLicenses = ortResult.analyzer?.result?.packages?.flatMapTo(sortedSetOf()) { curated ->
+            curated.pkg.declaredLicenses
+        } ?: sortedSetOf<String>()
+
+        val allDeclaredSpdxLicenses = allDeclaredLicenses
+                .flatMap { LicenseMapping.map(it) }
+                .mapTo(sortedSetOf()) { it.license }
+
+        return licenseFindings.filterTo(sortedMapOf()) { (license, _) ->
+            // Only consider detected licenses that also are declared licenses. We associate detected and declared
+            // licenses this way as otherwise we would not know which copyrights to use for which declared license.
+            (license in allDeclaredSpdxLicenses)
+        }
+    }
+}

--- a/reporter/src/main/kotlin/reporters/TableReporter.kt
+++ b/reporter/src/main/kotlin/reporters/TableReporter.kt
@@ -232,13 +232,13 @@ abstract class TableReporter : Reporter() {
         val errorSummaryRows = mutableMapOf<Identifier, ErrorRow>()
         val summaryRows = mutableMapOf<Identifier, SummaryRow>()
 
-        require(ortResult.analyzer?.result != null) {
+        requireNotNull(ortResult.analyzer?.result) {
             "The provided ORT result does not contain an analyzer result."
         }
 
         val analyzerResult = ortResult.analyzer!!.result
 
-        require(ortResult.scanner?.results != null) {
+        requireNotNull(ortResult.scanner?.results) {
             "The provided ORT result does not contain any scan results."
         }
 

--- a/reporter/src/main/resources/META-INF/services/com.here.ort.reporter.Reporter
+++ b/reporter/src/main/resources/META-INF/services/com.here.ort.reporter.Reporter
@@ -1,4 +1,5 @@
 com.here.ort.reporter.reporters.ExcelReporter
+com.here.ort.reporter.reporters.NoticeOnlyDeclaredReporter
 com.here.ort.reporter.reporters.NoticeReporter
 com.here.ort.reporter.reporters.StaticHtmlReporter
 com.here.ort.reporter.reporters.WebAppReporter

--- a/reporter/src/test/assets/NPM-is-windows-1.0.2-expected-NOTICE_ONLY_DECLARED
+++ b/reporter/src/test/assets/NPM-is-windows-1.0.2-expected-NOTICE_ONLY_DECLARED
@@ -1,0 +1,270 @@
+Copyright (c) 2015 AJ ONeal
+
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+(a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability. END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!) The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+
+distributed under the License is distributed on an "AS IS" BASIS,
+
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+
+limitations under the License.
+
+----
+
+Copyright (c) 2007, Parakey Inc.
+Copyright (c) 2008 Ariel Flesler
+Copyright (c) 2009-2011, Mozilla Foundation and contributors
+Copyright (c) 2009-2015, Kevin Decker <kpdecker@gmail.com>
+Copyright 2009, Microsoft Corporation.
+Copyright 2009, The Dojo Foundation
+Copyright 2009-2011 Mozilla Foundation and contributors
+Copyright 2011 Mozilla Foundation and contributors
+Copyright 2011 The Closure Compiler
+Copyright 2011, The Dojo Foundation
+Copyright 2012 Mozilla Foundation and contributors
+Copyright 2014 Mozilla Foundation and contributors
+
+Copyright (c) <year> <owner> . All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+----
+
+Copyright (c) Isaac Z. Schlueter
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+ISC License
+
+Copyright (c) 2004-2010 by Internet Systems Consortium, Inc. ("ISC")
+
+Copyright (c) 1995-2003 by Internet Software Consortium
+
+Permission to use, copy, modify, and /or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND ISC DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL ISC BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+----
+
+(c) (c) (tm)
+(c) 2005-2009 Sam Stephenson
+(c) 2009-2012 Jeremy Ashkenas, DocumentCloud Inc.
+(c) 2009-2014 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors Underscore
+(c) 2009-2015, Jeremy Ashkenas.
+(c) 2010 Esa-Matti Suuronen
+(c) 2010-2014 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors Backbone
+(c) 2010-2015 Google, Inc. http://angularjs.org
+(c) 2012-2014 http://kitcambridge.be/' Kit Cambridge
+(c) 2012-2015, The Dojo Foundation.copyright
+(c) Sam Verschueren (https://github.com/SamVerschueren)
+(c) Sindre Sorhus (http://sindresorhus.com)
+(c) Sindre Sorhus (https://sindresorhus.com)
+(c) Vasily Polovnyov <vast@whiteants.net>
+(c) copyright 2010-2013 B Cavalier & J Hann
+Code copyright 2012-2018 AJ ONeal
+Copyright (c) 2008-2009, Robert Kieffer
+Copyright (c) 2009 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2009-2014 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+Copyright (c) 2010-2011 Marcus Westin
+Copyright (c) 2010-2014 Jeremy Ashkenas, DocumentCloud
+Copyright (c) 2010-2014, The Dojo Foundation
+Copyright (c) 2011 Esa-Matti Suuronen esa-matti@suuronen.org
+Copyright (c) 2011 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2011 by fent
+Copyright (c) 2011-2013, Christopher Jeffrey. (MIT Licensed) https://github.com/chjj/marked
+Copyright (c) 2011-2015 Paul Vorbach <paul@vorba.ch>
+Copyright (c) 2011-2016 Paul Vorbach (https://paul.vorba.ch/) and contributors (https://github.com/pvorb/clone/graphs/contributors).
+Copyright (c) 2011-2017 JS Foundation
+Copyright (c) 2012 Vitaly Puzrin (https://github.com/puzrin).
+Copyright (c) 2012 by Vitaly Puzrin
+Copyright (c) 2012-2014 Kit Cambridge. http://kitcambridge.be
+Copyright (c) 2012-2014 Raynos.
+Copyright (c) 2013 Blaine Bublitz <blaine.bublitz@gmail.com> , Eric Schoffstall <yo@contra.io> and other contributors
+Copyright (c) 2013 Julian Gruber <julian@juliangruber.com>
+Copyright (c) 2013 Rod Vagg rvagg (https://twitter.com/rvagg)
+Copyright (c) 2013 Simon Lydell
+Copyright (c) 2013-2017, Jon Schlinkert.
+Copyright (c) 2014 Blaine Bublitz <blaine.bublitz@gmail.com> , Eric Schoffstall <yo@contra.io> and other contributors
+Copyright (c) 2014 Component
+Copyright (c) 2014 Gregory Jacobs (http://greg-jacobs.com)
+Copyright (c) 2014 Hugh Kennedy
+Copyright (c) 2014 Jon Schlinkert, Vitaly Puzrin.
+Copyright (c) 2014 Jon Schlinkert, contributors.
+Copyright (c) 2014 Nathan Rajlich <nathan@tootallnate.net>
+Copyright (c) 2014 Simon Lydell
+Copyright (c) 2014 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2014, 2015, 2016, 2017 Simon Lydell
+Copyright (c) 2014, 2017, Jon Schlinkert.
+Copyright (c) 2014-2015 Jon Schlinkert.
+Copyright (c) 2014-2015, 2017, Jon Schlinkert
+Copyright (c) 2014-2015, 2017, Jon Schlinkert.
+Copyright (c) 2014-2015, Jon
+Copyright (c) 2014-2015, Jon Schlinkert.
+Copyright (c) 2014-2016 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2014-2016, Jon Schlinkert
+Copyright (c) 2014-2016, Jon Schlinkert.
+Copyright (c) 2014-2017, Jon Schlinkert
+Copyright (c) 2014-2017, Jon Schlinkert.
+Copyright (c) 2014-2018, Jon Schlinkert.
+Copyright (c) 2015
+Copyright (c) 2015 AJ ONeal
+Copyright (c) 2015 Calvin Metcalf
+Copyright (c) 2015 Gregory Jacobs <greg@greg-jacobs.com> MIT Licensed. http://www.opensource.org/licenses/mit-license.php
+Copyright (c) 2015 Jon Schlinkert
+Copyright (c) 2015 Jon Schlinkert (https://github.com/jonschlinkert)
+Copyright (c) 2015 Jon Schlinkert.
+Copyright (c) 2015 Zhiye Li
+Copyright (c) 2015, 2017, Jon Schlinkert
+Copyright (c) 2015, 2017, Jon Schlinkert.
+Copyright (c) 2015, 2017-2018, Jon Schlinkert.
+Copyright (c) 2015, Jon Schlinkert.
+Copyright (c) 2015-2016, Jon Schlinkert
+Copyright (c) 2015-2016, Jon Schlinkert.
+Copyright (c) 2015-2017, Jon Schlinkert
+Copyright (c) 2015-2017, Jon Schlinkert.
+Copyright (c) 2015-2018, Jon Schlinkert.
+Copyright (c) 2016 Blaine Bublitz <blaine.bublitz@gmail.com> , Eric Schoffstall <yo@contra.io> and other contributors
+Copyright (c) 2016 Jon Schlinkert (https://github.com/jonschlinkert)
+Copyright (c) 2016 Joshua Boy Nicolai Appelman <joshua@jbna.nl>
+Copyright (c) 2016 Matteo Collina
+Copyright (c) 2016 Rod Vagg
+Copyright (c) 2016 Segment.io, Inc. (friends@segment.com)
+Copyright (c) 2016 Zeit, Inc.
+Copyright (c) 2016, 2018, Jon Schlinkert.
+Copyright (c) 2016, Brian Woodward (https://github.com/doowb).
+Copyright (c) 2016, Brian Woodward.
+Copyright (c) 2016, Jon Schlinkert (http://github.com/jonschlinkert).
+Copyright (c) 2016, Jon Schlinkert (https://github.com/jonschlinkert).
+Copyright (c) 2016, Jon Schlinkert.
+Copyright (c) 2016-2018, Jon Schlinkert.
+Copyright (c) 2017 Jon Schlinkert
+Copyright (c) 2017, Jon Schlinkert (https://github.com/jonschlinkert).
+Copyright (c) 2018, Jon Schlinkert (https://github.com/jonschlinkert).
+Copyright (c) < year() > , Jon Schlinkert.
+Copyright (c) Alexandru Marasteanu
+Copyright (c) Feross Aboukhadijeh
+Copyright (c) Feross Aboukhadijeh (http://feross.org)
+Copyright (c) Feross Aboukhadijeh (http://feross.org).
+Copyright (c) Sam Verschueren <sam.verschueren@gmail.com>
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+Copyright 2009, 2010, 2011 Isaac Z. Schlueter.
+Copyright 2009, The Dojo Foundation
+Copyright 2009-2013 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+Copyright 2009-2014 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+Copyright 2009-2015 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+Copyright 2010 James Halliday (mail@substack.net)
+Copyright 2010-2014 John-David Dalton <http://allyoucanleet.com/>
+Copyright 2010-2014 Mathias Bynens <http://mths.be/>
+Copyright 2010-2015 Mathias Bynens <http://mathiasbynens.be/>
+Copyright 2010-2015 Mathias Bynens <http://mths.be/>
+Copyright 2011, John Resig
+Copyright 2011, The Dojo Foundation
+Copyright 2011-2014, Kit Cambridge http://kitcambridge.github.com
+Copyright 2012 jQuery Foundation and other contributors
+Copyright 2012, Kit Cambridge
+Copyright 2012-2013 The Dojo Foundation <http://dojofoundation.org/>
+Copyright 2012-2014 The Dojo Foundation <http://dojofoundation.org/>
+Copyright 2012-2014, Kit Cambridge http://kit.mit-license.org
+Copyright 2012-2015 The Dojo Foundation <http://dojofoundation.org/>
+Copyright 2013 jQuery Foundation and other contributors
+Copyright 2014 Simon Lydell X11 (MIT) Licensed.
+Copyright 2014, 2015, 2016, 2017 Simon Lydell X11 (MIT) Licensed.
+Copyright 2014, 2017 Simon Lydell X11 (MIT) Licensed.
+Copyright 2017 Simon Lydell X11 (MIT) Licensed.
+Copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+Copyright Joyent, Inc. and other Node contributors.
+Copyright Mathias Bynens <http://mths.be/>
+Copyright Mathias Bynens <https://mathiasbynens.be/>
+Copyright TJ Holowaychuk <tj@vision-media.ca>
+Copyright jQuery Foundation and other contributors <https://jquery.org/>
+CxD Copyright 2011 by Jan Tonellato.
+TarHeader (c)
+copyright 2009-2015 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+copyright 2012-2018 AJ ONeal
+copyright Robert Kieffer <http://broofa.com/>
+
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/reporter/src/test/kotlin/reporters/NoticeOnlyDeclaredReporterTest.kt
+++ b/reporter/src/test/kotlin/reporters/NoticeOnlyDeclaredReporterTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2017-2018 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.reporter.reporters
+
+import com.here.ort.model.OrtResult
+import com.here.ort.model.readValue
+import com.here.ort.reporter.DefaultResolutionProvider
+
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.WordSpec
+
+import java.io.File
+
+class NoticeOnlyDeclaredReporterTest : WordSpec({
+    "NoticesOnlyDeclaredReporter" should {
+        "generate the correct license notes" {
+            val expectedResultFile = File("src/test/assets/NPM-is-windows-1.0.2-expected-NOTICE_ONLY_DECLARED")
+            val expectedText = expectedResultFile.readText()
+            val scanRecordFile = File("src/test/assets/NPM-is-windows-1.0.2-scan-result.json")
+            val ortResult = scanRecordFile.readValue<OrtResult>()
+            val outputDir = createTempDir().also { it.deleteOnExit() }
+
+            NoticeOnlyDeclaredReporter().generateReport(ortResult, DefaultResolutionProvider(), outputDir)
+
+            val resultFile = File(outputDir, "NOTICE_ONLY_DECLARED")
+            val actualText = resultFile.readText()
+
+            actualText shouldBe expectedText
+        }
+    }
+})

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -81,7 +81,7 @@ abstract class Scanner(protected val config: ScannerConfiguration) {
 
         val ortResult = dependenciesFile.readValue<OrtResult>()
 
-        require(ortResult.analyzer != null) {
+        requireNotNull(ortResult.analyzer) {
             "The provided dependencies file '${dependenciesFile.invariantSeparatorsPath}' does not contain an " +
                     "analyzer result."
         }


### PR DESCRIPTION
Please see the commit messages for details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/974)
<!-- Reviewable:end -->
