### PR TITLE
Improve filtering of version names

### DIFF
--- a/utils/src/test/kotlin/UtilsTest.kt
+++ b/utils/src/test/kotlin/UtilsTest.kt
@@ -188,6 +188,12 @@ class UtilsTest : WordSpec({
 
             filterVersionNames("4711", names).joinToString("\n") shouldBe "my_project-4711"
         }
+
+        "find names that have a numeric suffix as part of the name" {
+            val names = listOf("my_project_v1-1.0.2", "my_project_v1-1.0.3", "my_project_v1-1.1.0")
+
+            filterVersionNames("1.0.3", names).joinToString("\n") shouldBe "my_project_v1-1.0.3"
+        }
     }
 
     "getPathFromEnvironment" should {

--- a/utils/src/test/kotlin/UtilsTest.kt
+++ b/utils/src/test/kotlin/UtilsTest.kt
@@ -182,6 +182,12 @@ class UtilsTest : WordSpec({
 
             filterVersionNames("1.11.6", names).joinToString("\n") shouldBe "1.11.6"
         }
+
+        "find names with only a single revision number as the version" {
+            val names = listOf("my_project-123", "my_project-4711", "my_project-8888")
+
+            filterVersionNames("4711", names).joinToString("\n") shouldBe "my_project-4711"
+        }
     }
 
     "getPathFromEnvironment" should {


### PR DESCRIPTION
Please have a look at the individual commit messages for the details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1024)
<!-- Reviewable:end -->
