### PR TITLE
README: Add install instructions for Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ Follow these steps to run the OSS Review Toolkit from source code:
    `JAVA_HOME` environment variable set.
 
 2. Clone this repository with submodules by running `git clone --recurse-submodules`. If you have already cloned
-   non-recursively, you can initialize submodules afterwards by running `git submodule update --init --recursive`.
+   non-recursively, you can initialize submodules afterwards by running `git submodule update --init --recursive`. Note
+   that submodules are only required if you intend to run tests, though.
 
 3. Change into the created directory and run `./gradlew installDist` to build / install the start script for ORT. On
    the first run, this will also bootstrap Gradle and download required dependencies. The start script can then be run

--- a/README.md
+++ b/README.md
@@ -81,14 +81,16 @@ Follow these steps to run the OSS Review Toolkit from source code:
 
 Alternatively, you can also run the OSS Review Toolkit by building its Docker image:
 
-1. Ensure you have recent versions of Git and Docker installed.
+1. Ensure you have Docker installed and its daemon running.
 
 2. Clone this repository with submodules by running `git clone --recurse-submodules`. If you have already cloned
-   non-recursively, you can initialize submodules afterwards by running `git submodule update --init --recursive`.
+   non-recursively, you can initialize submodules afterwards by running `git submodule update --init --recursive`. Note
+   that submodules are only required if you intend to run tests, though.
 
-3. Change into the created directory and run `./gradlew cli:dockerBuildImage` to build the Docker image.
+3. Change into the created directory and run `./gradlew cli:dockerBuildImage` to build the Docker image and send it to
+   the locally running daemon.
 
-4. Run `docker run ort requirements` to execute the image and install required command line tools into the container.
+4. Execute `docker run ort requirements` to verify all required command line tools are available in the container.
 
 ## Tools
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ Follow these steps to run the OSS Review Toolkit from source code:
 
    * `./gradlew cli:run --args="requirements"`
 
+Alternatively, you can also run the OSS Review Toolkit by building its Docker image:
+
+1. Ensure you have recent versions of Git and Docker installed.
+
+2. Clone this repository with submodules by running `git clone --recurse-submodules`. If you have already cloned
+   non-recursively, you can initialize submodules afterwards by running `git submodule update --init --recursive`.
+
+3. Change into the created directory and run `./gradlew cli:dockerBuildImage` to build the Docker image.
+
+4. Run `docker run ort requirements` to execute the image and install required command line tools into the container.
+
 ## Tools
 
 ### [analyzer](./analyzer/src/main/kotlin)


### PR DESCRIPTION
Adding instructions how to build the Docker Image to make this  option more visible to ORT users.

Signed-off-by: Thomas Steenbergen <thomas.steenbergen@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1159)
<!-- Reviewable:end -->
