### PR TITLE
ReporterCommand: Only require the individual report files to not exist

### DIFF
--- a/cli/src/main/kotlin/commands/ReporterCommand.kt
+++ b/cli/src/main/kotlin/commands/ReporterCommand.kt
@@ -75,7 +75,7 @@ object ReporterCommand : CommandWithHelp() {
             converter = ReporterConverter::class,
             required = true,
             order = PARAMETER_ORDER_MANDATORY)
-    private lateinit var reportFormats: List<Reporter>
+    private lateinit var reporters: List<Reporter>
 
     @Parameter(description = "A file containing error resolutions.",
             names = ["--resolutions-file"],
@@ -99,11 +99,17 @@ object ReporterCommand : CommandWithHelp() {
     private var repositoryConfigurationFile: File? = null
 
     override fun runCommand(jc: JCommander): Int {
-        require(!outputDir.exists()) {
-            "The output directory '${outputDir.absolutePath}' must not exist yet."
+        val absoluteOutputDir = outputDir.absoluteFile
+
+        val reports = reporters.associateWith { reporter ->
+            File(absoluteOutputDir, reporter.defaultFilename)
         }
 
-        outputDir.safeMkdirs()
+        val existingReportFiles = reports.values.filter { it.exists() }
+        if (existingReportFiles.isNotEmpty()) {
+            log.error { "None of the report files $existingReportFiles must exist yet." }
+            return 2
+        }
 
         var ortResult = ortFile.readValue<OrtResult>()
         repositoryConfigurationFile?.let {
@@ -113,21 +119,26 @@ object ReporterCommand : CommandWithHelp() {
         val resolutionProvider = DefaultResolutionProvider()
         ortResult.repository.config.resolutions?.let { resolutionProvider.add(it) }
         resolutionsFile?.readValue<Resolutions>()?.let { resolutionProvider.add(it) }
+
         val copyrightGarbage = copyrightGarbageFile?.readValue() ?: CopyrightGarbage()
 
         var exitCode = 0
 
-        reportFormats.distinct().forEach {
-            val name = it.toString().removeSuffix("Reporter")
+        absoluteOutputDir.safeMkdirs()
+
+        reports.forEach { reporter, file ->
+            val name = reporter.toString().removeSuffix("Reporter")
+
             try {
-                val reportFile = it.generateReport(
+                reporter.generateReport(
                         ortResult,
                         resolutionProvider,
                         copyrightGarbage,
-                        outputDir,
+                        file.outputStream(),
                         postProcessingScript?.readText()
                 )
-                println("Created '$name' report:\n\t$reportFile")
+
+                println("Created '$name' report:\n\t$file")
             } catch (e: Exception) {
                 e.showStackTrace()
 

--- a/reporter/src/funTest/kotlin/reporters/ExcelReporterTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/ExcelReporterTest.kt
@@ -39,9 +39,10 @@ class ExcelReporterTest : WordSpec({
     "ExcelReporter" should {
         "successfully export to an Excel sheet".config(enabled = OS.isWindows) {
             val outputDir = createTempDir().apply { deleteOnExit() }
-            ExcelReporter().generateReport(ortResult, DefaultResolutionProvider(), CopyrightGarbage(), outputDir)
 
             val actualFile = outputDir.resolve("scan-report.xlsx")
+            ExcelReporter().generateReport(ortResult, DefaultResolutionProvider(), CopyrightGarbage(),
+                    actualFile.outputStream())
             val actualXlsxUnpacked = createTempDir().apply { deleteOnExit() }
             actualFile.unpackZip(actualXlsxUnpacked)
 

--- a/reporter/src/funTest/kotlin/reporters/NoticeReporterTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/NoticeReporterTest.kt
@@ -23,47 +23,18 @@ import com.here.ort.model.OrtResult
 import com.here.ort.model.config.CopyrightGarbage
 import com.here.ort.model.readValue
 import com.here.ort.reporter.DefaultResolutionProvider
-import com.here.ort.utils.safeDeleteRecursively
 
-import io.kotlintest.TestCase
-import io.kotlintest.TestResult
 import io.kotlintest.matchers.string.shouldContain
 import io.kotlintest.matchers.string.shouldNotContain
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.WordSpec
 
+import java.io.ByteArrayOutputStream
 import java.io.File
 
 class NoticeReporterTest : WordSpec() {
     companion object {
         private fun readOrtResult(file: String) = File(file).readValue<OrtResult>()
-    }
-
-    private lateinit var tempDir: File
-
-    override fun beforeTest(testCase: TestCase) {
-        super.beforeTest(testCase)
-        tempDir = createTempDir()
-    }
-
-    override fun afterTest(testCase: TestCase, result: TestResult) {
-        tempDir.safeDeleteRecursively(force = true)
-        super.afterTest(testCase, result)
-    }
-
-    private fun generateReport(ortResult: OrtResult,
-                               copyrightGarbage: CopyrightGarbage = CopyrightGarbage(),
-                               postProcessingScript: String? = null
-    ): String {
-        NoticeReporter().generateReport(
-                ortResult,
-                DefaultResolutionProvider(),
-                copyrightGarbage,
-                tempDir,
-                postProcessingScript
-        )
-
-        return File(tempDir, "NOTICE").readText()
     }
 
     init {
@@ -153,4 +124,19 @@ class NoticeReporterTest : WordSpec() {
             }
         }
     }
+
+    private fun generateReport(
+            ortResult: OrtResult,
+            copyrightGarbage: CopyrightGarbage = CopyrightGarbage(),
+            postProcessingScript: String? = null
+    ) =
+            ByteArrayOutputStream().also { outputStream ->
+                NoticeReporter().generateReport(
+                        ortResult,
+                        DefaultResolutionProvider(),
+                        copyrightGarbage,
+                        outputStream,
+                        postProcessingScript
+                )
+            }.toString("UTF-8")
 }

--- a/reporter/src/funTest/kotlin/reporters/StaticHtmlReporterTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/StaticHtmlReporterTest.kt
@@ -27,6 +27,7 @@ import com.here.ort.reporter.DefaultResolutionProvider
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.WordSpec
 
+import java.io.ByteArrayOutputStream
 import java.io.File
 
 import javax.xml.transform.TransformerFactory
@@ -54,10 +55,13 @@ class StaticHtmlReporterTest : WordSpec() {
         }
     }
 
-    private fun generateReport(ortResult: OrtResult): String {
-        val outputDir = createTempDir().apply { deleteOnExit() }
-        StaticHtmlReporter().generateReport(ortResult, DefaultResolutionProvider(), CopyrightGarbage(), outputDir)
-
-        return outputDir.resolve("scan-report.html").readText()
-    }
+    private fun generateReport(ortResult: OrtResult) =
+            ByteArrayOutputStream().also { outputStream ->
+                StaticHtmlReporter().generateReport(
+                        ortResult,
+                        DefaultResolutionProvider(),
+                        CopyrightGarbage(),
+                        outputStream
+                )
+            }.toString("UTF-8")
 }

--- a/reporter/src/funTest/kotlin/reporters/WebAppReporterTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/WebAppReporterTest.kt
@@ -24,9 +24,10 @@ import com.here.ort.model.config.CopyrightGarbage
 import com.here.ort.model.readValue
 import com.here.ort.reporter.DefaultResolutionProvider
 
-import io.kotlintest.shouldBe
+import io.kotlintest.shouldNotBe
 import io.kotlintest.specs.WordSpec
 
+import java.io.ByteArrayOutputStream
 import java.io.File
 
 class WebAppReporterTest : WordSpec({
@@ -35,9 +36,9 @@ class WebAppReporterTest : WordSpec({
 
     "WebAppReporter" should {
         "successfully export to a web application" {
-            val outputDir = createTempDir().apply { deleteOnExit() }
-            WebAppReporter().generateReport(ortResult, DefaultResolutionProvider(), CopyrightGarbage(), outputDir)
-            outputDir.resolve("scan-report-web-app.html").isFile shouldBe true
+            val outputStream = ByteArrayOutputStream()
+            WebAppReporter().generateReport(ortResult, DefaultResolutionProvider(), CopyrightGarbage(), outputStream)
+            outputStream.size() shouldNotBe 0
         }
     }
 })

--- a/reporter/src/main/kotlin/Reporter.kt
+++ b/reporter/src/main/kotlin/Reporter.kt
@@ -24,7 +24,7 @@ import com.here.ort.model.OrtResult
 import com.here.ort.model.ScanRecord
 import com.here.ort.model.config.CopyrightGarbage
 
-import java.io.File
+import java.io.OutputStream
 import java.util.ServiceLoader
 
 /**
@@ -42,19 +42,25 @@ abstract class Reporter {
     }
 
     /**
+     * The default output filename to use with this reporter format.
+     */
+    abstract val defaultFilename: String
+
+    /**
      * Return the Java class name as a simple way to refer to the [Reporter].
      */
     override fun toString(): String = javaClass.simpleName
 
     /**
-     * Generate a report for the [ortResult] taking into account any issue resolutions provided by [resolutionProvider].
-     * The report, whose file name is determined internally, is written to [outputDir] and returned as the result.
+     * Generate a report for the [ortResult], taking into account any issue resolutions provided by [resolutionProvider]
+     * and the given known [copyrightGarbage]. The report may be post-processed by a [postProcessingScript] before it is
+     * written to [outputStream].
      */
     abstract fun generateReport(
             ortResult: OrtResult,
             resolutionProvider: ResolutionProvider,
             copyrightGarbage: CopyrightGarbage,
-            outputDir: File,
+            outputStream: OutputStream,
             postProcessingScript: String? = null
-    ): File
+    )
 }

--- a/reporter/src/main/kotlin/reporters/ExcelReporter.kt
+++ b/reporter/src/main/kotlin/reporters/ExcelReporter.kt
@@ -19,8 +19,6 @@
 
 package com.here.ort.reporter.reporters
 
-import ch.frankel.slf4k.*
-
 import com.here.ort.model.AnalyzerResult
 import com.here.ort.model.OrtResult
 import com.here.ort.model.VcsInfo
@@ -31,10 +29,9 @@ import com.here.ort.reporter.ResolutionProvider
 import com.here.ort.reporter.reporters.ReportTableModel.ProjectTable
 import com.here.ort.reporter.reporters.ReportTableModel.SummaryTable
 import com.here.ort.utils.isValidUri
-import com.here.ort.utils.log
 
 import java.awt.Color
-import java.io.File
+import java.io.OutputStream
 
 import org.apache.poi.common.usermodel.HyperlinkType
 import org.apache.poi.ss.usermodel.BorderStyle
@@ -83,13 +80,15 @@ class ExcelReporter : Reporter() {
 
     private lateinit var creationHelper: CreationHelper
 
+    override val defaultFilename = "scan-report.xlsx"
+
     override fun generateReport(
             ortResult: OrtResult,
             resolutionProvider: ResolutionProvider,
             copyrightGarbage: CopyrightGarbage,
-            outputDir: File,
+            outputStream: OutputStream,
             postProcessingScript: String?
-    ): File {
+    ) {
         val tabularScanRecord = ReportTableModelMapper(resolutionProvider).mapToReportTableModel(ortResult)
         val workbook = XSSFWorkbook()
 
@@ -157,15 +156,7 @@ class ExcelReporter : Reporter() {
                     tabularScanRecord.extraColumns)
         }
 
-        val outputFile = File(outputDir, "scan-report.xlsx")
-
-        log.info { "Writing Excel report to '${outputFile.absolutePath}'." }
-
-        outputFile.outputStream().use {
-            workbook.write(it)
-        }
-
-        return outputFile
+        workbook.write(outputStream)
     }
 
     private fun createMetadataSheet(workbook: XSSFWorkbook, metadata: Map<String, String>) {

--- a/reporter/src/main/kotlin/reporters/WebAppReporter.kt
+++ b/reporter/src/main/kotlin/reporters/WebAppReporter.kt
@@ -19,25 +19,24 @@
 
 package com.here.ort.reporter.reporters
 
-import ch.frankel.slf4k.*
-
 import com.here.ort.model.OrtResult
 import com.here.ort.model.config.CopyrightGarbage
 import com.here.ort.model.jsonMapper
 import com.here.ort.reporter.Reporter
 import com.here.ort.reporter.ResolutionProvider
-import com.here.ort.utils.log
 
-import java.io.File
+import java.io.OutputStream
 
 class WebAppReporter : Reporter() {
+    override val defaultFilename = "scan-report-web-app.html"
+
     override fun generateReport(
             ortResult: OrtResult,
             resolutionProvider: ResolutionProvider,
             copyrightGarbage: CopyrightGarbage,
-            outputDir: File,
+            outputStream: OutputStream,
             postProcessingScript: String?
-    ): File {
+    ) {
         val template = javaClass.classLoader.getResource("scan-report-template.html").readText()
         val resultJson = jsonMapper.writeValueAsString(ortResult)
 
@@ -48,12 +47,8 @@ class WebAppReporter : Reporter() {
                 .replace("id=\"ort-report-data\"><", "id=\"ort-report-data\">$resultJson<")
                 .replace("id=\"ort-report-resolution-data\"><", "id=\"ort-report-resolution-data\">$resolutionsJson<")
 
-        val outputFile = File(outputDir, "scan-report-web-app.html")
-
-        log.info { "Writing web app report to '${outputFile.absolutePath}'." }
-
-        outputFile.writeText(result)
-
-        return outputFile
+        outputStream.bufferedWriter().use {
+            it.write(result)
+        }
     }
 }


### PR DESCRIPTION
This required some refactoring to not determine the report names
internally so their existence can be checked beforehand.

"generateReport()" now takes an "OutputStream" instead of a "File" which
also has the advantage that fewer temporary files neeed to be created in
the tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1219)
<!-- Reviewable:end -->
