### PR TITLE
License policy violations resolutions

### DIFF
--- a/model/src/main/kotlin/config/EvaluatorErrorResolution.kt
+++ b/model/src/main/kotlin/config/EvaluatorErrorResolution.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2017-2018 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.model.config
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+
+import com.here.ort.model.OrtIssue
+
+/**
+ * Defines the resolution of an error. This can be used to silence errors that have been identified as not being
+ * relevant.
+ */
+data class EvaluatorErrorResolution(
+        /**
+         * A regular expression string to match the messages of errors to resolve. Will be converted to a [Regex] using
+         * [RegexOption.DOT_MATCHES_ALL].
+         */
+        val message: String,
+
+        /**
+         * The reason why the errors is resolved.
+         */
+        val reason: EvaluatorErrorResolutionReason,
+
+        /**
+         * A comment to further explain why the [reason] is applicable here.
+         */
+        val comment: String
+) {
+    @JsonIgnore
+    private val regex = Regex(message, RegexOption.DOT_MATCHES_ALL)
+
+    /**
+     * True if [message] matches the message of [error].
+     */
+    fun matches(error: OrtIssue) = regex.matches(error.message)
+}

--- a/model/src/main/kotlin/config/EvaluatorErrorResolutionReason.kt
+++ b/model/src/main/kotlin/config/EvaluatorErrorResolutionReason.kt
@@ -1,0 +1,27 @@
+package com.here.ort.model.config
+
+/*
+ * Copyright (C) 2017-2018 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+enum class EvaluatorErrorResolutionReason {
+    /**
+     * The evaluator rule violation leading has been approved.
+     */
+    APPROVED
+}

--- a/model/src/main/kotlin/config/Resolutions.kt
+++ b/model/src/main/kotlin/config/Resolutions.kt
@@ -29,10 +29,20 @@ class Resolutions(
      * Resolutions for issues with the analysis or scan of the projects in this repository and their dependencies.
      */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val errors: List<ErrorResolution> = emptyList()
+    val errors: List<ErrorResolution> = emptyList(),
+
+    /**
+     * Resolutions for license policy violations.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val evaluatorErrors: List<EvaluatorErrorResolution> = emptyList()
 ) {
     /**
      * Merge this [Resolutions] with [other] [Resolutions]. Duplicates are removed.
      */
-    fun merge(other: Resolutions) = Resolutions((errors + other.errors).distinct())
+    fun merge(other: Resolutions) =
+            Resolutions(
+                    errors = (errors + other.errors).distinct(),
+                    evaluatorErrors = (evaluatorErrors + other.evaluatorErrors).distinct()
+            )
 }

--- a/model/src/test/kotlin/config/RepositoryConfigurationTest.kt
+++ b/model/src/test/kotlin/config/RepositoryConfigurationTest.kt
@@ -79,6 +79,10 @@ class RepositoryConfigurationTest : WordSpec() {
                       - message: "message"
                         reason: "CANT_FIX_ISSUE"
                         comment: "error comment"
+                      evaluator_errors:
+                      - message: "evaluator error message"
+                        reason: "APPROVED"
+                        comment: "evaluator error comment"
                     """.trimIndent()
 
                 val repositoryConfiguration = yamlMapper.readValue<RepositoryConfiguration>(configuration)
@@ -119,6 +123,13 @@ class RepositoryConfigurationTest : WordSpec() {
                 error.message shouldBe "message"
                 error.reason shouldBe ErrorResolutionReason.CANT_FIX_ISSUE
                 error.comment shouldBe "error comment"
+
+                val evalErrors = repositoryConfiguration.resolutions!!.evaluatorErrors
+                evalErrors should haveSize(1)
+                val evalError = evalErrors.first()
+                evalError.message shouldBe "evaluator error message"
+                evalError.reason shouldBe EvaluatorErrorResolutionReason.APPROVED
+                evalError.comment shouldBe "evaluator error comment"
             }
         }
     }

--- a/model/src/test/kotlin/config/RepositoryConfigurationTest.kt
+++ b/model/src/test/kotlin/config/RepositoryConfigurationTest.kt
@@ -112,6 +112,13 @@ class RepositoryConfigurationTest : WordSpec() {
                 scopes.first().name.pattern shouldBe "scope"
                 scopes.first().reason shouldBe ScopeExcludeReason.TEST_TOOL_OF
                 scopes.first().comment shouldBe "scope comment"
+
+                val errors = repositoryConfiguration.resolutions!!.errors
+                errors should haveSize(1)
+                val error = errors.first()
+                error.message shouldBe "message"
+                error.reason shouldBe ErrorResolutionReason.CANT_FIX_ISSUE
+                error.comment shouldBe "error comment"
             }
         }
     }

--- a/reporter/src/funTest/assets/file-counter-expected-scan-report.html
+++ b/reporter/src/funTest/assets/file-counter-expected-scan-report.html
@@ -230,7 +230,7 @@
             <body>
             <div id="report-container">
                   <div class="ort-report-label">Scan Report</div>
-                <h2>Index</h2><ul><li><a href="#error-summary">Error Summary (1)</a></li><li><a href="#Gradle:com.here.ort.gradle.example:lib:1.0.0">Gradle:com.here.ort.gradle.example:lib:1.0.0</a></li></ul><h2><a id="error-summary"></a>Error Summary (1)</h2>
+                <h2>Index</h2><ul><li><a href="#license-check-results">License Check Results (0 errors)</a></li><li><a href="#error-summary">Error Summary (1)</a></li><li><a href="#Gradle:com.here.ort.gradle.example:lib:1.0.0">Gradle:com.here.ort.gradle.example:lib:1.0.0</a></li></ul><h2><a id="license-check-results"></a>License Check Results</h2>No issues found.<h2><a id="error-summary"></a>Error Summary (1)</h2>
 <p>Errors from excluded components are not shown in this summary.</p>
 <h3>Packages</h3>
 <table class="ort-report-table ort-errors">

--- a/reporter/src/funTest/assets/file-counter-expected-scan-report.html
+++ b/reporter/src/funTest/assets/file-counter-expected-scan-report.html
@@ -17,6 +17,12 @@
                     color: black;
                   }
 
+                  ul {
+                      list-style: none;
+                      margin: 0;
+                      padding: 0;
+                  }
+
                   #report-container {
                     background-color: #fff;
                     border: 1px solid rgba(34,36,38,.15);
@@ -25,7 +31,7 @@
                     margin: 1em 2em 1em 2em;
                   }
 
-                  .report-label {
+                  .ort-report-label {
                     background-color: #f9fafb;
                     border-left: 1px solid rgba(34,36,38,.15);
                     border-right: 1px solid rgba(34,36,38,.15);
@@ -44,46 +50,43 @@
                     width: 110px;
                   }
 
-                  .report-metadata {
+                  .ort-report-metadata {
                     font-size: 12px;
                     border-spacing: 0;
                     table-layout:fixed;
                   }
 
-                  .report-metadata tr {
-                  }
-
-                  .report-metadata td {
+                  .ort-report-metadata td {
                     border-bottom: 1px solid rgba(34,36,38,.15);
-                    overflow: hidden; 
+                    overflow: hidden;
                     padding: 5px 20px 5px 0px;
-                    text-overflow: ellipsis; 
+                    text-overflow: ellipsis;
                     word-wrap: break-word;
                   }
 
-                  .report-metadata tr:first-child td {
+                  .ort-report-metadata tr:first-child td {
                     border-top: 1px solid rgba(34,36,38,.15);
                   }
 
-                  .report-packages {
+                  .ort-report-table {
                     border-spacing: 0;
                     width: 100%;
                     table-layout:fixed;
                   }
 
-                  .report-packages th {
+                  .ort-report-table th {
                     background-color: #f9fafb;
                     padding: 5px 5px 5px .8em !important;
                     text-align: left;
                   }
 
-                  .report-packages th:first-child {
+                  .ort-report-table th:first-child {
                     border-top-left-radius: .28rem;
                     border-left: 1px solid rgba(34,36,38,.15);
                     border-top: 1px solid rgba(34,36,38,.15);
                   }
 
-                  .report-packages th {
+                  .ort-report-table th {
                     border-left: 1px solid rgba(34,36,38,.15);
                     border-top: 1px solid rgba(34,36,38,.15);
                     overflow: hidden;
@@ -91,18 +94,18 @@
                     text-overflow: ellipsis;
                   }
 
-                  .report-packages th:last-child {
+                  .ort-report-table th:last-child {
                     border-top-right-radius: .28rem;
                     border-right: 1px solid rgba(34,36,38,.15);
                     border-top: 1px solid rgba(34,36,38,.15);
                   }
 
-                  .report-packages {
+                  .ort-report-table {
                     overflow: hidden;
                     text-overflow: ellipsis;
                   }
 
-                  .report-packages td {
+                  .ort-report-table td {
                     border-left: 1px solid rgba(34,36,38,.15);
                     border-top: 1px solid rgba(34,36,38,.15);
                     padding: 8px;
@@ -112,43 +115,55 @@
                     word-wrap: break-word;
                   }
 
-                  .report-packages td:last-child {
+                  .ort-report-table td:last-child {
                     border-right: 1px solid rgba(34,36,38,.15);
                   }
 
-                  .report-packages tr:last-child td {
+                  .ort-report-table tr:last-child td {
                     border-bottom: 1px solid rgba(34,36,38,.15);
                   }
 
-                  .report-packages tr:last-child td:first-child {
+                  .ort-report-table tr:last-child td:first-child {
                     border-bottom-left-radius: .28rem;
                   }
 
-                  .report-packages tr:last-child td:last-child {
+                  .ort-report-table tr:last-child td:last-child {
                     border-bottom-right-radius: .28rem;
                   }
 
-                  .report-packages tr.error {
+                  .ort-report-table tr.ort-error {
                     background: #fff6f6;
                     color: #9f3a38;
                   }
 
-                  .report-packages tr.warning {
+                  .ort-report-table tr.ort-warning {
                     background: #fffaf3;
                     color: #573a08;
                   }
 
-                  .report-packages tr.ok {
+                  .ort-report-table tr.ort-ok {
                     background: #fcfff5;
                     color: #2c662d;
                   }
 
-                  .report-packages tr:hover {
+                  .ort-report-table tr:hover {
                     background: rgba(34,36,38,.15);
                   }
 
+                  .ort-excluded {
+                    filter: opacity(50%);
+                  }
+
+                  .ort-reason {
+                      border-radius: 3px;
+                      background: #EEE;
+                      padding: 2px;
+                      font-size: 12px;
+                      display: inline;
+                  }
+
                   @media all and (max-width: 1000px) {
-                      .report-packages th:nth-child(2), .report-packages td:nth-child(2) {
+                      .ort-report-table th:nth-child(2), .ort-report-table td:nth-child(2) {
                           display:none;
                           width:0;
                           height:0;
@@ -158,20 +173,20 @@
                   }
 
                   @media all and (max-width: 900px) {
-                      .report-packages th:nth-child(3), .report-packages td:nth-child(3) {
+                      .ort-report-table th:nth-child(3), .ort-report-table td:nth-child(3) {
                           display:none;
                           width:0;
                           height:0;
                           opacity:0;
                           visibility: collapse;
-                      } 
+                      }
                   }
 
                   @media all and (max-width: 800px) {
-                      .report-packages th:nth-child(5),
-                      .report-packages td:nth-child(5),
-                      .report-packages th:nth-child(6),
-                      .report-packages td:nth-child(6) {
+                      .ort-report-table th:nth-child(5),
+                      .ort-report-table td:nth-child(5),
+                      .ort-report-table th:nth-child(6),
+                      .ort-report-table td:nth-child(6) {
                           display:none;
                           width:0;
                           height:0;
@@ -179,23 +194,23 @@
                           visibility: collapse;
                       }
 
-                      .report-packages th:nth-child(4) {
+                      .ort-report-table th:nth-child(4) {
                         border-top-right-radius: .28rem;
                         border-right: 1px solid rgba(34,36,38,.15);
                       }
 
-                      .report-packages td:nth-child(4) {
+                      .ort-report-table td:nth-child(4) {
                         border-right: 1px solid rgba(34,36,38,.15);
                       }
 
-                      .report-packages tr:last-child td:nth-child(4) {
+                      .ort-report-table tr:last-child td:nth-child(4) {
                         border-bottom-right-radius: .28rem;
                       }
                   }
 
                   @media all and (max-width: 500px) {
-                      .report-packages th:nth-child(4),
-                      .report-packages td:nth-child(4) {
+                      .ort-report-table th:nth-child(4),
+                      .ort-report-table td:nth-child(4) {
                           display:none;
                           width:0;
                           height:0;
@@ -203,46 +218,28 @@
                           visibility: collapse;
                       }
 
-                      .report-packages th:first-child {
+                      .ort-report-table th:first-child {
                         border-top-right-radius: .28rem;
                         border-right: 1px solid rgba(34,36,38,.15);
                       }
 
-                      .report-packages td:first-child {
+                      .ort-report-table td:first-child {
                         border-right: 1px solid rgba(34,36,38,.15);
                       }
 
-                      .report-packages tr:last-child td:first-child {
+                      .ort-report-table tr:last-child td:first-child {
                         border-bottom-right-radius: .28rem;
                       }
-                  }
-
-                  ul {
-                      list-style-position: inside;
-                      margin: 0;
-                      padding: 0;
-                  }
-
-                  .excluded {
-                      filter: opacity(50%);
-                  }
-
-                  .reason {
-                      border-radius: 3px;
-                      background: #EEE;
-                      padding: 2px;
-                      font-size: 12px;
-                      display: inline;
                   }
                 </style>
             </head>
             <body>
-                <div id="report-container">
-                  <div class="report-label">Scan Report</div>
+            <div id="report-container">
+                  <div class="ort-report-label">Scan Report</div>
                 <h2>Index</h2><ul><li><a href="#error-summary">Error Summary (1)</a></li><li><a href="#Gradle:com.here.ort.gradle.example:lib:1.0.0">Gradle:com.here.ort.gradle.example:lib:1.0.0</a></li></ul><h2><a id="error-summary"></a>Error Summary (1)</h2>
 <p>Errors from excluded components are not shown in this summary.</p>
 <h3>Packages</h3>
-<table class="report-packages">
+<table class="ort-report-table ort-errors">
 <thead>
 <tr>
     <th>Package</th>
@@ -250,7 +247,7 @@
     <th>Scanner Errors</th>
 </tr>
 </thead>
-<tbody><tr class="error">
+<tbody><tr class="ort-error">
     <td>Gradle:com.here.ort.gradle.example:lib:1.0.0</td>
     <td></td>
 <td><a href="#Gradle:com.here.ort.gradle.example:lib:1.0.0">Gradle:com.here.ort.gradle.example:lib:1.0.0</a>
@@ -258,7 +255,7 @@
     <li>n/a: FileCounter - DownloadException: No source artifact URL provided for 'Gradle:com.here.ort.gradle.example:lib:1.0.0'.<br/>Caused by: DownloadException: No VCS URL provided for 'Gradle:com.here.ort.gradle.example:lib:1.0.0'. Please make sure the release POM file includes the SCM connection, see: https://docs.gradle.org/current/userguide/publishing_maven.html#example_customizing_the_pom_file</li>
 </ul>    </td>
 </tr></tbody></table><h2><a id="Gradle:com.here.ort.gradle.example:lib:1.0.0"></a>Gradle:com.here.ort.gradle.example:lib:1.0.0 (analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle)</h2><h3 class="">VCS Information</h3>
-<table class="report-metadata">
+<table class="ort-report-metadata">
 <tbody>
     <tr>
         <td>Type</td>
@@ -278,7 +275,7 @@
     </tr>
 </tbody>
 </table><h3 class="">Packages</h3>
-<table class="report-packages">
+<table class="ort-report-table ort-packages">
 <thead>
 <tr>
     <th>Package</th>
@@ -289,55 +286,75 @@
     <th>Scanner Errors</th>
 </tr>
 </thead>
-<tbody><tr class="error">
+<tbody><tr class="ort-error">
     <td>Gradle:com.here.ort.gradle.example:lib:1.0.0</td>
     <td><ul></ul></td>
-    <td></td>
-    <td></td>
+    <td><ul>
+        
+    </ul></td>
+    <td><ul>
+        
+    </ul></td>
     <td><ul>
         
     </ul></td>
     <td><ul>
         <li>n/a: FileCounter - DownloadException: No source artifact URL provided for 'Gradle:com.here.ort.gradle.example:lib:1.0.0'.<br/>Caused by: DownloadException: No VCS URL provided for 'Gradle:com.here.ort.gradle.example:lib:1.0.0'. Please make sure the release POM file includes the SCM connection, see: https://docs.gradle.org/current/userguide/publishing_maven.html#example_customizing_the_pom_file</li>
     </ul></td>
-</tr><tr class="success">
+</tr><tr class="ort-success">
     <td>Maven:junit:junit:4.12</td>
     <td><ul><li class="">testCompile</li></ul></td>
-    <td>Eclipse Public License 1.0</td>
-    <td></td>
+    <td><ul>
+        <li>Eclipse Public License 1.0</li>
+    </ul></td>
+    <td><ul>
+        
+    </ul></td>
     <td><ul>
         
     </ul></td>
     <td><ul>
         
     </ul></td>
-</tr><tr class="success">
+</tr><tr class="ort-success">
     <td>Maven:org.apache.commons:commons-lang3:3.5</td>
     <td><ul><li class="">compile</li><li class="">testCompile</li></ul></td>
-    <td>Apache License, Version 2.0</td>
-    <td></td>
+    <td><ul>
+        <li>Apache License, Version 2.0</li>
+    </ul></td>
+    <td><ul>
+        
+    </ul></td>
     <td><ul>
         
     </ul></td>
     <td><ul>
         
     </ul></td>
-</tr><tr class="success">
+</tr><tr class="ort-success">
     <td>Maven:org.apache.commons:commons-text:1.1</td>
     <td><ul><li class="">compile</li><li class="">testCompile</li></ul></td>
-    <td>Apache License, Version 2.0</td>
-    <td></td>
+    <td><ul>
+        <li>Apache License, Version 2.0</li>
+    </ul></td>
+    <td><ul>
+        
+    </ul></td>
     <td><ul>
         
     </ul></td>
     <td><ul>
         
     </ul></td>
-</tr><tr class="success">
+</tr><tr class="ort-success">
     <td>Maven:org.hamcrest:hamcrest-core:1.3</td>
     <td><ul><li class="">testCompile</li></ul></td>
-    <td>New BSD License</td>
-    <td></td>
+    <td><ul>
+        <li>New BSD License</li>
+    </ul></td>
+    <td><ul>
+        
+    </ul></td>
     <td><ul>
         
     </ul></td>

--- a/reporter/src/funTest/assets/file-counter-expected-scan-report.html
+++ b/reporter/src/funTest/assets/file-counter-expected-scan-report.html
@@ -252,7 +252,7 @@
     <td></td>
 <td><a href="#Gradle:com.here.ort.gradle.example:lib:1.0.0">Gradle:com.here.ort.gradle.example:lib:1.0.0</a>
 <ul>
-    <li>n/a: FileCounter - DownloadException: No source artifact URL provided for 'Gradle:com.here.ort.gradle.example:lib:1.0.0'.<br/>Caused by: DownloadException: No VCS URL provided for 'Gradle:com.here.ort.gradle.example:lib:1.0.0'. Please make sure the release POM file includes the SCM connection, see: https://docs.gradle.org/current/userguide/publishing_maven.html#example_customizing_the_pom_file</li>
+    <li><p>n/a: FileCounter - DownloadException: No source artifact URL provided for 'Gradle:com.here.ort.gradle.example:lib:1.0.0'.</br>Caused by: DownloadException: No VCS URL provided for 'Gradle:com.here.ort.gradle.example:lib:1.0.0'. Please make sure the release POM file includes the SCM connection, see: https://docs.gradle.org/current/userguide/publishing_maven.html#example_customizing_the_pom_file</p><p></p></li>
 </ul>    </td>
 </tr></tbody></table><h2><a id="Gradle:com.here.ort.gradle.example:lib:1.0.0"></a>Gradle:com.here.ort.gradle.example:lib:1.0.0 (analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle)</h2><h3 class="">VCS Information</h3>
 <table class="ort-report-metadata">
@@ -299,7 +299,7 @@
         
     </ul></td>
     <td><ul>
-        <li>n/a: FileCounter - DownloadException: No source artifact URL provided for 'Gradle:com.here.ort.gradle.example:lib:1.0.0'.<br/>Caused by: DownloadException: No VCS URL provided for 'Gradle:com.here.ort.gradle.example:lib:1.0.0'. Please make sure the release POM file includes the SCM connection, see: https://docs.gradle.org/current/userguide/publishing_maven.html#example_customizing_the_pom_file</li>
+        <li><p>n/a: FileCounter - DownloadException: No source artifact URL provided for 'Gradle:com.here.ort.gradle.example:lib:1.0.0'.<br/>Caused by: DownloadException: No VCS URL provided for 'Gradle:com.here.ort.gradle.example:lib:1.0.0'. Please make sure the release POM file includes the SCM connection, see: https://docs.gradle.org/current/userguide/publishing_maven.html#example_customizing_the_pom_file</p><p></p></li>
     </ul></td>
 </tr><tr class="ort-success">
     <td>Maven:junit:junit:4.12</td>

--- a/reporter/src/funTest/assets/file-counter-expected-scan-report.html
+++ b/reporter/src/funTest/assets/file-counter-expected-scan-report.html
@@ -70,53 +70,24 @@
 
                   .ort-report-table {
                     border-spacing: 0;
-                    width: 100%;
+                    overflow: hidden;
                     table-layout:fixed;
-                  }
-
-                  .ort-report-table th {
-                    background-color: #f9fafb;
-                    padding: 5px 5px 5px .8em !important;
-                    text-align: left;
-                  }
-
-                  .ort-report-table th:first-child {
-                    border-top-left-radius: .28rem;
-                    border-left: 1px solid rgba(34,36,38,.15);
-                    border-top: 1px solid rgba(34,36,38,.15);
-                  }
-
-                  .ort-report-table th {
-                    border-left: 1px solid rgba(34,36,38,.15);
-                    border-top: 1px solid rgba(34,36,38,.15);
-                    overflow: hidden;
-                    white-space: nowrap;
                     text-overflow: ellipsis;
+                    width: 100%;
                   }
 
-                  .ort-report-table th:last-child {
-                    border-top-right-radius: .28rem;
-                    border-right: 1px solid rgba(34,36,38,.15);
-                    border-top: 1px solid rgba(34,36,38,.15);
+                  .ort-report-table tr:hover {
+                    background: rgba(34,36,38,.15);
                   }
 
-                  .ort-report-table {
-                    overflow: hidden;
-                    text-overflow: ellipsis;
+                  .ort-report-table tr.ort-error {
+                    background: #fff6f6;
+                    color: #9f3a38;
                   }
 
-                  .ort-report-table td {
-                    border-left: 1px solid rgba(34,36,38,.15);
-                    border-top: 1px solid rgba(34,36,38,.15);
-                    padding: 8px;
-                    vertical-align: top;
-                    overflow: hidden; 
-                    text-overflow: ellipsis; 
-                    word-wrap: break-word;
-                  }
-
-                  .ort-report-table td:last-child {
-                    border-right: 1px solid rgba(34,36,38,.15);
+                  .ort-report-table tr.ort-warning {
+                    background: #fffaf3;
+                    color: #573a08;
                   }
 
                   .ort-report-table tr:last-child td {
@@ -131,35 +102,58 @@
                     border-bottom-right-radius: .28rem;
                   }
 
-                  .ort-report-table tr.ort-error {
-                    background: #fff6f6;
-                    color: #9f3a38;
+                  .ort-report-table th {
+                    background-color: #f9fafb;
+                    border-left: 1px solid rgba(34,36,38,.15);
+                    border-top: 1px solid rgba(34,36,38,.15);
+                    overflow: hidden;
+                    padding: 5px 5px 5px .8em !important;
+                    text-align: left;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
                   }
 
-                  .ort-report-table tr.ort-warning {
-                    background: #fffaf3;
-                    color: #573a08;
+                  .ort-report-table th:first-child {
+                    border-top-left-radius: .28rem;
+                    border-left: 1px solid rgba(34,36,38,.15);
+                    border-top: 1px solid rgba(34,36,38,.15);
                   }
 
-                  .ort-report-table tr.ort-ok {
-                    background: #fcfff5;
-                    color: #2c662d;
+                  .ort-report-table th:last-child {
+                    border-top-right-radius: .28rem;
+                    border-right: 1px solid rgba(34,36,38,.15);
+                    border-top: 1px solid rgba(34,36,38,.15);
                   }
 
-                  .ort-report-table tr:hover {
-                    background: rgba(34,36,38,.15);
+                  .ort-report-table td {
+                    border-left: 1px solid rgba(34,36,38,.15);
+                    border-top: 1px solid rgba(34,36,38,.15);
+                    padding: 8px;
+                    vertical-align: top;
+                    overflow: hidden; 
+                    text-overflow: ellipsis; 
+                    word-wrap: break-word;
                   }
 
-                  .ort-excluded {
+                  .ort-report-table td li.ort-excluded {
                     filter: opacity(50%);
                   }
 
-                  .ort-reason {
+                  .ort-report-table td li div.ort-reason {
                       border-radius: 3px;
                       background: #EEE;
                       padding: 2px;
                       font-size: 12px;
                       display: inline;
+                  }
+
+                  .ort-report-table td:last-child {
+                    border-right: 1px solid rgba(34,36,38,.15);
+                  }
+
+                  .ort-report-table.ort-violations tr.ort-addressed {
+                    background: #fcfff5;
+                    color: #2c662d;
                   }
 
                   @media all and (max-width: 1000px) {

--- a/reporter/src/main/kotlin/DefaultResolutionProvider.kt
+++ b/reporter/src/main/kotlin/DefaultResolutionProvider.kt
@@ -30,4 +30,6 @@ class DefaultResolutionProvider : ResolutionProvider {
     }
 
     override fun getResolutionsFor(error: OrtIssue) = resolutions.errors.filter { it.matches(error) }
+
+    override fun getEvaluatorResolutionsFor(error: OrtIssue) = resolutions.evaluatorErrors.filter { it.matches(error) }
 }

--- a/reporter/src/main/kotlin/ResolutionProvider.kt
+++ b/reporter/src/main/kotlin/ResolutionProvider.kt
@@ -21,6 +21,7 @@ package com.here.ort.reporter
 
 import com.here.ort.model.OrtIssue
 import com.here.ort.model.config.ErrorResolution
+import com.here.ort.model.config.EvaluatorErrorResolution
 
 /**
  * A provider for [ErrorResolution]s.
@@ -30,4 +31,9 @@ interface ResolutionProvider {
      * Get all resolutions that match [error].
      */
     fun getResolutionsFor(error: OrtIssue): List<ErrorResolution>
+
+    /**
+     * Get all resolutions that match [error].
+     */
+    fun getEvaluatorResolutionsFor(error: OrtIssue): List<EvaluatorErrorResolution>
 }

--- a/reporter/src/main/kotlin/reporters/ExcelReporter.kt
+++ b/reporter/src/main/kotlin/reporters/ExcelReporter.kt
@@ -89,7 +89,7 @@ class ExcelReporter : Reporter() {
             outputDir: File,
             postProcessingScript: String?
     ): File {
-        val tabularScanRecord = ReportTableModelMapper().mapToReportTableModel(ortResult, resolutionProvider)
+        val tabularScanRecord = ReportTableModelMapper(resolutionProvider).mapToReportTableModel(ortResult)
         val workbook = XSSFWorkbook()
 
         defaultStyle = workbook.createCellStyle().apply {

--- a/reporter/src/main/kotlin/reporters/ReportTableModel.kt
+++ b/reporter/src/main/kotlin/reporters/ReportTableModel.kt
@@ -213,6 +213,7 @@ data class ReportTableModel(
 
     data class ResolvableIssue(
             val description: String,
+            val resolutionDescription: String,
             val isResolved: Boolean
     )
 }

--- a/reporter/src/main/kotlin/reporters/ReportTableModel.kt
+++ b/reporter/src/main/kotlin/reporters/ReportTableModel.kt
@@ -20,7 +20,6 @@
 package com.here.ort.reporter.reporters
 
 import com.here.ort.model.Identifier
-import com.here.ort.model.OrtIssue
 import com.here.ort.model.OrtResult
 import com.here.ort.model.Project
 import com.here.ort.model.VcsInfo
@@ -45,7 +44,7 @@ data class ReportTableModel(
         /**
          * A list containing all evaluator errors. `null` if no evaluator result is available.
          */
-        val evaluatorErrors: List<OrtIssue>?,
+        val evaluatorErrors: List<ResolvableIssue>?,
 
         /**
          * A [ErrorTable] containing all dependencies that caused errors.
@@ -212,6 +211,7 @@ data class ReportTableModel(
     }
 
     data class ResolvableIssue(
+            val source: String,
             val description: String,
             val resolutionDescription: String,
             val isResolved: Boolean

--- a/reporter/src/main/kotlin/reporters/ReportTableModelMapper.kt
+++ b/reporter/src/main/kotlin/reporters/ReportTableModelMapper.kt
@@ -38,25 +38,24 @@ private fun Collection<ResolvableIssue>.filterUnresolved() = filter { !it.isReso
 /**
  * A mapper which converts an [OrtIssue] to a [ReportTableModel] view model.
  */
-class ReportTableModelMapper {
-    fun mapToReportTableModel(
-            ortResult: OrtResult,
-            resolutionProvider: ResolutionProvider
-    ): ReportTableModel {
-        fun OrtIssue.toResolvableError(): ResolvableIssue {
-            val resolutions = resolutionProvider.getResolutionsFor(this)
-            return ResolvableIssue(
-                    description = buildString {
-                        append(this@toResolvableError)
-                        if (resolutions.isNotEmpty()) {
-                            append(resolutions.joinToString(
-                                    prefix = "\nResolved by: ") { "${it.reason} - ${it.comment}" }
-                            )
-                        }
-                    }, isResolved = resolutions.isNotEmpty()
-            )
-        }
+class ReportTableModelMapper(private val resolutionProvider: ResolutionProvider) {
+    private fun OrtIssue.toResolvableIssue(): ResolvableIssue {
+        val resolutions = resolutionProvider.getResolutionsFor(this)
+        return ResolvableIssue(
+                description = buildString {
+                    append(this@toResolvableIssue)
+                    if (resolutions.isNotEmpty()) {
+                        append(resolutions.joinToString(
+                                prefix = "\nResolved by: ") { "${it.reason} - ${it.comment}" }
+                        )
+                    }
+                }, isResolved = resolutions.isNotEmpty()
+        )
+    }
 
+    fun mapToReportTableModel(
+            ortResult: OrtResult
+    ): ReportTableModel {
         val errorSummaryRows = mutableMapOf<Identifier, ErrorRow>()
         val summaryRows = mutableMapOf<Identifier, SummaryRow>()
 
@@ -108,8 +107,8 @@ class ReportTableModelMapper {
                         scopes = scopes,
                         declaredLicenses = declaredLicenses,
                         detectedLicenses = detectedLicenses,
-                        analyzerErrors = analyzerErrors.map { it.toResolvableError() },
-                        scanErrors = scanErrors.map { it.toResolvableError() }
+                        analyzerErrors = analyzerErrors.map { it.toResolvableIssue() },
+                        scanErrors = scanErrors.map { it.toResolvableIssue() }
                 ).also { row ->
                     val isRowExcluded = projectExclude != null
                             || (scopes.isNotEmpty() && scopes.all { it.value.isNotEmpty() })

--- a/reporter/src/main/kotlin/reporters/ReportTableModelMapper.kt
+++ b/reporter/src/main/kotlin/reporters/ReportTableModelMapper.kt
@@ -42,14 +42,15 @@ class ReportTableModelMapper(private val resolutionProvider: ResolutionProvider)
     private fun OrtIssue.toResolvableIssue(): ResolvableIssue {
         val resolutions = resolutionProvider.getResolutionsFor(this)
         return ResolvableIssue(
-                description = buildString {
-                    append(this@toResolvableIssue)
+                description = this@toResolvableIssue.toString(),
+                resolutionDescription = buildString {
                     if (resolutions.isNotEmpty()) {
                         append(resolutions.joinToString(
                                 prefix = "\nResolved by: ") { "${it.reason} - ${it.comment}" }
                         )
                     }
-                }, isResolved = resolutions.isNotEmpty()
+                },
+                isResolved = resolutions.isNotEmpty()
         )
     }
 

--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -21,7 +21,6 @@ package com.here.ort.reporter.reporters
 
 import ch.frankel.slf4k.*
 
-import com.here.ort.model.OrtIssue
 import com.here.ort.model.OrtResult
 import com.here.ort.model.VcsInfo
 import com.here.ort.model.config.CopyrightGarbage
@@ -30,6 +29,7 @@ import com.here.ort.reporter.Reporter
 import com.here.ort.reporter.ResolutionProvider
 import com.here.ort.reporter.reporters.ReportTableModel.ErrorTable
 import com.here.ort.reporter.reporters.ReportTableModel.ProjectTable
+import com.here.ort.reporter.reporters.ReportTableModel.ResolvableIssue
 
 import com.here.ort.utils.isValidUrl
 import com.here.ort.utils.log
@@ -347,7 +347,7 @@ class StaticHtmlReporter : Reporter() {
                 }
             }
 
-    private fun createEvaluatorTable(evaluatorErrors: List<OrtIssue>) =
+    private fun createEvaluatorTable(evaluatorErrors: List<ResolvableIssue>) =
             buildString {
                 append("<h2><a id=\"license-check-results\"></a>License Check Results</h2>")
 
@@ -366,10 +366,14 @@ class StaticHtmlReporter : Reporter() {
                         """.trimIndent())
 
                     evaluatorErrors.forEach { error ->
+                        val cssClass = when {
+                            error.isResolved -> "ort-addressed"
+                            else -> "ort-error"
+                        }
                         append("""
-                            <tr class="ort-error">
+                            <tr class="$cssClass">
                                 <td>${error.source}</td>
-                                <td>${error.message}</td>
+                                <td><p>${error.description}</p><p>${error.resolutionDescription}</p></td>
                             </tr>
                             """.trimIndent())
                     }

--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -120,53 +120,24 @@ class StaticHtmlReporter : Reporter() {
 
                   .ort-report-table {
                     border-spacing: 0;
-                    width: 100%;
+                    overflow: hidden;
                     table-layout:fixed;
-                  }
-
-                  .ort-report-table th {
-                    background-color: #f9fafb;
-                    padding: 5px 5px 5px .8em !important;
-                    text-align: left;
-                  }
-
-                  .ort-report-table th:first-child {
-                    border-top-left-radius: .28rem;
-                    border-left: 1px solid rgba(34,36,38,.15);
-                    border-top: 1px solid rgba(34,36,38,.15);
-                  }
-
-                  .ort-report-table th {
-                    border-left: 1px solid rgba(34,36,38,.15);
-                    border-top: 1px solid rgba(34,36,38,.15);
-                    overflow: hidden;
-                    white-space: nowrap;
                     text-overflow: ellipsis;
+                    width: 100%;
                   }
 
-                  .ort-report-table th:last-child {
-                    border-top-right-radius: .28rem;
-                    border-right: 1px solid rgba(34,36,38,.15);
-                    border-top: 1px solid rgba(34,36,38,.15);
+                  .ort-report-table tr:hover {
+                    background: rgba(34,36,38,.15);
                   }
 
-                  .ort-report-table {
-                    overflow: hidden;
-                    text-overflow: ellipsis;
+                  .ort-report-table tr.ort-error {
+                    background: #fff6f6;
+                    color: #9f3a38;
                   }
 
-                  .ort-report-table td {
-                    border-left: 1px solid rgba(34,36,38,.15);
-                    border-top: 1px solid rgba(34,36,38,.15);
-                    padding: 8px;
-                    vertical-align: top;
-                    overflow: hidden; 
-                    text-overflow: ellipsis; 
-                    word-wrap: break-word;
-                  }
-
-                  .ort-report-table td:last-child {
-                    border-right: 1px solid rgba(34,36,38,.15);
+                  .ort-report-table tr.ort-warning {
+                    background: #fffaf3;
+                    color: #573a08;
                   }
 
                   .ort-report-table tr:last-child td {
@@ -181,35 +152,58 @@ class StaticHtmlReporter : Reporter() {
                     border-bottom-right-radius: .28rem;
                   }
 
-                  .ort-report-table tr.ort-error {
-                    background: #fff6f6;
-                    color: #9f3a38;
+                  .ort-report-table th {
+                    background-color: #f9fafb;
+                    border-left: 1px solid rgba(34,36,38,.15);
+                    border-top: 1px solid rgba(34,36,38,.15);
+                    overflow: hidden;
+                    padding: 5px 5px 5px .8em !important;
+                    text-align: left;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
                   }
 
-                  .ort-report-table tr.ort-warning {
-                    background: #fffaf3;
-                    color: #573a08;
+                  .ort-report-table th:first-child {
+                    border-top-left-radius: .28rem;
+                    border-left: 1px solid rgba(34,36,38,.15);
+                    border-top: 1px solid rgba(34,36,38,.15);
                   }
 
-                  .ort-report-table tr.ort-ok {
-                    background: #fcfff5;
-                    color: #2c662d;
+                  .ort-report-table th:last-child {
+                    border-top-right-radius: .28rem;
+                    border-right: 1px solid rgba(34,36,38,.15);
+                    border-top: 1px solid rgba(34,36,38,.15);
                   }
 
-                  .ort-report-table tr:hover {
-                    background: rgba(34,36,38,.15);
+                  .ort-report-table td {
+                    border-left: 1px solid rgba(34,36,38,.15);
+                    border-top: 1px solid rgba(34,36,38,.15);
+                    padding: 8px;
+                    vertical-align: top;
+                    overflow: hidden; 
+                    text-overflow: ellipsis; 
+                    word-wrap: break-word;
                   }
 
-                  .ort-excluded {
+                  .ort-report-table td li.ort-excluded {
                     filter: opacity(50%);
                   }
 
-                  .ort-reason {
+                  .ort-report-table td li div.ort-reason {
                       border-radius: 3px;
                       background: #EEE;
                       padding: 2px;
                       font-size: 12px;
                       display: inline;
+                  }
+
+                  .ort-report-table td:last-child {
+                    border-right: 1px solid rgba(34,36,38,.15);
+                  }
+
+                  .ort-report-table.ort-violations tr.ort-addressed {
+                    background: #fcfff5;
+                    color: #2c662d;
                   }
 
                   @media all and (max-width: 1000px) {

--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -416,9 +416,10 @@ class StaticHtmlReporter : Reporter() {
                         append("""
                                 <a href="#$id">$id</a>
                                 <ul>
-                                    ${errors.joinToString("\n") {
-                            "<li>${it.description.replace("\n", "<br/>")}</li>"
-                        }}
+                                ${errors.joinToString("\n") {
+                                    "    <li><p>${it.description.replace("\n", "</br>")}</p>" +
+                                            "<p>${it.resolutionDescription}</p></li>"
+                                }}
                                 </ul>""".trimIndent())
                     }
 
@@ -430,9 +431,10 @@ class StaticHtmlReporter : Reporter() {
                         append("""
                                 <a href="#$id">$id</a>
                                 <ul>
-                                    ${errors.joinToString("\n") {
-                            "<li>${it.description.replace("\n", "<br/>")}</li>"
-                        }}
+                                ${errors.joinToString("\n") {
+                                    "    <li><p>${it.description.replace("\n", "</br>")}</p>" +
+                                            "<p>${it.resolutionDescription}</p></li>"
+                                }}
                                 </ul>""".trimIndent())
                     }
 
@@ -527,12 +529,14 @@ class StaticHtmlReporter : Reporter() {
                             </ul></td>
                             <td><ul>
                                 ${row.analyzerErrors.joinToString("\n") {
-                                    "<li>${it.description.replace("\n", "<br/>")}</li>"
+                                    "<li><p>${it.description.replace("\n", "<br/>")}</p>" +
+                                            "<p>${it.resolutionDescription}</p></li>"
                                 }}
                             </ul></td>
                             <td><ul>
                                 ${row.scanErrors.joinToString("\n") {
-                                    "<li>${it.description.replace("\n", "<br/>")}</li>"
+                                    "<li><p>${it.description.replace("\n", "<br/>")}</p>" +
+                                            "<p>${it.resolutionDescription}</p></li>"
                                 }}
                             </ul></td>
                         </tr>""".trimIndent())

--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -45,7 +45,7 @@ class StaticHtmlReporter : Reporter() {
             outputDir: File,
             postProcessingScript: String?
     ): File {
-        val tabularScanRecord = ReportTableModelMapper().mapToReportTableModel(ortResult, resolutionProvider)
+        val tabularScanRecord = ReportTableModelMapper(resolutionProvider).mapToReportTableModel(ortResult)
 
         val html = """
             <!DOCTYPE html>

--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -67,6 +67,12 @@ class StaticHtmlReporter : Reporter() {
                     color: black;
                   }
 
+                  ul {
+                      list-style: none;
+                      margin: 0;
+                      padding: 0;
+                  }
+
                   #report-container {
                     background-color: #fff;
                     border: 1px solid rgba(34,36,38,.15);
@@ -75,7 +81,7 @@ class StaticHtmlReporter : Reporter() {
                     margin: 1em 2em 1em 2em;
                   }
 
-                  .report-label {
+                  .ort-report-label {
                     background-color: #f9fafb;
                     border-left: 1px solid rgba(34,36,38,.15);
                     border-right: 1px solid rgba(34,36,38,.15);
@@ -94,46 +100,43 @@ class StaticHtmlReporter : Reporter() {
                     width: 110px;
                   }
 
-                  .report-metadata {
+                  .ort-report-metadata {
                     font-size: 12px;
                     border-spacing: 0;
                     table-layout:fixed;
                   }
 
-                  .report-metadata tr {
-                  }
-
-                  .report-metadata td {
+                  .ort-report-metadata td {
                     border-bottom: 1px solid rgba(34,36,38,.15);
-                    overflow: hidden; 
+                    overflow: hidden;
                     padding: 5px 20px 5px 0px;
-                    text-overflow: ellipsis; 
+                    text-overflow: ellipsis;
                     word-wrap: break-word;
                   }
 
-                  .report-metadata tr:first-child td {
+                  .ort-report-metadata tr:first-child td {
                     border-top: 1px solid rgba(34,36,38,.15);
                   }
 
-                  .report-packages {
+                  .ort-report-table {
                     border-spacing: 0;
                     width: 100%;
                     table-layout:fixed;
                   }
 
-                  .report-packages th {
+                  .ort-report-table th {
                     background-color: #f9fafb;
                     padding: 5px 5px 5px .8em !important;
                     text-align: left;
                   }
 
-                  .report-packages th:first-child {
+                  .ort-report-table th:first-child {
                     border-top-left-radius: .28rem;
                     border-left: 1px solid rgba(34,36,38,.15);
                     border-top: 1px solid rgba(34,36,38,.15);
                   }
 
-                  .report-packages th {
+                  .ort-report-table th {
                     border-left: 1px solid rgba(34,36,38,.15);
                     border-top: 1px solid rgba(34,36,38,.15);
                     overflow: hidden;
@@ -141,18 +144,18 @@ class StaticHtmlReporter : Reporter() {
                     text-overflow: ellipsis;
                   }
 
-                  .report-packages th:last-child {
+                  .ort-report-table th:last-child {
                     border-top-right-radius: .28rem;
                     border-right: 1px solid rgba(34,36,38,.15);
                     border-top: 1px solid rgba(34,36,38,.15);
                   }
 
-                  .report-packages {
+                  .ort-report-table {
                     overflow: hidden;
                     text-overflow: ellipsis;
                   }
 
-                  .report-packages td {
+                  .ort-report-table td {
                     border-left: 1px solid rgba(34,36,38,.15);
                     border-top: 1px solid rgba(34,36,38,.15);
                     padding: 8px;
@@ -162,43 +165,55 @@ class StaticHtmlReporter : Reporter() {
                     word-wrap: break-word;
                   }
 
-                  .report-packages td:last-child {
+                  .ort-report-table td:last-child {
                     border-right: 1px solid rgba(34,36,38,.15);
                   }
 
-                  .report-packages tr:last-child td {
+                  .ort-report-table tr:last-child td {
                     border-bottom: 1px solid rgba(34,36,38,.15);
                   }
 
-                  .report-packages tr:last-child td:first-child {
+                  .ort-report-table tr:last-child td:first-child {
                     border-bottom-left-radius: .28rem;
                   }
 
-                  .report-packages tr:last-child td:last-child {
+                  .ort-report-table tr:last-child td:last-child {
                     border-bottom-right-radius: .28rem;
                   }
 
-                  .report-packages tr.error {
+                  .ort-report-table tr.ort-error {
                     background: #fff6f6;
                     color: #9f3a38;
                   }
 
-                  .report-packages tr.warning {
+                  .ort-report-table tr.ort-warning {
                     background: #fffaf3;
                     color: #573a08;
                   }
 
-                  .report-packages tr.ok {
+                  .ort-report-table tr.ort-ok {
                     background: #fcfff5;
                     color: #2c662d;
                   }
 
-                  .report-packages tr:hover {
+                  .ort-report-table tr:hover {
                     background: rgba(34,36,38,.15);
                   }
 
+                  .ort-excluded {
+                    filter: opacity(50%);
+                  }
+
+                  .ort-reason {
+                      border-radius: 3px;
+                      background: #EEE;
+                      padding: 2px;
+                      font-size: 12px;
+                      display: inline;
+                  }
+
                   @media all and (max-width: 1000px) {
-                      .report-packages th:nth-child(2), .report-packages td:nth-child(2) {
+                      .ort-report-table th:nth-child(2), .ort-report-table td:nth-child(2) {
                           display:none;
                           width:0;
                           height:0;
@@ -208,20 +223,20 @@ class StaticHtmlReporter : Reporter() {
                   }
 
                   @media all and (max-width: 900px) {
-                      .report-packages th:nth-child(3), .report-packages td:nth-child(3) {
+                      .ort-report-table th:nth-child(3), .ort-report-table td:nth-child(3) {
                           display:none;
                           width:0;
                           height:0;
                           opacity:0;
                           visibility: collapse;
-                      } 
+                      }
                   }
 
                   @media all and (max-width: 800px) {
-                      .report-packages th:nth-child(5),
-                      .report-packages td:nth-child(5),
-                      .report-packages th:nth-child(6),
-                      .report-packages td:nth-child(6) {
+                      .ort-report-table th:nth-child(5),
+                      .ort-report-table td:nth-child(5),
+                      .ort-report-table th:nth-child(6),
+                      .ort-report-table td:nth-child(6) {
                           display:none;
                           width:0;
                           height:0;
@@ -229,23 +244,23 @@ class StaticHtmlReporter : Reporter() {
                           visibility: collapse;
                       }
 
-                      .report-packages th:nth-child(4) {
+                      .ort-report-table th:nth-child(4) {
                         border-top-right-radius: .28rem;
                         border-right: 1px solid rgba(34,36,38,.15);
                       }
 
-                      .report-packages td:nth-child(4) {
+                      .ort-report-table td:nth-child(4) {
                         border-right: 1px solid rgba(34,36,38,.15);
                       }
 
-                      .report-packages tr:last-child td:nth-child(4) {
+                      .ort-report-table tr:last-child td:nth-child(4) {
                         border-bottom-right-radius: .28rem;
                       }
                   }
 
                   @media all and (max-width: 500px) {
-                      .report-packages th:nth-child(4),
-                      .report-packages td:nth-child(4) {
+                      .ort-report-table th:nth-child(4),
+                      .ort-report-table td:nth-child(4) {
                           display:none;
                           width:0;
                           height:0;
@@ -253,46 +268,29 @@ class StaticHtmlReporter : Reporter() {
                           visibility: collapse;
                       }
 
-                      .report-packages th:first-child {
+                      .ort-report-table th:first-child {
                         border-top-right-radius: .28rem;
                         border-right: 1px solid rgba(34,36,38,.15);
                       }
 
-                      .report-packages td:first-child {
+                      .ort-report-table td:first-child {
                         border-right: 1px solid rgba(34,36,38,.15);
                       }
 
-                      .report-packages tr:last-child td:first-child {
+                      .ort-report-table tr:last-child td:first-child {
                         border-bottom-right-radius: .28rem;
                       }
-                  }
-
-                  ul {
-                      list-style-position: inside;
-                      margin: 0;
-                      padding: 0;
-                  }
-
-                  .excluded {
-                      filter: opacity(50%);
-                  }
-
-                  .reason {
-                      border-radius: 3px;
-                      background: #EEE;
-                      padding: 2px;
-                      font-size: 12px;
-                      display: inline;
                   }
                 </style>
             </head>
             <body>
-                <div id="report-container">
-                  <div class="report-label">Scan Report</div>
+            <div id="report-container">
+                  <div class="ort-report-label">Scan Report</div>
                 ${createContent(tabularScanRecord)}
                 </div>
             </body>
             </html>
+
             """.trimIndent()
 
         val outputFile = File(outputDir, "scan-report.html")
@@ -308,7 +306,7 @@ class StaticHtmlReporter : Reporter() {
             buildString {
                 if (tabularScanRecord.metadata.isNotEmpty()) {
                     append("<h2>Metadata</h2>")
-                    append("<table class=\"report-metadata\"><tbody>")
+                    append("<table class=\"ort-report-metadata\"><tbody>")
                     tabularScanRecord.metadata.forEach { (key, value) ->
                         append("""
                         <tr>
@@ -334,7 +332,7 @@ class StaticHtmlReporter : Reporter() {
                 tabularScanRecord.projectDependencies.forEach { (project, projectTable) ->
                     append("<li><a href=\"#${project.id}\">${project.id}")
                     projectTable.exclude?.let { exclude ->
-                        append(" <div class=\"reason\">Excluded: ${exclude.reason} - ${exclude.comment}</div>")
+                        append(" <div class=\"ort-reason\">Excluded: ${exclude.reason} - ${exclude.comment}</div>")
                     }
                     append("</a></li>")
                 }
@@ -363,7 +361,7 @@ class StaticHtmlReporter : Reporter() {
                     append("No issues found.")
                 } else {
                     append("""
-                        <table class="report-packages">
+                        <table class="ort-report-table ort-violations">
                         <thead>
                         <tr>
                             <th>Source</th>
@@ -375,7 +373,7 @@ class StaticHtmlReporter : Reporter() {
 
                     evaluatorErrors.forEach { error ->
                         append("""
-                            <tr class="error">
+                            <tr class="ort-error">
                                 <td>${error.source}</td>
                                 <td>${error.message}</td>
                             </tr>
@@ -395,7 +393,7 @@ class StaticHtmlReporter : Reporter() {
                     <h2><a id="$anchor"></a>$title</h2>
                     <p>Errors from excluded components are not shown in this summary.</p>
                     <h3>Packages</h3>
-                    <table class="report-packages">
+                    <table class="ort-report-table ort-errors">
                     <thead>
                     <tr>
                         <th>Package</th>
@@ -407,7 +405,7 @@ class StaticHtmlReporter : Reporter() {
                     """.trimIndent())
 
                 errors.rows.forEach { row ->
-                    val cssClass = "error"
+                    val cssClass = "ort-error"
 
                     append("""
                         <tr class="$cssClass">
@@ -448,7 +446,7 @@ class StaticHtmlReporter : Reporter() {
 
     private fun createTable(title: String, vcsInfo: VcsInfo?, summary: ProjectTable, anchor: String) =
             buildString {
-                val excludedClass = if (summary.exclude != null) " excluded" else ""
+                val excludedClass = if (summary.exclude != null) " ort-excluded" else ""
 
                 append("<h2><a id=\"$anchor\"></a>$title</h2>")
 
@@ -464,7 +462,7 @@ class StaticHtmlReporter : Reporter() {
                 if (vcsInfo != null) {
                     append("""
                         <h3 class="$excludedClass">VCS Information</h3>
-                        <table class="report-metadata$excludedClass">
+                        <table class="ort-report-metadata$excludedClass">
                         <tbody>
                             <tr>
                                 <td>Type</td>
@@ -488,7 +486,7 @@ class StaticHtmlReporter : Reporter() {
 
                 append("""
                     <h3 class="$excludedClass">Packages</h3>
-                    <table class="report-packages$excludedClass">
+                    <table class="ort-report-table ort-packages$excludedClass">
                     <thead>
                     <tr>
                         <th>Package</th>
@@ -505,20 +503,28 @@ class StaticHtmlReporter : Reporter() {
                 summary.rows.forEach { row ->
                     // Only mark the row as excluded if all scopes the dependency appears in are excluded.
                     val rowExcludedClass = if (row.scopes.isNotEmpty() && row.scopes.all { it.value.isNotEmpty() })
-                        " excluded" else ""
+                        " ort-excluded" else ""
 
                     val cssClass = when {
-                        row.analyzerErrors.containsUnresolved() || row.scanErrors.containsUnresolved() -> "error"
-                        row.declaredLicenses.isEmpty() && row.detectedLicenses.isEmpty() -> "warning"
-                        else -> "success"
+                        row.analyzerErrors.containsUnresolved() || row.scanErrors.containsUnresolved() -> "ort-error"
+                        row.declaredLicenses.isEmpty() && row.detectedLicenses.isEmpty() -> "ort-warning"
+                        else -> "ort-success"
                     }
 
                     append("""
                         <tr class="$cssClass$rowExcludedClass">
                             <td>${row.id}</td>
                             <td>${formatScopes(row.scopes)}</td>
-                            <td>${row.declaredLicenses.joinToString("<br/>")}</td>
-                            <td>${row.detectedLicenses.joinToString("<br/>")}</td>
+                            <td><ul>
+                                ${row.declaredLicenses.joinToString("\n") {
+                                    "<li>$it</li>"
+                                }}
+                            </ul></td>
+                            <td><ul>
+                                ${row.detectedLicenses.joinToString("\n") {
+                                    "<li>$it</li>"
+                                }}
+                            </ul></td>
                             <td><ul>
                                 ${row.analyzerErrors.joinToString("\n") {
                                     "<li>${it.description.replace("\n", "<br/>")}</li>"
@@ -538,14 +544,14 @@ class StaticHtmlReporter : Reporter() {
     private fun formatScopes(scopes: SortedMap<String, List<ScopeExclude>>) =
             scopes.entries.asSequence().sortedWith(compareBy({ it.value.isNotEmpty() }, { it.key }))
                     .joinToString(separator = "", prefix = "<ul>", postfix = "</ul>") {
-                        val excludedClass = if (it.value.isNotEmpty()) "excluded" else ""
+                        val excludedClass = if (it.value.isNotEmpty()) "ort-excluded" else ""
                         "<li class=\"$excludedClass\">${it.key}${formatScopeExcludes(it.value)}</li>"
                     }
 
     private fun formatScopeExcludes(scopeExcludes: List<ScopeExclude>) =
             buildString {
                 if (scopeExcludes.isNotEmpty()) {
-                    append(" <div class=\"reason\">Excluded: ")
+                    append(" <div class=\"ort-reason\">Excluded: ")
                     append(scopeExcludes.joinToString { "${it.reason} - ${it.comment}" })
                     append("</div>")
                 }


### PR DESCRIPTION
Extend the model to allows specifying resolations for evaluator rule violations for local and global config.
Adjust the HTML reporter to display resolved error in green.
Refactor the HTML and CSS to improve it before touching it.

Note: this PR is based on https://github.com/heremaps/oss-review-toolkit/pull/1079 and has to be merged afterwards. Also the commit " Fix-up building the error description" will be merged as part of another PR where this one will depend on.
The PR now also depends on: https://github.com/heremaps/oss-review-toolkit/pull/1095

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1090)
<!-- Reviewable:end -->
