### PR TITLE
model: Rename `Error` to `OrtIssue`

### DIFF
--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -22,7 +22,7 @@ package com.here.ort.analyzer
 import ch.frankel.slf4k.*
 
 import com.here.ort.downloader.VersionControlSystem
-import com.here.ort.model.Error
+import com.here.ort.model.OrtIssue
 import com.here.ort.model.Identifier
 import com.here.ort.model.Project
 import com.here.ort.model.ProjectAnalyzerResult
@@ -221,7 +221,7 @@ abstract class PackageManager(
                             vcsProcessed = processProjectVcs(definitionFile.parentFile)
                     )
 
-                    val errors = listOf(Error(source = javaClass.simpleName, message = e.collectMessagesAsString()))
+                    val errors = listOf(OrtIssue(source = javaClass.simpleName, message = e.collectMessagesAsString()))
 
                     result[definitionFile] = ProjectAnalyzerResult(errorProject, sortedSetOf(), errors)
                 }

--- a/analyzer/src/main/kotlin/managers/Bundler.kt
+++ b/analyzer/src/main/kotlin/managers/Bundler.kt
@@ -27,7 +27,7 @@ import com.here.ort.analyzer.HTTP_CACHE_PATH
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.analyzer.AbstractPackageManagerFactory
 import com.here.ort.downloader.VersionControlSystem
-import com.here.ort.model.Error
+import com.here.ort.model.OrtIssue
 import com.here.ort.model.HashAlgorithm
 import com.here.ort.model.Identifier
 import com.here.ort.model.Package
@@ -90,7 +90,7 @@ class Bundler(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfi
         stashDirectories(File(workingDir, "vendor")).use {
             val scopes = mutableSetOf<Scope>()
             val packages = mutableSetOf<Package>()
-            val errors = mutableListOf<Error>()
+            val errors = mutableListOf<OrtIssue>()
 
             installDependencies(workingDir)
 
@@ -117,7 +117,7 @@ class Bundler(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfi
     }
 
     private fun parseScope(workingDir: File, projectId: Identifier, groupName: String, dependencyList: List<String>,
-                           scopes: MutableSet<Scope>, packages: MutableSet<Package>, errors: MutableList<Error>) {
+                           scopes: MutableSet<Scope>, packages: MutableSet<Package>, errors: MutableList<OrtIssue>) {
         log.debug { "Parsing scope: $groupName\nscope top level deps list=$dependencyList" }
 
         val scopeDependencies = mutableSetOf<PackageReference>()
@@ -130,7 +130,7 @@ class Bundler(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfi
     }
 
     private fun parseDependency(workingDir: File, projectId: Identifier, gemName: String, packages: MutableSet<Package>,
-                                scopeDependencies: MutableSet<PackageReference>, errors: MutableList<Error>) {
+                                scopeDependencies: MutableSet<PackageReference>, errors: MutableList<OrtIssue>) {
         log.debug { "Parsing dependency '$gemName'." }
 
         try {
@@ -174,7 +174,7 @@ class Bundler(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfi
             val errorMsg = "Failed to parse package (gem) $gemName: ${e.collectMessagesAsString()}"
             log.error { errorMsg }
 
-            errors += Error(source = toString(), message = errorMsg)
+            errors += OrtIssue(source = toString(), message = errorMsg)
         }
     }
 

--- a/analyzer/src/main/kotlin/managers/GoDep.kt
+++ b/analyzer/src/main/kotlin/managers/GoDep.kt
@@ -24,7 +24,7 @@ import ch.frankel.slf4k.*
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.analyzer.AbstractPackageManagerFactory
 import com.here.ort.downloader.VersionControlSystem
-import com.here.ort.model.Error
+import com.here.ort.model.OrtIssue
 import com.here.ort.model.Identifier
 import com.here.ort.model.Package
 import com.here.ort.model.PackageReference
@@ -89,7 +89,7 @@ class GoDep(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfigu
             val revision = project["revision"]!!
             val version = project["version"]!!
 
-            val errors = mutableListOf<Error>()
+            val errors = mutableListOf<OrtIssue>()
 
             val vcsProcessed = try {
                 resolveVcsInfo(name, revision, gopath)
@@ -98,7 +98,7 @@ class GoDep(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfigu
 
                 log.error { "Could not resolve VCS information for project '$name': ${e.collectMessagesAsString()}" }
 
-                errors += Error(source = toString(), message = e.collectMessagesAsString())
+                errors += OrtIssue(source = toString(), message = e.collectMessagesAsString())
                 VcsInfo.EMPTY
             }
 

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -29,7 +29,7 @@ import com.here.ort.analyzer.PackageManager
 import com.here.ort.analyzer.AbstractPackageManagerFactory
 import com.here.ort.analyzer.identifier
 import com.here.ort.downloader.VersionControlSystem
-import com.here.ort.model.Error
+import com.here.ort.model.OrtIssue
 import com.here.ort.model.Identifier
 import com.here.ort.model.Package
 import com.here.ort.model.PackageReference
@@ -155,7 +155,7 @@ class Gradle(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfig
             )
 
             val errors = dependencyTreeModel.errors.map {
-                Error(source = toString(), message = it)
+                OrtIssue(source = toString(), message = it)
             }
 
             return ProjectAnalyzerResult(project, packages.values.map { it.toCuratedPackage() }.toSortedSet(), errors)
@@ -164,7 +164,7 @@ class Gradle(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfig
 
     private fun parseDependency(dependency: Dependency, packages: MutableMap<String, Package>,
                                 repositories: List<RemoteRepository>): PackageReference {
-        val errors = dependency.error?.let { mutableListOf(Error(source = toString(), message = it)) }
+        val errors = dependency.error?.let { mutableListOf(OrtIssue(source = toString(), message = it)) }
                 ?: mutableListOf()
 
         // Only look for a package when there was no error resolving the dependency.
@@ -201,7 +201,7 @@ class Gradle(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfig
                             "Could not get package information for dependency '$identifier': ${e.message}"
                         }
 
-                        errors += Error(source = toString(), message = e.collectMessagesAsString())
+                        errors += OrtIssue(source = toString(), message = e.collectMessagesAsString())
 
                         rawPackage
                     }

--- a/analyzer/src/main/kotlin/managers/Maven.kt
+++ b/analyzer/src/main/kotlin/managers/Maven.kt
@@ -26,7 +26,7 @@ import com.here.ort.analyzer.PackageManager
 import com.here.ort.analyzer.AbstractPackageManagerFactory
 import com.here.ort.analyzer.identifier
 import com.here.ort.downloader.VersionControlSystem
-import com.here.ort.model.Error
+import com.here.ort.model.OrtIssue
 import com.here.ort.model.Identifier
 import com.here.ort.model.Package
 import com.here.ort.model.PackageReference
@@ -191,7 +191,7 @@ class Maven(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfigu
             return PackageReference(
                     Identifier(toString(), node.artifact.groupId, node.artifact.artifactId, node.artifact.version),
                     dependencies = sortedSetOf(),
-                    errors = listOf(Error(source = toString(), message = e.collectMessagesAsString()))
+                    errors = listOf(OrtIssue(source = toString(), message = e.collectMessagesAsString()))
             )
         }
     }

--- a/analyzer/src/main/kotlin/managers/NPM.kt
+++ b/analyzer/src/main/kotlin/managers/NPM.kt
@@ -28,7 +28,7 @@ import com.here.ort.analyzer.AbstractPackageManagerFactory
 import com.here.ort.analyzer.HTTP_CACHE_PATH
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.downloader.VersionControlSystem
-import com.here.ort.model.Error
+import com.here.ort.model.OrtIssue
 import com.here.ort.model.HashAlgorithm
 import com.here.ort.model.Identifier
 import com.here.ort.model.Package
@@ -423,7 +423,7 @@ open class NPM(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConf
             }
 
             return PackageReference(Identifier(toString(), "", name, ""), sortedSetOf(),
-                    listOf(Error(source = toString(), message = "Package '$name' was not installed.")))
+                    listOf(OrtIssue(source = toString(), message = "Package '$name' was not installed.")))
         } else {
             // Skip the package name directory when going up.
             var parentModulesDir = startModulesDir.parentFile.parentFile

--- a/analyzer/src/main/kotlin/managers/PhpComposer.kt
+++ b/analyzer/src/main/kotlin/managers/PhpComposer.kt
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode
 import com.here.ort.analyzer.AbstractPackageManagerFactory
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.downloader.VersionControlSystem
-import com.here.ort.model.Error
+import com.here.ort.model.OrtIssue
 import com.here.ort.model.HashAlgorithm
 import com.here.ort.model.Identifier
 import com.here.ort.model.Package
@@ -176,7 +176,7 @@ class PhpComposer(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryC
 
                     log.error { "Could not resolve dependencies of '$packageName': ${e.collectMessagesAsString()}" }
 
-                    packageInfo.toReference(errors = listOf(Error(source = toString(),
+                    packageInfo.toReference(errors = listOf(OrtIssue(source = toString(),
                             message = e.collectMessagesAsString())))
                 }
             }

--- a/evaluator/src/main/kotlin/Evaluator.kt
+++ b/evaluator/src/main/kotlin/Evaluator.kt
@@ -19,14 +19,14 @@
 
 package com.here.ort.evaluator
 
-import com.here.ort.model.Error
+import com.here.ort.model.OrtIssue
 import com.here.ort.model.EvaluatorRun
 import com.here.ort.model.OrtResult
 import com.here.ort.utils.ScriptRunner
 
 class Evaluator(ortResult: OrtResult) : ScriptRunner() {
     override val preface = """
-            import com.here.ort.model.Error
+            import com.here.ort.model.OrtIssue
             import com.here.ort.model.OrtResult
             import com.here.ort.model.Package
 
@@ -34,7 +34,7 @@ class Evaluator(ortResult: OrtResult) : ScriptRunner() {
             val ortResult = bindings["ortResult"] as OrtResult
 
             // Output:
-            val evalErrors = mutableListOf<Error>()
+            val evalErrors = mutableListOf<OrtIssue>()
 
         """.trimIndent()
 
@@ -49,7 +49,7 @@ class Evaluator(ortResult: OrtResult) : ScriptRunner() {
 
     override fun run(script: String): EvaluatorRun {
         @Suppress("UNCHECKED_CAST")
-        val errors = super.run(script) as List<Error>
+        val errors = super.run(script) as List<OrtIssue>
 
         return EvaluatorRun(errors)
     }

--- a/evaluator/src/main/resources/rules/no_gpl_declared.kts
+++ b/evaluator/src/main/resources/rules/no_gpl_declared.kts
@@ -10,5 +10,5 @@ val pkgWithGpl = ortResult.analyzer?.result?.packages?.filter { (pkg, _) ->
 
 // Populate the list of errors to return.
 pkgWithGpl?.forEach { (pkg, _) ->
-    evalErrors += Error(source = pkg.id.toString(), message = "This package is declared under a GPL license.")
+    evalErrors += OrtIssue(source = pkg.id.toString(), message = "This package is declared under a GPL license.")
 }

--- a/evaluator/src/test/kotlin/EvaluatorTest.kt
+++ b/evaluator/src/test/kotlin/EvaluatorTest.kt
@@ -61,8 +61,8 @@ class EvaluatorTest : WordSpec() {
 
             "contain rule errors in the result" {
                 val result = Evaluator(ortResult).run("""
-                    evalErrors += Error(source = "source 1", message = "message 1")
-                    evalErrors += Error(source = "source 2", message = "message 2")
+                    evalErrors += OrtIssue(source = "source 1", message = "message 1")
+                    evalErrors += OrtIssue(source = "source 2", message = "message 2")
                     """.trimIndent())
 
                 result.errors should haveSize(2)

--- a/model/src/main/kotlin/AnalyzerResult.kt
+++ b/model/src/main/kotlin/AnalyzerResult.kt
@@ -51,7 +51,7 @@ data class AnalyzerResult(
         // Do not serialize if empty to reduce the size of the result file. If there are no errors at all,
         // [AnalyzerResult.hasErrors] already contains that information.
         @JsonInclude(JsonInclude.Include.NON_EMPTY)
-        val errors: SortedMap<Identifier, List<Error>> = sortedMapOf(),
+        val errors: SortedMap<Identifier, List<OrtIssue>> = sortedMapOf(),
 
         /**
          * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.
@@ -84,7 +84,7 @@ data class AnalyzerResult(
 class AnalyzerResultBuilder {
     private val projects = sortedSetOf<Project>()
     private val packages = sortedSetOf<CuratedPackage>()
-    private val errors = sortedMapOf<Identifier, List<Error>>()
+    private val errors = sortedMapOf<Identifier, List<OrtIssue>>()
 
     fun build(): AnalyzerResult {
         return AnalyzerResult(projects, packages, errors)
@@ -104,7 +104,7 @@ class AnalyzerResultBuilder {
                         "${it.vcsProcessed.url}/${it.definitionFilePath}"
                     }
 
-                    val error = Error(
+                    val error = OrtIssue(
                             source = "analyzer",
                             message = "Multiple projects with the same id '${existingProject.id}' found. Not adding " +
                                     "the project defined in '$incomingDefinitionFileUrl' to the analyzer results " +

--- a/model/src/main/kotlin/EvaluatorRun.kt
+++ b/model/src/main/kotlin/EvaluatorRun.kt
@@ -23,5 +23,5 @@ package com.here.ort.model
  * The summary of a single run of the evaluator.
  */
 data class EvaluatorRun(
-        val errors: List<Error>
+        val errors: List<OrtIssue>
 )

--- a/model/src/main/kotlin/Mappers.kt
+++ b/model/src/main/kotlin/Mappers.kt
@@ -34,11 +34,11 @@ import com.here.ort.model.config.AnalyzerConfigurationDeserializer
 
 private val ortModelModule = SimpleModule("OrtModelModule").apply {
     addDeserializer(AnalyzerConfiguration::class.java, AnalyzerConfigurationDeserializer())
-    addDeserializer(Error::class.java, ErrorDeserializer())
+    addDeserializer(OrtIssue::class.java, ErrorDeserializer())
     addDeserializer(Identifier::class.java, IdentifierFromStringDeserializer())
     addDeserializer(VcsInfo::class.java, VcsInfoDeserializer())
 
-    addSerializer(Error::class.java, ErrorSerializer())
+    addSerializer(OrtIssue::class.java, ErrorSerializer())
     addSerializer(Identifier::class.java, IdentifierToStringSerializer())
 
     addKeyDeserializer(Identifier::class.java, IdentifierFromStringKeyDeserializer())

--- a/model/src/main/kotlin/OrtIssue.kt
+++ b/model/src/main/kotlin/OrtIssue.kt
@@ -34,7 +34,7 @@ import java.time.Instant
 /**
  * An error that occured while executing ORT.
  */
-data class Error(
+data class OrtIssue(
         /**
          * The timestamp of the error.
          */
@@ -53,21 +53,21 @@ data class Error(
     override fun toString() = "${if (timestamp == Instant.EPOCH) "n/a" else timestamp.toString()}: $source - $message"
 }
 
-class ErrorDeserializer : StdDeserializer<Error>(Error::class.java) {
-    override fun deserialize(p: JsonParser, ctxt: DeserializationContext): Error {
+class ErrorDeserializer : StdDeserializer<OrtIssue>(OrtIssue::class.java) {
+    override fun deserialize(p: JsonParser, ctxt: DeserializationContext): OrtIssue {
         val node = p.codec.readTree<JsonNode>(p)
         return if (node.isTextual) {
             // For backward-compatibility if only an error string is specified.
-            Error(Instant.EPOCH, "", node.textValue())
+            OrtIssue(Instant.EPOCH, "", node.textValue())
         } else {
-            Error(Instant.parse(node.get("timestamp").textValue()), node.get("source").textValue(),
+            OrtIssue(Instant.parse(node.get("timestamp").textValue()), node.get("source").textValue(),
                     node.get("message").textValue())
         }
     }
 }
 
-class ErrorSerializer : StdSerializer<Error>(Error::class.java) {
-    override fun serialize(value: Error, gen: JsonGenerator, provider: SerializerProvider) {
+class ErrorSerializer : StdSerializer<OrtIssue>(OrtIssue::class.java) {
+    override fun serialize(value: OrtIssue, gen: JsonGenerator, provider: SerializerProvider) {
         gen.writeStartObject()
         gen.writeObjectField("timestamp", value.timestamp)
         gen.writeStringField("source", value.source)

--- a/model/src/main/kotlin/Package.kt
+++ b/model/src/main/kotlin/Package.kt
@@ -127,6 +127,6 @@ data class Package(
     /**
      * Return a [PackageReference] to refer to this [Package] with optional [dependencies] and [errors].
      */
-    fun toReference(dependencies: SortedSet<PackageReference> = sortedSetOf(), errors: List<Error> = emptyList()) =
+    fun toReference(dependencies: SortedSet<PackageReference> = sortedSetOf(), errors: List<OrtIssue> = emptyList()) =
             PackageReference(id, dependencies, errors)
 }

--- a/model/src/main/kotlin/PackageReference.kt
+++ b/model/src/main/kotlin/PackageReference.kt
@@ -48,7 +48,7 @@ data class PackageReference(
         // Do not serialize if empty to reduce the size of the result file. If there are no errors at all,
         // [AnalyzerResult.hasErrors] already contains that information.
         @JsonInclude(JsonInclude.Include.NON_EMPTY)
-        val errors: List<Error> = emptyList(),
+        val errors: List<OrtIssue> = emptyList(),
 
         /**
          * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.

--- a/model/src/main/kotlin/Project.kt
+++ b/model/src/main/kotlin/Project.kt
@@ -97,8 +97,8 @@ data class Project(
     /**
      * Return a de-duplicated list of all errors for the provided [id].
      */
-    fun collectErrors(id: Identifier): List<Error> {
-        val collectedErrors = mutableListOf<Error>()
+    fun collectErrors(id: Identifier): List<OrtIssue> {
+        val collectedErrors = mutableListOf<OrtIssue>()
 
         fun addErrors(pkgRef: PackageReference) {
             if (pkgRef.id == id) {

--- a/model/src/main/kotlin/ProjectAnalyzerResult.kt
+++ b/model/src/main/kotlin/ProjectAnalyzerResult.kt
@@ -44,7 +44,7 @@ data class ProjectAnalyzerResult(
         // Do not serialize if empty for consistency with the error properties in other classes, even if this class is
         // not serialized as part of an [OrtResult].
         @JsonInclude(JsonInclude.Include.NON_EMPTY)
-        val errors: List<Error> = emptyList()
+        val errors: List<OrtIssue> = emptyList()
 ) {
     init {
         // Perform a sanity check to ensure we have no references to non-existing packages.
@@ -57,8 +57,8 @@ data class ProjectAnalyzerResult(
         }
     }
 
-    fun collectErrors(): Map<Identifier, List<Error>> {
-        val collectedErrors = mutableMapOf<Identifier, MutableList<Error>>()
+    fun collectErrors(): Map<Identifier, List<OrtIssue>> {
+        val collectedErrors = mutableMapOf<Identifier, MutableList<OrtIssue>>()
 
         fun addErrors(pkgReference: PackageReference) {
             val errorsForPkg = collectedErrors.getOrPut(pkgReference.id) { mutableListOf() }
@@ -73,7 +73,7 @@ data class ProjectAnalyzerResult(
             }
         }
 
-        return mutableMapOf<Identifier, List<Error>>().apply {
+        return mutableMapOf<Identifier, List<OrtIssue>>().apply {
             if (errors.isNotEmpty()) {
                 this[project.id] = errors.toMutableList()
             }

--- a/model/src/main/kotlin/ScanSummary.kt
+++ b/model/src/main/kotlin/ScanSummary.kt
@@ -60,7 +60,7 @@ data class ScanSummary(
         // Do not serialize if empty to reduce the size of the result file. If there are no errors at all,
         // [ScanRecord.hasErrors] already contains that information.
         @JsonInclude(JsonInclude.Include.NON_EMPTY)
-        val errors: List<Error> = emptyList()
+        val errors: List<OrtIssue> = emptyList()
 ) {
     @get:JsonIgnore
     val licenses: SortedSet<String> = licenseFindings.map { it.license }.toSortedSet()

--- a/model/src/main/kotlin/config/ErrorResolution.kt
+++ b/model/src/main/kotlin/config/ErrorResolution.kt
@@ -21,7 +21,7 @@ package com.here.ort.model.config
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 
-import com.here.ort.model.Error
+import com.here.ort.model.OrtIssue
 
 /**
  * Defines the resolution of an error. This can be used to silence false positives, or errors that have been identified
@@ -50,5 +50,5 @@ data class ErrorResolution(
     /**
      * True if [message] matches the message of [error].
      */
-    fun matches(error: Error) = regex.matches(error.message)
+    fun matches(error: OrtIssue) = regex.matches(error.message)
 }

--- a/model/src/test/kotlin/AnalyzerResultTest.kt
+++ b/model/src/test/kotlin/AnalyzerResultTest.kt
@@ -44,8 +44,8 @@ class AnalyzerResultTest : WordSpec() {
             scopes = sortedSetOf(scope1, scope2)
     )
 
-    private val error1 = Error(source = "source-1", message = "message-1")
-    private val error2 = Error(source = "source-2", message = "message-2")
+    private val error1 = OrtIssue(source = "source-1", message = "message-1")
+    private val error2 = OrtIssue(source = "source-2", message = "message-2")
 
     private val analyzerResult1 = ProjectAnalyzerResult(project1, sortedSetOf(package1.toCuratedPackage()),
             listOf(error1, error2))

--- a/model/src/test/kotlin/PackageReferenceTest.kt
+++ b/model/src/test/kotlin/PackageReferenceTest.kt
@@ -52,7 +52,7 @@ class PackageReferenceTest : WordSpec() {
                     val name = "${it.id.name}_suffix"
                     it.copy(
                             id = it.id.copy(name = name),
-                            errors = listOf(com.here.ort.model.Error(source = "test", message = "error $name"))
+                            errors = listOf(com.here.ort.model.OrtIssue(source = "test", message = "error $name"))
                     )
                 }
 

--- a/model/src/test/kotlin/ProjectAnalyzerResultTest.kt
+++ b/model/src/test/kotlin/ProjectAnalyzerResultTest.kt
@@ -24,14 +24,14 @@ import io.kotlintest.specs.StringSpec
 
 class ProjectAnalyzerResultTest : StringSpec({
     "collectErrors should find all errors" {
-        val error1 = Error(source = "source-1", message = "error-1")
-        val error2 = Error(source = "source-2", message = "error-2")
-        val error3 = Error(source = "source-3", message = "error-3")
-        val error4 = Error(source = "source-4", message = "error-4")
-        val error5 = Error(source = "source-5", message = "error-5")
-        val error6 = Error(source = "source-6", message = "error-6")
-        val error7 = Error(source = "source-7", message = "error-7")
-        val error8 = Error(source = "source-8", message = "error-8")
+        val error1 = OrtIssue(source = "source-1", message = "error-1")
+        val error2 = OrtIssue(source = "source-2", message = "error-2")
+        val error3 = OrtIssue(source = "source-3", message = "error-3")
+        val error4 = OrtIssue(source = "source-4", message = "error-4")
+        val error5 = OrtIssue(source = "source-5", message = "error-5")
+        val error6 = OrtIssue(source = "source-6", message = "error-6")
+        val error7 = OrtIssue(source = "source-7", message = "error-7")
+        val error8 = OrtIssue(source = "source-8", message = "error-8")
 
         val result = ProjectAnalyzerResult(
                 project = Project(

--- a/model/src/test/kotlin/ScanResultContainerTest.kt
+++ b/model/src/test/kotlin/ScanResultContainerTest.kt
@@ -53,10 +53,10 @@ class ScanResultContainerTest : WordSpec() {
     private val scannerStartTime2 = downloadTime2 + Duration.ofMinutes(1)
     private val scannerEndTime2 = scannerStartTime2 + Duration.ofMinutes(1)
 
-    private val error11 = Error(source = "source-11", message = "error-11")
-    private val error12 = Error(source = "source-12", message = "error-12")
-    private val error21 = Error(source = "source-21", message = "error-21")
-    private val error22 = Error(source = "source-22", message = "error-22")
+    private val error11 = OrtIssue(source = "source-11", message = "error-11")
+    private val error12 = OrtIssue(source = "source-12", message = "error-12")
+    private val error21 = OrtIssue(source = "source-21", message = "error-21")
+    private val error22 = OrtIssue(source = "source-22", message = "error-22")
 
     private val scanSummary1 = ScanSummary(
             scannerStartTime1,
@@ -120,13 +120,13 @@ class ScanResultContainerTest : WordSpec() {
                 val scanResults = deprecatedScanResultsFile.readValue<ScanResultContainer>()
 
                 scanResults.results[0].summary.errors shouldBe listOf(
-                        Error(timestamp = Instant.EPOCH, source = "", message = "error-11"),
-                        Error(timestamp = Instant.EPOCH, source = "", message = "error-12")
+                        OrtIssue(timestamp = Instant.EPOCH, source = "", message = "error-11"),
+                        OrtIssue(timestamp = Instant.EPOCH, source = "", message = "error-12")
                 )
 
                 scanResults.results[1].summary.errors shouldBe listOf(
-                        Error(timestamp = Instant.EPOCH, source = "", message = "error-21"),
-                        Error(timestamp = Instant.EPOCH, source = "", message = "error-22")
+                        OrtIssue(timestamp = Instant.EPOCH, source = "", message = "error-21"),
+                        OrtIssue(timestamp = Instant.EPOCH, source = "", message = "error-22")
                 )
             }
         }

--- a/reporter/src/main/kotlin/DefaultResolutionProvider.kt
+++ b/reporter/src/main/kotlin/DefaultResolutionProvider.kt
@@ -19,7 +19,7 @@
 
 package com.here.ort.reporter
 
-import com.here.ort.model.Error
+import com.here.ort.model.OrtIssue
 import com.here.ort.model.config.Resolutions
 
 class DefaultResolutionProvider : ResolutionProvider {
@@ -29,5 +29,5 @@ class DefaultResolutionProvider : ResolutionProvider {
         this.resolutions = this.resolutions.merge(resolutions)
     }
 
-    override fun getResolutionsFor(error: Error) = resolutions.errors.filter { it.matches(error) }
+    override fun getResolutionsFor(error: OrtIssue) = resolutions.errors.filter { it.matches(error) }
 }

--- a/reporter/src/main/kotlin/ResolutionProvider.kt
+++ b/reporter/src/main/kotlin/ResolutionProvider.kt
@@ -19,7 +19,7 @@
 
 package com.here.ort.reporter
 
-import com.here.ort.model.Error
+import com.here.ort.model.OrtIssue
 import com.here.ort.model.config.ErrorResolution
 
 /**
@@ -29,5 +29,5 @@ interface ResolutionProvider {
     /**
      * Get all resolutions that match [error].
      */
-    fun getResolutionsFor(error: Error): List<ErrorResolution>
+    fun getResolutionsFor(error: OrtIssue): List<ErrorResolution>
 }

--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -21,7 +21,7 @@ package com.here.ort.reporter.reporters
 
 import ch.frankel.slf4k.*
 
-import com.here.ort.model.Error
+import com.here.ort.model.OrtIssue
 import com.here.ort.model.VcsInfo
 import com.here.ort.model.config.ScopeExclude
 import com.here.ort.utils.isValidUrl
@@ -340,7 +340,7 @@ class StaticHtmlReporter : TableReporter() {
                 }
             }
 
-    private fun createEvaluatorTable(evaluatorErrors: List<Error>) =
+    private fun createEvaluatorTable(evaluatorErrors: List<OrtIssue>) =
             buildString {
                 append("<h2><a id=\"license-check-results\"></a>License Check Results</h2>")
 

--- a/reporter/src/main/kotlin/reporters/TableReporter.kt
+++ b/reporter/src/main/kotlin/reporters/TableReporter.kt
@@ -19,7 +19,7 @@
 
 package com.here.ort.reporter.reporters
 
-import com.here.ort.model.Error
+import com.here.ort.model.OrtIssue
 import com.here.ort.model.Identifier
 import com.here.ort.model.OrtResult
 import com.here.ort.model.Project
@@ -50,7 +50,7 @@ abstract class TableReporter : Reporter() {
             /**
              * A list containing all evaluator errors. `null` if no evaluator result is available.
              */
-            val evaluatorErrors: List<Error>?,
+            val evaluatorErrors: List<OrtIssue>?,
 
             /**
              * A [ErrorTable] containing all dependencies that caused errors.
@@ -218,8 +218,8 @@ abstract class TableReporter : Reporter() {
     }
 
     data class ResolvableError(
-        val error: Error,
-        val resolutions: List<ErrorResolution>
+            val error: OrtIssue,
+            val resolutions: List<ErrorResolution>
     ) {
         override fun toString() =
                 buildString {
@@ -236,7 +236,7 @@ abstract class TableReporter : Reporter() {
             outputDir: File,
             postProcessingScript: String?
     ): File {
-        fun Error.toResolvableError(): TableReporter.ResolvableError {
+        fun OrtIssue.toResolvableError(): TableReporter.ResolvableError {
             return ResolvableError(this, resolutionProvider.getResolutionsFor(this))
         }
 

--- a/scanner/src/funTest/kotlin/HttpCacheTest.kt
+++ b/scanner/src/funTest/kotlin/HttpCacheTest.kt
@@ -20,7 +20,7 @@
 package com.here.ort.scanner
 
 import com.here.ort.model.EMPTY_JSON_NODE
-import com.here.ort.model.Error
+import com.here.ort.model.OrtIssue
 import com.here.ort.model.HashAlgorithm
 import com.here.ort.model.Identifier
 import com.here.ort.model.LicenseFinding
@@ -127,8 +127,8 @@ class HttpCacheTest : StringSpec() {
     private val scannerStartTime2 = downloadTime2 + Duration.ofMinutes(1)
     private val scannerEndTime2 = scannerStartTime2 + Duration.ofMinutes(1)
 
-    private val error1 = Error(source = "source-1", message = "error-1")
-    private val error2 = Error(source = "source-2", message = "error-2")
+    private val error1 = OrtIssue(source = "source-1", message = "error-1")
+    private val error2 = OrtIssue(source = "source-2", message = "error-2")
 
     private val scanSummaryWithFiles = ScanSummary(
             scannerStartTime1,

--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -28,7 +28,7 @@ import com.here.ort.downloader.Downloader
 import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.EMPTY_JSON_NODE
 import com.here.ort.model.Environment
-import com.here.ort.model.Error
+import com.here.ort.model.OrtIssue
 import com.here.ort.model.Identifier
 import com.here.ort.model.OrtResult
 import com.here.ort.model.Package
@@ -160,7 +160,7 @@ abstract class LocalScanner(config: ScannerConfiguration) : Scanner(config), Com
                                 endTime = now,
                                 fileCount = 0,
                                 licenseFindings = sortedSetOf(),
-                                errors = listOf(Error(source = javaClass.simpleName,
+                                errors = listOf(OrtIssue(source = javaClass.simpleName,
                                         message = e.collectMessagesAsString()))
                         ),
                         rawResult = EMPTY_JSON_NODE)
@@ -196,7 +196,7 @@ abstract class LocalScanner(config: ScannerConfiguration) : Scanner(config), Com
 
             val now = Instant.now()
             val summary = ScanSummary(now, now, 0, sortedSetOf(),
-                    listOf(Error(source = toString(), message = e.collectMessagesAsString())))
+                    listOf(OrtIssue(source = toString(), message = e.collectMessagesAsString())))
             ScanResult(Provenance(now), getDetails(), summary)
         }
 
@@ -260,7 +260,10 @@ abstract class LocalScanner(config: ScannerConfiguration) : Scanner(config), Com
                             endTime = now,
                             fileCount = 0,
                             licenseFindings = sortedSetOf(),
-                            errors = listOf(Error(source = javaClass.simpleName, message = e.collectMessagesAsString()))
+                            errors = listOf(OrtIssue(
+                                    source = javaClass.simpleName,
+                                    message = e.collectMessagesAsString()
+                            ))
                     ),
                     EMPTY_JSON_NODE
             )

--- a/scanner/src/main/kotlin/scanners/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/ScanCode.kt
@@ -25,7 +25,7 @@ import ch.qos.logback.classic.Level
 import com.fasterxml.jackson.databind.JsonNode
 
 import com.here.ort.model.EMPTY_JSON_NODE
-import com.here.ort.model.Error
+import com.here.ort.model.OrtIssue
 import com.here.ort.model.LicenseFinding
 import com.here.ort.model.Provenance
 import com.here.ort.model.ScanResult
@@ -242,12 +242,12 @@ class ScanCode(config: ScannerConfiguration) : LocalScanner(config) {
     override fun generateSummary(startTime: Instant, endTime: Instant, result: JsonNode): ScanSummary {
         val fileCount = result["files_count"].intValue()
         val findings = associateFindings(result)
-        val errors = mutableListOf<Error>()
+        val errors = mutableListOf<OrtIssue>()
 
         result["files"]?.forEach { file ->
             val path = file["path"].textValue()
             errors += file["scan_errors"].map {
-                Error(source = javaClass.simpleName, message = "${it.textValue()} (File: $path)")
+                OrtIssue(source = javaClass.simpleName, message = "${it.textValue()} (File: $path)")
             }
         }
 
@@ -258,7 +258,7 @@ class ScanCode(config: ScannerConfiguration) : LocalScanner(config) {
      * Map messages about unknown errors to a more compact form. Return true if solely memory errors occurred, return
      * false otherwise.
      */
-    internal fun mapUnknownErrors(errors: MutableList<Error>): Boolean {
+    internal fun mapUnknownErrors(errors: MutableList<OrtIssue>): Boolean {
         if (errors.isEmpty()) {
             return false
         }
@@ -294,7 +294,7 @@ class ScanCode(config: ScannerConfiguration) : LocalScanner(config) {
      * Map messages about timeout errors to a more compact form. Return true if solely timeout errors occurred, return
      * false otherwise.
      */
-    internal fun mapTimeoutErrors(errors: MutableList<Error>): Boolean {
+    internal fun mapTimeoutErrors(errors: MutableList<OrtIssue>): Boolean {
         if (errors.isEmpty()) {
             return false
         }


### PR DESCRIPTION
The old name was conflicting with `kotlin.Error` which is imported by
default.

Signed-off-by: Martin Nonnenmacher <martin.nonnenmacher@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1055)
<!-- Reviewable:end -->
