### PR TITLE
Gradle: Move application dependencies to the only "cli" application

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,22 +62,6 @@ subprojects {
         }
     }
 
-    plugins.withType(ApplicationPlugin) {
-        dependencies {
-            compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
-
-            testCompile "io.kotlintest:kotlintest-core:$kotlintestVersion"
-            testCompile "io.kotlintest:kotlintest-assertions:$kotlintestVersion"
-            testCompile "io.kotlintest:kotlintest-runner-junit5:$kotlintestVersion"
-            testCompile project(':utils-test')
-
-            funTestCompile sourceSets.main.output
-            funTestCompile sourceSets.test.output
-            funTestCompile configurations.testCompile
-            funTestRuntime configurations.testRuntime
-        }
-    }
-
     // TODO: Remove this once jackson-module-kotlin and kotlintest are updated.
     configurations.all {
         resolutionStrategy {

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -23,6 +23,20 @@ dependencies {
     compile project(':utils')
 
     compile "com.beust:jcommander:$jcommanderVersion"
-    compile "org.jetbrains.kotlin:kotlin-reflect"
+
+    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    compile 'org.jetbrains.kotlin:kotlin-reflect'
+
     compile "org.reflections:reflections:$reflectionsVersion"
+
+    testCompile project(':utils-test')
+
+    testCompile "io.kotlintest:kotlintest-core:$kotlintestVersion"
+    testCompile "io.kotlintest:kotlintest-assertions:$kotlintestVersion"
+    testCompile "io.kotlintest:kotlintest-runner-junit5:$kotlintestVersion"
+
+    funTestCompile sourceSets.main.output
+    funTestCompile sourceSets.test.output
+    funTestCompile configurations.testCompile
+    funTestRuntime configurations.testRuntime
 }


### PR DESCRIPTION
Now that we only have one application project, move application
dependencies directly to there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/994)
<!-- Reviewable:end -->
