### PR TITLE
Bower: Remove the toString() override

### DIFF
--- a/analyzer/src/main/kotlin/managers/Bower.kt
+++ b/analyzer/src/main/kotlin/managers/Bower.kt
@@ -62,10 +62,9 @@ class Bower(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfigu
         private const val REQUIRED_BOWER_VERSION = "1.8.4"
         private const val SCOPE_NAME_DEPENDENCIES = "dependencies"
         private const val SCOPE_NAME_DEV_DEPENDENCIES = "devDependencies"
-        private const val PACKAGE_TYPE = "Bower"
 
         private fun extractPackageId(node: JsonNode) = Identifier(
-                type = PACKAGE_TYPE,
+                type = "Bower",
                 namespace = "",
                 name = node["pkgMeta"]["name"].textValueOrEmpty(),
                 version = node["pkgMeta"]["version"].textValueOrEmpty()
@@ -205,8 +204,6 @@ class Bower(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfigu
         override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
                 Bower(analyzerConfig, repoConfig)
     }
-
-    override fun toString() = PACKAGE_TYPE
 
     override fun command(workingDir: File?) = if (OS.isWindows) "bower.cmd" else "bower"
 


### PR DESCRIPTION
The toString() override introduced in e30f74f does nothing different than
the implementation inherited from PackageManager (see 50f03e9). Also
inline the single last remaining use of "PACKAGE_TYPE" now.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1118)
<!-- Reviewable:end -->
