### PR TITLE
reporter: Do not use `unsafe` for error descriptions

### DIFF
--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -477,7 +477,7 @@ class StaticHtmlReporter : Reporter() {
                     ul {
                         errors.forEach { error ->
                             li {
-                                p { unsafe { +error.description.replace("\n", "<br/>") } }
+                                errorDescription(error)
                                 p { +error.resolutionDescription }
                             }
                         }
@@ -492,7 +492,7 @@ class StaticHtmlReporter : Reporter() {
                     ul {
                         errors.forEach { error ->
                             li {
-                                p { unsafe { +error.description.replace("\n", "<br/>") } }
+                                errorDescription(error)
                                 p { +error.resolutionDescription }
                             }
                         }
@@ -622,13 +622,23 @@ class StaticHtmlReporter : Reporter() {
         ul {
             errors.forEach {
                 li {
-                    p { unsafe { +it.description.replace("\n", "<br/>") } }
+                    errorDescription(it)
 
                     if (it.isResolved) {
                         classes = setOf("ort-resolved")
                         p { +it.resolutionDescription }
                     }
                 }
+            }
+        }
+    }
+
+    private fun LI.errorDescription(error: ResolvableIssue) {
+        p {
+            var first = true
+            error.description.lines().forEach {
+                if (first) first = false else br
+                +it
             }
         }
     }


### PR DESCRIPTION
Instead of using `unsafe` to be able to replace linebreaks with `<br>` use
a loop in combination with the `br` DSL function. This makes sure that
error strings are properly escaped. Otherwise HTML special characters like
`&` in the error message could cause a `SAXParseException`.

Signed-off-by: Martin Nonnenmacher <martin.nonnenmacher@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1161)
<!-- Reviewable:end -->
