### PR TITLE
More pretty copyright statements

### DIFF
--- a/reporter/src/funTest/assets/NPM-is-windows-1.0.2-expected-NOTICE
+++ b/reporter/src/funTest/assets/NPM-is-windows-1.0.2-expected-NOTICE
@@ -763,6 +763,7 @@ Copyright (c) < year() > , Jon Schlinkert.
 copyright 2012-2018 AJ ONeal
 Copyright (c) 2015 AJ ONeal
 Copyright (c) Alexandru Marasteanu
+(c) copyright 2010-2013 B Cavalier & J Hann
 Copyright (c) 2013-2014, 2016 Blaine Bublitz <blaine.bublitz@gmail.com> , Eric Schoffstall <yo@contra.io> and other contributors
 Copyright (c) 2016 Brian Woodward (https://github.com/doowb).
 Copyright (c) 2016 Brian Woodward.
@@ -837,7 +838,6 @@ Copyright (c) 2016 Zeit, Inc.
 Copyright (c) 2015 Zhiye Li
 Copyright (c) 2012 by Vitaly Puzrin
 Copyright (c) 2011 by fent
-(c) 2010-2013 copyright B Cavalier & J Hann
 (c) 2012-2014 http://kitcambridge.be/' Kit Cambridge
 Copyright 2012-2013 jQuery Foundation and other contributors
 Copyright jQuery Foundation and other contributors <https://jquery.org/>

--- a/utils/src/main/kotlin/CopyrightStatementsProcessor.kt
+++ b/utils/src/main/kotlin/CopyrightStatementsProcessor.kt
@@ -193,8 +193,11 @@ class CopyrightStatementsProcessor {
     private fun replaceYears(copyrightStatement: String, placeholder: String): Pair<String, Set<Int>> {
         val resultYears = mutableSetOf<Int>()
 
-        val replaceRangeResult = replaceAllYearRanges(copyrightStatement, placeholder)
-        var currentStatement = replaceRangeResult.first
+        // Fix up strings containing e.g.: 'copyright u'2013'
+        var currentStatement = copyrightStatement.replace("(.*\\b)u'(\\d{4}\\b)".toRegex(), "$1$2")
+
+        val replaceRangeResult = replaceAllYearRanges(currentStatement, placeholder)
+        currentStatement = replaceRangeResult.first
         resultYears += replaceRangeResult.second
 
         // Replace comma separated years.

--- a/utils/src/main/kotlin/CopyrightStatementsProcessor.kt
+++ b/utils/src/main/kotlin/CopyrightStatementsProcessor.kt
@@ -66,8 +66,14 @@ class CopyrightStatementsProcessor {
         private val YEAR_PLACEHOLDER = "<ORT_YEAR_PLACEHOLDER_TRO>"
         private val KNOWN_PREFIX_REGEX = listOf(
                 "^(\\(c\\))",
+                "^(\\(c\\) [C|c]opyright)",
+                "^(\\(c\\) [C|c]opyrighted)",
                 "^([C|c]opyright)",
                 "^([C|c]opyright \\(c\\))",
+                "^([C|c]opyright [O|o]wnership)",
+                "^([C|c]opyright')",
+                "^([C|c]opyright' \\(c\\))",
+                "^(COPYRIGHT)",
                 "^([C|c]opyrighted)",
                 "^([C|c]opyrighted \\(c\\))",
                 "^([P|p]ortions [C|c]opyright)",

--- a/utils/src/main/kotlin/CopyrightStatementsProcessor.kt
+++ b/utils/src/main/kotlin/CopyrightStatementsProcessor.kt
@@ -65,13 +65,13 @@ class CopyrightStatementsProcessor {
     companion object {
         private val YEAR_PLACEHOLDER = "<ORT_YEAR_PLACEHOLDER_TRO>"
         private val KNOWN_PREFIX_REGEX = listOf(
-                "^([C|c]opyrighted \\(c\\))",
-                "^([C|c]opyrighted)",
-                "^([C|c]opyright \\(c\\))",
+                "^(\\(c\\))",
                 "^([C|c]opyright)",
-                "^([P|p]ortions [C|c]opyright \\(c\\))",
+                "^([C|c]opyright \\(c\\))",
+                "^([C|c]opyrighted)",
+                "^([C|c]opyrighted \\(c\\))",
                 "^([P|p]ortions [C|c]opyright)",
-                "^(\\(c\\))"
+                "^([P|p]ortions [C|c]opyright \\(c\\))"
         ).map { it.toRegex() }
 
         private fun prettyPrintYears(years: Collection<Int>) =
@@ -162,16 +162,16 @@ class CopyrightStatementsProcessor {
     }
 
     private fun stripKnownCopyrightPrefix(copyrightStatement: String): Pair<String, String> {
-        KNOWN_PREFIX_REGEX.forEach { regex ->
-            regex.find(copyrightStatement)?.let { matchResult ->
-                return Pair(
-                        first = copyrightStatement.removeRange(matchResult.groups[1]!!.range),
-                        second = matchResult.groups[1]!!.value
-                )
-            }
-        }
+        val match = KNOWN_PREFIX_REGEX.mapNotNull { regex ->
+            regex.find(copyrightStatement)
+        }.maxBy {
+            it.groups[1]!!.value.length
+        } ?: return Pair(first = copyrightStatement, second = "")
 
-        return Pair(first = copyrightStatement, second = "")
+        return Pair(
+                first = copyrightStatement.removeRange(match.groups[1]!!.range),
+                second = match.groups[1]!!.value
+        )
     }
 
     private fun stripYears(copyrightStatement: String): Pair<String, Set<Int>> =

--- a/utils/src/test/assets/copyright-statements-expected-output.yml
+++ b/utils/src/test/assets/copyright-statements-expected-output.yml
@@ -2,14 +2,6 @@
 processed_statements:
   "(c) \eL (c) GNC":
   - "(c) \eL (c) GNC"
-  Copyright 1990 ' (c) ABC:
-  - "Copyright' (c) 1990 ABC"
-  copyright 1990 ' (c) ABC:
-  - "copyright' (c) 1990 ABC"
-  Copyright 1990 ' ABC:
-  - "Copyright' 1990 ABC"
-  copyright 1990 ' ABC:
-  - "copyright' 1990 ABC"
   (c) (c) 11LE:
   - "(c) (c) 11LE"
   (c) (c) U0Vju:
@@ -34,6 +26,20 @@ processed_statements:
   - "(c) A3 nu omNG0C Oopa34E"
   (c) AAEB EuCY:
   - "(c) AAEB EuCY"
+  (c) Copyright 1990 ABC:
+  - "(c) Copyright 1990 ABC"
+  (c) copyright 1990 ABC:
+  - "(c) copyright 1990 ABC"
+  COPYRIGHT 1990 ABC:
+  - "COPYRIGHT 1990 ABC"
+  Copyright' 1990 ABC:
+  - "Copyright' 1990 ABC"
+  Copyright' (c) 1990 ABC:
+  - "Copyright' (c) 1990 ABC"
+  copyright' 1990 ABC:
+  - "copyright' 1990 ABC"
+  copyright' (c) 1990 ABC:
+  - "copyright' (c) 1990 ABC"
   (c) AE Ess0:
   - "(c) AE Ess0"
   (c) AG:
@@ -224,13 +230,6 @@ processed_statements:
   - "Copyright Cop"
   Copyright 2016 Copyright (c):
   - "Copyright Copyright (c) 2016"
-  (c) 2008 Copyright , Joe Gregorio.:
-  - "(c) Copyright 2008, Joe Gregorio."
-  (c) 1990 Copyright ABC:
-  - "(c) Copyright 1990 ABC"
-  - "(c) copyright 1990 ABC"
-  (c) 1996-2008 Copyright Hewlett-Packard Development Company, L.P.:
-  - "(c) Copyright 1996-2008 Hewlett-Packard Development Company, L.P."
   Copyright (c) 2010, 2012-2016 Cowboy Ben Alman:
   - "Copyright (c) 2010 Cowboy Ben Alman"
   - "Copyright (c) 2012-2016 Cowboy Ben Alman"
@@ -484,6 +483,8 @@ processed_statements:
   - "Copyright (c) 2011-2013 Hal Brodigan"
   (c) HeOEs i AicWoae:
   - "(c) HeOEs i AicWoae"
+  (c) Copyright 1996-2008 Hewlett-Packard Development Company, L.P.:
+  - "(c) Copyright 1996-2008 Hewlett-Packard Development Company, L.P."
   Copyright (c) 2010 Hiroshi Nakamura <nahi@ruby-lang.org>:
   - "Copyright (c) 2010 Hiroshi Nakamura <nahi@ruby-lang.org>"
   Copyright (c) 2009 Hongli Lai <hongli@phusion.nl>:
@@ -629,6 +630,8 @@ processed_statements:
   - "Copyright 2006, Joe Gregorio contributors Mark Pilgrim"
   Copyright 2006 Joe Gregorio contributors Thomas Broyer:
   - "Copyright 2006, Joe Gregorio contributors Thomas Broyer"
+  (c) Copyright 2008 Joe Gregorio.:
+  - "(c) Copyright 2008, Joe Gregorio."
   Copyright (c) 2009 John Resig:
   - "Copyright (c) 2009 John Resig"
   Copyright 2010-2011 John Resig:
@@ -1033,6 +1036,8 @@ processed_statements:
   - "(c) Th 8+-UfyAioO!P3@ Od"
   "(c) ThAEKG^u 2OZja u$?|wuIadaiom\\00a$!oY-eTh3\x15 xa\x02e\" cO":
   - "(c) ThAEKG^u 2OZja u$?|wuIadaiom\\00a$!oY-eTh3\x15 xa\x02e\" cO"
+  copyright ownership The ASF:
+  - "copyright ownership. The ASF"
   Copyright 2017 The Abseil Authors.:
   - "Copyright 2017 The Abseil Authors."
   Copyright (c) 2009-2010, 2015, 2017 The Android Open Source Project:
@@ -1372,8 +1377,6 @@ processed_statements:
   "(c) o!ZO\x03S O!'NaC/m1/2Di1/2f4 \x025!\"/GEi::!bk *k\"-\x0f\x16S\x01E-G2 M\x04 W SAM":
   - "(c) o!ZO\x03S O!'NaC/m1/2Di1/2f4 \x025!\"/GEi::!bk *k\"-\x0f\x16S\x01E-G2 M\x04\
     \ W SAM"
-  copyright ownership. The ASF:
-  - "copyright ownership. The ASF"
   Copyright (c) 2015 present, Jon Schlinkert.:
   - "Copyright (c) 2015-present, Jon Schlinkert."
   Copyright 2014-2016 s:
@@ -1406,7 +1409,6 @@ unprocessed_statements:
 - "Alloc1 a2 (c) R1"
 - "Ao (c) Y1"
 - "BbCcDW (c) WdYYFfGgMmPwpwSyWwsAAAAACEEEEIIIIWNOOOOOTUUUUYYaaaaaaceeeeiiiiwnoooootuuuuyyy"
-- "COPYRIGHT 1990 ABC"
 - "Code copyright 2012-2018 AJ ONeal"
 - "Cw (c) Ie"
 - "DAeX (c) OjNduV"

--- a/utils/src/test/assets/copyright-statements-expected-output.yml
+++ b/utils/src/test/assets/copyright-statements-expected-output.yml
@@ -1391,6 +1391,10 @@ processed_statements:
   - "(c) 2008 thawte, Inc."
   Copyright 2014 the Melange authors.:
   - "Copyright 2014 the Melange authors."
+  copyright 2000-2005 u' CDE:
+  - "copyright 2001,u'2002 CDE"
+  - "copyright u'2000 CDE"
+  - "copyright u'2003 - 2005 CDE"
   copyright 2009 u' N EN:
   - "copyright u'2009 N EN"
   copyright 2011-2017 u', LLVM Project:

--- a/utils/src/test/assets/copyright-statements-expected-output.yml
+++ b/utils/src/test/assets/copyright-statements-expected-output.yml
@@ -178,6 +178,10 @@ processed_statements:
   - "(c) Bud Xml@"
   (c) C1 a!sSaT DyiYyEM:
   - "(c) C1 a!sSaT DyiYyEM"
+  copyright 2000-2005 CDE:
+  - "copyright 2001,u'2002 CDE"
+  - "copyright u'2000 CDE"
+  - "copyright u'2003 - 2005 CDE"
   Copyright (c) 2015 Calvin Metcalf:
   - "Copyright (c) 2015 Calvin Metcalf"
   Copyright 2010-2014 Caolan McMahon:
@@ -726,6 +730,8 @@ processed_statements:
     \ Stockholm, Sweden)."
   Copyright (c) 2013 Kyle Robinson Young:
   - "Copyright (c) 2013 Kyle Robinson Young"
+  copyright 2011-2017 LLVM Project:
+  - "copyright u'2011-2017, LLVM Project"
   Copyright (c) 2015 Lars Kanis:
   - "Copyright (c) 2015 Lars Kanis"
   Copyright 2013 LinkedIn Corp.:
@@ -779,6 +785,8 @@ processed_statements:
   Copyright (c) 2010-2018 Michael Bleigh, Josh Kalderimis, Erik Michaels-Ober, and Pavel Pravosud.:
   - "Copyright (c) 2010-2018 Michael Bleigh, Josh Kalderimis, Erik Michaels-Ober,\
     \ and Pavel Pravosud."
+  copyright 2015 Michael Dowling:
+  - "copyright u'2015, Michael Dowling"
   Copyright (c) 2015 Michael Dowling <https://github.com/mtdowling>:
   - "Copyright (c) 2015 Michael Dowling <https://github.com/mtdowling>"
   Copyright (c) 2011-2018 Michael Dowling, https://github.com/mtdowling <mtdowling@gmail.com>:
@@ -816,6 +824,8 @@ processed_statements:
   - "Copyright 2014 Mozilla Foundation and contributors"
   Copyright (c) 2013 My C-Sense:
   - "Copyright (c) 2013 My C-Sense"
+  copyright 2009 N EN:
+  - "copyright u'2009 N EN"
   Copyright (c) 2018 NAN WG Members:
   - "Copyright (c) 2018 NAN WG Members"
   Copyright (c) 2018 NAN contributors:
@@ -1391,16 +1401,6 @@ processed_statements:
   - "(c) 2008 thawte, Inc."
   Copyright 2014 the Melange authors.:
   - "Copyright 2014 the Melange authors."
-  copyright 2000-2005 u' CDE:
-  - "copyright 2001,u'2002 CDE"
-  - "copyright u'2000 CDE"
-  - "copyright u'2003 - 2005 CDE"
-  copyright 2009 u' N EN:
-  - "copyright u'2009 N EN"
-  copyright 2011-2017 u', LLVM Project:
-  - "copyright u'2011-2017, LLVM Project"
-  copyright 2015 u', Michael Dowling:
-  - "copyright u'2015, Michael Dowling"
   Copyright (c) 2000-2006 www.hamcrest.org:
   - "Copyright (c) 2000-2006, www.hamcrest.org"
   copyright xmlns https://phar.io/xml/manifest/1.0:

--- a/utils/src/test/assets/copyright-statements-expected-output.yml
+++ b/utils/src/test/assets/copyright-statements-expected-output.yml
@@ -2,6 +2,14 @@
 processed_statements:
   "(c) \eL (c) GNC":
   - "(c) \eL (c) GNC"
+  Copyright 1990 ' (c) ABC:
+  - "Copyright' (c) 1990 ABC"
+  copyright 1990 ' (c) ABC:
+  - "copyright' (c) 1990 ABC"
+  Copyright 1990 ' ABC:
+  - "Copyright' 1990 ABC"
+  copyright 1990 ' ABC:
+  - "copyright' 1990 ABC"
   (c) (c) 11LE:
   - "(c) (c) 11LE"
   (c) (c) U0Vju:
@@ -218,6 +226,9 @@ processed_statements:
   - "Copyright Copyright (c) 2016"
   (c) 2008 Copyright , Joe Gregorio.:
   - "(c) Copyright 2008, Joe Gregorio."
+  (c) 1990 Copyright ABC:
+  - "(c) Copyright 1990 ABC"
+  - "(c) copyright 1990 ABC"
   (c) 1996-2008 Copyright Hewlett-Packard Development Company, L.P.:
   - "(c) Copyright 1996-2008 Hewlett-Packard Development Company, L.P."
   Copyright (c) 2010, 2012-2016 Cowboy Ben Alman:
@@ -850,6 +861,12 @@ processed_statements:
   - "Copyright (c) 2007, 2008 Ola Bini <ola@ologix.com>"
   "(c) Oo E\x16P\x1aIAyMoU1/4Hl+-BD En":
   - "(c) Oo E\x16P\x1aIAyMoU1/4Hl+-BD En"
+  Copyrighted 1990 Ownership ABC:
+  - "Copyrighted Ownership 1990 ABC"
+  - "Copyrighted ownership 1990 ABC"
+  copyrighted 1990 Ownership ABC:
+  - "copyrighted Ownership 1990 ABC"
+  - "copyrighted ownership 1990 ABC"
   (c) Ox Ao:
   - "(c) Ox Ao"
   Copyright (c) 2012, 2014-2015 PHP Framework Interoperability Group:
@@ -1389,6 +1406,7 @@ unprocessed_statements:
 - "Alloc1 a2 (c) R1"
 - "Ao (c) Y1"
 - "BbCcDW (c) WdYYFfGgMmPwpwSyWwsAAAAACEEEEIIIIWNOOOOOTUUUUYYaaaaaaceeeeiiiiwnoooootuuuuyyy"
+- "COPYRIGHT 1990 ABC"
 - "Code copyright 2012-2018 AJ ONeal"
 - "Cw (c) Ie"
 - "DAeX (c) OjNduV"

--- a/utils/src/test/assets/copyright-statements.txt
+++ b/utils/src/test/assets/copyright-statements.txt
@@ -941,3 +941,6 @@ copyright' 1990 ABC
 Copyright' (c) 1990 ABC
 copyright' (c) 1990 ABC
 COPYRIGHT 1990 ABC
+copyright u'2000 CDE
+copyright 2001,u'2002 CDE
+copyright u'2003 - 2005 CDE

--- a/utils/src/test/assets/copyright-statements.txt
+++ b/utils/src/test/assets/copyright-statements.txt
@@ -930,3 +930,14 @@ TarHeader (c)
 Ui vEak.O7!YciBuqu2kim',cJoSo2olm (c) EMoK
 use (c)
 Vi EEL64eaae!2TeOau (c) Noj
+(c) Copyright 1990 ABC
+(c) copyright 1990 ABC
+Copyrighted Ownership 1990 ABC
+copyrighted Ownership 1990 ABC
+Copyrighted ownership 1990 ABC
+copyrighted ownership 1990 ABC
+Copyright' 1990 ABC
+copyright' 1990 ABC
+Copyright' (c) 1990 ABC
+copyright' (c) 1990 ABC
+COPYRIGHT 1990 ABC


### PR DESCRIPTION
Further improve the copyright statements processing by improving copyright prefix matchers and
adding a workaround for prefixed years. See individual commits for details

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1103)
<!-- Reviewable:end -->
