### PR TITLE
reporter-web-app: Go back to using Yarn 1.9.4 again

### DIFF
--- a/analyzer/src/main/kotlin/managers/PackageJsonUtil.kt
+++ b/analyzer/src/main/kotlin/managers/PackageJsonUtil.kt
@@ -107,7 +107,7 @@ internal class PackageJsonUtil {
 
         private fun getWorkspaceMatchers(definitionFile: File): List<PathMatcher> =
                 definitionFile.readValue<ObjectNode>()["workspaces"]?.map {
-                    val pattern = "glob:${definitionFile.parentFile}/${it.textValue()}"
+                    val pattern = "glob:${definitionFile.parentFile.invariantSeparatorsPath}/${it.textValue()}"
                     FileSystems.getDefault().getPathMatcher(pattern)
                 } ?: emptyList()
     }

--- a/analyzer/src/main/kotlin/managers/PackageJsonUtil.kt
+++ b/analyzer/src/main/kotlin/managers/PackageJsonUtil.kt
@@ -63,7 +63,7 @@ internal class PackageJsonUtil {
         private fun isHandledByYarn(entry: DefinitionFileInfo) =
                 entry.isYarnWorkspaceRoot || entry.isYarnWorkspaceSubmodule || entry.hasYarnLockfile
 
-        private fun getDefinitionFileInfo(definitionFiles: Set<File> ): Collection<DefinitionFileInfo> {
+        private fun getDefinitionFileInfo(definitionFiles: Set<File>): Collection<DefinitionFileInfo> {
             val yarnWorkspaceSubmodules = getYarnWorkspaceSubmodules(definitionFiles)
 
             return definitionFiles.map { definitionFile ->

--- a/analyzer/src/test/kotlin/PackageJsonUtilTest.kt
+++ b/analyzer/src/test/kotlin/PackageJsonUtilTest.kt
@@ -38,20 +38,21 @@ import java.io.File
 class PackageJsonUtilTest : StringSpec() {
     companion object {
         private fun createPackageJson(matchers: List<String>) =
-                if (!matchers.isEmpty())
-                """
-                {
-                   "workspaces" : ${matchers.joinToString (prefix = "[\"", separator = "\",\"", postfix = "\"]")}
+                if (!matchers.isEmpty()) {
+                    """
+                    {
+                       "workspaces" : ${matchers.joinToString(prefix = "[\"", separator = "\",\"", postfix = "\"]")}
+                    }
+                    """.trimIndent()
+                } else {
+                    "{}"
                 }
-                """.trimIndent()
-                else "{}"
 
         private fun mapDefinitionFiles(definitionFiles: Collection<File>) =
                 mapDefinitionFilesForNpm(definitionFiles).plus(mapDefinitionFilesForYarn(definitionFiles))
     }
 
     init {
-
         "given no NPM lockfile present, hasNpmLockFile returns false" {
             setupProject(path = "a")
 
@@ -149,13 +150,8 @@ class PackageJsonUtilTest : StringSpec() {
         definitionFile.writeText(createPackageJson(matchers))
         definitionFiles.add(definitionFile)
 
-        if (hasNpmLockFile) {
-            projectDir.resolve("package-lock.json").createNewFile()
-        }
-
-        if (hasYarnLockFile) {
-            projectDir.resolve("yarn.lock").createNewFile()
-        }
+        if (hasNpmLockFile) projectDir.resolve("package-lock.json").createNewFile()
+        if (hasYarnLockFile) projectDir.resolve("yarn.lock").createNewFile()
     }
 
     private fun absolutePaths(vararg files: String) =

--- a/analyzer/src/test/kotlin/PackageJsonUtilTest.kt
+++ b/analyzer/src/test/kotlin/PackageJsonUtilTest.kt
@@ -49,7 +49,7 @@ class PackageJsonUtilTest : StringSpec() {
                 }
 
         private fun mapDefinitionFiles(definitionFiles: Collection<File>) =
-                mapDefinitionFilesForNpm(definitionFiles).plus(mapDefinitionFilesForYarn(definitionFiles))
+                mapDefinitionFilesForNpm(definitionFiles) + mapDefinitionFilesForYarn(definitionFiles)
     }
 
     init {
@@ -143,7 +143,7 @@ class PackageJsonUtilTest : StringSpec() {
     ) {
         val projectDir = tempDir.resolve(path)
 
-        require(!projectDir.isFile && !projectDir.isDirectory)
+        require(!projectDir.exists())
         projectDir.safeMkdirs()
 
         val definitionFile = projectDir.resolve("package.json")

--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ subprojects {
         kotlinOptions {
             allWarningsAsErrors = true
             jvmTarget = '1.8'
-            apiVersion = '1.2'
+            apiVersion = '1.3'
         }
     }
 
@@ -81,7 +81,7 @@ subprojects {
         kotlinOptions {
             allWarningsAsErrors = true
             jvmTarget = '1.8'
-            apiVersion = '1.2'
+            apiVersion = '1.3'
         }
     }
 
@@ -89,7 +89,7 @@ subprojects {
         kotlinOptions {
             allWarningsAsErrors = true
             jvmTarget = '1.8'
-            apiVersion = '1.2'
+            apiVersion = '1.3'
         }
     }
 

--- a/reporter-web-app/build.gradle
+++ b/reporter-web-app/build.gradle
@@ -4,7 +4,13 @@ plugins {
 
 node {
     version = '8.11.4'
-    yarnVersion = '1.12.1'
+    // Version 1.12.1 of Yarn does not work on AppVeyor and gives
+    //
+    //     Failed to capture fingerprint of output files for task ':reporter-web-app:install' property '$1' during up-to-date check.
+    //     > Could not read path 'reporter-web-app\node_modules\@babel\generator\node_modules\jsesc\.bin\jsesc'.
+    //
+    // Maybe this is because of https://github.com/gradle/gradle/issues/1365.
+    yarnVersion = '1.9.4'
     // Installing NPM is needed for installing Yarn because the Gradle Node plugin installs Yarn via NPM.
     npmVersion = '6.4.0'
     // Setting download flag is required for bootstrapping NPM.

--- a/scanner/src/funTest/kotlin/HttpCacheTest.kt
+++ b/scanner/src/funTest/kotlin/HttpCacheTest.kt
@@ -76,15 +76,15 @@ class HttpCacheTest : StringSpec() {
     }
 
     override fun beforeTest(description: Description) {
-        // Start the local HTTP server.
+        // Start the local HTTP server with the system default value for queued incoming connections.
         server = HttpServer.create(InetSocketAddress(loopback, port), 0)
         server.createContext("/", MyHttpHandler())
         server.start()
     }
 
     override fun afterTest(description: Description, result: TestResult) {
-        // Ensure the server is properly stopped even in case of exceptions.
-        server.stop(0)
+        // Ensure the server is properly stopped even in case of exceptions, but wait at most 5 seconds.
+        server.stop(5)
     }
 
     private val id = Identifier("provider", "namespace", "name", "version")

--- a/scanner/src/funTest/kotlin/HttpCacheTest.kt
+++ b/scanner/src/funTest/kotlin/HttpCacheTest.kt
@@ -50,9 +50,11 @@ import java.net.InetSocketAddress
 import java.time.Duration
 import java.time.Instant
 
+import kotlin.random.Random
+
 class HttpCacheTest : StringSpec() {
     private val loopback = InetAddress.getLoopbackAddress()
-    private val port = 8888
+    private val port = Random.nextInt(1024, 49152) // See https://en.wikipedia.org/wiki/Registered_port.
 
     private lateinit var server: HttpServer
 


### PR DESCRIPTION
Partly revert 5e4ab2c to work around an issue on AppVeyor. While it was
nice to align with the analyzer on version 1.12.1, it is not strictly
required for this project.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1018)
<!-- Reviewable:end -->
