### PR TITLE
Travis: Remove the work-around to use system cacerts for Java

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,6 @@ env:
     - GIMME_GO_VERSION="1.10"
     - DEP_RELEASE_TAG="v0.4.1"
 
-before_install:
-  - rm -f $JAVA_HOME/lib/security/cacerts
-  - ln -s /etc/ssl/certs/java/cacerts $JAVA_HOME/lib/security/cacerts
-
 install:
   - sudo apt install -y cvs
   - eval "$(gimme)"


### PR DESCRIPTION
Looks like Travis has fixed this in the base image now as still doing it
started to result in

$ rm -f $JAVA_HOME/lib/security/cacerts
rm: cannot remove '/usr/local/lib/jvm/openjdk10/lib/security/cacerts': Permission denied
The command "rm -f $JAVA_HOME/lib/security/cacerts" failed and exited with 1 during .

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1099)
<!-- Reviewable:end -->
