### PR TITLE
reporter-web-app: Replace the unmaintained gradle-node-plugin with custom code

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -19,6 +19,7 @@ tools need to be installed. In the context of this tutorial the following tools 
 * Git (any recent version will do)
 * [Node.js](https://nodejs.org) 8.*
 * [NPM](https://www.npmjs.com) 5.5.* - 6.4.*
+* [Yarn](https://yarnpkg.com) 1.9.* - 1.12.*
 
 For the full list of supported package managers and Version Control Systems see the [README](../README.md).
 

--- a/reporter-web-app/build.gradle
+++ b/reporter-web-app/build.gradle
@@ -1,43 +1,33 @@
-plugins {
-    id 'com.moowork.node' version '1.2.0'
+import org.apache.tools.ant.taskdefs.condition.Os
+
+tasks.addRule('Pattern: yarn<Command>') { String taskName ->
+    if (taskName.startsWith('yarn')) {
+        def yarn = Os.isFamily(Os.FAMILY_WINDOWS) ? "yarn.cmd" : "yarn"
+        def command = (taskName - 'yarn').uncapitalize()
+
+        task(taskName, type: Exec) {
+            commandLine yarn, command
+        }
+    }
 }
 
-node {
-    version = '8.11.4'
-    // Version 1.12.1 of Yarn does not work on AppVeyor and gives
-    //
-    //     Failed to capture fingerprint of output files for task ':reporter-web-app:install' property '$1' during up-to-date check.
-    //     > Could not read path 'reporter-web-app\node_modules\@babel\generator\node_modules\jsesc\.bin\jsesc'.
-    //
-    // Maybe this is because of https://github.com/gradle/gradle/issues/1365.
-    yarnVersion = '1.9.4'
-    // Installing NPM is needed for installing Yarn because the Gradle Node plugin installs Yarn via NPM.
-    npmVersion = '6.4.0'
-    // Setting download flag is required for bootstrapping NPM.
-    download = true
-    nodeModulesDir = file("${project.projectDir}/node")
-}
+/*
+ * Further configure rule tasks, e.g. with inputs and outputs.
+ */
 
-task clean(type: Delete) {
-    delete 'build'
-    delete 'node_modules'
-    delete 'yarn-error.log'
-}
-
-task install(type: YarnTask) {
-    description 'Use Yarn to install the node dependencies. Similar to the "yarn" task but with up-to-date checks.'
+yarnInstall {
+    description 'Use Yarn to install the Node.js dependencies.'
     group = 'Node'
-    args = ['install']
 
     inputs.files 'package.json', 'yarn.lock'
-
     outputs.dir 'node_modules'
 }
 
-task build(type: YarnTask, dependsOn: install) {
-    description 'Use Yarn to build the package. Similar to the "yarn_build" task but with up-to-date checks.'
+yarnBuild {
+    description 'Use Yarn to build the Node.js application.'
     group = 'Node'
-    args = ['build']
+
+    dependsOn yarnInstall
 
     inputs.dir 'config'
     inputs.dir 'node_modules'
@@ -48,4 +38,24 @@ task build(type: YarnTask, dependsOn: install) {
     outputs.dir 'build'
 }
 
-task check(dependsOn: [build, yarn_lint])
+yarnLint {
+    description 'Let Yarn run the linter to check for style issues.'
+    group = 'Node'
+
+    dependsOn yarnInstall
+}
+
+/*
+ * Resemble the Java plugin tasks for convenience.
+ */
+
+
+task install(dependsOn: yarnInstall)
+task build(dependsOn: [yarnBuild, yarnLint])
+task check(dependsOn: yarnLint)
+
+task clean(type: Delete) {
+    delete 'build'
+    delete 'node_modules'
+    delete 'yarn-error.log'
+}


### PR DESCRIPTION
The custom code properly caches e.g. "yarn install" already on the
Gradle-level instead of leaving it to Yarn. On the downside, the new
implemenation does not bootstrap Node, NPM or Yarn anymore, but we have
these already installed for the Analyzer anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1113)
<!-- Reviewable:end -->
