### PR TITLE
Override repository config

### DIFF
--- a/cli/src/main/kotlin/commands/EvaluatorCommand.kt
+++ b/cli/src/main/kotlin/commands/EvaluatorCommand.kt
@@ -69,12 +69,21 @@ object EvaluatorCommand : CommandWithHelp() {
             order = PARAMETER_ORDER_OPTIONAL)
     private var syntaxCheck = false
 
+    @Parameter(description = "A file containing the repository configuration. If set the .ort.yml " +
+            "overrides the repository configuration contained in the ort result from the input file.",
+            names = ["--repository-configuration-file"],
+            order = PARAMETER_ORDER_OPTIONAL)
+    private var repositoryConfigurationFile: File? = null
+
     override fun runCommand(jc: JCommander): Int {
         require((rulesFile == null) != (rulesResource == null)) {
             "Either '--rules-file' or '--rules-resource' must be specified."
         }
 
-        val ortResultInput = ortFile.readValue<OrtResult>()
+        var ortResultInput = ortFile.readValue<OrtResult>()
+        if (repositoryConfigurationFile != null) {
+            ortResultInput = ortResultInput.replaceConfig(repositoryConfigurationFile!!.readValue())
+        }
 
         val script = rulesFile?.readText() ?: javaClass.getResource(rulesResource).readText()
 

--- a/cli/src/main/kotlin/commands/ReporterCommand.kt
+++ b/cli/src/main/kotlin/commands/ReporterCommand.kt
@@ -92,6 +92,12 @@ object ReporterCommand : CommandWithHelp() {
             order = PARAMETER_ORDER_OPTIONAL)
     private var copyrightGarbageFile: File? = null
 
+    @Parameter(description = "A file containing the repository configuration. If set the .ort.yml " +
+            "overrides the repository configuration contained in the ort result from the input file.",
+            names = ["--repository-configuration-file"],
+            order = PARAMETER_ORDER_OPTIONAL)
+    private var repositoryConfigurationFile: File? = null
+
     override fun runCommand(jc: JCommander): Int {
         require(!outputDir.exists()) {
             "The output directory '${outputDir.absolutePath}' must not exist yet."
@@ -99,7 +105,10 @@ object ReporterCommand : CommandWithHelp() {
 
         outputDir.safeMkdirs()
 
-        val ortResult = ortFile.readValue<OrtResult>()
+        var ortResult = ortFile.readValue<OrtResult>()
+        if (repositoryConfigurationFile != null) {
+            ortResult = ortResult.replaceConfig(repositoryConfigurationFile!!.readValue())
+        }
 
         val resolutionProvider = DefaultResolutionProvider()
         ortResult.repository.config.resolutions?.let { resolutionProvider.add(it) }

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -21,6 +21,7 @@ package com.here.ort.model
 
 import com.fasterxml.jackson.annotation.JsonInclude
 
+import com.here.ort.model.config.RepositoryConfiguration
 import com.here.ort.model.spdx.SpdxExpression
 
 import java.util.SortedSet
@@ -194,4 +195,10 @@ data class OrtResult(
                     }
                 }
             }
+
+    /**
+     * Return a copy of this [OrtResult] with the [Repository.config] replaced by [config].
+     */
+    fun replaceConfig(config: RepositoryConfiguration) =
+            copy(repository = repository.copy(config = config))
 }


### PR DESCRIPTION
Allow running `evaluation` and `report` with a changed repository configuration without needing to run the `analyzer` and `scanner` again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1127)
<!-- Reviewable:end -->
