### PR TITLE
Docker: Update npm and python-pip versions

### DIFF
--- a/cli/docker/Dockerfile
+++ b/cli/docker/Dockerfile
@@ -35,8 +35,8 @@ RUN apt install -y --no-install-recommends \
 # Add package managers (in versions known to work).
 RUN apt install -y --no-install-recommends \
         composer=1.8.0-1 \
-        npm=5.8.0+ds6-2 \
-        python-pip=18.1-2 \
+        npm=5.8.0+ds6-3 \
+        python-pip=18.1-4 \
         bundler=1.16.1-3 \
         sbt=0.13.13-2 \
     && \


### PR DESCRIPTION
This PR updates the npm and python-pip version for the Docker image build, because with the current `openjdk:11-jre-slim-sid` image I get the following error:

```
E: Version '5.8.0+ds6-2' for 'npm' was not found
E: Version '18.1-2' for 'python-pip' was not found
```

The newer versions of npm (5.8.0+ds6-3) and python-pip (18.1-4) solve this problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1190)
<!-- Reviewable:end -->
