### PR TITLE
reporter: Get license texts also for non-SPDX licenses

### DIFF
--- a/reporter/src/funTest/assets/NPM-is-windows-1.0.2-expected-NOTICE
+++ b/reporter/src/funTest/assets/NPM-is-windows-1.0.2-expected-NOTICE
@@ -1996,6 +1996,87 @@ THIS SOFTWARE.
 
 ----
 
+
+
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+
+
+----
+
+Public Domain
+
+No warranty expressed or implied. Use at your own risk.
+
+This file has been superceded by http://www.JSON.org/json2.js
+
+See http://www.JSON.org/js.html
+
+----
+
+json2.js
+ 2011-10-19
+
+ Public Domain.
+
+ NO WARRANTY EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+
+ See http://www.JSON.org/js.html
+
+This code should be minified before deployment.
+See http://javascript.crockford.com/jsmin.html
+
+USE YOUR OWN COPY. IT IS EXTREMELY UNWISE TO LOAD CODE FROM SERVERS YOU DO NOT CONTROL.
+
+----
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with
+or without fee is hereby granted, provided that the above copyright notice and this
+permission notice appear in all copies.
+
+The software is  provided "as is", without warranty of any kind, including all
+implied warranties of merchantability and fitness. In no event shall the authors or
+copyright holders be liable for any claim, damages, or other liability, whether in an
+action of contract, tort, or otherwise, arising from, out of, or in connection with
+the software or the use or other dealings in the software.
+
+----
+
 Code copyright 2012-2018 AJ ONeal
 CxD Copyright 2011 by Jan Tonellato.
 TarHeader (c)
@@ -2014,7 +2095,7 @@ Copyright (c) 2014 Component
 (c) 2010 Esa-Matti Suuronen
 Copyright (c) 2011 Esa-Matti Suuronen esa-matti@suuronen.org
 Copyright (c) Feross Aboukhadijeh
-Copyright (c) Feross Aboukhadijeh (http://feross.org)
+Copyright (c) Feross Aboukhadijeh (http://feross.org).
 (c) 2010-2015 Google, Inc. http://angularjs.org
 Copyright (c) 2014 Gregory Jacobs (http://greg-jacobs.com)
 Copyright (c) 2015 Gregory Jacobs <greg@greg-jacobs.com> MIT Licensed. http://www.opensource.org/licenses/mit-license.php
@@ -2033,11 +2114,11 @@ copyright 2009-2015 Jeremy Ashkenas, DocumentCloud and Investigative Reporters &
 Copyright 2011 John Resig
 Copyright 2010-2014 John-David Dalton <http://allyoucanleet.com/>
 Copyright (c) 2014-2015 Jon
+Copyright (c) 2013-2018 Jon Schlinkert
 Copyright (c) 2016 Jon Schlinkert (http://github.com/jonschlinkert).
 Copyright (c) 2015-2018 Jon Schlinkert (https://github.com/jonschlinkert)
 Copyright (c) 2014 Jon Schlinkert, Vitaly Puzrin.
 Copyright (c) 2014 Jon Schlinkert, contributors.
-Copyright (c) 2013-2018 Jon Schlinkert.
 Copyright (c) 2016 Joshua Boy Nicolai Appelman <joshua@jbna.nl>
 Copyright Joyent, Inc. and other Node contributors.
 Copyright (c) 2013 Julian Gruber <julian@juliangruber.com>

--- a/reporter/src/funTest/assets/NPM-is-windows-1.0.2-expected-NOTICE_UNPROCESSED
+++ b/reporter/src/funTest/assets/NPM-is-windows-1.0.2-expected-NOTICE_UNPROCESSED
@@ -261,18 +261,18 @@ POSSIBILITY OF SUCH DAMAGE.
 
 ----
 
-Copyright (c) 2007, Parakey Inc.
-Copyright (c) 2008 Ariel Flesler
-Copyright (c) 2009-2011, Mozilla Foundation and contributors
 Copyright (c) 2009-2015, Kevin Decker <kpdecker@gmail.com>
 Copyright 2009, Microsoft Corporation.
+Copyright (c) 2007, Parakey Inc.
 Copyright 2009, The Dojo Foundation
+Copyright (c) 2009-2011, Mozilla Foundation and contributors
 Copyright 2009-2011 Mozilla Foundation and contributors
 Copyright 2011 Mozilla Foundation and contributors
 Copyright 2011 The Closure Compiler
-Copyright 2011, The Dojo Foundation
 Copyright 2012 Mozilla Foundation and contributors
 Copyright 2014 Mozilla Foundation and contributors
+Copyright (c) 2008 Ariel Flesler
+Copyright 2011, The Dojo Foundation
 
 Copyright (c) <year> <owner> . All rights reserved.
 
@@ -1985,8 +1985,8 @@ of this License.
 
 ----
 
-Copyright (c) Isaac Z. Schlueter
 Copyright (c) Isaac Z. Schlueter and Contributors
+Copyright (c) Isaac Z. Schlueter
 
 Permission to use, copy, modify, and/or distribute this software for any purpose
 with or without fee is hereby granted, provided that the above copyright notice
@@ -2002,142 +2002,223 @@ THIS SOFTWARE.
 
 ----
 
-(c) (c) (tm)
-(c) 2005-2009 Sam Stephenson
-(c) 2009-2012 Jeremy Ashkenas, DocumentCloud Inc.
-(c) 2009-2014 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors Underscore
-(c) 2009-2015, Jeremy Ashkenas.
-(c) 2010 Esa-Matti Suuronen
-(c) 2010-2014 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors Backbone
-(c) 2010-2015 Google, Inc. http://angularjs.org
-(c) 2012-2014 http://kitcambridge.be/' Kit Cambridge
-(c) 2012-2015, The Dojo Foundation.copyright
-(c) Sam Verschueren (https://github.com/SamVerschueren)
-(c) Sindre Sorhus (http://sindresorhus.com)
-(c) Sindre Sorhus (https://sindresorhus.com)
-(c) Vasily Polovnyov <vast@whiteants.net>
-(c) copyright 2010-2013 B Cavalier & J Hann
-Code copyright 2012-2018 AJ ONeal
-Copyright (c) 2008-2009, Robert Kieffer
-Copyright (c) 2009 TJ Holowaychuk <tj@vision-media.ca>
-Copyright (c) 2009-2014 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
-Copyright (c) 2010-2011 Marcus Westin
-Copyright (c) 2010-2014 Jeremy Ashkenas, DocumentCloud
-Copyright (c) 2010-2014, The Dojo Foundation
-Copyright (c) 2011 Esa-Matti Suuronen esa-matti@suuronen.org
-Copyright (c) 2011 TJ Holowaychuk <tj@vision-media.ca>
-Copyright (c) 2011 by fent
-Copyright (c) 2011-2013, Christopher Jeffrey. (MIT Licensed) https://github.com/chjj/marked
-Copyright (c) 2011-2015 Paul Vorbach <paul@vorba.ch>
-Copyright (c) 2011-2016 Paul Vorbach (https://paul.vorba.ch/) and contributors (https://github.com/pvorb/clone/graphs/contributors).
-Copyright (c) 2011-2017 JS Foundation
+
+
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+
+
+----
+
+Public Domain
+
+No warranty expressed or implied. Use at your own risk.
+
+This file has been superceded by http://www.JSON.org/json2.js
+
+See http://www.JSON.org/js.html
+
+----
+
+json2.js
+ 2011-10-19
+
+ Public Domain.
+
+ NO WARRANTY EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+
+ See http://www.JSON.org/js.html
+
+This code should be minified before deployment.
+See http://javascript.crockford.com/jsmin.html
+
+USE YOUR OWN COPY. IT IS EXTREMELY UNWISE TO LOAD CODE FROM SERVERS YOU DO NOT CONTROL.
+
+----
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with
+or without fee is hereby granted, provided that the above copyright notice and this
+permission notice appear in all copies.
+
+The software is  provided "as is", without warranty of any kind, including all
+implied warranties of merchantability and fitness. In no event shall the authors or
+copyright holders be liable for any claim, damages, or other liability, whether in an
+action of contract, tort, or otherwise, arising from, out of, or in connection with
+the software or the use or other dealings in the software.
+
+----
+
+Copyright (c) 2015 Jon Schlinkert
+Copyright (c) 2015, Jon Schlinkert.
+Copyright (c) < year() > , Jon Schlinkert.
 Copyright (c) 2012 Vitaly Puzrin (https://github.com/puzrin).
 Copyright (c) 2012 by Vitaly Puzrin
-Copyright (c) 2012-2014 Kit Cambridge. http://kitcambridge.be
-Copyright (c) 2012-2014 Raynos.
-Copyright (c) 2013 Blaine Bublitz <blaine.bublitz@gmail.com> , Eric Schoffstall <yo@contra.io> and other contributors
-Copyright (c) 2013 Julian Gruber <julian@juliangruber.com>
-Copyright (c) 2013 Rod Vagg rvagg (https://twitter.com/rvagg)
-Copyright (c) 2013 Simon Lydell
-Copyright (c) 2013-2017, Jon Schlinkert.
-Copyright (c) 2014 Blaine Bublitz <blaine.bublitz@gmail.com> , Eric Schoffstall <yo@contra.io> and other contributors
-Copyright (c) 2014 Component
-Copyright (c) 2014 Gregory Jacobs (http://greg-jacobs.com)
-Copyright (c) 2014 Hugh Kennedy
-Copyright (c) 2014 Jon Schlinkert, Vitaly Puzrin.
-Copyright (c) 2014 Jon Schlinkert, contributors.
-Copyright (c) 2014 Nathan Rajlich <nathan@tootallnate.net>
-Copyright (c) 2014 Simon Lydell
-Copyright (c) 2014 TJ Holowaychuk <tj@vision-media.ca>
-Copyright (c) 2014, 2015, 2016, 2017 Simon Lydell
-Copyright (c) 2014, 2017, Jon Schlinkert.
-Copyright (c) 2014-2015 Jon Schlinkert.
-Copyright (c) 2014-2015, 2017, Jon Schlinkert
-Copyright (c) 2014-2015, 2017, Jon Schlinkert.
-Copyright (c) 2014-2015, Jon
 Copyright (c) 2014-2015, Jon Schlinkert.
-Copyright (c) 2014-2016 TJ Holowaychuk <tj@vision-media.ca>
-Copyright (c) 2014-2016, Jon Schlinkert
 Copyright (c) 2014-2016, Jon Schlinkert.
-Copyright (c) 2014-2017, Jon Schlinkert
-Copyright (c) 2014-2017, Jon Schlinkert.
-Copyright (c) 2014-2018, Jon Schlinkert.
-Copyright (c) 2015
-Copyright (c) 2015 AJ ONeal
-Copyright (c) 2015 Calvin Metcalf
-Copyright (c) 2015 Gregory Jacobs <greg@greg-jacobs.com> MIT Licensed. http://www.opensource.org/licenses/mit-license.php
-Copyright (c) 2015 Jon Schlinkert
-Copyright (c) 2015 Jon Schlinkert (https://github.com/jonschlinkert)
-Copyright (c) 2015 Jon Schlinkert.
-Copyright (c) 2015 Zhiye Li
+Copyright (c) 2016 Jon Schlinkert (https://github.com/jonschlinkert)
 Copyright (c) 2015, 2017, Jon Schlinkert
 Copyright (c) 2015, 2017, Jon Schlinkert.
-Copyright (c) 2015, 2017-2018, Jon Schlinkert.
-Copyright (c) 2015, Jon Schlinkert.
-Copyright (c) 2015-2016, Jon Schlinkert
-Copyright (c) 2015-2016, Jon Schlinkert.
-Copyright (c) 2015-2017, Jon Schlinkert
-Copyright (c) 2015-2017, Jon Schlinkert.
-Copyright (c) 2015-2018, Jon Schlinkert.
-Copyright (c) 2016 Blaine Bublitz <blaine.bublitz@gmail.com> , Eric Schoffstall <yo@contra.io> and other contributors
-Copyright (c) 2016 Jon Schlinkert (https://github.com/jonschlinkert)
-Copyright (c) 2016 Joshua Boy Nicolai Appelman <joshua@jbna.nl>
-Copyright (c) 2016 Matteo Collina
-Copyright (c) 2016 Rod Vagg
-Copyright (c) 2016 Segment.io, Inc. (friends@segment.com)
-Copyright (c) 2016 Zeit, Inc.
-Copyright (c) 2016, 2018, Jon Schlinkert.
-Copyright (c) 2016, Brian Woodward (https://github.com/doowb).
-Copyright (c) 2016, Brian Woodward.
-Copyright (c) 2016, Jon Schlinkert (http://github.com/jonschlinkert).
-Copyright (c) 2016, Jon Schlinkert (https://github.com/jonschlinkert).
-Copyright (c) 2016, Jon Schlinkert.
-Copyright (c) 2016-2018, Jon Schlinkert.
-Copyright (c) 2017 Jon Schlinkert
 Copyright (c) 2017, Jon Schlinkert (https://github.com/jonschlinkert).
-Copyright (c) 2018, Jon Schlinkert (https://github.com/jonschlinkert).
-Copyright (c) < year() > , Jon Schlinkert.
-Copyright (c) Alexandru Marasteanu
-Copyright (c) Feross Aboukhadijeh
-Copyright (c) Feross Aboukhadijeh (http://feross.org)
-Copyright (c) Feross Aboukhadijeh (http://feross.org).
-Copyright (c) Sam Verschueren <sam.verschueren@gmail.com>
-Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
-Copyright 2009, 2010, 2011 Isaac Z. Schlueter.
-Copyright 2009, The Dojo Foundation
-Copyright 2009-2013 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+(c) 2009-2015, Jeremy Ashkenas.
+(c) 2012-2015, The Dojo Foundation.copyright
+Copyright (c) 2014 Jon Schlinkert, contributors.
+Copyright (c) 2014-2015, Jon
 Copyright 2009-2014 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
-Copyright 2009-2015 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+Copyright 2012-2014 The Dojo Foundation <http://dojofoundation.org/>
+Code copyright 2012-2018 AJ ONeal
+Copyright (c) 2015 AJ ONeal
+copyright 2012-2018 AJ ONeal
+Copyright (c) 2014 Gregory Jacobs (http://greg-jacobs.com)
+Copyright (c) 2015 Gregory Jacobs <greg@greg-jacobs.com> MIT Licensed. http://www.opensource.org/licenses/mit-license.php
+Copyright (c) 2013 Julian Gruber <julian@juliangruber.com>
+Copyright (c) 2015-2016, Jon Schlinkert.
+Copyright (c) 2014-2017, Jon Schlinkert.
+Copyright (c) 2015, 2017-2018, Jon Schlinkert.
+Copyright (c) 2018, Jon Schlinkert (https://github.com/jonschlinkert).
+Copyright (c) 2016 Blaine Bublitz <blaine.bublitz@gmail.com> , Eric Schoffstall <yo@contra.io> and other contributors
+Copyright (c) 2014 Hugh Kennedy
+Copyright (c) 2011-2015 Paul Vorbach <paul@vorba.ch>
+Copyright (c) 2011-2016 Paul Vorbach (https://paul.vorba.ch/) and contributors (https://github.com/pvorb/clone/graphs/contributors).
+Copyright (c) 2016 Matteo Collina
+Copyright (c) 2015-2016, Jon Schlinkert
+Copyright (c) 2011 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2014 Component
+Copyright (c) 2016, Jon Schlinkert (https://github.com/jonschlinkert).
+Copyright Joyent, Inc. and other Node contributors.
+Copyright (c) 2014 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2014-2016 TJ Holowaychuk <tj@vision-media.ca>
+(c) Sam Verschueren (https://github.com/SamVerschueren)
+Copyright (c) Sam Verschueren <sam.verschueren@gmail.com>
+Copyright (c) 2015-2018, Jon Schlinkert.
+(c) Sindre Sorhus (http://sindresorhus.com)
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+Copyright (c) 2016, Jon Schlinkert.
+Copyright (c) 2014-2015, 2017, Jon Schlinkert.
+Copyright (c) 2014-2018, Jon Schlinkert.
+Copyright (c) 2014-2017, Jon Schlinkert
+Copyright (c) 2014, 2017, Jon Schlinkert.
+Copyright (c) 2014-2015, 2017, Jon Schlinkert
+Copyright (c) 2015 Zhiye Li
+Copyright (c) 2009 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2016 Joshua Boy Nicolai Appelman <joshua@jbna.nl>
+Copyright TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2015-2017, Jon Schlinkert.
+Copyright Mathias Bynens <https://mathiasbynens.be/>
+Copyright (c) 2015 Jon Schlinkert (https://github.com/jonschlinkert)
+Copyright (c) Feross Aboukhadijeh
+Copyright (c) Feross Aboukhadijeh (http://feross.org).
+Copyright (c) 2015
+Copyright (c) 2014-2016, Jon Schlinkert
+(c) 2005-2009 Sam Stephenson
+(c) 2012-2014 http://kitcambridge.be/' Kit Cambridge
+(c) copyright 2010-2013 B Cavalier & J Hann
+Copyright (c) 2010-2014, The Dojo Foundation
+Copyright (c) 2011-2013, Christopher Jeffrey. (MIT Licensed) https://github.com/chjj/marked
+Copyright (c) 2012-2014 Kit Cambridge. http://kitcambridge.be
+Copyright 2009, 2010, 2011 Isaac Z. Schlueter.
+Copyright 2009-2013 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
 Copyright 2010 James Halliday (mail@substack.net)
 Copyright 2010-2014 John-David Dalton <http://allyoucanleet.com/>
 Copyright 2010-2014 Mathias Bynens <http://mths.be/>
-Copyright 2010-2015 Mathias Bynens <http://mathiasbynens.be/>
-Copyright 2010-2015 Mathias Bynens <http://mths.be/>
-Copyright 2011, John Resig
-Copyright 2011, The Dojo Foundation
 Copyright 2011-2014, Kit Cambridge http://kitcambridge.github.com
-Copyright 2012 jQuery Foundation and other contributors
 Copyright 2012, Kit Cambridge
 Copyright 2012-2013 The Dojo Foundation <http://dojofoundation.org/>
-Copyright 2012-2014 The Dojo Foundation <http://dojofoundation.org/>
 Copyright 2012-2014, Kit Cambridge http://kit.mit-license.org
+Copyright Mathias Bynens <http://mths.be/>
+TarHeader (c)
+copyright Robert Kieffer <http://broofa.com/>
+(c) 2009-2014 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors Underscore
+(c) 2010-2014 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors Backbone
+Copyright (c) 2009-2014 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+Copyright (c) 2010-2011 Marcus Westin
+Copyright (c) 2010-2014 Jeremy Ashkenas, DocumentCloud
+Copyright 2009, The Dojo Foundation
+Copyright 2009-2015 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+Copyright 2010-2015 Mathias Bynens <http://mathiasbynens.be/>
+Copyright 2010-2015 Mathias Bynens <http://mths.be/>
 Copyright 2012-2015 The Dojo Foundation <http://dojofoundation.org/>
-Copyright 2013 jQuery Foundation and other contributors
+copyright 2009-2015 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+Copyright (c) 2014-2015 Jon Schlinkert.
+Copyright (c) 2011-2017 JS Foundation
+Copyright (c) 2016 Segment.io, Inc. (friends@segment.com)
+Copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+Copyright jQuery Foundation and other contributors <https://jquery.org/>
+Copyright (c) 2016 Zeit, Inc.
+(c) Sindre Sorhus (https://sindresorhus.com)
+Copyright (c) 2015-2017, Jon Schlinkert
+Copyright (c) 2015 Calvin Metcalf
+Copyright (c) 2013-2017, Jon Schlinkert.
+Copyright (c) 2016, 2018, Jon Schlinkert.
+(c) (c) (tm)
+Copyright (c) 2014 Jon Schlinkert, Vitaly Puzrin.
+Copyright (c) 2015 Jon Schlinkert.
+Copyright (c) 2016, Jon Schlinkert (http://github.com/jonschlinkert).
+Copyright (c) 2014 Blaine Bublitz <blaine.bublitz@gmail.com> , Eric Schoffstall <yo@contra.io> and other contributors
+Copyright (c) 2013 Simon Lydell
 Copyright 2014 Simon Lydell X11 (MIT) Licensed.
+Copyright (c) 2011 by fent
+Copyright (c) Feross Aboukhadijeh (http://feross.org)
+Copyright (c) 2016, Brian Woodward (https://github.com/doowb).
+Copyright (c) 2016, Brian Woodward.
+Copyright (c) 2017 Jon Schlinkert
+Copyright (c) 2014, 2015, 2016, 2017 Simon Lydell
 Copyright 2014, 2015, 2016, 2017 Simon Lydell X11 (MIT) Licensed.
 Copyright 2014, 2017 Simon Lydell X11 (MIT) Licensed.
 Copyright 2017 Simon Lydell X11 (MIT) Licensed.
-Copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
-Copyright Joyent, Inc. and other Node contributors.
-Copyright Mathias Bynens <http://mths.be/>
-Copyright Mathias Bynens <https://mathiasbynens.be/>
-Copyright TJ Holowaychuk <tj@vision-media.ca>
-Copyright jQuery Foundation and other contributors <https://jquery.org/>
+Copyright (c) 2014 Simon Lydell
+Copyright (c) 2013 Rod Vagg rvagg (https://twitter.com/rvagg)
+Copyright (c) 2016 Rod Vagg
+Copyright (c) 2016-2018, Jon Schlinkert.
+(c) 2010-2015 Google, Inc. http://angularjs.org
+(c) 2009-2012 Jeremy Ashkenas, DocumentCloud Inc.
+(c) 2010 Esa-Matti Suuronen
+Copyright (c) 2008-2009, Robert Kieffer
+Copyright (c) 2011 Esa-Matti Suuronen esa-matti@suuronen.org
+Copyright (c) Alexandru Marasteanu
+Copyright 2011, John Resig
+Copyright 2011, The Dojo Foundation
+Copyright 2012 jQuery Foundation and other contributors
+(c) Vasily Polovnyov <vast@whiteants.net>
+Copyright 2013 jQuery Foundation and other contributors
 CxD Copyright 2011 by Jan Tonellato.
-TarHeader (c)
-copyright 2009-2015 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
-copyright 2012-2018 AJ ONeal
-copyright Robert Kieffer <http://broofa.com/>
+Copyright (c) 2014 Nathan Rajlich <nathan@tootallnate.net>
+Copyright (c) 2013 Blaine Bublitz <blaine.bublitz@gmail.com> , Eric Schoffstall <yo@contra.io> and other contributors
+Copyright (c) 2012-2014 Raynos.
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/reporter/src/funTest/assets/post-processed-expected-NOTICE
+++ b/reporter/src/funTest/assets/post-processed-expected-NOTICE
@@ -798,6 +798,87 @@ Creative Commons may be contacted at creativecommons.org.
 
 ----
 
+
+
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+
+
+----
+
+Public Domain
+
+No warranty expressed or implied. Use at your own risk.
+
+This file has been superceded by http://www.JSON.org/json2.js
+
+See http://www.JSON.org/js.html
+
+----
+
+json2.js
+ 2011-10-19
+
+ Public Domain.
+
+ NO WARRANTY EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+
+ See http://www.JSON.org/js.html
+
+This code should be minified before deployment.
+See http://javascript.crockford.com/jsmin.html
+
+USE YOUR OWN COPY. IT IS EXTREMELY UNWISE TO LOAD CODE FROM SERVERS YOU DO NOT CONTROL.
+
+----
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with
+or without fee is hereby granted, provided that the above copyright notice and this
+permission notice appear in all copies.
+
+The software is  provided "as is", without warranty of any kind, including all
+implied warranties of merchantability and fitness. In no event shall the authors or
+copyright holders be liable for any claim, damages, or other liability, whether in an
+action of contract, tort, or otherwise, arising from, out of, or in connection with
+the software or the use or other dealings in the software.
+
+----
+
 Footer 1
 
 ----


### PR DESCRIPTION
This is possible now as of d307aab.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1180)
<!-- Reviewable:end -->
