### PR TITLE
downloader: Add a final fallback to scan the Maven POM itself

### DIFF
--- a/downloader/src/main/kotlin/Downloader.kt
+++ b/downloader/src/main/kotlin/Downloader.kt
@@ -41,8 +41,10 @@ import okhttp3.Request
 import okio.Okio
 
 import java.io.File
+import java.io.FileNotFoundException
 import java.io.IOException
 import java.net.URI
+import java.net.URL
 import java.time.Instant
 import java.util.SortedSet
 
@@ -133,51 +135,89 @@ class Downloader {
 
         val targetDir = File(outputDirectory, target.id.toPath()).apply { safeMkdirs() }
 
-        try {
-            if (target.vcsProcessed.url.isBlank()) {
-                val details = when (target.id.type) {
-                    "Bundler" -> " Please define the \"source_code_uri\" in the \"metadata\" of the Gemspec, see: " +
-                            "https://guides.rubygems.org/specification-reference/#metadata"
-                    "Gradle" -> " Please make sure the release POM file includes the SCM connection, see: " +
-                            "https://docs.gradle.org/current/userguide/publishing_maven.html#" +
-                            "example_customizing_the_pom_file"
-                    "Maven" -> " Please define the \"connection\" tag within the \"scm\" tag in the POM file, see: " +
-                            "http://maven.apache.org/pom.html#SCM"
-                    "NPM" -> " Please define the \"repository\" in the package.json file, see: " +
-                            "https://docs.npmjs.com/files/package.json#repository"
-                    "PIP", "PyPI" -> " Please make sure the setup.py defines the 'Source' attribute in " +
-                            "'project_urls', see: " +
-                            "https://packaging.python.org/guides/distributing-packages-using-setuptools/#project-urls"
-                    "SBT" -> " Please make sure the released POM file includes the SCM connection, see: " +
-                            "http://maven.apache.org/pom.html#SCM"
-                    else -> ""
-                }
-                throw DownloadException("No VCS URL provided for '${target.id}'.$details")
-            } else {
-                return downloadFromVcs(target, targetDir, allowMovingRevisions)
-            }
-        } catch (vcsDownloadException: DownloadException) {
-            log.debug { "VCS download failed for '${target.id}': ${vcsDownloadException.message}" }
+        var previousException: DownloadException? = null
 
-            // Clean up any files left from the failed VCS download (i.e. a ".git" directory).
+        // Try downloading from VCS.
+        try {
+            try {
+                return downloadFromVcs(target, targetDir, allowMovingRevisions)
+            } catch (e: DownloadException) {
+                val message = if (target.vcsProcessed.url.isBlank()) {
+                    val hint = when (target.id.type) {
+                        "Bundler" -> " Please define the \"source_code_uri\" in the \"metadata\" of the Gemspec, " +
+                                "see: https://guides.rubygems.org/specification-reference/#metadata"
+                        "Gradle" -> " Please make sure the release POM file includes the SCM connection, see: " +
+                                "https://docs.gradle.org/current/userguide/publishing_maven.html#" +
+                                "example_customizing_the_pom_file"
+                        "Maven" -> " Please define the \"connection\" tag within the \"scm\" tag in the POM file, " +
+                                "see: http://maven.apache.org/pom.html#SCM"
+                        "NPM" -> " Please define the \"repository\" in the package.json file, see: " +
+                                "https://docs.npmjs.com/files/package.json#repository"
+                        "PIP", "PyPI" -> " Please make sure the setup.py defines the 'Source' attribute in " +
+                                "'project_urls', see: https://packaging.python.org/guides/" +
+                                "distributing-packages-using-setuptools/#project-urls"
+                        "SBT" -> " Please make sure the released POM file includes the SCM connection, see: " +
+                                "http://maven.apache.org/pom.html#SCM"
+                        else -> ""
+                    }
+                    e.message + hint
+                } else {
+                    e.message
+                }
+                throw DownloadException(message)
+            }
+        } catch (e: DownloadException) {
+            log.debug { "VCS download failed for '${target.id}': ${e.message}" }
+
+            // Clean up any left-over files.
             targetDir.safeDeleteRecursively()
             targetDir.safeMkdirs()
 
+            e.initCause(previousException)
+            previousException = e
+        }
+
+        // Try downloading the source artifact.
+        try {
+            return downloadSourceArtifact(target, targetDir)
+        } catch (e: DownloadException) {
+            log.debug { "Source artifact download failed for '${target.id}': ${e.message}" }
+
+            // Clean up any left-over files.
+            targetDir.safeDeleteRecursively()
+            targetDir.safeMkdirs()
+
+            e.initCause(previousException)
+            previousException = e
+        }
+
+        // Try downloading the Maven POM.
+        if (target.id.type == "Maven") {
             try {
-                return downloadSourceArtifact(target, targetDir)
-            } catch (sourceDownloadException: DownloadException) {
-                if (sourceDownloadException.cause != null) {
-                    throw sourceDownloadException
-                } else {
-                    throw sourceDownloadException.initCause(vcsDownloadException)
-                }
+                return downloadPomArtifact(target, targetDir)
+            } catch (e: DownloadException) {
+                log.debug { "POM artifact download failed for '${target.id}': ${e.message}" }
+
+                // Clean up any left-over files.
+                targetDir.safeDeleteRecursively()
+                targetDir.safeMkdirs()
+
+                e.initCause(previousException)
+                previousException = e
             }
         }
+
+        // By now we know there must have been a previous exception, otherwise we would have returned earlier.
+        throw previousException!!
     }
 
     private fun downloadFromVcs(target: Package, outputDirectory: File, allowMovingRevisions: Boolean): DownloadResult {
         log.info {
             "Trying to download '${target.id}' sources to '${outputDirectory.absolutePath}' from VCS..."
+        }
+
+        if (target.vcsProcessed.url.isBlank()) {
+            throw DownloadException("No VCS URL provided for '${target.id}'.")
         }
 
         if (target.vcsProcessed != target.vcs) {
@@ -249,12 +289,12 @@ class Downloader {
     }
 
     private fun downloadSourceArtifact(target: Package, outputDirectory: File): DownloadResult {
-        if (target.sourceArtifact.url.isBlank()) {
-            throw DownloadException("No source artifact URL provided for '${target.id}'.")
-        }
-
         log.info {
             "Trying to download source artifact for '${target.id}' from '${target.sourceArtifact.url}'..."
+        }
+
+        if (target.sourceArtifact.url.isBlank()) {
+            throw DownloadException("No source artifact URL provided for '${target.id}'.")
         }
 
         val startTime = Instant.now()
@@ -319,6 +359,32 @@ class Downloader {
         }
 
         return DownloadResult(startTime, outputDirectory, sourceArtifact = target.sourceArtifact)
+    }
+
+    private fun downloadPomArtifact(target: Package, outputDirectory: File): DownloadResult {
+        val pomUrl = target.binaryArtifact.url.replaceAfterLast('.', "pom")
+
+        log.info {
+            "Trying to download POM artifact for '${target.id}' from '$pomUrl'..."
+        }
+
+        return try {
+            val startTime = Instant.now()
+
+            val pomName = pomUrl.substringAfterLast('/')
+            val pomFile = File(outputDirectory, pomName)
+            pomFile.writeBytes(URL(pomUrl).readBytes())
+
+            val pomArtifact = RemoteArtifact(
+                    url = pomUrl,
+                    hash = pomFile.hash(target.binaryArtifact.hashAlgorithm.name),
+                    hashAlgorithm = target.binaryArtifact.hashAlgorithm
+            )
+
+            DownloadResult(startTime, outputDirectory, sourceArtifact = pomArtifact)
+        } catch (e: FileNotFoundException) {
+            throw DownloadException("Failed to download the Maven POM for '${target.id}'.")
+        }
     }
 
     private fun verifyChecksum(file: File, hash: String, hashAlgorithm: HashAlgorithm) {


### PR DESCRIPTION
Un-nest the fallback code to try them sequentially for a better
overview, and add a new final fallback to try downloading and scanning
the Maven POM to detect licenses added as XML comments in there.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1181)
<!-- Reviewable:end -->
