### PR TITLE
VcsInfo: Fail deserialization on unknown property

### DIFF
--- a/model/build.gradle
+++ b/model/build.gradle
@@ -17,4 +17,6 @@ dependencies {
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
 
     implementation "com.vdurmont:semver4j:$semverVersion"
+
+    implementation 'org.jetbrains.kotlin:kotlin-reflect'
 }

--- a/model/src/main/kotlin/Mappers.kt
+++ b/model/src/main/kotlin/Mappers.kt
@@ -42,6 +42,8 @@ private val ortModelModule = SimpleModule("OrtModelModule").apply {
     addSerializer(Identifier::class.java, IdentifierToStringSerializer())
 }
 
+val PROPERTY_NAMING_STRATEGY = PropertyNamingStrategy.SNAKE_CASE as PropertyNamingStrategy.PropertyNamingStrategyBase
+
 /**
  * A lambda expression that can be [applied][apply] to all [ObjectMapper]s to configure them the same way.
  */
@@ -53,7 +55,7 @@ private val mapperConfig: ObjectMapper.() -> Unit = {
 
     registerModule(ortModelModule)
 
-    propertyNamingStrategy = PropertyNamingStrategy.SNAKE_CASE
+    propertyNamingStrategy = PROPERTY_NAMING_STRATEGY
 }
 
 val jsonMapper = ObjectMapper().apply(mapperConfig)

--- a/model/src/test/kotlin/VcsInfoTest.kt
+++ b/model/src/test/kotlin/VcsInfoTest.kt
@@ -19,10 +19,13 @@
 
 package com.here.ort.model
 
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException
 import com.fasterxml.jackson.module.kotlin.readValue
 
+import io.kotlintest.matchers.containAll
 import io.kotlintest.should
 import io.kotlintest.shouldBe
+import io.kotlintest.shouldThrow
 import io.kotlintest.specs.StringSpec
 
 class VcsInfoTest : StringSpec({
@@ -72,6 +75,28 @@ class VcsInfoTest : StringSpec({
             vcsInfo.url shouldBe ""
             vcsInfo.revision shouldBe ""
             vcsInfo.path shouldBe "path"
+        }
+
+        "fail if the input contains unknown fields" {
+            val yaml = """
+                ---
+                type: "type"
+                url: "url"
+                revision: "revision"
+                resolved_revision: "resolved_revision"
+                path: "path"
+                data:
+                  key: "value"
+                unknown: "unknown"
+                """.trimIndent()
+
+            val exception = shouldThrow<UnrecognizedPropertyException> {
+                yamlMapper.readValue<VcsInfo>(yaml)
+            }
+
+            exception.propertyName shouldBe "unknown"
+            exception.knownPropertyIds should
+                    containAll<Any>("type", "url", "revision", "resolved_revision", "path", "data")
         }
     }
 


### PR DESCRIPTION
This is especially useful on deserializing manually created curations which
might contain typos in the property names.

Signed-off-by: Martin Nonnenmacher <martin.nonnenmacher@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1204)
<!-- Reviewable:end -->
