### PR TITLE
Gradle: Skip looking for plugin version properties for core plugins

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -2,7 +2,7 @@ pluginManagement {
     resolutionStrategy {
         eachPlugin {
             // Work around https://github.com/gradle/gradle/issues/1697.
-            if (requested.version == null) {
+            if (requested.id.namespace != null && requested.version == null) {
                 def pluginName = requested.id.name.split('-').collect { it.capitalize() }.join().uncapitalize()
                 def versionPropertyName = (requested.id.id == 'org.jetbrains.kotlin.jvm') ?
                         "kotlinPluginVersion" : "${pluginName}PluginVersion"


### PR DESCRIPTION
To avoid warnings like

    No version specified for plugin 'antlr' and property 'antlrPluginVersion' does not exist.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1078)
<!-- Reviewable:end -->
