### PR TITLE
reporter: Improve naming of `ResolutionProvider` functions

### DIFF
--- a/reporter/src/main/kotlin/DefaultResolutionProvider.kt
+++ b/reporter/src/main/kotlin/DefaultResolutionProvider.kt
@@ -29,7 +29,8 @@ class DefaultResolutionProvider : ResolutionProvider {
         this.resolutions = this.resolutions.merge(resolutions)
     }
 
-    override fun getResolutionsFor(error: OrtIssue) = resolutions.errors.filter { it.matches(error) }
+    override fun getErrorResolutionsFor(error: OrtIssue) = resolutions.errors.filter { it.matches(error) }
 
-    override fun getEvaluatorResolutionsFor(error: OrtIssue) = resolutions.ruleViolations.filter { it.matches(error) }
+    override fun getRuleViolationResolutionsFor(error: OrtIssue) =
+            resolutions.ruleViolations.filter { it.matches(error) }
 }

--- a/reporter/src/main/kotlin/ResolutionProvider.kt
+++ b/reporter/src/main/kotlin/ResolutionProvider.kt
@@ -24,16 +24,16 @@ import com.here.ort.model.config.ErrorResolution
 import com.here.ort.model.config.RuleViolationResolution
 
 /**
- * A provider for [ErrorResolution]s.
+ * A provider for resolutions of [OrtIssue]s.
  */
 interface ResolutionProvider {
     /**
-     * Get all resolutions that match [error].
+     * Get all error resolutions that match [error].
      */
-    fun getResolutionsFor(error: OrtIssue): List<ErrorResolution>
+    fun getErrorResolutionsFor(error: OrtIssue): List<ErrorResolution>
 
     /**
-     * Get all resolutions that match [error].
+     * Get all rule violation resolutions that match [error].
      */
-    fun getEvaluatorResolutionsFor(error: OrtIssue): List<RuleViolationResolution>
+    fun getRuleViolationResolutionsFor(error: OrtIssue): List<RuleViolationResolution>
 }

--- a/reporter/src/main/kotlin/reporters/ReportTableModelMapper.kt
+++ b/reporter/src/main/kotlin/reporters/ReportTableModelMapper.kt
@@ -40,7 +40,7 @@ private fun Collection<ResolvableIssue>.filterUnresolved() = filter { !it.isReso
  */
 class ReportTableModelMapper(private val resolutionProvider: ResolutionProvider) {
     private fun OrtIssue.toResolvableIssue(): ResolvableIssue {
-        val resolutions = resolutionProvider.getResolutionsFor(this)
+        val resolutions = resolutionProvider.getErrorResolutionsFor(this)
         return ResolvableIssue(
                 source = this@toResolvableIssue.source,
                 description = this@toResolvableIssue.toString(),
@@ -56,7 +56,7 @@ class ReportTableModelMapper(private val resolutionProvider: ResolutionProvider)
     }
 
     private fun OrtIssue.toResolvableEvaluatorIssue(): ResolvableIssue {
-        val resolutions = resolutionProvider.getEvaluatorResolutionsFor(this)
+        val resolutions = resolutionProvider.getRuleViolationResolutionsFor(this)
         return ResolvableIssue(
                 source = this@toResolvableEvaluatorIssue.source,
                 description = this@toResolvableEvaluatorIssue.toString(),


### PR DESCRIPTION
And slightly improve the documentation.

Signed-off-by: Martin Nonnenmacher <martin.nonnenmacher@here.com>