### PR TITLE
SpdxExpression: Fix the support for DocumentRefs

### DIFF
--- a/spdx-utils/src/main/antlr/com/here/ort/spdx/SpdxExpression.g4
+++ b/spdx-utils/src/main/antlr/com/here/ort/spdx/SpdxExpression.g4
@@ -31,9 +31,9 @@ package com.here.ort.spdx;
  * Parser Rules
  */
 
-licenseRefExpression
+licenseReferenceExpression
     :
-    LICENSEREF
+    LICENSEREFERENCE
     ;
 
 licenseExceptionExpression
@@ -49,7 +49,7 @@ licenseIdExpression
 
 simpleExpression
     :
-    licenseRefExpression
+    licenseReferenceExpression
     | licenseIdExpression
     ;
 
@@ -83,7 +83,7 @@ OPEN  : '(' ;
 CLOSE : ')' ;
 PLUS  : '+' ;
 
-LICENSEREF : ('DocumentRef-' | 'LicenseRef-') IDSTRING ;
+LICENSEREFERENCE : ('DocumentRef-' IDSTRING ':')? 'LicenseRef-' IDSTRING ;
 IDSTRING   : (ALPHA | DIGIT)(ALPHA | DIGIT | '-' | '.')* ;
 
 WHITESPACE : ' ' -> skip ;

--- a/spdx-utils/src/main/kotlin/SpdxExpression.kt
+++ b/spdx-utils/src/main/kotlin/SpdxExpression.kt
@@ -69,12 +69,14 @@ sealed class SpdxExpression {
     }
 
     /**
-     * Return all [SpdxLicense]s contained in this expression. Non-SPDX licenses and LicenseRefs are ignored.
+     * Return all [SpdxLicense]s contained in this expression. Non-SPDX licenses and SPDX license references are
+     * ignored.
      */
     abstract fun spdxLicenses(): EnumSet<SpdxLicense>
 
     /**
-     * Validate this expression to only contain SPDX identifiers. This includes licenses, exceptions and LicenseRefs.
+     * Validate this expression to only contain SPDX identifiers. This includes SPDX licenses, exceptions and license
+     * references.
      */
     abstract fun validate(): Boolean
 }
@@ -145,16 +147,16 @@ data class SpdxLicenseIdExpression(
 }
 
 /**
- * An SPDX expression for a LicenseRef as defined by version 2.1 of the SPDX specification, appendix IV, see
+ * An SPDX expression for a license reference as defined by version 2.1 of the SPDX specification, appendix IV, see
  * https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60.
  */
-data class SpdxLicenseRefExpression(
+data class SpdxLicenseReferenceExpression(
         val id: String
 ) : SpdxExpression() {
     override fun spdxLicenses() = enumSetOf<SpdxLicense>()
 
-    // TODO: Think about whether we should also accept "DocumentRef-" here, or model those as a separate class.
-    override fun validate() = id.startsWith("LicenseRef-")
+    override fun validate() = id.startsWith("LicenseRef-") ||
+            (id.startsWith("DocumentRef-") && id.contains(":LicenseRef-"))
 
     override fun toString() = id
 }

--- a/spdx-utils/src/main/kotlin/SpdxExpressionDefaultVisitor.kt
+++ b/spdx-utils/src/main/kotlin/SpdxExpressionDefaultVisitor.kt
@@ -23,7 +23,7 @@ import com.here.ort.spdx.SpdxExpressionParser.CompoundExpressionContext
 import com.here.ort.spdx.SpdxExpressionParser.LicenseExceptionExpressionContext
 import com.here.ort.spdx.SpdxExpressionParser.LicenseExpressionContext
 import com.here.ort.spdx.SpdxExpressionParser.LicenseIdExpressionContext
-import com.here.ort.spdx.SpdxExpressionParser.LicenseRefExpressionContext
+import com.here.ort.spdx.SpdxExpressionParser.LicenseReferenceExpressionContext
 import com.here.ort.spdx.SpdxExpressionParser.SimpleExpressionContext
 
 class SpdxExpressionDefaultVisitor : SpdxExpressionBaseVisitor<SpdxExpression>() {
@@ -88,9 +88,9 @@ class SpdxExpressionDefaultVisitor : SpdxExpressionBaseVisitor<SpdxExpression>()
         }
     }
 
-    override fun visitLicenseRefExpression(ctx: LicenseRefExpressionContext): SpdxExpression {
+    override fun visitLicenseReferenceExpression(ctx: LicenseReferenceExpressionContext): SpdxExpression {
         return when (ctx.childCount) {
-            1 -> SpdxLicenseRefExpression(ctx.text)
+            1 -> SpdxLicenseReferenceExpression(ctx.text)
             else -> throw SpdxException("SpdxLicenseRefExpression has invalid amount of children: '${ctx.childCount}'")
         }
     }

--- a/spdx-utils/src/test/kotlin/SpdxExpressionParserTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxExpressionParserTest.kt
@@ -45,15 +45,15 @@ class SpdxExpressionParserTest : WordSpec() {
             }
 
             "parse a document ref correctly" {
-                val spdxExpression = SpdxExpression.parse("DocumentRef-license")
+                val spdxExpression = SpdxExpression.parse("DocumentRef-document:LicenseRef-license")
 
-                spdxExpression shouldBe SpdxLicenseRefExpression("DocumentRef-license")
+                spdxExpression shouldBe SpdxLicenseReferenceExpression("DocumentRef-document:LicenseRef-license")
             }
 
             "parse a license ref correctly" {
                 val spdxExpression = SpdxExpression.parse("LicenseRef-license")
 
-                spdxExpression shouldBe SpdxLicenseRefExpression("LicenseRef-license")
+                spdxExpression shouldBe SpdxLicenseReferenceExpression("LicenseRef-license")
             }
 
             "parse a complex expression correctly" {


### PR DESCRIPTION
DocumentRefs are a special kind of LicenseRefs, and both DocumentRefs and
LicenseRefs are license references. Clarify that also in variable names
and comments by not referring to license references as (only) LicenseRefs.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1202)
<!-- Reviewable:end -->
