### PR TITLE
ScanCode: Do not scan the ORT configuration file

### DIFF
--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -33,6 +33,7 @@ import com.here.ort.model.Repository
 import com.here.ort.model.config.AnalyzerConfiguration
 import com.here.ort.model.config.RepositoryConfiguration
 import com.here.ort.model.readValue
+import com.here.ort.utils.ORT_CONFIG_FILENAME
 import com.here.ort.utils.log
 import com.here.ort.utils.realFile
 
@@ -135,8 +136,8 @@ class Analyzer(private val config: AnalyzerConfiguration) {
     private fun locateRepositoryConfigurationFile(absoluteProjectPath: File) =
             if (GitRepo().getWorkingTree(absoluteProjectPath).isValid()) {
                 val manifestFile = absoluteProjectPath.resolve(".repo/manifest.xml").realFile()
-                manifestFile.resolveSibling("${manifestFile.name}.ort.yml")
+                manifestFile.resolveSibling("${manifestFile.name}$ORT_CONFIG_FILENAME")
             } else {
-                File(absoluteProjectPath, ".ort.yml")
+                File(absoluteProjectPath, ORT_CONFIG_FILENAME)
             }
 }

--- a/scanner/src/main/kotlin/scanners/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/ScanCode.kt
@@ -42,6 +42,7 @@ import com.here.ort.scanner.ScanException
 import com.here.ort.scanner.ScanResultsCache
 import com.here.ort.spdx.LICENSE_FILE_NAMES
 import com.here.ort.utils.CommandLineTool
+import com.here.ort.utils.ORT_CONFIG_FILENAME
 import com.here.ort.utils.OS
 import com.here.ort.utils.OkHttpClientHelper
 import com.here.ort.utils.ProcessCapture
@@ -95,6 +96,7 @@ class ScanCode(config: ScannerConfiguration) : LocalScanner(config) {
         private val DEFAULT_CONFIGURATION_OPTIONS = listOf(
                 "--copyright",
                 "--license",
+                "--ignore", "*$ORT_CONFIG_FILENAME",
                 "--info",
                 "--strip-root",
                 "--timeout", TIMEOUT.toString()

--- a/scanner/src/test/kotlin/ScanCodeTest.kt
+++ b/scanner/src/test/kotlin/ScanCodeTest.kt
@@ -379,7 +379,8 @@ class ScanCodeTest : WordSpec({
             val scanCode = ScanCode(ScannerConfiguration())
 
             scanCode.getConfiguration() shouldBe
-                    "--copyright --license --info --strip-root --timeout 300 --json-pp --license-diag"
+                    "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --json-pp " +
+                    "--license-diag"
         }
 
         "return the non config values from the scanner configuration" {
@@ -401,8 +402,8 @@ class ScanCodeTest : WordSpec({
             val scanCode = ScanCode(ScannerConfiguration())
 
             scanCode.commandLineOptions.joinToString(" ") should
-                    match("--copyright --license --info --strip-root --timeout 300 --processes \\d+ --license-diag " +
-                            "--verbose")
+                    match("--copyright --license --ignore \\*.ort.yml --info --strip-root --timeout 300 " +
+                            "--processes \\d+ --license-diag --verbose")
         }
 
         "contain the values from the scanner configuration" {

--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -34,6 +34,11 @@ val log = org.slf4j.LoggerFactory.getLogger({}.javaClass) as ch.qos.logback.clas
 var printStackTrace = false
 
 /**
+ * The name of the ORT configuration file.
+ */
+const val ORT_CONFIG_FILENAME = ".ort.yml"
+
+/**
  * Ordinal for mandatory program parameters.
  */
 const val PARAMETER_ORDER_MANDATORY = 0


### PR DESCRIPTION
While at it, extract the file name to a global constant.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1209)
<!-- Reviewable:end -->
