### PR TITLE
reporter-web-app: Align copyright headers to those in Kotlin code

### DIFF
--- a/reporter-web-app/public/index.html
+++ b/reporter-web-app/public/index.html
@@ -8,7 +8,7 @@
 
         <title>ORT Scan Report</title>
         <!--
-            Copyright (c) 2018 HERE Europe B.V. 
+            Copyright (C) 2017-2019 HERE Europe B.V.
             SPDX-License-Identifier: Apache-2.0
 
             Created with https://github.com/heremaps/oss-review-toolkit

--- a/reporter-web-app/src/App.js
+++ b/reporter-web-app/src/App.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 HERE Europe B.V.
+ * Copyright (C) 2017-2019 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reporter-web-app/src/components/ExpandablePanel.js
+++ b/reporter-web-app/src/components/ExpandablePanel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 HERE Europe B.V.
+ * Copyright (C) 2017-2019 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reporter-web-app/src/components/ExpandablePanelContent.js
+++ b/reporter-web-app/src/components/ExpandablePanelContent.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 HERE Europe B.V.
+ * Copyright (C) 2017-2019 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reporter-web-app/src/components/ExpandablePanelTitle.js
+++ b/reporter-web-app/src/components/ExpandablePanelTitle.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 HERE Europe B.V.
+ * Copyright (C) 2017-2019 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reporter-web-app/src/components/LicenseChart.js
+++ b/reporter-web-app/src/components/LicenseChart.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 HERE Europe B.V.
+ * Copyright (C) 2017-2019 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reporter-web-app/src/components/LicenseSummaryCard.js
+++ b/reporter-web-app/src/components/LicenseSummaryCard.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 HERE Europe B.V.
+ * Copyright (C) 2017-2019 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reporter-web-app/src/components/LicenseTag.js
+++ b/reporter-web-app/src/components/LicenseTag.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 HERE Europe B.V.
+ * Copyright (C) 2017-2019 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reporter-web-app/src/components/PackageDetails.js
+++ b/reporter-web-app/src/components/PackageDetails.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 HERE Europe B.V.
+ * Copyright (C) 2017-2019 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reporter-web-app/src/components/PackageErrors.js
+++ b/reporter-web-app/src/components/PackageErrors.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 HERE Europe B.V.
+ * Copyright (C) 2017-2019 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reporter-web-app/src/components/PackageLicenses.js
+++ b/reporter-web-app/src/components/PackageLicenses.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 HERE Europe B.V.
+ * Copyright (C) 2017-2019 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reporter-web-app/src/components/PackagePaths.js
+++ b/reporter-web-app/src/components/PackagePaths.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 HERE Europe B.V.
+ * Copyright (C) 2017-2019 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reporter-web-app/src/components/PackageScansSummary.js
+++ b/reporter-web-app/src/components/PackageScansSummary.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 HERE Europe B.V.
+ * Copyright (C) 2017-2019 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reporter-web-app/src/components/SummaryViewLicenses.js
+++ b/reporter-web-app/src/components/SummaryViewLicenses.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 HERE Europe B.V.
+ * Copyright (C) 2017-2019 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reporter-web-app/src/components/SummaryViewTableIssues.js
+++ b/reporter-web-app/src/components/SummaryViewTableIssues.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 HERE Europe B.V.
+ * Copyright (C) 2017-2019 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reporter-web-app/src/components/SummaryViewTableMetadata.js
+++ b/reporter-web-app/src/components/SummaryViewTableMetadata.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 HERE Europe B.V.
+ * Copyright (C) 2017-2019 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reporter-web-app/src/components/SummaryViewTimeline.js
+++ b/reporter-web-app/src/components/SummaryViewTimeline.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 HERE Europe B.V.
+ * Copyright (C) 2017-2019 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reporter-web-app/src/components/TreeView.js
+++ b/reporter-web-app/src/components/TreeView.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 HERE Europe B.V.
+ * Copyright (C) 2017-2019 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reporter-web-app/src/data/choosealicense/index.js
+++ b/reporter-web-app/src/data/choosealicense/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 HERE Europe B.V.
+ * Copyright (C) 2017-2019 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reporter-web-app/src/data/colors/index.js
+++ b/reporter-web-app/src/data/colors/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 HERE Europe B.V.
+ * Copyright (C) 2017-2019 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reporter-web-app/src/index.js
+++ b/reporter-web-app/src/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 HERE Europe B.V.
+ * Copyright (C) 2017-2019 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reporter-web-app/src/reducers/index.js
+++ b/reporter-web-app/src/reducers/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 HERE Europe B.V.
+ * Copyright (C) 2017-2019 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reporter-web-app/src/reducers/selectors.js
+++ b/reporter-web-app/src/reducers/selectors.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 HERE Europe B.V.
+ * Copyright (C) 2017-2019 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reporter-web-app/src/sagas/convertReportData.js
+++ b/reporter-web-app/src/sagas/convertReportData.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 HERE Europe B.V.
+ * Copyright (C) 2017-2019 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reporter-web-app/src/sagas/index.js
+++ b/reporter-web-app/src/sagas/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 HERE Europe B.V.
+ * Copyright (C) 2017-2019 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reporter-web-app/src/store/index.js
+++ b/reporter-web-app/src/store/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 HERE Europe B.V.
+ * Copyright (C) 2017-2019 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reporter-web-app/src/utils/index.js
+++ b/reporter-web-app/src/utils/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 HERE Europe B.V.
+ * Copyright (C) 2017-2019 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
So we do not miss them when updating copyright headers next time like in
ff0645e.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1184)
<!-- Reviewable:end -->
