### PR TITLE
Gradle: Make version property name deduction work for plugin names with dashes

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -3,8 +3,9 @@ pluginManagement {
         eachPlugin {
             // Work around https://github.com/gradle/gradle/issues/1697.
             if (requested.version == null) {
+                def pluginName = requested.id.name.split('-').collect { it.capitalize() }.join().uncapitalize()
                 def versionPropertyName = (requested.id.id == 'org.jetbrains.kotlin.jvm') ?
-                        "kotlinPluginVersion" : "${requested.id.name}PluginVersion"
+                        "kotlinPluginVersion" : "${pluginName}PluginVersion"
                 logger.info("Checking for plugin version property '$versionPropertyName'.")
                 if (gradle.rootProject.hasProperty(versionPropertyName)) {
                     def version = gradle.rootProject.properties[versionPropertyName]


### PR DESCRIPTION
This will be needed to centrally define the version number via
properties for plugin IDs like "com.bmuschko.docker-java-application".
For this example, the deduced version property name would be
"dockerJavaApplicationPluginVersion".

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1011)
<!-- Reviewable:end -->
