### PR TITLE
reporter: Show the evaluator errors in the static HTML report

### DIFF
--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -21,6 +21,7 @@ package com.here.ort.reporter.reporters
 
 import ch.frankel.slf4k.*
 
+import com.here.ort.model.Error
 import com.here.ort.model.VcsInfo
 import com.here.ort.model.config.ScopeExclude
 import com.here.ort.utils.isValidUrl
@@ -308,6 +309,10 @@ class StaticHtmlReporter : TableReporter() {
 
                 append("<h2>Index</h2>")
                 append("<ul>")
+                tabularScanRecord.evaluatorErrors?.let { evaluatorErrors ->
+                    append("<li><a href=\"#license-check-results\">" +
+                            "License Check Results (${evaluatorErrors.size} errors)</a></li>")
+                }
                 if (numberOfErrors > 0) {
                     append("<li><a href=\"#error-summary\">Error Summary ($numberOfErrors)</a></li>")
                 }
@@ -320,6 +325,10 @@ class StaticHtmlReporter : TableReporter() {
                 }
                 append("</ul>")
 
+                tabularScanRecord.evaluatorErrors?.let { evaluatorErrors ->
+                    append(createEvaluatorTable(evaluatorErrors))
+                }
+
                 if (numberOfErrors > 0) {
                     append(createErrorTable("Error Summary ($numberOfErrors)", tabularScanRecord.errorSummary,
                             "error-summary"))
@@ -328,6 +337,40 @@ class StaticHtmlReporter : TableReporter() {
                 tabularScanRecord.projectDependencies.forEach { project, table ->
                     append(createTable("${project.id} (${project.definitionFilePath})", project.vcsProcessed, table,
                             project.id.toString()))
+                }
+            }
+
+    private fun createEvaluatorTable(evaluatorErrors: List<Error>) =
+            buildString {
+                append("<h2><a id=\"license-check-results\"></a>License Check Results</h2>")
+
+                if (evaluatorErrors.isEmpty()) {
+                    append("No issues found.")
+                } else {
+                    append("""
+                        <table class="report-packages">
+                        <thead>
+                        <tr>
+                            <th>Source</th>
+                            <th>Error</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        """.trimIndent())
+
+                    evaluatorErrors.forEach { error ->
+                        append("""
+                            <tr class="error">
+                                <td>${error.source}</td>
+                                <td>${error.message}</td>
+                            </tr>
+                            """.trimIndent())
+                    }
+
+                    append("""
+                        </tbody>
+                        </table>
+                        """.trimIndent())
                 }
             }
 

--- a/reporter/src/main/kotlin/reporters/TableReporter.kt
+++ b/reporter/src/main/kotlin/reporters/TableReporter.kt
@@ -48,6 +48,11 @@ abstract class TableReporter : Reporter() {
             val vcsInfo: VcsInfo,
 
             /**
+             * A list containing all evaluator errors. `null` if no evaluator result is available.
+             */
+            val evaluatorErrors: List<Error>?,
+
+            /**
              * A [ErrorTable] containing all dependencies that caused errors.
              */
             val errorSummary: ErrorTable,
@@ -353,8 +358,18 @@ abstract class TableReporter : Reporter() {
             extraColumns.map { it.toString() }
         }.orEmpty()
 
-        return generateReport(TabularScanRecord(ortResult.repository.vcsProcessed, errorSummaryTable, summaryTable,
-                projectTables, metadata, extraColumns), outputDir)
+        return generateReport(
+                TabularScanRecord(
+                        ortResult.repository.vcsProcessed,
+                        ortResult.evaluator?.errors,
+                        errorSummaryTable,
+                        summaryTable,
+                        projectTables,
+                        metadata,
+                        extraColumns
+                ),
+                outputDir
+        )
     }
 
     abstract fun generateReport(tabularScanRecord: TabularScanRecord, outputDir: File): File


### PR DESCRIPTION
If an evaluator result is available show the errors in a new table on top
of the report.

Signed-off-by: Martin Nonnenmacher <martin.nonnenmacher@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1044)
<!-- Reviewable:end -->
