### PR TITLE
AbstractNoticeReporter: Add SpdxLicense to the PostProcessor imports

### DIFF
--- a/model/src/main/kotlin/spdx/SpdxLicenseMapping.kt
+++ b/model/src/main/kotlin/spdx/SpdxLicenseMapping.kt
@@ -17,16 +17,15 @@
  * License-Filename: LICENSE
  */
 
-package com.here.ort.model.config
+package com.here.ort.model.spdx
 
-import com.here.ort.model.spdx.SpdxLicense
 import com.here.ort.utils.enumSetOf
 
 /**
  * A mapping from license strings collected from the declared licenses of open source packages to SPDX license
  * identifiers.
  */
-object LicenseMapping {
+object SpdxLicenseMapping {
     private val mapping = mapOf(
             "(0BSD OR MIT)" to enumSetOf(SpdxLicense._0BSD, SpdxLicense.MIT),
             "(BSD-2-Clause OR MIT OR Apache-2.0)"

--- a/reporter/src/main/kotlin/reporters/AbstractNoticeReporter.kt
+++ b/reporter/src/main/kotlin/reporters/AbstractNoticeReporter.kt
@@ -24,7 +24,7 @@ import ch.frankel.slf4k.*
 import com.here.ort.model.LicenseFindingsMap
 import com.here.ort.model.OrtResult
 import com.here.ort.model.config.CopyrightGarbage
-import com.here.ort.model.config.LicenseMapping
+import com.here.ort.model.spdx.SpdxLicenseMapping
 import com.here.ort.reporter.CopyrightStatementsProcessor
 import com.here.ort.reporter.Reporter
 import com.here.ort.reporter.ResolutionProvider
@@ -128,7 +128,7 @@ abstract class AbstractNoticeReporter : Reporter() {
         var result = mapOf<String, SortedSet<String>>()
 
         licenseFindings.forEach { finding ->
-            LicenseMapping.map(finding.key).map { spdxLicense ->
+            SpdxLicenseMapping.map(finding.key).map { spdxLicense ->
                 sortedMapOf(spdxLicense.id to finding.value)
             }.forEach {
                 result = result.zipWithDefault(it, sortedSetOf()) { left, right ->

--- a/reporter/src/main/kotlin/reporters/AbstractNoticeReporter.kt
+++ b/reporter/src/main/kotlin/reporters/AbstractNoticeReporter.kt
@@ -56,10 +56,9 @@ abstract class AbstractNoticeReporter : Reporter() {
 
     class PostProcessor(ortResult: OrtResult, noticeReport: NoticeReport) : ScriptRunner() {
         override val preface = """
-            import com.here.ort.model.OrtResult
+            import com.here.ort.model.*
+            import com.here.ort.model.spdx.*
             import com.here.ort.reporter.reporters.AbstractNoticeReporter.NoticeReport
-
-            import java.util.SortedSet
 
             // Input:
             val ortResult = bindings["ortResult"] as OrtResult

--- a/reporter/src/main/kotlin/reporters/NoticeOnlyDeclaredReporter.kt
+++ b/reporter/src/main/kotlin/reporters/NoticeOnlyDeclaredReporter.kt
@@ -21,7 +21,7 @@ package com.here.ort.reporter.reporters
 
 import com.here.ort.model.LicenseFindingsMap
 import com.here.ort.model.OrtResult
-import com.here.ort.model.config.LicenseMapping
+import com.here.ort.model.spdx.SpdxLicenseMapping
 
 import java.util.SortedSet
 
@@ -50,7 +50,7 @@ class NoticeOnlyDeclaredReporter : AbstractNoticeReporter() {
         } ?: sortedSetOf<String>()
 
         val allDeclaredSpdxLicenses = allDeclaredLicenses
-                .flatMap { LicenseMapping.map(it) }
+                .flatMap { SpdxLicenseMapping.map(it) }
                 .mapTo(sortedSetOf()) { it.id }
 
         return licenseFindings.filterTo(sortedMapOf()) { (license, _) ->


### PR DESCRIPTION
This allows to shorten the script by not using fully-qualified names in
several places.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1084)
<!-- Reviewable:end -->
