### PR TITLE
analyzer: Add a default location for the `.ort.yml` file for Git-Repo

### DIFF
--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -23,6 +23,7 @@ import ch.frankel.slf4k.*
 
 import com.here.ort.analyzer.managers.Unmanaged
 import com.here.ort.downloader.VersionControlSystem
+import com.here.ort.downloader.vcs.GitRepo
 import com.here.ort.model.AnalyzerResultBuilder
 import com.here.ort.model.AnalyzerRun
 import com.here.ort.model.Environment
@@ -33,6 +34,7 @@ import com.here.ort.model.config.AnalyzerConfiguration
 import com.here.ort.model.config.RepositoryConfiguration
 import com.here.ort.model.readValue
 import com.here.ort.utils.log
+import com.here.ort.utils.realFile
 
 import java.io.File
 
@@ -49,7 +51,8 @@ class Analyzer(private val config: AnalyzerConfiguration) {
             packageCurationsFile: File? = null,
             repositoryConfigurationFile: File? = null
     ): OrtResult {
-        val actualRepositoryConfigurationFile = repositoryConfigurationFile ?: File(absoluteProjectPath, ".ort.yml")
+        val actualRepositoryConfigurationFile = repositoryConfigurationFile
+                ?: locateRepositoryConfigurationFile(absoluteProjectPath)
 
         val repositoryConfiguration = if (actualRepositoryConfigurationFile.isFile) {
             actualRepositoryConfigurationFile.readValue()
@@ -128,4 +131,12 @@ class Analyzer(private val config: AnalyzerConfiguration) {
 
         return OrtResult(repository, run)
     }
+
+    private fun locateRepositoryConfigurationFile(absoluteProjectPath: File) =
+            if (GitRepo().getWorkingTree(absoluteProjectPath).isValid()) {
+                val manifestFile = absoluteProjectPath.resolve(".repo/manifest.xml").realFile()
+                manifestFile.resolveSibling("${manifestFile.name}.ort.yml")
+            } else {
+                File(absoluteProjectPath, ".ort.yml")
+            }
 }

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -8,6 +8,9 @@ ORT's behavior can be customized for a specific repository by adding an `.ort.ym
 Currently this file can only be used to configure the excludes described below, but more features are planned for the
 future.
 
+Note that for Git-Repo repositories the default location of the configuration file is next to the manifest file. For
+example, if the manifest is called `manifest.xml` the configuration is expected to be called `manifest.xml.ort.yml`.
+
 ### Excludes
 
 ORT's philosophy is to always analyze and scan everything it can find to get a complete picture of a repository and its


### PR DESCRIPTION
If the input directory of the analyzer is a Git-Repo project the root
directory cannot by default contain an `.ort.yml` file that is associated
to the manifest. Instead look for the file in the manifest repository,
using the pattern `[manifest-file-name].ort.yml`, e.g.
`manifest.xml.ort.yml`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1003)
<!-- Reviewable:end -->
