### PR TITLE
OkHttpClientHelper: Increase the HTTP cache size to 1 GiB

### DIFF
--- a/utils/src/main/kotlin/OkHttpClientHelper.kt
+++ b/utils/src/main/kotlin/OkHttpClientHelper.kt
@@ -55,7 +55,8 @@ object OkHttpClientHelper {
     fun execute(cachePath: String, request: Request): Response {
         val client = clients.getOrPut(cachePath) {
             val cacheDirectory = File(getUserConfigDirectory(), cachePath)
-            val cache = Cache(cacheDirectory, 10 * 1024 * 1024)
+            val maxCacheSizeInBytes = 1024L * 1024L * 1024L
+            val cache = Cache(cacheDirectory, maxCacheSizeInBytes)
             val specs = listOf(ConnectionSpec.MODERN_TLS, ConnectionSpec.COMPATIBLE_TLS, ConnectionSpec.CLEARTEXT)
             OkHttpClient.Builder()
                     .cache(cache)


### PR DESCRIPTION
The previous 10 MiB were too little to cache e.g. the ScanCode
distribution which has about 110 MiB.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/992)
<!-- Reviewable:end -->
