### PR TITLE
Remove the .mention-bot configuration file

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -1,4 +1,0 @@
-{
-  "createReviewRequest": true,
-  "createComment": false
-}


### PR DESCRIPTION
This was not working for a long time already as the upstream project is
archived, see

https://github.com/facebookarchive/mention-bot

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1010)
<!-- Reviewable:end -->
