### PR TITLE
LicenseFinding: Fix the `compareTo` function

### DIFF
--- a/model/src/main/kotlin/LicenseFinding.kt
+++ b/model/src/main/kotlin/LicenseFinding.kt
@@ -54,8 +54,34 @@ data class LicenseFinding @JsonCreator constructor(
         val license: String,
         val copyrights: SortedSet<String>
 ) : Comparable<LicenseFinding> {
+    companion object {
+        private val COPYRIGHTS_COMPARATOR = Comparator<SortedSet<String>> { o1, o2 ->
+            val iterator1 = o1.iterator()
+            val iterator2 = o2.iterator()
+
+            while (iterator1.hasNext() && iterator2.hasNext()) {
+                val value1 = iterator1.next()
+                val value2 = iterator2.next()
+
+                value1.compareTo(value2).let {
+                    if (it != 0) return@Comparator it
+                }
+            }
+
+            return@Comparator when {
+                iterator1.hasNext() -> 1
+                iterator2.hasNext() -> -1
+                else -> 0
+            }
+        }
+    }
+
     @JsonCreator
     constructor(licenseName: String) : this(licenseName, sortedSetOf())
 
-    override fun compareTo(other: LicenseFinding) = license.compareTo(other.license)
+    override fun compareTo(other: LicenseFinding) =
+            when {
+                license != other.license -> license.compareTo(other.license)
+                else -> COPYRIGHTS_COMPARATOR.compare(copyrights, other.copyrights)
+            }
 }

--- a/scanner/src/test/kotlin/ScanCodeTest.kt
+++ b/scanner/src/test/kotlin/ScanCodeTest.kt
@@ -243,7 +243,21 @@ class ScanCodeTest : WordSpec({
                     LicenseFinding(
                             "Apache-2.0",
                             sortedSetOf(
-                                    "Copyright 2013-2017 Amazon.com, Inc."
+                                    "Copyright (c) 2016 Amazon.com, Inc.",
+                                    "Copyright (c) 2016. Amazon.com, Inc.",
+                                    "Copyright 2010-2017 Amazon.com, Inc.",
+                                    "Copyright 2011-2017 Amazon Technologies, Inc.",
+                                    "Copyright 2011-2017 Amazon.com, Inc.",
+                                    "Copyright 2012-2017 Amazon Technologies, Inc.",
+                                    "Copyright 2012-2017 Amazon.com, Inc.",
+                                    "Copyright 2013-2017 Amazon Technologies, Inc.",
+                                    "Copyright 2013-2017 Amazon.com, Inc.",
+                                    "Copyright 2014-2017 Amazon Technologies, Inc.",
+                                    "Copyright 2014-2017 Amazon.com, Inc.",
+                                    "Copyright 2015-2017 Amazon Technologies, Inc.",
+                                    "Copyright 2015-2017 Amazon.com, Inc.",
+                                    "Copyright 2016-2017 Amazon.com, Inc.",
+                                    "Portions copyright 2006-2009 James Murty."
                             )
                     )
             )


### PR DESCRIPTION
The `compareTo` function of a comparable class should be consistent with
`equals`, otherwise using the class in a sorted set or as a key in a sorted
map can result in unexpected behaviour [1][2]. Fix the `compareTo` function
of `LicenseFinding` accordingly. This also unveiled an issue in one of the
ScanCode tests.

Note that there are several other model classes with the same issue which
also need to be fixed.

[1] https://docs.oracle.com/javase/8/docs/api/java/util/SortedSet.html
[2] https://docs.oracle.com/javase/8/docs/api/java/lang/Comparable.html

Signed-off-by: Martin Nonnenmacher <martin.nonnenmacher@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1153)
<!-- Reviewable:end -->
