### PR TITLE
HTML report: Add row indexes and anchors

### DIFF
--- a/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
+++ b/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
@@ -135,6 +135,8 @@ table.ort-excluded tr.ort-excluded td li.ort-excluded {
 }
 
 .ort-report-table th:first-child {
+  width: 30px;
+  white-space: nowrap;
   border-top-left-radius: .28rem;
   border-left: 1px solid rgba(34,36,38,.15);
   border-top: 1px solid rgba(34,36,38,.15);
@@ -276,24 +278,24 @@ table.ort-excluded tr.ort-excluded td li.ort-excluded {
       <table class="ort-report-table ort-violations">
         <thead>
           <tr>
-            <th>Source</th><th>Error</th>
+            <th>#</th><th>Source</th><th>Error</th>
           </tr>
         </thead>
         <tbody>
-          <tr class="ort-error">
-            <td>GPL-1.0-only</td><td>
+          <tr class="ort-ruleViolation">
+            <td>1</td><td>GPL-1.0-only</td><td>
               <p>2019-01-02T17:23:55.486Z: GPL-1.0-only - GPL 1 error</p>
               <p></p>
             </td>
           </tr>
           <tr class="ort-warning">
-            <td>GPL-2.0-only</td><td>
+            <td>2</td><td>GPL-2.0-only</td><td>
               <p>2019-01-02T17:23:55.486Z: GPL-2.0-only - GPL 2 warning</p>
               <p></p>
             </td>
           </tr>
           <tr class="ort-hint">
-            <td>GPL-3.0-only</td><td>
+            <td>3</td><td>GPL-3.0-only</td><td>
               <p>2019-01-02T17:23:55.486Z: GPL-3.0-only - GPL 3 hint</p>
               <p></p>
             </td>
@@ -306,12 +308,12 @@ table.ort-excluded tr.ort-excluded td li.ort-excluded {
       <table class="ort-report-table">
         <thead>
           <tr>
-            <th>Package</th><th>Analyzer Errors</th><th>Scanner Errors</th>
+            <th>#</th><th>Package</th><th>Analyzer Errors</th><th>Scanner Errors</th>
           </tr>
         </thead>
         <tbody>
           <tr class="ort-error">
-            <td>Gradle:com.here.ort.gradle.example:lib:1.0.0</td><td></td><td><a href="#Gradle:com.here.ort.gradle.example:lib:1.0.0">Gradle:com.here.ort.gradle.example:lib:1.0.0</a>
+            <td>1</td><td>Gradle:com.here.ort.gradle.example:lib:1.0.0</td><td></td><td><a href="#Gradle:com.here.ort.gradle.example:lib:1.0.0">Gradle:com.here.ort.gradle.example:lib:1.0.0</a>
               <ul>
                 <li>
                   <p>n/a: FileCounter - DownloadException: No source artifact URL provided for 'Gradle:com.here.ort.gradle.example:lib:1.0.0'.<br>Caused by: DownloadException: No VCS URL provided for 'Gradle:com.here.ort.gradle.example:lib:1.0.0'. Please make sure the release POM file includes the SCM connection, see: https://docs.gradle.org/current/userguide/publishing_maven.html#example_customizing_the_pom_file</p>
@@ -344,12 +346,12 @@ table.ort-excluded tr.ort-excluded td li.ort-excluded {
       <table class="ort-report-table ort-packages ">
         <thead>
           <tr>
-            <th>Package</th><th>Scopes</th><th>Licenses</th><th>Analyzer Errors</th><th>Scanner Errors</th>
+            <th>#</th><th>Package</th><th>Scopes</th><th>Licenses</th><th>Analyzer Errors</th><th>Scanner Errors</th>
           </tr>
         </thead>
         <tbody>
           <tr class="ort-error ">
-            <td>Gradle:com.here.ort.gradle.example:lib:1.0.0</td><td></td><td><em>Detected Licenses:</em>
+            <td>1</td><td>Gradle:com.here.ort.gradle.example:lib:1.0.0</td><td></td><td><em>Detected Licenses:</em>
               <dl>
                 <dd>MIT</dd>
               </dl>
@@ -364,7 +366,7 @@ table.ort-excluded tr.ort-excluded td li.ort-excluded {
             </td>
           </tr>
           <tr class="ort-success ">
-            <td>Maven:junit:junit:4.12</td><td>
+            <td>2</td><td>Maven:junit:junit:4.12</td><td>
               <ul>
                 <li class="">testCompile</li>
               </ul>
@@ -379,7 +381,7 @@ table.ort-excluded tr.ort-excluded td li.ort-excluded {
             </td>
           </tr>
           <tr class="ort-success ">
-            <td>Maven:org.apache.commons:commons-lang3:3.5</td><td>
+            <td>3</td><td>Maven:org.apache.commons:commons-lang3:3.5</td><td>
               <ul>
                 <li class="">compile</li>
                 <li class="">testCompile</li>
@@ -395,7 +397,7 @@ table.ort-excluded tr.ort-excluded td li.ort-excluded {
             </td>
           </tr>
           <tr class="ort-success ">
-            <td>Maven:org.apache.commons:commons-text:1.1</td><td>
+            <td>4</td><td>Maven:org.apache.commons:commons-text:1.1</td><td>
               <ul>
                 <li class="">compile</li>
                 <li class="">testCompile</li>
@@ -411,7 +413,7 @@ table.ort-excluded tr.ort-excluded td li.ort-excluded {
             </td>
           </tr>
           <tr class="ort-success ">
-            <td>Maven:org.hamcrest:hamcrest-core:1.3</td><td>
+            <td>5</td><td>Maven:org.hamcrest:hamcrest-core:1.3</td><td>
               <ul>
                 <li class="">testCompile</li>
               </ul>

--- a/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
+++ b/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
@@ -282,20 +282,20 @@ table.ort-excluded tr.ort-excluded td li.ort-excluded {
           </tr>
         </thead>
         <tbody>
-          <tr class="ort-ruleViolation">
-            <td>1</td><td>GPL-1.0-only</td><td>
+          <tr class="ort-ruleViolation" id="violation-1">
+            <td><a href="#violation-1">1</a></td><td>GPL-1.0-only</td><td>
               <p>2019-01-02T17:23:55.486Z: GPL-1.0-only - GPL 1 error</p>
               <p></p>
             </td>
           </tr>
-          <tr class="ort-warning">
-            <td>2</td><td>GPL-2.0-only</td><td>
+          <tr class="ort-warning" id="violation-2">
+            <td><a href="#violation-2">2</a></td><td>GPL-2.0-only</td><td>
               <p>2019-01-02T17:23:55.486Z: GPL-2.0-only - GPL 2 warning</p>
               <p></p>
             </td>
           </tr>
-          <tr class="ort-hint">
-            <td>3</td><td>GPL-3.0-only</td><td>
+          <tr class="ort-hint" id="violation-3">
+            <td><a href="#violation-3">3</a></td><td>GPL-3.0-only</td><td>
               <p>2019-01-02T17:23:55.486Z: GPL-3.0-only - GPL 3 hint</p>
               <p></p>
             </td>
@@ -312,8 +312,8 @@ table.ort-excluded tr.ort-excluded td li.ort-excluded {
           </tr>
         </thead>
         <tbody>
-          <tr class="ort-error">
-            <td>1</td><td>Gradle:com.here.ort.gradle.example:lib:1.0.0</td><td></td><td><a href="#Gradle:com.here.ort.gradle.example:lib:1.0.0">Gradle:com.here.ort.gradle.example:lib:1.0.0</a>
+          <tr class="ort-error" id="error-1">
+            <td><a href="#error-1">1</a></td><td>Gradle:com.here.ort.gradle.example:lib:1.0.0</td><td></td><td><a href="#Gradle:com.here.ort.gradle.example:lib:1.0.0">Gradle:com.here.ort.gradle.example:lib:1.0.0</a>
               <ul>
                 <li>
                   <p>n/a: FileCounter - DownloadException: No source artifact URL provided for 'Gradle:com.here.ort.gradle.example:lib:1.0.0'.<br>Caused by: DownloadException: No VCS URL provided for 'Gradle:com.here.ort.gradle.example:lib:1.0.0'. Please make sure the release POM file includes the SCM connection, see: https://docs.gradle.org/current/userguide/publishing_maven.html#example_customizing_the_pom_file</p>
@@ -350,8 +350,8 @@ table.ort-excluded tr.ort-excluded td li.ort-excluded {
           </tr>
         </thead>
         <tbody>
-          <tr class="ort-error ">
-            <td>1</td><td>Gradle:com.here.ort.gradle.example:lib:1.0.0</td><td></td><td><em>Detected Licenses:</em>
+          <tr class="ort-error " id="Gradle:com.here.ort.gradle.example:lib:1.0.0-pkg-1">
+            <td><a href="#Gradle:com.here.ort.gradle.example:lib:1.0.0-pkg-1">1</a></td><td>Gradle:com.here.ort.gradle.example:lib:1.0.0</td><td></td><td><em>Detected Licenses:</em>
               <dl>
                 <dd>MIT</dd>
               </dl>
@@ -365,8 +365,8 @@ table.ort-excluded tr.ort-excluded td li.ort-excluded {
               </ul>
             </td>
           </tr>
-          <tr class="ort-success ">
-            <td>2</td><td>Maven:junit:junit:4.12</td><td>
+          <tr class="ort-success " id="Gradle:com.here.ort.gradle.example:lib:1.0.0-pkg-2">
+            <td><a href="#Gradle:com.here.ort.gradle.example:lib:1.0.0-pkg-2">2</a></td><td>Maven:junit:junit:4.12</td><td>
               <ul>
                 <li class="">testCompile</li>
               </ul>
@@ -380,8 +380,8 @@ table.ort-excluded tr.ort-excluded td li.ort-excluded {
               <ul></ul>
             </td>
           </tr>
-          <tr class="ort-success ">
-            <td>3</td><td>Maven:org.apache.commons:commons-lang3:3.5</td><td>
+          <tr class="ort-success " id="Gradle:com.here.ort.gradle.example:lib:1.0.0-pkg-3">
+            <td><a href="#Gradle:com.here.ort.gradle.example:lib:1.0.0-pkg-3">3</a></td><td>Maven:org.apache.commons:commons-lang3:3.5</td><td>
               <ul>
                 <li class="">compile</li>
                 <li class="">testCompile</li>
@@ -396,8 +396,8 @@ table.ort-excluded tr.ort-excluded td li.ort-excluded {
               <ul></ul>
             </td>
           </tr>
-          <tr class="ort-success ">
-            <td>4</td><td>Maven:org.apache.commons:commons-text:1.1</td><td>
+          <tr class="ort-success " id="Gradle:com.here.ort.gradle.example:lib:1.0.0-pkg-4">
+            <td><a href="#Gradle:com.here.ort.gradle.example:lib:1.0.0-pkg-4">4</a></td><td>Maven:org.apache.commons:commons-text:1.1</td><td>
               <ul>
                 <li class="">compile</li>
                 <li class="">testCompile</li>
@@ -412,8 +412,8 @@ table.ort-excluded tr.ort-excluded td li.ort-excluded {
               <ul></ul>
             </td>
           </tr>
-          <tr class="ort-success ">
-            <td>5</td><td>Maven:org.hamcrest:hamcrest-core:1.3</td><td>
+          <tr class="ort-success " id="Gradle:com.here.ort.gradle.example:lib:1.0.0-pkg-5">
+            <td><a href="#Gradle:com.here.ort.gradle.example:lib:1.0.0-pkg-5">5</a></td><td>Maven:org.hamcrest:hamcrest-core:1.3</td><td>
               <ul>
                 <li class="">testCompile</li>
               </ul>

--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -175,6 +175,8 @@ class StaticHtmlReporter : Reporter() {
         }
 
         .ort-report-table th:first-child {
+          width: 30px;
+          white-space: nowrap;
           border-top-left-radius: .28rem;
           border-left: 1px solid rgba(34,36,38,.15);
           border-top: 1px solid rgba(34,36,38,.15);
@@ -418,17 +420,22 @@ class StaticHtmlReporter : Reporter() {
             table("ort-report-table ort-violations") {
                 thead {
                     tr {
+                        th { +"#" }
                         th { +"Source" }
                         th { +"Error" }
                     }
                 }
 
-                tbody { ruleViolations.forEach { evaluatorRow(it) } }
+                tbody {
+                    ruleViolations.forEachIndexed { rowIndex, ruleViolation ->
+                        evaluatorRow(rowIndex + 1, ruleViolation)
+                    }
+                }
             }
         }
     }
 
-    private fun TBODY.evaluatorRow(ruleViolation: ResolvableIssue) {
+    private fun TBODY.evaluatorRow(rowIndex: Int, ruleViolation: ResolvableIssue) {
         val cssClass = if (ruleViolation.isResolved) {
             "ort-resolved"
         } else {
@@ -440,6 +447,7 @@ class StaticHtmlReporter : Reporter() {
         }
 
         tr(cssClass) {
+            td { +rowIndex.toString() }
             td { +ruleViolation.source }
             td {
                 p { +ruleViolation.description }
@@ -461,18 +469,24 @@ class StaticHtmlReporter : Reporter() {
         table("ort-report-table") {
             thead {
                 tr {
+                    th { +"#" }
                     th { +"Package" }
                     th { +"Analyzer Errors" }
                     th { +"Scanner Errors" }
                 }
             }
 
-            tbody { errorSummary.rows.forEach { errorRow(it) } }
+            tbody {
+                errorSummary.rows.forEachIndexed { rowIndex, error ->
+                    errorRow(rowIndex + 1, error)
+                }
+            }
         }
     }
 
-    private fun TBODY.errorRow(row: ReportTableModel.ErrorRow) {
+    private fun TBODY.errorRow(rowIndex: Int, row: ReportTableModel.ErrorRow) {
         tr("ort-error") {
+            td { +rowIndex.toString() }
             td { +"${row.id}" }
 
             td {
@@ -554,6 +568,7 @@ class StaticHtmlReporter : Reporter() {
         table("ort-report-table ort-packages $excludedClass") {
             thead {
                 tr {
+                    th { +"#" }
                     th { +"Package" }
                     th { +"Scopes" }
                     th { +"Licenses" }
@@ -562,11 +577,15 @@ class StaticHtmlReporter : Reporter() {
                 }
             }
 
-            tbody { table.rows.forEach { projectRow(it) } }
+            tbody {
+                table.rows.forEachIndexed { rowIndex, pkg ->
+                    projectRow(rowIndex + 1, pkg)
+                }
+            }
         }
     }
 
-    private fun TBODY.projectRow(row: ReportTableModel.DependencyRow) {
+    private fun TBODY.projectRow(rowIndex: Int, row: ReportTableModel.DependencyRow) {
         // Only mark the row as excluded if all scopes the dependency appears in are excluded.
         val rowExcludedClass =
                 if (row.scopes.isNotEmpty() && row.scopes.all { it.value.isNotEmpty() }) "ort-excluded" else ""
@@ -578,6 +597,7 @@ class StaticHtmlReporter : Reporter() {
         }
 
         tr("$cssClass $rowExcludedClass") {
+            td { +rowIndex.toString() }
             td { +"${row.id}" }
 
             td {

--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -406,13 +406,13 @@ class StaticHtmlReporter : Reporter() {
         }
     }
 
-    private fun DIV.evaluatorTable(evaluatorErrors: List<ResolvableIssue>) {
+    private fun DIV.evaluatorTable(ruleViolations: List<ResolvableIssue>) {
         h2 {
             id = "policy-violation-summary"
-            +"Rule Violation Summary (${evaluatorErrors.size} violations)"
+            +"Rule Violation Summary (${ruleViolations.size} violations)"
         }
 
-        if (evaluatorErrors.isEmpty()) {
+        if (ruleViolations.isEmpty()) {
             +"No issues found."
         } else {
             table("ort-report-table ort-violations") {
@@ -423,27 +423,27 @@ class StaticHtmlReporter : Reporter() {
                     }
                 }
 
-                tbody { evaluatorErrors.forEach { evaluatorRow(it) } }
+                tbody { ruleViolations.forEach { evaluatorRow(it) } }
             }
         }
     }
 
-    private fun TBODY.evaluatorRow(error: ResolvableIssue) {
-        val cssClass = if (error.isResolved) {
+    private fun TBODY.evaluatorRow(ruleViolation: ResolvableIssue) {
+        val cssClass = if (ruleViolation.isResolved) {
             "ort-resolved"
         } else {
-            when (error.severity) {
-                Severity.ERROR -> "ort-error"
+            when (ruleViolation.severity) {
+                Severity.ERROR -> "ort-ruleViolation"
                 Severity.WARNING -> "ort-warning"
                 Severity.HINT -> "ort-hint"
             }
         }
 
         tr(cssClass) {
-            td { +error.source }
+            td { +ruleViolation.source }
             td {
-                p { +error.description }
-                p { +error.resolutionDescription }
+                p { +ruleViolation.description }
+                p { +ruleViolation.resolutionDescription }
             }
         }
     }

--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -446,8 +446,16 @@ class StaticHtmlReporter : Reporter() {
             }
         }
 
+        val rowId = "violation-$rowIndex"
+
         tr(cssClass) {
-            td { +rowIndex.toString() }
+            id = rowId
+            td {
+                a  {
+                    href = "#$rowId"
+                    +rowIndex.toString()
+                }
+            }
             td { +ruleViolation.source }
             td {
                 p { +ruleViolation.description }
@@ -485,8 +493,16 @@ class StaticHtmlReporter : Reporter() {
     }
 
     private fun TBODY.errorRow(rowIndex: Int, row: ReportTableModel.ErrorRow) {
+        val rowId = "error-$rowIndex"
+
         tr("ort-error") {
-            td { +rowIndex.toString() }
+            id = rowId
+            td {
+                a  {
+                    href = "#$rowId"
+                    +rowIndex.toString()
+                }
+            }
             td { +"${row.id}" }
 
             td {
@@ -579,13 +595,13 @@ class StaticHtmlReporter : Reporter() {
 
             tbody {
                 table.rows.forEachIndexed { rowIndex, pkg ->
-                    projectRow(rowIndex + 1, pkg)
+                    projectRow(project.id.toString(), rowIndex + 1, pkg)
                 }
             }
         }
     }
 
-    private fun TBODY.projectRow(rowIndex: Int, row: ReportTableModel.DependencyRow) {
+    private fun TBODY.projectRow(projectId: String, rowIndex: Int, row: ReportTableModel.DependencyRow) {
         // Only mark the row as excluded if all scopes the dependency appears in are excluded.
         val rowExcludedClass =
                 if (row.scopes.isNotEmpty() && row.scopes.all { it.value.isNotEmpty() }) "ort-excluded" else ""
@@ -596,8 +612,16 @@ class StaticHtmlReporter : Reporter() {
             else -> "ort-success"
         }
 
+        val rowId = "$projectId-pkg-$rowIndex"
+
         tr("$cssClass $rowExcludedClass") {
-            td { +rowIndex.toString() }
+            id = rowId
+            td {
+                a  {
+                    href = "#$rowId"
+                    +rowIndex.toString()
+                }
+            }
             td { +"${row.id}" }
 
             td {


### PR DESCRIPTION
Add row indexes to all the tables of the HTML report to increase readablity.
Moreover add anchors to the rows of the error and rule violation summary table to enable
linking to a specific issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1173)
<!-- Reviewable:end -->
