### PR TITLE
Travis: Re-link cacerts as root

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ env:
     - DEP_RELEASE_TAG="v0.4.1"
 
 before_install:
-  - rm -f $JAVA_HOME/lib/security/cacerts
-  - ln -s /etc/ssl/certs/java/cacerts $JAVA_HOME/lib/security/cacerts
+  - sudo rm -f $JAVA_HOME/lib/security/cacerts
+  - sudo ln -s /etc/ssl/certs/java/cacerts $JAVA_HOME/lib/security/cacerts
 
 install:
   - sudo apt install -y cvs


### PR DESCRIPTION
Running without "sudo" stopped working today (which actually makes
sense) by giving

$ rm -f $JAVA_HOME/lib/security/cacerts
rm: cannot remove '/usr/local/lib/jvm/openjdk10/lib/security/cacerts': Permission denied
The command "rm -f $JAVA_HOME/lib/security/cacerts" failed and exited with 1 during .

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1101)
<!-- Reviewable:end -->
