### PR TITLE
Fixup GitHub detected language statistics once more

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,9 @@
 */src/*/assets/**/*expected*.yml		text eol=lf
 reporter/src/funTest/assets/*-expected-*	text eol=lf
 
-# Fix GitHub language statistics, see https://github.com/github/linguist#generated-code.
+# Fix GitHub language statistics, see https://github.com/github/linguist#using-gitattributes.
 reporter-web-app/public/index.html		linguist-generated=true
+spdx-utils/src/main/resources/exceptions/*	linguist-detectable=false
+spdx-utils/src/main/resources/licenses/*	linguist-detectable=false
 
 reporter-web-app/**/*.js			text eol=lf


### PR DESCRIPTION
Avoid SPDX license / exception texts to be detected as Roff files.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1144)
<!-- Reviewable:end -->
