### PR TITLE
Git: Enable the more efficient Git Wire Protocol version 2, if possible

### DIFF
--- a/downloader/src/main/kotlin/vcs/Git.kt
+++ b/downloader/src/main/kotlin/vcs/Git.kt
@@ -31,6 +31,8 @@ import com.here.ort.utils.safeMkdirs
 import com.here.ort.utils.showStackTrace
 import com.here.ort.utils.spdx.LICENSE_FILE_NAMES
 
+import com.vdurmont.semver4j.Semver
+
 import java.io.File
 import java.io.IOException
 
@@ -69,6 +71,12 @@ class Git : GitBase() {
         // Do not use "git clone" to have more control over what is being fetched.
         run(targetDir, "init")
         run(targetDir, "remote", "add", "origin", pkg.vcsProcessed.url)
+
+        // Enable the more efficient Git Wire Protocol version 2, if possible. See
+        // https://github.com/git/git/blob/master/Documentation/technical/protocol-v2.txt
+        if (Semver(getVersion()).isGreaterThanOrEqualTo("2.18.0")) {
+            run(targetDir, "config", "protocol.version", "2")
+        }
 
         if (OS.isWindows) {
             run(targetDir, "config", "core.longpaths", "true")


### PR DESCRIPTION
GitHub recently added server-side support for this, so enable it for
speedier clones from GitHub. Also see

https://blog.github.com/changelog/2018-11-08-git-protocol-v2-support/

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1032)
<!-- Reviewable:end -->
