### PR TITLE
Improve Yarn workspaces handling

### DIFF
--- a/analyzer/src/main/kotlin/managers/PackageJsonUtil.kt
+++ b/analyzer/src/main/kotlin/managers/PackageJsonUtil.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2017-2018 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.analyzer.managers
+
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.here.ort.model.readValue
+import java.io.File
+import java.nio.file.FileSystems
+import java.nio.file.PathMatcher
+
+internal class PackageJsonUtil {
+    companion object {
+        private val NPM_LOCK_FILES = listOf("npm-shrinkwrap.json", "package-lock.json")
+        private val YARN_LOCK_FILES = listOf("yarn.lock")
+
+        private data class DefinitionFileInfo(
+                val definitionFile: File,
+                var hasYarnLockfile: Boolean = false,
+                var hasNpmLockfile: Boolean = false,
+                var isYarnWorkspaceRoot: Boolean = false,
+                var isYarnWorkspaceSubmodule: Boolean = false
+        )
+
+        fun hasNpmLockFile(directory: File) =
+                NPM_LOCK_FILES.any { lockfile ->
+                    File(directory, lockfile).isFile
+                }
+
+        fun hasYarnLockFile(directory: File) =
+                YARN_LOCK_FILES.any { lockfile ->
+                    File(directory, lockfile).isFile
+                }
+
+        fun mapDefinitionFilesForNpm(definitionFiles: Collection<File>) =
+                getDefinitionFileInfo(definitionFiles.toSet()).filter { entry ->
+                    !isHandledByYarn(entry)
+                }.map { it.definitionFile }.toSet()
+
+        fun mapDefinitionFilesForYarn(definitionFiles: Collection<File>) =
+                getDefinitionFileInfo(definitionFiles.toSet()).filter { entry ->
+                    isHandledByYarn(entry) && !entry.isYarnWorkspaceSubmodule
+                }.map { it.definitionFile }.toSet()
+
+        private fun isHandledByYarn(entry: DefinitionFileInfo) =
+                entry.isYarnWorkspaceRoot || entry.isYarnWorkspaceSubmodule || entry.hasYarnLockfile
+
+        private fun getDefinitionFileInfo(definitionFiles: Set<File> ): Collection<DefinitionFileInfo> {
+            val result = definitionFiles.associate { definitionFile ->
+                definitionFile to DefinitionFileInfo(definitionFile = definitionFile)
+            }
+
+            result.values.forEach { entry ->
+                entry.isYarnWorkspaceRoot = isYarnWorkspaceRoot(entry.definitionFile)
+                entry.hasYarnLockfile = hasYarnLockFile(entry.definitionFile.parentFile)
+                entry.hasNpmLockfile = hasNpmLockFile(entry.definitionFile.parentFile)
+            }
+
+            getYarnWorkspaceSubmodules(definitionFiles).forEach { definitionFile ->
+                result[definitionFile]!!.isYarnWorkspaceSubmodule = true
+            }
+
+            return result.values
+        }
+
+        private fun isYarnWorkspaceRoot(definitionFile: File): Boolean {
+            return definitionFile.readValue<ObjectNode>()["workspaces"] != null
+        }
+
+        private fun getYarnWorkspaceSubmodules(definitionFiles: Set<File>): Set<File> {
+            val result = mutableSetOf<File>()
+
+            definitionFiles.forEach { definitionFile ->
+                val workspaceMatchers = getWorkspaceMatchers(definitionFile)
+                workspaceMatchers.forEach { matcher ->
+                    definitionFiles.forEach inner@ { other ->
+                        // Since yarn workspaces matchers support '*' and '**' to match multiple directories the matcher
+                        // cannot be used as is for matching the 'package.json' file. Thus matching against the project
+                        // directory since this works out of the box. See also:
+                        //   https://github.com/yarnpkg/yarn/issues/3986
+                        //   https://github.com/yarnpkg/yarn/pull/5607
+                        val projectDir = other.parentFile.toPath()
+                        if (other != definitionFile && matcher.matches(projectDir)) {
+                            result.add(other)
+                            return@inner
+                        }
+                    }
+                }
+            }
+
+            return result
+        }
+
+        private fun getWorkspaceMatchers(definitionFile: File): List<PathMatcher> =
+                definitionFile.readValue<ObjectNode>()["workspaces"]?.map {
+                    val pattern = "glob:${definitionFile.parentFile}/${it.textValue()}"
+                    FileSystems.getDefault().getPathMatcher(pattern)
+                } ?: emptyList()
+    }
+}

--- a/analyzer/src/main/kotlin/managers/Yarn.kt
+++ b/analyzer/src/main/kotlin/managers/Yarn.kt
@@ -40,20 +40,14 @@ class Yarn(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfigur
                 Yarn(analyzerConfig, repoConfig)
     }
 
+    override fun hasLockFile(projectDir: File) = PackageJsonUtil.hasYarnLockFile(projectDir)
+
     override fun command(workingDir: File?) = if (OS.isWindows) "yarn.cmd" else "yarn"
 
     override fun getVersionRequirement(): Requirement = Requirement.buildNPM("1.3.* - 1.9.*")
 
-    override fun hasLockFile(projectDir: File) = hasYarnLockFile(projectDir)
-
-    override fun mapDefinitionFiles(definitionFiles: List<File>): List<File> {
-        val yarnDefinitionFiles = definitionFiles - super.mapDefinitionFiles(definitionFiles)
-
-        // Only keep those Yarn definition files that are accompanied by a Yarn lock file. Deliberately omit Yarn
-        // definition files managed by Yarn workspaces as then installation of dependencies only needs to happen in the
-        // project root.
-        return yarnDefinitionFiles.filter { hasYarnLockFile(it.parentFile, false) }
-    }
+    override fun mapDefinitionFiles(definitionFiles: List<File>) =
+            PackageJsonUtil.mapDefinitionFilesForYarn(definitionFiles).toList()
 
     override fun prepareResolution(definitionFiles: List<File>) =
             // We do not actually depend on any features specific to a Yarn version, but we still want to stick to a

--- a/analyzer/src/test/kotlin/PackageJsonUtilTest.kt
+++ b/analyzer/src/test/kotlin/PackageJsonUtilTest.kt
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2017-2018 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.analyzer
+
+import com.here.ort.utils.safeDeleteRecursively
+import com.here.ort.utils.safeMkdirs
+
+import io.kotlintest.Description
+import io.kotlintest.TestResult
+import io.kotlintest.matchers.collections.shouldBeEmpty
+import io.kotlintest.matchers.collections.shouldContainExactly
+import io.kotlintest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.StringSpec
+
+import com.here.ort.analyzer.managers.PackageJsonUtil
+import com.here.ort.analyzer.managers.PackageJsonUtil.Companion.mapDefinitionFilesForNpm
+import com.here.ort.analyzer.managers.PackageJsonUtil.Companion.mapDefinitionFilesForYarn
+
+import java.io.File
+
+class PackageJsonUtilTest() : StringSpec() {
+    companion object {
+        private fun createPackageJson(matchers: List<String>) =
+                if (!matchers.isEmpty())
+                """
+                {
+                   "workspaces" : ${matchers.joinToString (prefix = "[\"", separator = "\",\"", postfix = "\"]")}
+                }
+                """.trimIndent()
+                else "{}"
+
+        private fun mapDefinitionFiles(definitionFiles: Collection<File>) =
+                mapDefinitionFilesForNpm(definitionFiles).plus(mapDefinitionFilesForYarn(definitionFiles))
+    }
+
+    init {
+
+        "given no NPM lockfile present, hasNpmLockFile returns false" {
+            setupProject(path = "a")
+
+            hasNpmLockFile("a") shouldBe false
+        }
+
+        "given NPM lockfile present, hasNpmLockFile returns true" {
+            setupProject(path = "a", hasNpmLockFile = true)
+
+            hasNpmLockFile("a") shouldBe true
+        }
+
+        "given no Yarn lockfile present, hasYarnLockFile returns false" {
+            setupProject(path = "a")
+
+            hasNpmLockFile("a") shouldBe false
+        }
+
+        "given Yarn lockfile present, hasYarnLockFile returns true" {
+            setupProject(path = "a", hasYarnLockFile = true)
+
+            hasYarnLockFile("a") shouldBe true
+        }
+
+        "given project with Yarn and NPM lockfile, definition file is mapped for Yarn only" {
+            setupProject(path = "a", hasNpmLockFile = true, hasYarnLockFile = true)
+
+            mapDefinitionFilesForNpm(definitionFiles).shouldBeEmpty()
+            mapDefinitionFilesForYarn(definitionFiles) shouldContainExactly
+                    absolutePaths(
+                    "a/package.json")
+        }
+
+        "given project with no lockfile, definition file is mapped for NPM only" {
+            setupProject(path = "a")
+
+            mapDefinitionFilesForNpm(definitionFiles) shouldContainExactly absolutePaths("a/package.json")
+            mapDefinitionFilesForYarn(definitionFiles).shouldBeEmpty()
+        }
+
+        "given project matched exactly by workspace, matched project is not mapped" {
+            setupProject(path = "a", matchers = listOf("b"))
+            setupProject(path = "a/b")
+            setupProject(path = "a/c")
+
+            mapDefinitionFiles(definitionFiles) shouldContainExactlyInAnyOrder
+                    absolutePaths("a/package.json", "a/c/package.json")
+        }
+
+        "given projects matched via * by workspace, matched projects are not mapped" {
+            setupProject(path = "a", matchers = listOf("*", "*/f"))
+            setupProject(path = "a/b")
+            setupProject(path = "a/c")
+            setupProject(path = "a/d/e")
+            setupProject(path = "a/d/f")
+
+            mapDefinitionFiles(definitionFiles) shouldContainExactlyInAnyOrder
+                    absolutePaths("a/package.json", "a/d/e/package.json")
+        }
+
+        "given projects matched via ** by workspace, matched projects are not mapped" {
+            setupProject(path = "a", matchers = listOf("**/d"))
+            setupProject(path = "a/b/c/d")
+            setupProject(path = "a/b/c/e")
+
+            mapDefinitionFiles(definitionFiles) shouldContainExactlyInAnyOrder
+                    absolutePaths("a/package.json", "a/b/c/e/package.json")
+        }
+    }
+
+    private lateinit var tempDir: File
+    private val definitionFiles = mutableSetOf<File>()
+
+    override fun beforeTest(description: Description) {
+        super.beforeTest(description)
+        tempDir = createTempDir()
+        definitionFiles.clear()
+    }
+
+    override fun afterTest(description: Description, result: TestResult) {
+        tempDir.safeDeleteRecursively()
+        definitionFiles.clear()
+        super.afterTest(description, result)
+    }
+
+    private fun setupProject(path: String, matchers: List<String> = emptyList(), hasNpmLockFile: Boolean = false,
+                             hasYarnLockFile: Boolean = false
+    ) {
+        val projectDir = tempDir.resolve(path)
+
+        require(!projectDir.isFile && !projectDir.isDirectory)
+        projectDir.safeMkdirs()
+
+        val definitionFile = projectDir.resolve("package.json")
+        definitionFile.writeText(createPackageJson(matchers))
+        definitionFiles.add(definitionFile)
+
+        if (hasNpmLockFile) {
+            projectDir.resolve("package-lock.json").createNewFile()
+        }
+
+        if (hasYarnLockFile) {
+            projectDir.resolve("yarn.lock").createNewFile()
+        }
+    }
+
+    fun absolutePaths(vararg files: String) =
+            files.asList().map { file ->
+                tempDir.resolve(file)
+            }
+
+    fun hasNpmLockFile(path: String) =
+            PackageJsonUtil.hasNpmLockFile(tempDir.resolve(path))
+
+    fun hasYarnLockFile(path: String) =
+            PackageJsonUtil.hasYarnLockFile(tempDir.resolve(path))
+}

--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -110,7 +110,7 @@ fun filterVersionNames(version: String, names: List<String>, project: String? = 
 /**
  * Return the longest prefix that is common to all [files].
  */
-fun getCommonFilePrefix(files: List<File>) =
+fun getCommonFilePrefix(files: Collection<File>) =
         files.map {
             it.normalize().absolutePath
         }.reduce { prefix, path ->


### PR DESCRIPTION
    Fix several issues related to Yarn workspaces
    
    The existing logic for deciding between Yarn and NPM for a given list of
    packages was intentionally designed to be very basic, but it also exhibits
    several issues. As an incremental refactoring for fixing those seems to be
    much more effort this change re-writes that logic for mapping the definition
    files - that is the decision whether Yarn, Npm or none of them should handle
    a given 'package.json'.
    
    As of this change a definition file is handled by Yarn if and only if at
    least one of the folowing conditions is fulfilled:
    (1) it belongs to a Yarn workspace, e.g. either it is the root or a submodule
    (2) it has a yarn lockfile as sibling
    
    The logic for computing the root project directory was not working in some
    cases, e.g. given '/ab/package.json' and '/aa/package.json' it tries to
    locate the root project at '/a/package.json' which may not exist at all
    resulting in no workspace being found. Now the logic isn't based on
    'getCommonFilePrefix' which fixes that. Moreover this enables support
    for multiple Yarn workspaces as the detection is now independent of the
    actual project path.
    
    The logic for matching workspaces is extended to support the glob style
    wildcard matcher '*' and '**' for matching either a single or multiple
    directories. It is enabled by using the given glob pattern as is, but
    matching them against the project directory instead of against the
    definition file.
    
    Finally moving the code into a separate class elminates some knowledge
    from NPM about Yarn and more importantly makes NPM stateless again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/995)
<!-- Reviewable:end -->
