### PR TITLE
Identifier: Extend isFromVendor() to also check .net and .org "domains"

### DIFF
--- a/model/src/main/kotlin/Identifier.kt
+++ b/model/src/main/kotlin/Identifier.kt
@@ -95,12 +95,12 @@ data class Identifier(
     fun isFromVendor(name: String): Boolean {
         val lowerName = name.toLowerCase()
         val vendorNamespace = when (type) {
-            "NPM" -> "@$lowerName"
-            "Gradle", "Maven", "SBT" -> "com.$lowerName"
+            "NPM" -> "^@$lowerName$"
+            "Gradle", "Maven", "SBT" -> "^(com|net|org)\\.$lowerName"
             else -> ""
         }
 
-        return vendorNamespace.isNotEmpty() && namespace.startsWith(vendorNamespace)
+        return vendorNamespace.isNotEmpty() && namespace.matches(vendorNamespace.toRegex())
     }
 
     /**

--- a/model/src/test/kotlin/IdentifierTest.kt
+++ b/model/src/test/kotlin/IdentifierTest.kt
@@ -21,6 +21,7 @@ package com.here.ort.model
 
 import com.fasterxml.jackson.module.kotlin.readValue
 
+import io.kotlintest.assertSoftly
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.StringSpec
 
@@ -131,6 +132,17 @@ class IdentifierTest : StringSpec() {
             val map = yamlMapper.readValue<Map<Identifier, Int>>(serializedMap)
 
             map shouldBe mapOf(Identifier("type", "namespace", "", "") to 1)
+        }
+
+        "Checking the vendor works as expected" {
+            assertSoftly {
+                Identifier("Maven:com.here:name:version").isFromVendor("here") shouldBe true
+                Identifier("Maven:org.apache:name:version").isFromVendor("apache") shouldBe true
+                Identifier("NPM:@scope:name:version").isFromVendor("scope") shouldBe true
+
+                Identifier("").isFromVendor("here") shouldBe false
+                Identifier("type:namespace:name:version").isFromVendor("here") shouldBe false
+            }
         }
     }
 }


### PR DESCRIPTION
Also add some tests along the way. Use kotlintest's "assertSoftly" [1]
as these checks are too small for tests on their own, but we still want
to see all possible failures, if any, at once.

[1] https://github.com/kotlintest/kotlintest/blob/master/doc/reference.md#soft-assertions

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1175)
<!-- Reviewable:end -->
