### PR TITLE
scanner: Really bootstrap ScanCode instead of using it from a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,10 +14,6 @@
 	path = analyzer/src/funTest/assets/projects/external/spdx-tools-python
 	url = https://github.com/spdx/tools-python.git
 	ignore = untracked
-[submodule "scancode-toolkit"]
-	path = scanner/src/funTest/assets/scanners/scancode-toolkit
-	url = https://github.com/nexb/scancode-toolkit.git
-	ignore = untracked
 [submodule "qmstr"]
 	path = analyzer/src/funTest/assets/projects/external/qmstr
 	url = https://github.com/QMSTR/qmstr.git


### PR DESCRIPTION
The Git submodule is not available when running ORT from a (future)
binary distribution. Hence we need to really bootstrap ScanCode instead
of "fake-bootstrapping" it by directly using it from the checked out
submodule. This aligns with the other scanners which are bootstrapped
properly already.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/988)
<!-- Reviewable:end -->
