### PR TITLE
model: Add a `concludedLicense` field to `Package`

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -176,6 +176,7 @@ provide the location of source artifacts. The structure of the curations file is
 # Example for a complete curation object:
 #- id: "Maven:org.hamcrest:hamcrest-core:1.3"
 #  curations:
+#    concluded_license: "Apache-2.0 OR MIT" # Has to be a valid SPDX license expression.
 #    declared_licenses:
 #    - "license a"
 #    - "license b"

--- a/model/src/main/kotlin/Package.kt
+++ b/model/src/main/kotlin/Package.kt
@@ -21,6 +21,8 @@ package com.here.ort.model
 
 import com.fasterxml.jackson.annotation.JsonInclude
 
+import com.here.ort.model.spdx.SpdxExpression
+
 import java.util.SortedSet
 
 /**
@@ -43,6 +45,15 @@ data class Package(
          * licenses as detected by a scanner. Both need to be taken into account for any conclusions.
          */
         val declaredLicenses: SortedSet<String>,
+
+        /**
+         * The concluded license as an [SpdxExpression]. It can be used to correct the license of a package in case the
+         * [declaredLicenses] found in the packages metadata or the licenses detected by a scanner do not match reality.
+         *
+         * ORT itself does not set this field, it needs to be set by the user using a [PackageCuration].
+         */
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        val concludedLicense: SpdxExpression? = null,
 
         /**
          * The description of the package, as provided by the package manager.

--- a/model/src/main/kotlin/PackageCurationData.kt
+++ b/model/src/main/kotlin/PackageCurationData.kt
@@ -21,6 +21,8 @@ package com.here.ort.model
 
 import com.fasterxml.jackson.annotation.JsonInclude
 
+import com.here.ort.model.spdx.SpdxExpression
+
 import java.util.SortedSet
 
 /**
@@ -35,6 +37,13 @@ data class PackageCurationData(
          */
         @JsonInclude(JsonInclude.Include.NON_NULL)
         val declaredLicenses: SortedSet<String>? = null,
+
+        /**
+         * The concluded license as an [SpdxExpression]. It can be used to correct the license of a package in case the
+         * [declaredLicenses] found in the packages metadata or the licenses detected by a scanner do not match reality.
+         */
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        val concludedLicense: SpdxExpression? = null,
 
         /**
          * The description of the package, as provided by the package manager.
@@ -104,6 +113,7 @@ data class PackageCurationData(
             Package(
                     id = pkg.id,
                     declaredLicenses = declaredLicenses ?: pkg.declaredLicenses,
+                    concludedLicense = concludedLicense ?: pkg.concludedLicense,
                     description = description ?: pkg.description,
                     homepageUrl = homepageUrl ?: pkg.homepageUrl,
                     binaryArtifact = binaryArtifact ?: pkg.binaryArtifact,

--- a/model/src/test/kotlin/PackageCurationTest.kt
+++ b/model/src/test/kotlin/PackageCurationTest.kt
@@ -19,6 +19,8 @@
 
 package com.here.ort.model
 
+import com.here.ort.model.spdx.SpdxExpression
+
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldThrow
 import io.kotlintest.specs.StringSpec
@@ -44,6 +46,7 @@ class PackageCurationTest : StringSpec() {
                     id = pkg.id,
                     data = PackageCurationData(
                             declaredLicenses = sortedSetOf("license a", "license b"),
+                            concludedLicense = SpdxExpression.parse("license1 OR license2"),
                             description = "description",
                             homepageUrl = "http://home.page",
                             binaryArtifact = RemoteArtifact(
@@ -71,6 +74,7 @@ class PackageCurationTest : StringSpec() {
             curatedPkg.pkg.apply {
                 id.toString() shouldBe pkg.id.toString()
                 declaredLicenses shouldBe curation.data.declaredLicenses
+                concludedLicense shouldBe curation.data.concludedLicense
                 description shouldBe curation.data.description
                 homepageUrl shouldBe curation.data.homepageUrl
                 binaryArtifact shouldBe curation.data.binaryArtifact
@@ -121,6 +125,7 @@ class PackageCurationTest : StringSpec() {
             curatedPkg.pkg.apply {
                 id.toString() shouldBe pkg.id.toString()
                 declaredLicenses shouldBe pkg.declaredLicenses
+                concludedLicense shouldBe pkg.concludedLicense
                 description shouldBe pkg.description
                 homepageUrl shouldBe curation.data.homepageUrl
                 binaryArtifact shouldBe pkg.binaryArtifact


### PR DESCRIPTION
The concluded license can be used to define the license of a package in
case the license declared in the metadata or the license detected by the
scanner do not match reality.

Signed-off-by: Martin Nonnenmacher <martin.nonnenmacher@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1085)
<!-- Reviewable:end -->
