### PR TITLE
Gradle: Upgrade the Docker plugins to version 4.2.0

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -12,7 +12,7 @@ mainClassName = 'com.here.ort.Main'
 task dockerBuildBaseImage(type: com.bmuschko.gradle.docker.tasks.image.DockerBuildImage) {
     // This task uses 'docker/Dockerfile' as the input file.
     description = 'Builds the base Docker image to run ORT.'
-    tag = 'ort-base:latest'
+    tags = ['ort-base:latest']
 }
 
 docker {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 detektPluginVersion = 1.0.0-RC12
-dockerJavaApplicationPluginVersion = 4.1.0
-dockerRemoteApiPluginVersion = 4.1.0
+dockerJavaApplicationPluginVersion = 4.2.0
+dockerRemoteApiPluginVersion = 4.2.0
 dokkaPluginVersion = 0.9.17
 ideaExtPluginVersion = 0.4.2
 kotlinPluginVersion = 1.3.11


### PR DESCRIPTION
See https://bmuschko.github.io/gradle-docker-plugin/#v4_2_0_december_16_2018.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>