### PR TITLE
GitRepoDownloadTest: Sort on String instead of File objects

### DIFF
--- a/downloader/src/funTest/kotlin/GitRepoDownloadTest.kt
+++ b/downloader/src/funTest/kotlin/GitRepoDownloadTest.kt
@@ -71,26 +71,22 @@ class GitRepoDownloadTest : StringSpec() {
                     "third_party",
                     "tools",
                     "vsprojects"
-            ).map { File(grpcDir, it) }
+            )
 
-            val actualGrpcFiles = grpcDir.listFiles(FileFilter {
-                it.isDirectory
-            }).sorted()
+            val actualGrpcFiles = grpcDir.listFiles(FileFilter { it.isDirectory }).map { it.name }.sorted()
 
             val spdxDir = File(outputDir, "spdx-tools")
             val expectedSpdxFiles = listOf(
                     ".git",
-                    "doc",
                     "Examples",
-                    "resources",
-                    "src",
                     "Test",
-                    "TestFiles"
-            ).map { File(spdxDir, it) }
+                    "TestFiles",
+                    "doc",
+                    "resources",
+                    "src"
+            )
 
-            val actualSpdxFiles = spdxDir.listFiles(FileFilter {
-                it.isDirectory
-            }).sorted()
+            val actualSpdxFiles = spdxDir.listFiles(FileFilter { it.isDirectory }).map { it.name }.sorted()
 
             workingTree.isValid() shouldBe true
             workingTree.getInfo() shouldBe vcs


### PR DESCRIPTION
The Java comparator used for File objects on Windows is case-insensitve,
just like Windows file systems. To avoid differences to Linux'
case-sensitive sorting, sort on String objects instead.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1133)
<!-- Reviewable:end -->
