### PR TITLE
cli: Fix `MainTest`

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
@@ -184,6 +184,7 @@ analyzer:
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency org.apache.commons:commons-text:1.1 because no repositories\
               \ are defined."
+            severity: "ERROR"
       - name: "compileClasspath"
         dependencies:
         - id: "Maven:org.apache.commons:commons-text:1.1"
@@ -193,6 +194,7 @@ analyzer:
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency org.apache.commons:commons-text:1.1 because no repositories\
               \ are defined."
+            severity: "ERROR"
       - name: "compileOnly"
         dependencies: []
       - name: "default"
@@ -204,6 +206,7 @@ analyzer:
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency org.apache.commons:commons-text:1.1 because no repositories\
               \ are defined."
+            severity: "ERROR"
       - name: "runtime"
         dependencies:
         - id: "Maven:org.apache.commons:commons-text:1.1"
@@ -213,6 +216,7 @@ analyzer:
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency org.apache.commons:commons-text:1.1 because no repositories\
               \ are defined."
+            severity: "ERROR"
       - name: "runtimeClasspath"
         dependencies:
         - id: "Maven:org.apache.commons:commons-text:1.1"
@@ -222,6 +226,7 @@ analyzer:
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency org.apache.commons:commons-text:1.1 because no repositories\
               \ are defined."
+            severity: "ERROR"
       - name: "testAnnotationProcessor"
         dependencies: []
       - name: "testCompile"
@@ -232,6 +237,7 @@ analyzer:
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency junit:junit:4.12 because no repositories are defined."
+            severity: "ERROR"
         - id: "Maven:org.apache.commons:commons-text:1.1"
           errors:
           - timestamp: "1970-01-01T00:00:00Z"
@@ -239,6 +245,7 @@ analyzer:
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency org.apache.commons:commons-text:1.1 because no repositories\
               \ are defined."
+            severity: "ERROR"
       - name: "testCompileClasspath"
         dependencies:
         - id: "Maven:junit:junit:4.12"
@@ -247,6 +254,7 @@ analyzer:
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency junit:junit:4.12 because no repositories are defined."
+            severity: "ERROR"
         - id: "Maven:org.apache.commons:commons-text:1.1"
           errors:
           - timestamp: "1970-01-01T00:00:00Z"
@@ -254,6 +262,7 @@ analyzer:
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency org.apache.commons:commons-text:1.1 because no repositories\
               \ are defined."
+            severity: "ERROR"
       - name: "testCompileOnly"
         dependencies: []
       - name: "testRuntime"
@@ -264,6 +273,7 @@ analyzer:
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency junit:junit:4.12 because no repositories are defined."
+            severity: "ERROR"
         - id: "Maven:org.apache.commons:commons-text:1.1"
           errors:
           - timestamp: "1970-01-01T00:00:00Z"
@@ -271,6 +281,7 @@ analyzer:
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency org.apache.commons:commons-text:1.1 because no repositories\
               \ are defined."
+            severity: "ERROR"
       - name: "testRuntimeClasspath"
         dependencies:
         - id: "Maven:junit:junit:4.12"
@@ -279,6 +290,7 @@ analyzer:
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency junit:junit:4.12 because no repositories are defined."
+            severity: "ERROR"
         - id: "Maven:org.apache.commons:commons-text:1.1"
           errors:
           - timestamp: "1970-01-01T00:00:00Z"
@@ -286,6 +298,7 @@ analyzer:
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency org.apache.commons:commons-text:1.1 because no repositories\
               \ are defined."
+            severity: "ERROR"
     - id: "Gradle:com.here.ort.gradle.example:lib:1.0.0"
       definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
       declared_licenses: []

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
@@ -184,6 +184,7 @@ analyzer:
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency org.apache.commons:commons-text:1.1 because no repositories\
               \ are defined."
+            severity: "ERROR"
       - name: "compileClasspath"
         dependencies:
         - id: "Maven:org.apache.commons:commons-text:1.1"
@@ -193,6 +194,7 @@ analyzer:
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency org.apache.commons:commons-text:1.1 because no repositories\
               \ are defined."
+            severity: "ERROR"
       - name: "compileOnly"
         dependencies: []
       - name: "default"
@@ -204,6 +206,7 @@ analyzer:
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency org.apache.commons:commons-text:1.1 because no repositories\
               \ are defined."
+            severity: "ERROR"
       - name: "runtime"
         dependencies:
         - id: "Maven:org.apache.commons:commons-text:1.1"
@@ -213,6 +216,7 @@ analyzer:
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency org.apache.commons:commons-text:1.1 because no repositories\
               \ are defined."
+            severity: "ERROR"
       - name: "runtimeClasspath"
         dependencies:
         - id: "Maven:org.apache.commons:commons-text:1.1"
@@ -222,6 +226,7 @@ analyzer:
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency org.apache.commons:commons-text:1.1 because no repositories\
               \ are defined."
+            severity: "ERROR"
       - name: "testAnnotationProcessor"
         dependencies: []
       - name: "testCompile"
@@ -232,6 +237,7 @@ analyzer:
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency junit:junit:4.12 because no repositories are defined."
+            severity: "ERROR"
         - id: "Maven:org.apache.commons:commons-text:1.1"
           errors:
           - timestamp: "1970-01-01T00:00:00Z"
@@ -239,6 +245,7 @@ analyzer:
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency org.apache.commons:commons-text:1.1 because no repositories\
               \ are defined."
+            severity: "ERROR"
       - name: "testCompileClasspath"
         dependencies:
         - id: "Maven:junit:junit:4.12"
@@ -247,6 +254,7 @@ analyzer:
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency junit:junit:4.12 because no repositories are defined."
+            severity: "ERROR"
         - id: "Maven:org.apache.commons:commons-text:1.1"
           errors:
           - timestamp: "1970-01-01T00:00:00Z"
@@ -254,6 +262,7 @@ analyzer:
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency org.apache.commons:commons-text:1.1 because no repositories\
               \ are defined."
+            severity: "ERROR"
       - name: "testCompileOnly"
         dependencies: []
       - name: "testRuntime"
@@ -264,6 +273,7 @@ analyzer:
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency junit:junit:4.12 because no repositories are defined."
+            severity: "ERROR"
         - id: "Maven:org.apache.commons:commons-text:1.1"
           errors:
           - timestamp: "1970-01-01T00:00:00Z"
@@ -271,6 +281,7 @@ analyzer:
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency org.apache.commons:commons-text:1.1 because no repositories\
               \ are defined."
+            severity: "ERROR"
       - name: "testRuntimeClasspath"
         dependencies:
         - id: "Maven:junit:junit:4.12"
@@ -279,6 +290,7 @@ analyzer:
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency junit:junit:4.12 because no repositories are defined."
+            severity: "ERROR"
         - id: "Maven:org.apache.commons:commons-text:1.1"
           errors:
           - timestamp: "1970-01-01T00:00:00Z"
@@ -286,6 +298,7 @@ analyzer:
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency org.apache.commons:commons-text:1.1 because no repositories\
               \ are defined."
+            severity: "ERROR"
     - id: "Gradle:com.here.ort.gradle.example:lib:1.0.0"
       definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
       declared_licenses: []

--- a/cli/src/funTest/kotlin/MainTest.kt
+++ b/cli/src/funTest/kotlin/MainTest.kt
@@ -63,12 +63,14 @@ class MainTest : StringSpec() {
             System.setOut(PrintStream(streamOut))
 
             try {
-                Main.main(arrayOf(
+                val exitCode = Main.run(arrayOf(
                         "analyze",
                         "-m", "Gradle",
                         "-i", inputDir.path,
                         "-o", File(outputDir, "gradle").path
                 ))
+
+                exitCode shouldBe 0
 
                 val lines = streamOut.toString().lineSequence().iterator()
 
@@ -89,12 +91,14 @@ class MainTest : StringSpec() {
             System.setOut(PrintStream(streamOut))
 
             try {
-                Main.main(arrayOf(
+                val exitCode = Main.run(arrayOf(
                         "analyze",
                         "-m", "NPM",
                         "-i", inputDir.path,
                         "-o", File(outputDir, "package-lock").path
                 ))
+
+                exitCode shouldBe 0
 
                 val lines = streamOut.toString().lineSequence().iterator()
 
@@ -115,13 +119,15 @@ class MainTest : StringSpec() {
             System.setOut(PrintStream(streamOut))
 
             try {
-                Main.main(arrayOf(
+                val exitCode = Main.run(arrayOf(
                         "analyze",
                         "-m", "Gradle",
                         "-i", inputDir.path,
                         "-o", File(outputDir, "gradle").path,
                         "-f", "json,yaml,json"
                 ))
+
+                exitCode shouldBe 0
 
                 val lines = streamOut.toString().lines().filter { it.startsWith("Writing analyzer result to ") }
 
@@ -142,12 +148,14 @@ class MainTest : StringSpec() {
                     urlProcessed = normalizeVcsUrl(vcsUrl)
             )
 
-            Main.main(arrayOf(
+            val exitCode = Main.run(arrayOf(
                     "analyze",
                     "-m", "Gradle",
                     "-i", File(projectDir, "gradle").absolutePath,
                     "-o", analyzerOutputDir.path
             ))
+
+            exitCode shouldBe 0
 
             val result = File(analyzerOutputDir, "analyzer-result.yml").readText()
 
@@ -167,13 +175,15 @@ class MainTest : StringSpec() {
             // The command below should include the "--merge-results" option, but setting this option here would disable
             // the feature because JCommander just switches the value of boolean options, and the option was already set
             // to true by the test before. See: https://github.com/cbeust/jcommander/issues/378
-            Main.main(arrayOf(
+            val exitCode = Main.run(arrayOf(
                     "analyze",
                     "-m", "Gradle",
                     "-i", File(projectDir, "gradle").absolutePath,
                     "-o", analyzerOutputDir.path,
                     "--package-curations-file", File(projectDir, "gradle/curations.yml").toString()
             ))
+
+            exitCode shouldBe 0
 
             val result = File(analyzerOutputDir, "analyzer-result.yml").readText()
 

--- a/cli/src/main/kotlin/Main.kt
+++ b/cli/src/main/kotlin/Main.kt
@@ -57,6 +57,13 @@ object Main : CommandWithHelp() {
      */
     @JvmStatic
     fun main(args: Array<String>) {
+        exitProcess(run(args))
+    }
+
+    /**
+     * Run the ORT CLI with the provided [args] and return the exit code of [CommandWithHelp.run].
+     */
+    fun run(args: Array<String>): Int {
         val jc = JCommander(this).apply {
             programName = TOOL_NAME
             addCommand(AnalyzerCommand)
@@ -68,7 +75,7 @@ object Main : CommandWithHelp() {
             parse(*args)
         }
 
-        exitProcess(run(jc))
+        return run(jc)
     }
 
     override fun runCommand(jc: JCommander): Int {


### PR DESCRIPTION
The `MainTest` was skipped since 546cda0 because `Main.main()` called
`exitProcess`. Fix this by moving the logic to a `run` function and calling
this function from the tests.

Because the test were skipped the expected result files need to be updated
to make it pass.

Signed-off-by: Martin Nonnenmacher <martin.nonnenmacher@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1214)
<!-- Reviewable:end -->
