### PR TITLE
model: Add a parser for SPDX expressions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,7 @@ dokkaPluginVersion = 0.9.17
 kotlinPluginVersion = 1.3.10
 versionsPluginVersion = 0.20.0
 
+antlrVersion = 4.7.1
 commonsCodecVersion = 1.11
 commonsCompressVersion = 1.18
 digraphVersion = 1.0

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -1,7 +1,19 @@
+plugins {
+    id 'antlr'
+}
+
 // Apply core plugins.
 apply plugin: 'java-library'
 
+generateGrammarSource {
+    arguments += '-visitor'
+}
+
+compileKotlin.dependsOn(generateGrammarSource)
+
 dependencies {
+    antlr "org.antlr:antlr4:$antlrVersion"
+
     api "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
     api "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion"
     api "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion"

--- a/model/src/main/antlr/com/here/ort/model/spdx/SpdxExpression.g4
+++ b/model/src/main/antlr/com/here/ort/model/spdx/SpdxExpression.g4
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2017-2018 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+/*
+ * All definitions are based on the specification for SPDX expressions:
+ * https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60
+ */
+grammar SpdxExpression;
+
+@header {
+package com.here.ort.model.spdx;
+}
+
+/*
+ * Parser Rules
+ */
+
+licenseRefExpression
+    :
+    LICENSEREF
+    ;
+
+licenseExceptionExpression
+    :
+    IDSTRING
+    ;
+
+licenseIdExpression
+    :
+    IDSTRING
+    (PLUS)?
+    ;
+
+simpleExpression
+    :
+    licenseRefExpression
+    | licenseIdExpression
+    ;
+
+compoundExpression
+    :
+    simpleExpression
+    | simpleExpression WITH licenseExceptionExpression
+    | compoundExpression AND compoundExpression
+    | compoundExpression OR compoundExpression
+    | OPEN compoundExpression CLOSE
+    ;
+
+licenseExpression
+    :
+    (simpleExpression | compoundExpression)
+    EOF
+    ;
+
+/*
+ * Lexer Rules
+ */
+
+fragment ALPHA : [A-Za-z] ;
+fragment DIGIT : [0-9] ;
+
+AND  : ('AND' | 'and') ;
+OR   : ('OR' | 'or') ;
+WITH : ('WITH' | 'with') ;
+
+OPEN  : '(' ;
+CLOSE : ')' ;
+PLUS  : '+';
+
+LICENSEREF : ('DocumentRef-' | 'LicenseRef-') IDSTRING ;
+IDSTRING   : (ALPHA | DIGIT)(ALPHA | DIGIT | '-' | '.')* ;
+
+WHITESPACE : ' ' -> skip ;

--- a/model/src/main/kotlin/spdx/SpdxException.kt
+++ b/model/src/main/kotlin/spdx/SpdxException.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2017-2018 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.model.spdx
+
+class SpdxException : Exception {
+    constructor(message: String?, cause: Throwable?): super(message, cause)
+    constructor(message: String?): super(message)
+    constructor(cause: Throwable?): super(cause)
+}

--- a/model/src/main/kotlin/spdx/SpdxExpression.kt
+++ b/model/src/main/kotlin/spdx/SpdxExpression.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2017-2018 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.model.spdx
+
+import org.antlr.v4.runtime.BaseErrorListener
+import org.antlr.v4.runtime.CharStreams
+import org.antlr.v4.runtime.CommonTokenStream
+import org.antlr.v4.runtime.RecognitionException
+import org.antlr.v4.runtime.Recognizer
+
+sealed class SpdxExpression
+
+data class SpdxCompoundExpression(
+        val left: SpdxExpression,
+        val operator: SpdxOperator,
+        val right: SpdxExpression
+) : SpdxExpression()
+
+data class SpdxLicenseExceptionExpression(
+        val id: String
+) : SpdxExpression()
+
+data class SpdxLicenseIdExpression(
+        val id: String,
+        val anyLaterVersion: Boolean = false
+) : SpdxExpression()
+
+data class SpdxLicenseRefExpression(
+        val id: String
+) : SpdxExpression()
+
+enum class SpdxOperator {
+    AND,
+    OR,
+    WITH
+}
+
+fun parseSpdxExpression(expression: String): SpdxExpression {
+    val charStream = CharStreams.fromString(expression)
+    val lexer = SpdxExpressionLexer(charStream)
+
+    lexer.addErrorListener(object : BaseErrorListener() {
+        override fun syntaxError(
+                recognizer: Recognizer<*, *>?,
+                offendingSymbol: Any?,
+                line: Int,
+                charPositionInLine: Int,
+                msg: String?,
+                e: RecognitionException?
+        ) {
+            throw SpdxException(msg)
+        }
+    })
+
+    val tokenStream = CommonTokenStream(lexer)
+    val parser = SpdxExpressionParser(tokenStream)
+    val visitor = SpdxExpressionDefaultVisitor()
+
+    return visitor.visit(parser.licenseExpression())
+}

--- a/model/src/main/kotlin/spdx/SpdxExpressionDefaultVisitor.kt
+++ b/model/src/main/kotlin/spdx/SpdxExpressionDefaultVisitor.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2017-2018 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.model.spdx
+
+import com.here.ort.model.spdx.SpdxExpressionParser.CompoundExpressionContext
+import com.here.ort.model.spdx.SpdxExpressionParser.LicenseExceptionExpressionContext
+import com.here.ort.model.spdx.SpdxExpressionParser.LicenseExpressionContext
+import com.here.ort.model.spdx.SpdxExpressionParser.LicenseIdExpressionContext
+import com.here.ort.model.spdx.SpdxExpressionParser.LicenseRefExpressionContext
+import com.here.ort.model.spdx.SpdxExpressionParser.SimpleExpressionContext
+
+class SpdxExpressionDefaultVisitor : SpdxExpressionBaseVisitor<SpdxExpression>() {
+    override fun visitLicenseExpression(ctx: LicenseExpressionContext): SpdxExpression {
+        return when (ctx.childCount) {
+            2 -> visit(ctx.getChild(0))
+            else -> throw SpdxException("SpdxExpression has invalid amount of children: '${ctx.childCount}'")
+        }
+    }
+
+    override fun visitCompoundExpression(ctx: CompoundExpressionContext): SpdxExpression {
+        return when (ctx.childCount) {
+            1 -> visit(ctx.getChild(0))
+            3 -> {
+                if (ctx.getChild(0).text == "(" && ctx.getChild(2).text == ")") {
+                    visit(ctx.getChild(1))
+                } else {
+                    val left = visit(ctx.getChild(0))
+
+                    val operatorName = ctx.getChild(1).text
+                    val operator = try {
+                        SpdxOperator.valueOf(operatorName.toUpperCase())
+                    } catch (e: IllegalArgumentException) {
+                        throw SpdxException("Illegal operator '$operatorName' in expression '${ctx.text}'.")
+                    }
+
+                    val right = visit(ctx.getChild(2))
+
+                    if (operator == SpdxOperator.WITH && right !is SpdxLicenseExceptionExpression) {
+                        throw SpdxException("Argument '$right' for WITH is not an SPDX license exception id in " +
+                                "'${ctx.text}'.")
+                    }
+
+                    SpdxCompoundExpression(left, operator, right)
+                }
+            }
+            else -> throw SpdxException("SpdxCompoundExpression has invalid amount of children: '${ctx.childCount}'")
+        }
+    }
+
+    override fun visitSimpleExpression(ctx: SimpleExpressionContext): SpdxExpression {
+        return when (ctx.childCount) {
+            1 -> visit(ctx.getChild(0))
+            else -> throw SpdxException("SpdxSimpleExpression has invalid amount of children: '${ctx.childCount}'")
+        }
+    }
+
+    override fun visitLicenseExceptionExpression(ctx: LicenseExceptionExpressionContext)
+            : SpdxExpression {
+        return when (ctx.childCount) {
+            1 -> SpdxLicenseExceptionExpression(ctx.text)
+            else -> throw SpdxException("SpdxLicenseExceptionExpression has invalid amount of children: " +
+                    "'${ctx.childCount}'")
+        }
+    }
+
+    override fun visitLicenseIdExpression(ctx: LicenseIdExpressionContext): SpdxExpression {
+        return when (ctx.childCount) {
+            1 -> SpdxLicenseIdExpression(ctx.text)
+            2 -> SpdxLicenseIdExpression(ctx.text.dropLast(1), anyLaterVersion = true)
+            else -> throw SpdxException("SpdxLicenseIdExpression has invalid amount of children: '${ctx.childCount}'")
+        }
+    }
+
+    override fun visitLicenseRefExpression(ctx: LicenseRefExpressionContext): SpdxExpression {
+        return when (ctx.childCount) {
+            1 -> SpdxLicenseRefExpression(ctx.text)
+            else -> throw SpdxException("SpdxLicenseRefExpression has invalid amount of children: '${ctx.childCount}'")
+        }
+    }
+}

--- a/model/src/test/kotlin/spdx/SpdxExpressionLexerTest.kt
+++ b/model/src/test/kotlin/spdx/SpdxExpressionLexerTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2017-2018 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.model.spdx
+
+import io.kotlintest.shouldBe
+import io.kotlintest.shouldThrow
+import io.kotlintest.specs.WordSpec
+
+import org.antlr.v4.runtime.BaseErrorListener
+import org.antlr.v4.runtime.CharStreams
+import org.antlr.v4.runtime.RecognitionException
+import org.antlr.v4.runtime.Recognizer
+
+class SpdxExpressionLexerTest : WordSpec() {
+    init {
+        "SpdxExpressionLexer" should {
+            "create the correct tokens for a valid expression" {
+                val expression = "(license-1 AND OR license.2 WITH 0LiCeNsE-3+) and (or with license-4 license-.5(("
+
+                val tokens = getTokensByTypeForExpression(expression)
+
+                tokens shouldBe listOf(
+                        SpdxExpressionLexer.OPEN to "(",
+                        SpdxExpressionLexer.IDSTRING to "license-1",
+                        SpdxExpressionLexer.AND to "AND",
+                        SpdxExpressionLexer.OR to "OR",
+                        SpdxExpressionLexer.IDSTRING to "license.2",
+                        SpdxExpressionLexer.WITH to "WITH",
+                        SpdxExpressionLexer.IDSTRING to "0LiCeNsE-3",
+                        SpdxExpressionLexer.PLUS to "+",
+                        SpdxExpressionLexer.CLOSE to ")",
+                        SpdxExpressionLexer.AND to "and",
+                        SpdxExpressionLexer.OPEN to "(",
+                        SpdxExpressionLexer.OR to "or",
+                        SpdxExpressionLexer.WITH to "with",
+                        SpdxExpressionLexer.IDSTRING to "license-4",
+                        SpdxExpressionLexer.IDSTRING to "license-.5",
+                        SpdxExpressionLexer.OPEN to "(",
+                        SpdxExpressionLexer.OPEN to "("
+                )
+            }
+
+            "fail for an invalid expression" {
+                val expression = "/"
+
+                val exception = shouldThrow<SpdxException> {
+                    getTokensByTypeForExpression(expression)
+                }
+
+                exception.message shouldBe "token recognition error at: '/'"
+            }
+        }
+    }
+
+    private fun getTokensByTypeForExpression(expression: String): List<Pair<Int, String>> {
+        val charStream = CharStreams.fromString(expression)
+        val lexer = SpdxExpressionLexer(charStream)
+        lexer.removeErrorListeners()
+        lexer.addErrorListener(object : BaseErrorListener() {
+            override fun syntaxError(
+                    recognizer: Recognizer<*, *>?,
+                    offendingSymbol: Any?,
+                    line: Int,
+                    charPositionInLine: Int,
+                    msg: String?,
+                    e: RecognitionException?
+            ) {
+                throw SpdxException(msg)
+            }
+        })
+
+        return lexer.allTokens.map { it.type to it.text }
+    }
+}

--- a/model/src/test/kotlin/spdx/SpdxExpressionParserTest.kt
+++ b/model/src/test/kotlin/spdx/SpdxExpressionParserTest.kt
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2017-2018 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.model.spdx
+
+import io.kotlintest.shouldBe
+import io.kotlintest.shouldThrow
+import io.kotlintest.specs.WordSpec
+
+class SpdxExpressionParserTest : WordSpec() {
+    init {
+        "SpdxExpressionParser" should {
+            "parse a license id correctly" {
+                val spdxExpression = parseSpdxExpression("spdx.license-id")
+
+                spdxExpression shouldBe SpdxLicenseIdExpression("spdx.license-id")
+            }
+
+            "parse a license id starting with a digit correctly" {
+                val spdxExpression = parseSpdxExpression("0license")
+
+                spdxExpression shouldBe SpdxLicenseIdExpression("0license")
+            }
+
+            "parse a license id with any later version correctly" {
+                val spdxExpression = parseSpdxExpression("license+")
+
+                spdxExpression shouldBe SpdxLicenseIdExpression("license", anyLaterVersion = true)
+            }
+
+            "parse a document ref correctly" {
+                val spdxExpression = parseSpdxExpression("DocumentRef-license")
+
+                spdxExpression shouldBe SpdxLicenseRefExpression("DocumentRef-license")
+            }
+
+            "parse a license ref correctly" {
+                val spdxExpression = parseSpdxExpression("LicenseRef-license")
+
+                spdxExpression shouldBe SpdxLicenseRefExpression("LicenseRef-license")
+            }
+
+            "parse a complex expression correctly" {
+                val expression = "license1+ and ((license2 with exception1) OR license3+ AND license4 WITH exception2)"
+
+                val spdxExpression = parseSpdxExpression(expression)
+
+                spdxExpression shouldBe SpdxCompoundExpression(
+                        SpdxLicenseIdExpression("license1", anyLaterVersion = true),
+                        SpdxOperator.AND,
+                        SpdxCompoundExpression(
+                                SpdxCompoundExpression(
+                                        SpdxLicenseIdExpression("license2"),
+                                        SpdxOperator.WITH,
+                                        SpdxLicenseExceptionExpression("exception1")
+                                ),
+                                SpdxOperator.OR,
+                                SpdxCompoundExpression(
+                                        SpdxLicenseIdExpression("license3", anyLaterVersion = true),
+                                        SpdxOperator.AND,
+                                        SpdxCompoundExpression(
+                                                SpdxLicenseIdExpression("license4"),
+                                                SpdxOperator.WITH,
+                                                SpdxLicenseExceptionExpression("exception2")
+                                        )
+                                )
+                        )
+                )
+            }
+
+            "bind + stronger than WITH" {
+                val spdxExpression = parseSpdxExpression("license+ WITH exception")
+
+                spdxExpression shouldBe SpdxCompoundExpression(
+                        SpdxLicenseIdExpression("license", anyLaterVersion = true),
+                        SpdxOperator.WITH,
+                        SpdxLicenseExceptionExpression("exception")
+                )
+            }
+
+            "bind WITH stronger than AND" {
+                val spdxExpression = parseSpdxExpression("license1 AND license2 WITH exception")
+
+                spdxExpression shouldBe SpdxCompoundExpression(
+                        SpdxLicenseIdExpression("license1"),
+                        SpdxOperator.AND,
+                        SpdxCompoundExpression(
+                                SpdxLicenseIdExpression("license2"),
+                                SpdxOperator.WITH,
+                                SpdxLicenseExceptionExpression("exception")
+                        )
+                )
+            }
+
+            "bind AND stronger than OR" {
+                val spdxExpression = parseSpdxExpression("license1 OR license2 AND license3")
+
+                spdxExpression shouldBe SpdxCompoundExpression(
+                        SpdxLicenseIdExpression("license1"),
+                        SpdxOperator.OR,
+                        SpdxCompoundExpression(
+                                SpdxLicenseIdExpression("license2"),
+                                SpdxOperator.AND,
+                                SpdxLicenseIdExpression("license3")
+                        )
+                )
+            }
+
+            "bind the and operator left associative" {
+                val spdxExpression = parseSpdxExpression("license1 AND license2 AND license3")
+
+                spdxExpression shouldBe SpdxCompoundExpression(
+                        SpdxCompoundExpression(
+                                SpdxLicenseIdExpression("license1"),
+                                SpdxOperator.AND,
+                                SpdxLicenseIdExpression("license2")
+                        ),
+                        SpdxOperator.AND,
+                        SpdxLicenseIdExpression("license3")
+                )
+            }
+
+            "bind the or operator left associative" {
+                val spdxExpression = parseSpdxExpression("license1 OR license2 OR license3")
+
+                spdxExpression shouldBe SpdxCompoundExpression(
+                        SpdxCompoundExpression(
+                                SpdxLicenseIdExpression("license1"),
+                                SpdxOperator.OR,
+                                SpdxLicenseIdExpression("license2")
+                        ),
+                        SpdxOperator.OR,
+                        SpdxLicenseIdExpression("license3")
+                )
+            }
+
+            "respect parentheses for binding strength of operators" {
+                val expression = "(license1 OR license2) AND license3"
+
+                val spdxExpression = parseSpdxExpression(expression)
+
+                spdxExpression shouldBe SpdxCompoundExpression(
+                        SpdxCompoundExpression(
+                                SpdxLicenseIdExpression("license1"),
+                                SpdxOperator.OR,
+                                SpdxLicenseIdExpression("license2")
+                        ),
+                        SpdxOperator.AND,
+                        SpdxLicenseIdExpression("license3")
+                )
+            }
+
+            "fail if + is used in an exception expression" {
+                val exception = shouldThrow<SpdxException> {
+                    parseSpdxExpression("license WITH exception+")
+                }
+
+                exception.message shouldBe "SpdxExpression has invalid amount of children: '3'"
+            }
+
+            "fail if a compound expression is used before WITH" {
+                val exception = shouldThrow<SpdxException> {
+                    parseSpdxExpression("(license1 AND license2) WITH exception")
+                }
+
+                exception.message shouldBe "SpdxExpression has invalid amount of children: '3'"
+            }
+
+            "fail on an invalid symbol" {
+                val exception = shouldThrow<SpdxException> {
+                    parseSpdxExpression("/")
+                }
+
+                exception.message shouldBe "token recognition error at: '/'"
+            }
+
+            "fail on a syntax error" {
+                val exception = shouldThrow<SpdxException> {
+                    parseSpdxExpression("((")
+                }
+
+                exception.message shouldBe "Illegal operator '(' in expression '((<missing ')'>'."
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implement a parser for SPDX expressions as specified in [1] using ANTLR
[2]. This is a prerequisite for implementing the evaluation of SPDX
expressions which will be used by upcoming features like evaluating the
compatibility of a license choice with an SPDX expression.

[1] https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60
[2] https://www.antlr.org/

Signed-off-by: Martin Nonnenmacher <martin.nonnenmacher@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1072)
<!-- Reviewable:end -->
