### PR TITLE
Evaluator: Import com.here.ort.model.Package by default

### DIFF
--- a/evaluator/src/main/kotlin/Evaluator.kt
+++ b/evaluator/src/main/kotlin/Evaluator.kt
@@ -38,6 +38,7 @@ class Evaluator {
     private val preface = """
             import com.here.ort.model.Error
             import com.here.ort.model.OrtResult
+            import com.here.ort.model.Package
 
             val ortResult = bindings["ortResult"] as OrtResult
             val evalErrors = mutableListOf<Error>()


### PR DESCRIPTION
To avoid strange errors when java.lang.Package is implicitly used instead.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1043)
<!-- Reviewable:end -->
