### PR TITLE
StaticHtmlReporter: Remove the invalid "ort-errors" class

### DIFF
--- a/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
+++ b/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
@@ -303,7 +303,7 @@ table.ort-excluded tr.ort-excluded td li.ort-excluded {
       <h2 id="error-summary">Error Summary (1 errors)</h2>
       <p>Errors from excluded components are not shown in this summary.</p>
       <h3>Packages</h3>
-      <table class="ort-report-table ort-errors">
+      <table class="ort-report-table">
         <thead>
           <tr>
             <th>Package</th><th>Analyzer Errors</th><th>Scanner Errors</th>

--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -458,7 +458,7 @@ class StaticHtmlReporter : Reporter() {
 
         h3 { +"Packages" }
 
-        table("ort-report-table ort-errors") {
+        table("ort-report-table") {
             thead {
                 tr {
                     th { +"Package" }


### PR DESCRIPTION
There is no such class, and it also should not be "ort-error" (singular)
as not all issues in the table are actually errors.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1174)
<!-- Reviewable:end -->
