### PR TITLE
Gradle: Upgrade Docker plugins to version 4.3.0

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -11,8 +11,8 @@ applicationName = 'ort'
 mainClassName = 'com.here.ort.Main'
 
 task dockerBuildBaseImage(type: com.bmuschko.gradle.docker.tasks.image.DockerBuildImage) {
-    // This task uses 'docker/Dockerfile' as the input file.
     description = 'Builds the base Docker image to run ORT.'
+    inputDir = file('docker')
     tags = ['ort-base:latest']
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 detektPluginVersion = 1.0.0-RC12
-dockerJavaApplicationPluginVersion = 4.2.0
-dockerRemoteApiPluginVersion = 4.2.0
+dockerJavaApplicationPluginVersion = 4.3.0
+dockerRemoteApiPluginVersion = 4.3.0
 dokkaPluginVersion = 0.9.17
 ideaExtPluginVersion = 0.5
 kotlinPluginVersion = 1.3.11


### PR DESCRIPTION
See https://bmuschko.github.io/gradle-docker-plugin/#v4_3_0_january_12_2019.

Note that "inputDir" defaults to "$buildDir/docker" now. As "$buildDir"
is not under version control, explicitly specify our "cli/docker"
directory now.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1203)
<!-- Reviewable:end -->
