### PR TITLE
safeDeleteRecursively: Remove the Windows-specific call to ProcessCapture()

### DIFF
--- a/utils/src/main/kotlin/Extensions.kt
+++ b/utils/src/main/kotlin/Extensions.kt
@@ -71,7 +71,7 @@ fun File.safeDeleteRecursively(force: Boolean = false) {
         override fun preVisitDirectory(dir: Path, attrs: BasicFileAttributes): FileVisitResult {
             if (OS.isWindows && attrs.isOther) {
                 // Unlink junctions to turn them into empty directories.
-                ProcessCapture("fsutil", "reparsepoint", "delete", dir.toString())
+                dir.toFile().delete()
                 return FileVisitResult.SKIP_SUBTREE
             }
 


### PR DESCRIPTION
As it turns out, File().delete() also just deletes / unlinks the
junction without touching the directory the junction points to.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1116)
<!-- Reviewable:end -->
