### PR TITLE
Fix GitHub language statistics by excluding generated HTML code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
-*/src/*/assets/**/*expected*.yml text eol=lf
-reporter/src/test/assets/*-expected-NOTICE* text eol=lf
+*/src/*/assets/**/*expected*.yml		text eol=lf
+reporter/src/test/assets/*-expected-NOTICE*	text eol=lf
+
+# Fix GitHub language statistics, see https://github.com/github/linguist#generated-code.
+reporter-web-app/public/index.html		linguist-generated=true


### PR DESCRIPTION
Our code is mainly Kotlin, not HTML.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1052)
<!-- Reviewable:end -->
