### PR TITLE
analyzer: Upgrade "rack" in synthetic test projects

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-gemspec.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-gemspec.yml
@@ -17,7 +17,7 @@ project:
   scopes:
   - name: "default"
     dependencies:
-    - id: "Bundler::rack:1.6.10"
+    - id: "Bundler::rack:1.6.11"
     - id: "Bundler::signet:0.8.1"
       dependencies:
       - id: "Bundler::addressable:2.5.2"
@@ -244,7 +244,7 @@ packages:
       path: ""
   curations: []
 - package:
-    id: "Bundler::rack:1.6.10"
+    id: "Bundler::rack:1.6.11"
     declared_licenses:
     - "MIT"
     description: "Rack provides a minimal, modular and adaptable interface for developing\n\
@@ -258,8 +258,8 @@ packages:
       hash: ""
       hash_algorithm: ""
     source_artifact:
-      url: "https://rubygems.org/gems/rack-1.6.10.gem"
-      hash: "58e8ae09c502f219a6ad2e7f932072faf2d2b38ce6fd0251ac7ff3096c55c046"
+      url: "https://rubygems.org/gems/rack-1.6.11.gem"
+      hash: "ee2016b1ddf820f6e5ee437d10a85319506b60c0d493da1d15815361a91129bd"
       hash_algorithm: "SHA-256"
     vcs:
       type: "git"

--- a/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-lockfile.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-lockfile.yml
@@ -20,7 +20,7 @@ project:
     - id: "Bundler::nokogiri:1.8.2"
       dependencies:
       - id: "Bundler::mini_portile2:2.3.0"
-    - id: "Bundler::rack:1.6.10"
+    - id: "Bundler::rack:1.6.11"
   - name: "test"
     dependencies:
     - id: "Bundler::rspec:3.7.0"
@@ -126,7 +126,7 @@ packages:
       path: ""
   curations: []
 - package:
-    id: "Bundler::rack:1.6.10"
+    id: "Bundler::rack:1.6.11"
     declared_licenses:
     - "MIT"
     description: "Rack provides a minimal, modular and adaptable interface for developing\n\
@@ -140,8 +140,8 @@ packages:
       hash: ""
       hash_algorithm: ""
     source_artifact:
-      url: "https://rubygems.org/gems/rack-1.6.10.gem"
-      hash: "58e8ae09c502f219a6ad2e7f932072faf2d2b38ce6fd0251ac7ff3096c55c046"
+      url: "https://rubygems.org/gems/rack-1.6.11.gem"
+      hash: "ee2016b1ddf820f6e5ee437d10a85319506b60c0d493da1d15815361a91129bd"
       hash_algorithm: "SHA-256"
     vcs:
       type: "git"

--- a/analyzer/src/funTest/assets/projects/synthetic/bundler/gemspec/Gemfile.lock
+++ b/analyzer/src/funTest/assets/projects/synthetic/bundler/gemspec/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
     multi_json (1.13.1)
     multipart-post (2.0.0)
     public_suffix (3.0.2)
-    rack (1.6.10)
+    rack (1.6.11)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
@@ -46,4 +46,4 @@ DEPENDENCIES
   test-project!
 
 BUNDLED WITH
-   1.16.1
+   1.17.1

--- a/analyzer/src/funTest/assets/projects/synthetic/bundler/lockfile/Gemfile.lock
+++ b/analyzer/src/funTest/assets/projects/synthetic/bundler/lockfile/Gemfile.lock
@@ -7,7 +7,7 @@ GEM
       mini_portile2 (~> 2.3.0)
     nokogiri (1.8.2-x64-mingw32)
       mini_portile2 (~> 2.3.0)
-    rack (1.6.10)
+    rack (1.6.11)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
@@ -32,4 +32,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.16.1
+   1.17.1


### PR DESCRIPTION
To address a security vulnerability as reported by GitHub. The upgrade
was performed by running

    bundle lock --update=rack

in the respective directories.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1031)
<!-- Reviewable:end -->
