### PR TITLE
spdx-utils: Support getting license texts for ScanCode LicenseRefs

### DIFF
--- a/spdx-utils/src/test/kotlin/SpdxUtilsTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxUtilsTest.kt
@@ -96,5 +96,16 @@ class SpdxUtilsTest : WordSpec({
                 getLicenseText(it.id) shouldNot beBlank()
             }
         }
+
+        "return the full license text for a known SPDX LicenseRef" {
+            val text = getLicenseText("LicenseRef-indiana-extreme").trim()
+
+            text should startWith("Indiana University Extreme! Lab Software License Version 1.1.1")
+            text should endWith("EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.")
+        }
+
+        "throw an exception for an unknown SPDX LicenseRef" {
+            shouldThrow<IOException> { getLicenseText("LicenseRef-foo-bar") }
+        }
     }
 })


### PR DESCRIPTION
Embedding license text for LicenseRefs is a bit tricky as there is no
fixed list of LicenseRefs that ScanCode supports, so download license
texts for LicenseRefs on the fly instead.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1168)
<!-- Reviewable:end -->
