### PR TITLE
AnalyzerCommand: Only require the individual output files to not exist

### DIFF
--- a/cli/src/main/kotlin/commands/EvaluatorCommand.kt
+++ b/cli/src/main/kotlin/commands/EvaluatorCommand.kt
@@ -54,7 +54,8 @@ object EvaluatorCommand : CommandWithHelp() {
     private var rulesResource: String? = null
 
     @Parameter(description = "The directory to write the evaluation results as ORT result file(s) to, in the " +
-            "specified output format(s).",
+            "specified output format(s). If no output directory is specified, no output formats are written and " +
+            "only the exit code signals a success or failure.",
             names = ["--output-dir", "-o"],
             order = PARAMETER_ORDER_OPTIONAL)
     private var outputDir: File? = null

--- a/downloader/src/main/kotlin/Downloader.kt
+++ b/downloader/src/main/kotlin/Downloader.kt
@@ -136,6 +136,10 @@ class Downloader {
 
         val targetDir = File(outputDirectory, target.id.toPath()).apply { safeMkdirs() }
 
+        require(!targetDir.exists() || targetDir.list().isEmpty()) {
+            "The output directory '$targetDir' must not contain any files yet."
+        }
+
         var previousException: DownloadException? = null
 
         // Try downloading from VCS.


### PR DESCRIPTION
Relax the existing check by not requiring anymore that the whole output
directory does not yet exist, but only require the individual output files
to not exist so they do not get overwritten.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1218)
<!-- Reviewable:end -->
