### PR TITLE
cli: Use exit code 2 in case of command failures

### DIFF
--- a/cli/src/main/kotlin/commands/AnalyzerCommand.kt
+++ b/cli/src/main/kotlin/commands/AnalyzerCommand.kt
@@ -107,7 +107,7 @@ object AnalyzerCommand : CommandWithHelp() {
         val absoluteOutputPath = outputDir.absoluteFile
         if (absoluteOutputPath.exists()) {
             log.error { "The output directory '$absoluteOutputPath' must not exist yet." }
-            return 1
+            return 2
         }
 
         require(packageCurationsFile?.isFile ?: true) {

--- a/cli/src/main/kotlin/commands/DownloaderCommand.kt
+++ b/cli/src/main/kotlin/commands/DownloaderCommand.kt
@@ -199,6 +199,6 @@ object DownloaderCommand : CommandWithHelp() {
             }
         }
 
-        return if (error) 1 else 0
+        return if (error) 2 else 0
     }
 }

--- a/cli/src/main/kotlin/commands/EvaluatorCommand.kt
+++ b/cli/src/main/kotlin/commands/EvaluatorCommand.kt
@@ -81,7 +81,7 @@ object EvaluatorCommand : CommandWithHelp() {
         val evaluator = Evaluator()
 
         if (syntaxCheck) {
-            return if (evaluator.checkSyntax(ortResultInput, script)) 0 else 1
+            return if (evaluator.checkSyntax(ortResultInput, script)) 0 else 2
         }
 
         @Suppress("UNCHECKED_CAST")
@@ -110,6 +110,6 @@ object EvaluatorCommand : CommandWithHelp() {
             }
         }
 
-        return if (evaluatorRun.errors.isEmpty()) 0 else 1
+        return if (evaluatorRun.errors.isEmpty()) 0 else 2
     }
 }


### PR DESCRIPTION
This is to distinguish from e.g. Gradle exit codes which returns 1 for
failed builds, see https://stackoverflow.com/a/26814641/1127485.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1039)
<!-- Reviewable:end -->
