### PR TITLE
analyzer: Move PackageJsonUtils out of managers

### DIFF
--- a/analyzer/src/main/kotlin/PackageJsonUtils.kt
+++ b/analyzer/src/main/kotlin/PackageJsonUtils.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package com.here.ort.analyzer.managers
+package com.here.ort.analyzer
 
 import com.fasterxml.jackson.databind.node.ArrayNode
 import com.fasterxml.jackson.databind.node.ObjectNode

--- a/analyzer/src/main/kotlin/managers/NPM.kt
+++ b/analyzer/src/main/kotlin/managers/NPM.kt
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode
 
 import com.here.ort.analyzer.AbstractPackageManagerFactory
 import com.here.ort.analyzer.HTTP_CACHE_PATH
+import com.here.ort.analyzer.PackageJsonUtils
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.OrtIssue

--- a/analyzer/src/main/kotlin/managers/Yarn.kt
+++ b/analyzer/src/main/kotlin/managers/Yarn.kt
@@ -20,6 +20,7 @@
 package com.here.ort.analyzer.managers
 
 import com.here.ort.analyzer.AbstractPackageManagerFactory
+import com.here.ort.analyzer.PackageJsonUtils
 import com.here.ort.model.config.AnalyzerConfiguration
 import com.here.ort.model.config.RepositoryConfiguration
 import com.here.ort.utils.OS

--- a/analyzer/src/test/kotlin/PackageJsonUtilsTest.kt
+++ b/analyzer/src/test/kotlin/PackageJsonUtilsTest.kt
@@ -19,9 +19,8 @@
 
 package com.here.ort.analyzer
 
-import com.here.ort.analyzer.managers.PackageJsonUtils
-import com.here.ort.analyzer.managers.PackageJsonUtils.Companion.mapDefinitionFilesForNpm
-import com.here.ort.analyzer.managers.PackageJsonUtils.Companion.mapDefinitionFilesForYarn
+import com.here.ort.analyzer.PackageJsonUtils.Companion.mapDefinitionFilesForNpm
+import com.here.ort.analyzer.PackageJsonUtils.Companion.mapDefinitionFilesForYarn
 import com.here.ort.utils.safeDeleteRecursively
 import com.here.ort.utils.safeMkdirs
 


### PR DESCRIPTION
As it is not a package manager itself.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1058)
<!-- Reviewable:end -->
