### PR TITLE
Gradle: Let detekt also check test code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,7 @@ subprojects {
         toolVersion = detektPluginVersion
 
         config = files('../detekt.yml')
+        input = files('src/main/kotlin', 'src/test/kotlin', 'src/funTest/kotlin')
     }
 
     task funTest(type: Test) {


### PR DESCRIPTION
By default detekt only uses 'src/main/kotlin' (and 'src/main/java') as
the input [1]. Extend the input to also check the source code for tests.

[1] https://arturbosch.github.io/detekt/groovydsl.html#available-plugin-tasks

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1196)
<!-- Reviewable:end -->
