### PR TITLE
Downloader: Increase fault tolerance of `Pom` downloads

### DIFF
--- a/downloader/src/main/kotlin/Downloader.kt
+++ b/downloader/src/main/kotlin/Downloader.kt
@@ -43,6 +43,7 @@ import okio.Okio
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.IOException
+import java.net.MalformedURLException
 import java.net.URI
 import java.net.URL
 import java.time.Instant
@@ -383,6 +384,11 @@ class Downloader {
 
             DownloadResult(startTime, outputDirectory, sourceArtifact = pomArtifact)
         } catch (e: FileNotFoundException) {
+            throw DownloadException("Failed to download the Maven POM for '${target.id}'.")
+        } catch (e: MalformedURLException) {
+            // Many packages do have an empty string as binary artifact URL.
+            // TODO: Investigate why the binary artifact URL is actually empty and update
+            // the implementation according to root cause.
             throw DownloadException("Failed to download the Maven POM for '${target.id}'.")
         }
     }


### PR DESCRIPTION
There are many artifacts with an empty string as binary artifact URL.
In this case the whole downloader command fails since the function
`Downloader.download()` throws a `MalformedUrlException` as of 0ee881c3.

Fix this for now by catching that exception.

Note: the reason why the URLs are empty is not yet known and should be
investigated. Guaranteeing that the binary artifact URL of any Maven
artifacts is always non-empty might be a better way to fix this problem.

Signed-off-by: Frank Viernau <frank.viernau@here.com>