### PR TITLE
Evaluator: Simplify writing rules by wildcard-importing some packages

### DIFF
--- a/evaluator/src/main/kotlin/Evaluator.kt
+++ b/evaluator/src/main/kotlin/Evaluator.kt
@@ -26,9 +26,9 @@ import com.here.ort.utils.ScriptRunner
 
 class Evaluator(ortResult: OrtResult) : ScriptRunner() {
     override val preface = """
-            import com.here.ort.model.OrtIssue
-            import com.here.ort.model.OrtResult
-            import com.here.ort.model.Package
+            import com.here.ort.model.*
+
+            import java.util.*
 
             // Input:
             val ortResult = bindings["ortResult"] as OrtResult


### PR DESCRIPTION
Rule scripts themselves cannot contain imports as they would come after
the variable declarations in the preface, which is not allowed.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1062)
<!-- Reviewable:end -->
