### PR TITLE
reporter: Return exit code 1 if any report could not be created

### DIFF
--- a/cli/src/main/kotlin/commands/ReporterCommand.kt
+++ b/cli/src/main/kotlin/commands/ReporterCommand.kt
@@ -115,6 +115,8 @@ object ReporterCommand : CommandWithHelp() {
         resolutionsFile?.readValue<Resolutions>()?.let { resolutionProvider.add(it) }
         val copyrightGarbage = copyrightGarbageFile?.readValue() ?: CopyrightGarbage()
 
+        var exitCode = 0
+
         reportFormats.distinct().forEach {
             val name = it.toString().removeSuffix("Reporter")
             try {
@@ -130,9 +132,11 @@ object ReporterCommand : CommandWithHelp() {
                 e.showStackTrace()
 
                 log.error { "Could not create '$name' report: ${e.message}" }
+
+                exitCode = 1
             }
         }
 
-        return 0
+        return exitCode
     }
 }


### PR DESCRIPTION
If an exception is thrown while creating a report still try to create the
other reports, but return exit code 1 to indicate that something went
wrong.

Signed-off-by: Martin Nonnenmacher <martin.nonnenmacher@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1138)
<!-- Reviewable:end -->
