### PR TITLE
model: Add a test for deserializing a repo config with escaped dots in the path

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -52,7 +52,7 @@ a single exclude:
 ```yaml
 excludes:
   projects:
-  - path: ".*build\.gradle"
+  - path: ".*build\\.gradle"
     reason: "EXAMPLE_OF"
     comment: "The project contains example code which is not distributed."
 ```

--- a/model/src/test/kotlin/config/RepositoryConfigurationTest.kt
+++ b/model/src/test/kotlin/config/RepositoryConfigurationTest.kt
@@ -45,6 +45,19 @@ class RepositoryConfigurationTest : WordSpec() {
                 repositoryConfiguration.excludes shouldBe null
             }
 
+            "deserialize to a path regex working with escaped dots" {
+                val configuration = """
+                    excludes:
+                      projects:
+                      - path: "android/.*build\\.gradle"
+                        reason: "BUILD_TOOL_OF"
+                        comment: "project comment"
+                    """.trimIndent()
+
+                val config = yamlMapper.readValue<RepositoryConfiguration>(configuration)
+                config.excludes!!.projects[0].path.matches("android/project1/build.gradle") shouldBe true
+            }
+
             "be deserializable" {
                 val configuration = """
                     excludes:


### PR DESCRIPTION
Fix a wrong configuration example along the way.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1041)
<!-- Reviewable:end -->
