### PR TITLE
model: Refactor isFromVendor to isFromOrg which can take multiple names

### DIFF
--- a/model/src/main/kotlin/Identifier.kt
+++ b/model/src/main/kotlin/Identifier.kt
@@ -90,17 +90,19 @@ data class Identifier(
     override fun compareTo(other: Identifier) = toString().compareTo(other.toString())
 
     /**
-     * Return whether this [Identifier] is likely to belong to the vendor of the given [name].
+     * Return whether this [Identifier] is likely to belong any of the organizations mentioned in [names].
      */
-    fun isFromVendor(name: String): Boolean {
-        val lowerName = name.toLowerCase()
-        val vendorNamespace = when (type) {
-            "NPM" -> "^@$lowerName$"
-            "Gradle", "Maven", "SBT" -> "^(com|net|org)\\.$lowerName"
-            else -> ""
-        }
+    fun isFromOrg(vararg names: String): Boolean {
+        return names.any { name ->
+            val lowerName = name.toLowerCase()
+            val vendorNamespace = when (type) {
+                "NPM" -> "^@$lowerName$"
+                "Gradle", "Maven", "SBT" -> "^(com|net|org)\\.$lowerName"
+                else -> ""
+            }
 
-        return vendorNamespace.isNotEmpty() && namespace.matches(vendorNamespace.toRegex())
+            vendorNamespace.isNotEmpty() && namespace.matches(vendorNamespace.toRegex())
+        }
     }
 
     /**

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -90,24 +90,24 @@ data class OrtResult(
     }
 
     /**
-     * Return all projects and packages that are likely to belong to the vendor of the given [name]. If [omitExcluded]
-     * is set to true, excluded projects / packages are omitted from the result. Projects are converted to packages in
-     * the result. If no analyzer result is present an empty set is returned.
+     * Return all projects and packages that are likely to belong to one of the organizations of the given [names]. If
+     * [omitExcluded] is set to true, excluded projects / packages are omitted from the result. Projects are converted
+     * to packages in the result. If no analyzer result is present an empty set is returned.
      */
     @Suppress("UNUSED") // This is intended to be mostly used via scripting.
-    fun getVendorPackages(name: String, omitExcluded: Boolean = false): SortedSet<Package> {
+    fun getOrgPackages(vararg names: String, omitExcluded: Boolean = false): SortedSet<Package> {
         val vendorPackages = sortedSetOf<Package>()
         val excludes = repository.config.excludes.takeIf { omitExcluded }
 
         analyzer?.result?.apply {
             projects.filter {
-                it.id.isFromVendor(name) && excludes?.isProjectExcluded(it) != true
+                it.id.isFromOrg(*names) && excludes?.isProjectExcluded(it) != true
             }.mapTo(vendorPackages) {
                 it.toPackage()
             }
 
             packages.filter { (pkg, _) ->
-                pkg.id.isFromVendor(name) && excludes?.isPackageExcluded(pkg.id, analyzer.result) != true
+                pkg.id.isFromOrg(*names) && excludes?.isPackageExcluded(pkg.id, analyzer.result) != true
             }.mapTo(vendorPackages) {
                 it.pkg
             }

--- a/model/src/test/kotlin/IdentifierTest.kt
+++ b/model/src/test/kotlin/IdentifierTest.kt
@@ -136,12 +136,12 @@ class IdentifierTest : StringSpec() {
 
         "Checking the vendor works as expected" {
             assertSoftly {
-                Identifier("Maven:com.here:name:version").isFromVendor("here") shouldBe true
-                Identifier("Maven:org.apache:name:version").isFromVendor("apache") shouldBe true
-                Identifier("NPM:@scope:name:version").isFromVendor("scope") shouldBe true
+                Identifier("Maven:com.here:name:version").isFromOrg("here", "traffic") shouldBe true
+                Identifier("Maven:org.apache:name:version").isFromOrg("apache") shouldBe true
+                Identifier("NPM:@scope:name:version").isFromOrg("scope") shouldBe true
 
-                Identifier("").isFromVendor("here") shouldBe false
-                Identifier("type:namespace:name:version").isFromVendor("here") shouldBe false
+                Identifier("").isFromOrg("here") shouldBe false
+                Identifier("type:namespace:name:version").isFromOrg("here") shouldBe false
             }
         }
     }


### PR DESCRIPTION
A single vendor, like HERE, can in fact claim multiple package
namespaces, like "com.here" and "com.traffic" for Maven.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1177)
<!-- Reviewable:end -->
