### PR TITLE
LicenseFinding: Store locations of detected copyrights

### DIFF
--- a/model/src/main/kotlin/CopyrightFinding.kt
+++ b/model/src/main/kotlin/CopyrightFinding.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.model
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+import com.fasterxml.jackson.module.kotlin.treeToValue
+
+import com.here.ort.utils.SortedSetComparator
+import com.here.ort.utils.textValueOrEmpty
+
+import java.util.SortedSet
+import java.util.TreeSet
+
+data class CopyrightFinding(
+        val statement: String,
+        val locations: SortedSet<TextLocation>
+) : Comparable<CopyrightFinding> {
+    companion object {
+        private val LOCATIONS_COMPARATOR = SortedSetComparator<TextLocation>()
+    }
+
+    override fun compareTo(other: CopyrightFinding) =
+            compareValuesBy(
+                    this,
+                    other,
+                    compareBy(CopyrightFinding::statement)
+                            .thenBy(LOCATIONS_COMPARATOR, CopyrightFinding::locations)
+            ) { it }
+}
+
+class CopyrightFindingDeserializer : StdDeserializer<CopyrightFinding>(CopyrightFinding::class.java) {
+    override fun deserialize(p: JsonParser, ctxt: DeserializationContext): CopyrightFinding {
+        val node = p.codec.readTree<JsonNode>(p)
+        return when {
+            node.isTextual -> CopyrightFinding(node.textValueOrEmpty(), sortedSetOf())
+            else -> {
+                val statement = jsonMapper.treeToValue<String>(node["statement"])
+
+                val locationsType = jsonMapper.typeFactory.constructCollectionType(
+                        TreeSet::class.java,
+                        TextLocation::class.java
+                )
+
+                val locations = jsonMapper.readValue<TreeSet<TextLocation>>(
+                        jsonMapper.treeAsTokens(node["locations"]),
+                        locationsType
+                )
+
+                CopyrightFinding(statement, locations)
+            }
+        }
+    }
+}

--- a/model/src/main/kotlin/CopyrightFinding.kt
+++ b/model/src/main/kotlin/CopyrightFinding.kt
@@ -37,7 +37,7 @@ data class CopyrightFinding(
         val locations: SortedSet<TextLocation>
 ) : Comparable<CopyrightFinding> {
     companion object {
-        private val LOCATIONS_COMPARATOR = SortedSetComparator<TextLocation>()
+        val SORTED_SET_COMPARATOR = SortedSetComparator<CopyrightFinding>()
     }
 
     override fun compareTo(other: CopyrightFinding) =
@@ -45,7 +45,7 @@ data class CopyrightFinding(
                     this,
                     other,
                     compareBy(CopyrightFinding::statement)
-                            .thenBy(LOCATIONS_COMPARATOR, CopyrightFinding::locations)
+                            .thenBy(TextLocation.SORTED_SET_COMPARATOR, CopyrightFinding::locations)
             ) { it }
 }
 

--- a/model/src/main/kotlin/CopyrightFinding.kt
+++ b/model/src/main/kotlin/CopyrightFinding.kt
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.module.kotlin.treeToValue
 
 import com.here.ort.utils.SortedSetComparator
+import com.here.ort.utils.constructTreeSetType
 import com.here.ort.utils.textValueOrEmpty
 
 import java.util.SortedSet
@@ -51,7 +52,7 @@ data class CopyrightFinding(
 class CopyrightFindingDeserializer : StdDeserializer<CopyrightFinding>(CopyrightFinding::class.java) {
     companion object {
         private val LOCATIONS_TYPE by lazy {
-            jsonMapper.typeFactory.constructCollectionType(TreeSet::class.java, TextLocation::class.java)
+            jsonMapper.typeFactory.constructTreeSetType(TextLocation::class.java)
         }
     }
 

--- a/model/src/main/kotlin/CopyrightFinding.kt
+++ b/model/src/main/kotlin/CopyrightFinding.kt
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.module.kotlin.treeToValue
 
 import com.here.ort.utils.SortedSetComparator
 import com.here.ort.utils.constructTreeSetType
-import com.here.ort.utils.textValueOrEmpty
 
 import java.util.SortedSet
 import java.util.TreeSet
@@ -59,7 +58,7 @@ class CopyrightFindingDeserializer : StdDeserializer<CopyrightFinding>(Copyright
     override fun deserialize(p: JsonParser, ctxt: DeserializationContext): CopyrightFinding {
         val node = p.codec.readTree<JsonNode>(p)
         return when {
-            node.isTextual -> CopyrightFinding(node.textValueOrEmpty(), sortedSetOf())
+            node.isTextual -> CopyrightFinding(node.textValue(), sortedSetOf())
             else -> {
                 val statement = jsonMapper.treeToValue<String>(node["statement"])
 

--- a/model/src/main/kotlin/CopyrightFinding.kt
+++ b/model/src/main/kotlin/CopyrightFinding.kt
@@ -37,6 +37,7 @@ data class CopyrightFinding(
 ) : Comparable<CopyrightFinding> {
     companion object {
         val SORTED_SET_COMPARATOR = SortedSetComparator<CopyrightFinding>()
+        val TREE_SET_TYPE by lazy { jsonMapper.typeFactory.constructTreeSetType(CopyrightFinding::class.java) }
     }
 
     override fun compareTo(other: CopyrightFinding) =
@@ -49,12 +50,6 @@ data class CopyrightFinding(
 }
 
 class CopyrightFindingDeserializer : StdDeserializer<CopyrightFinding>(CopyrightFinding::class.java) {
-    companion object {
-        private val LOCATIONS_TYPE by lazy {
-            jsonMapper.typeFactory.constructTreeSetType(TextLocation::class.java)
-        }
-    }
-
     override fun deserialize(p: JsonParser, ctxt: DeserializationContext): CopyrightFinding {
         val node = p.codec.readTree<JsonNode>(p)
         return when {
@@ -64,7 +59,7 @@ class CopyrightFindingDeserializer : StdDeserializer<CopyrightFinding>(Copyright
 
                 val locations = jsonMapper.readValue<TreeSet<TextLocation>>(
                         jsonMapper.treeAsTokens(node["locations"]),
-                        LOCATIONS_TYPE
+                        TextLocation.TREE_SET_TYPE
                 )
 
                 CopyrightFinding(statement, locations)

--- a/model/src/main/kotlin/CopyrightFinding.kt
+++ b/model/src/main/kotlin/CopyrightFinding.kt
@@ -49,6 +49,12 @@ data class CopyrightFinding(
 }
 
 class CopyrightFindingDeserializer : StdDeserializer<CopyrightFinding>(CopyrightFinding::class.java) {
+    companion object {
+        private val LOCATIONS_TYPE by lazy {
+            jsonMapper.typeFactory.constructCollectionType(TreeSet::class.java, TextLocation::class.java)
+        }
+    }
+
     override fun deserialize(p: JsonParser, ctxt: DeserializationContext): CopyrightFinding {
         val node = p.codec.readTree<JsonNode>(p)
         return when {
@@ -56,14 +62,9 @@ class CopyrightFindingDeserializer : StdDeserializer<CopyrightFinding>(Copyright
             else -> {
                 val statement = jsonMapper.treeToValue<String>(node["statement"])
 
-                val locationsType = jsonMapper.typeFactory.constructCollectionType(
-                        TreeSet::class.java,
-                        TextLocation::class.java
-                )
-
                 val locations = jsonMapper.readValue<TreeSet<TextLocation>>(
                         jsonMapper.treeAsTokens(node["locations"]),
-                        locationsType
+                        LOCATIONS_TYPE
                 )
 
                 CopyrightFinding(statement, locations)

--- a/model/src/main/kotlin/LicenseFinding.kt
+++ b/model/src/main/kotlin/LicenseFinding.kt
@@ -28,7 +28,6 @@ import com.fasterxml.jackson.module.kotlin.treeToValue
 import com.here.ort.model.config.CopyrightGarbage
 import com.here.ort.utils.CopyrightStatementsProcessor
 import com.here.ort.utils.constructTreeSetType
-import com.here.ort.utils.textValueOrEmpty
 
 import java.util.SortedMap
 import java.util.SortedSet
@@ -89,7 +88,7 @@ class LicenseFindingDeserializer : StdDeserializer<LicenseFinding>(LicenseFindin
     override fun deserialize(p: JsonParser, ctxt: DeserializationContext): LicenseFinding {
         val node = p.codec.readTree<JsonNode>(p)
         return when {
-            node.isTextual -> LicenseFinding(node.textValueOrEmpty(), sortedSetOf(), sortedSetOf())
+            node.isTextual -> LicenseFinding(node.textValue(), sortedSetOf(), sortedSetOf())
             else -> {
                 val license = jsonMapper.treeToValue<String>(node["license"])
 

--- a/model/src/main/kotlin/LicenseFinding.kt
+++ b/model/src/main/kotlin/LicenseFinding.kt
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.module.kotlin.treeToValue
 
 import com.here.ort.model.config.CopyrightGarbage
 import com.here.ort.utils.CopyrightStatementsProcessor
-import com.here.ort.utils.SortedSetComparator
 import com.here.ort.utils.constructTreeSetType
 import com.here.ort.utils.textValueOrEmpty
 
@@ -63,18 +62,13 @@ data class LicenseFinding(
         val locations: SortedSet<TextLocation>,
         val copyrights: SortedSet<CopyrightFinding>
 ) : Comparable<LicenseFinding> {
-    companion object {
-        private val COPYRIGHTS_COMPARATOR = SortedSetComparator<CopyrightFinding>()
-        private val LOCATIONS_COMPARATOR = SortedSetComparator<TextLocation>()
-    }
-
     override fun compareTo(other: LicenseFinding) =
             compareValuesBy(
                     this,
                     other,
                     compareBy(LicenseFinding::license)
-                            .thenBy(LOCATIONS_COMPARATOR, LicenseFinding::locations)
-                            .thenBy(COPYRIGHTS_COMPARATOR, LicenseFinding::copyrights)
+                            .thenBy(TextLocation.SORTED_SET_COMPARATOR, LicenseFinding::locations)
+                            .thenBy(CopyrightFinding.SORTED_SET_COMPARATOR, LicenseFinding::copyrights)
             ) { it }
 }
 

--- a/model/src/main/kotlin/LicenseFinding.kt
+++ b/model/src/main/kotlin/LicenseFinding.kt
@@ -55,8 +55,8 @@ fun LicenseFindingsMap.removeGarbage(copyrightGarbage: CopyrightGarbage) =
         }.toSortedMap()
 
 /**
- * A class to store a [license] finding along with its belonging [copyrights]. To support deserializing older versions
- * of this class which did not include the copyrights a secondary constructor is only taking a [licenseName].
+ * A class to store a [license] finding along with its belonging [copyrights] and the [locations] where the license was
+ * found.
  */
 data class LicenseFinding(
         val license: String,

--- a/model/src/main/kotlin/LicenseFinding.kt
+++ b/model/src/main/kotlin/LicenseFinding.kt
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.module.kotlin.treeToValue
 
 import com.here.ort.model.config.CopyrightGarbage
 import com.here.ort.utils.CopyrightStatementsProcessor
-import com.here.ort.utils.constructTreeSetType
 
 import java.util.SortedMap
 import java.util.SortedSet
@@ -75,16 +74,6 @@ data class LicenseFinding(
  * Custom deserializer to support old versions of the [LicenseFinding] class.
  */
 class LicenseFindingDeserializer : StdDeserializer<LicenseFinding>(LicenseFinding::class.java) {
-    companion object {
-        private val COPYRIGHTS_TYPE by lazy {
-            jsonMapper.typeFactory.constructTreeSetType(CopyrightFinding::class.java)
-        }
-
-        private val LOCATIONS_TYPE by lazy {
-            jsonMapper.typeFactory.constructTreeSetType(TextLocation::class.java)
-        }
-    }
-
     override fun deserialize(p: JsonParser, ctxt: DeserializationContext): LicenseFinding {
         val node = p.codec.readTree<JsonNode>(p)
         return when {
@@ -94,7 +83,7 @@ class LicenseFindingDeserializer : StdDeserializer<LicenseFinding>(LicenseFindin
 
                 val copyrights = jsonMapper.readValue<TreeSet<CopyrightFinding>>(
                         jsonMapper.treeAsTokens(node["copyrights"]),
-                        COPYRIGHTS_TYPE
+                        CopyrightFinding.TREE_SET_TYPE
                 )
 
                 val locations = deserializeLocations(node)
@@ -106,6 +95,9 @@ class LicenseFindingDeserializer : StdDeserializer<LicenseFinding>(LicenseFindin
 
     private fun deserializeLocations(node: JsonNode) =
             node["locations"]?.let { locations ->
-                jsonMapper.readValue<TreeSet<TextLocation>>(jsonMapper.treeAsTokens(locations), LOCATIONS_TYPE)
+                jsonMapper.readValue<TreeSet<TextLocation>>(
+                        jsonMapper.treeAsTokens(locations),
+                        TextLocation.TREE_SET_TYPE
+                )
             } ?: sortedSetOf()
 }

--- a/model/src/main/kotlin/LicenseFinding.kt
+++ b/model/src/main/kotlin/LicenseFinding.kt
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.module.kotlin.treeToValue
 import com.here.ort.model.config.CopyrightGarbage
 import com.here.ort.utils.CopyrightStatementsProcessor
 import com.here.ort.utils.SortedSetComparator
+import com.here.ort.utils.constructTreeSetType
 import com.here.ort.utils.textValueOrEmpty
 
 import java.util.SortedMap
@@ -83,11 +84,11 @@ data class LicenseFinding(
 class LicenseFindingDeserializer : StdDeserializer<LicenseFinding>(LicenseFinding::class.java) {
     companion object {
         private val COPYRIGHTS_TYPE by lazy {
-            jsonMapper.typeFactory.constructCollectionType(TreeSet::class.java, CopyrightFinding::class.java)
+            jsonMapper.typeFactory.constructTreeSetType(CopyrightFinding::class.java)
         }
 
         private val LOCATIONS_TYPE by lazy {
-            jsonMapper.typeFactory.constructCollectionType(TreeSet::class.java, TextLocation::class.java)
+            jsonMapper.typeFactory.constructTreeSetType(TextLocation::class.java)
         }
     }
 

--- a/model/src/main/kotlin/LicenseFinding.kt
+++ b/model/src/main/kotlin/LicenseFinding.kt
@@ -113,7 +113,7 @@ class LicenseFindingDeserializer : StdDeserializer<LicenseFinding>(LicenseFindin
                     }
                     else -> sortedSetOf()
                 }
-                return LicenseFinding(license, locations, copyrights)
+                LicenseFinding(license, locations, copyrights)
             }
         }
     }

--- a/model/src/main/kotlin/LicenseFinding.kt
+++ b/model/src/main/kotlin/LicenseFinding.kt
@@ -104,17 +104,21 @@ class LicenseFindingDeserializer : StdDeserializer<LicenseFinding>(LicenseFindin
                         COPYRIGHTS_TYPE
                 )
 
-                val locations = when {
-                    node.has("locations") -> {
-                        jsonMapper.readValue<TreeSet<TextLocation>>(
-                                jsonMapper.treeAsTokens(node["locations"]),
-                                LOCATIONS_TYPE
-                        )
-                    }
-                    else -> sortedSetOf()
-                }
+                val locations = deserializeLocations(node)
+
                 LicenseFinding(license, locations, copyrights)
             }
         }
     }
+
+    private fun deserializeLocations(node: JsonNode) =
+            when {
+                node.has("locations") -> {
+                    jsonMapper.readValue<TreeSet<TextLocation>>(
+                            jsonMapper.treeAsTokens(node["locations"]),
+                            LOCATIONS_TYPE
+                    )
+                }
+                else -> sortedSetOf()
+            }
 }

--- a/model/src/main/kotlin/LicenseFinding.kt
+++ b/model/src/main/kotlin/LicenseFinding.kt
@@ -105,13 +105,7 @@ class LicenseFindingDeserializer : StdDeserializer<LicenseFinding>(LicenseFindin
     }
 
     private fun deserializeLocations(node: JsonNode) =
-            when {
-                node.has("locations") -> {
-                    jsonMapper.readValue<TreeSet<TextLocation>>(
-                            jsonMapper.treeAsTokens(node["locations"]),
-                            LOCATIONS_TYPE
-                    )
-                }
-                else -> sortedSetOf()
-            }
+            node["locations"]?.let { locations ->
+                jsonMapper.readValue<TreeSet<TextLocation>>(jsonMapper.treeAsTokens(locations), LOCATIONS_TYPE)
+            } ?: sortedSetOf()
 }

--- a/model/src/main/kotlin/Mappers.kt
+++ b/model/src/main/kotlin/Mappers.kt
@@ -34,6 +34,7 @@ import com.here.ort.model.config.AnalyzerConfigurationDeserializer
 
 private val ortModelModule = SimpleModule("OrtModelModule").apply {
     addDeserializer(AnalyzerConfiguration::class.java, AnalyzerConfigurationDeserializer())
+    addDeserializer(CopyrightFinding::class.java, CopyrightFindingDeserializer())
     addDeserializer(LicenseFinding::class.java, LicenseFindingDeserializer())
     addDeserializer(OrtIssue::class.java, OrtIssueDeserializer())
     addDeserializer(VcsInfo::class.java, VcsInfoDeserializer())

--- a/model/src/main/kotlin/ScanSummary.kt
+++ b/model/src/main/kotlin/ScanSummary.kt
@@ -63,7 +63,7 @@ data class ScanSummary(
         val errors: List<OrtIssue> = emptyList()
 ) {
     @get:JsonIgnore
-    val licenseFindingsMap = sortedMapOf<String, SortedSet<String>>().also {
+    val licenseFindingsMap = sortedMapOf<String, SortedSet<CopyrightFinding>>().also {
         licenseFindings.forEach { finding ->
             it.getOrPut(finding.license) { sortedSetOf() } += finding.copyrights
         }

--- a/model/src/main/kotlin/TextLocation.kt
+++ b/model/src/main/kotlin/TextLocation.kt
@@ -19,6 +19,8 @@
 
 package com.here.ort.model
 
+import com.here.ort.utils.SortedSetComparator
+
 /**
  * A [TextLocation] references text located in a file.
  */
@@ -40,6 +42,7 @@ data class TextLocation(
 ) : Comparable<TextLocation> {
     companion object {
         private val COMPARATOR = compareBy<TextLocation>({ it.path }, { it.startLine }, { it.endLine })
+        val SORTED_SET_COMPARATOR = SortedSetComparator<TextLocation>()
     }
 
     override fun compareTo(other: TextLocation) = COMPARATOR.compare(this, other)

--- a/model/src/main/kotlin/TextLocation.kt
+++ b/model/src/main/kotlin/TextLocation.kt
@@ -20,6 +20,7 @@
 package com.here.ort.model
 
 import com.here.ort.utils.SortedSetComparator
+import com.here.ort.utils.constructTreeSetType
 
 /**
  * A [TextLocation] references text located in a file.
@@ -43,6 +44,7 @@ data class TextLocation(
     companion object {
         private val COMPARATOR = compareBy<TextLocation>({ it.path }, { it.startLine }, { it.endLine })
         val SORTED_SET_COMPARATOR = SortedSetComparator<TextLocation>()
+        val TREE_SET_TYPE by lazy { jsonMapper.typeFactory.constructTreeSetType(TextLocation::class.java) }
     }
 
     override fun compareTo(other: TextLocation) = COMPARATOR.compare(this, other)

--- a/model/src/test/assets/expected-scan-results.yml
+++ b/model/src/test/assets/expected-scan-results.yml
@@ -22,14 +22,22 @@ results:
         start_line: 1
         end_line: 1
       copyrights:
-      - "copyright 1"
+      - statement: "copyright 1"
+        locations:
+        - path: "copyright path 1.1"
+          start_line: 1
+          end_line: 1
     - license: "license 1.2"
       locations:
       - path: "path 1.2"
         start_line: 1
         end_line: 2
       copyrights:
-      - "copyright 2"
+      - statement: "copyright 2"
+        locations:
+        - path: "copyright path 1.2"
+          start_line: 1
+          end_line: 2
     errors:
     - timestamp: "1970-01-01T00:00:00Z"
       source: "source-11"
@@ -60,11 +68,13 @@ results:
     - license: "license 2.1"
       locations: []
       copyrights:
-      - "copyright 3"
+      - statement: "copyright 3"
+        locations: []
     - license: "license 2.2"
       locations: []
       copyrights:
-      - "copyright 4"
+      - statement: "copyright 4"
+        locations: []
     errors:
     - timestamp: "1970-01-01T00:00:00Z"
       source: "source-21"

--- a/model/src/test/kotlin/LicenseFindingTest.kt
+++ b/model/src/test/kotlin/LicenseFindingTest.kt
@@ -32,8 +32,8 @@ class LicenseFindingTest : StringSpec({
                     TextLocation("path 2", 3, 4)
             ),
             sortedSetOf(
-                    "copyright 1",
-                    "copyright 2"
+                    CopyrightFinding("copyright 1", sortedSetOf()),
+                    CopyrightFinding("copyright 2", sortedSetOf())
             )
     )
 
@@ -58,8 +58,10 @@ class LicenseFindingTest : StringSpec({
               start_line: 3
               end_line: 4
             copyrights:
-            - "copyright 1"
-            - "copyright 2"
+            - statement: "copyright 1"
+              locations: []
+            - statement: "copyright 2"
+              locations: []
             """.trimIndent()
     }
 
@@ -88,7 +90,10 @@ class LicenseFindingTest : StringSpec({
         deserializedLicenseFinding shouldBe LicenseFinding(
                 "license",
                 sortedSetOf(),
-                sortedSetOf("copyright 1", "copyright 2")
+                sortedSetOf(
+                        CopyrightFinding("copyright 1", sortedSetOf()),
+                        CopyrightFinding("copyright 2", sortedSetOf())
+                )
         )
     }
 })

--- a/model/src/test/kotlin/ScanResultContainerTest.kt
+++ b/model/src/test/kotlin/ScanResultContainerTest.kt
@@ -66,12 +66,18 @@ class ScanResultContainerTest : WordSpec() {
                     LicenseFinding(
                             "license 1.1",
                             sortedSetOf(TextLocation("path 1.1", 1, 1)),
-                            sortedSetOf("copyright 1")
+                            sortedSetOf(CopyrightFinding(
+                                    "copyright 1",
+                                    sortedSetOf(TextLocation("copyright path 1.1", 1, 1))
+                            ))
                     ),
                     LicenseFinding(
                             "license 1.2",
                             sortedSetOf(TextLocation("path 1.2", 1, 2)),
-                            sortedSetOf("copyright 2")
+                            sortedSetOf(CopyrightFinding(
+                                    "copyright 2",
+                                    sortedSetOf(TextLocation("copyright path 1.2", 1, 2))
+                            ))
                     )
             ),
             mutableListOf(error11, error12)
@@ -81,8 +87,16 @@ class ScanResultContainerTest : WordSpec() {
             scannerEndTime2,
             2,
             sortedSetOf(
-                    LicenseFinding("license 2.1", sortedSetOf(), sortedSetOf("copyright 3")),
-                    LicenseFinding("license 2.2", sortedSetOf(), sortedSetOf("copyright 4"))
+                    LicenseFinding(
+                            "license 2.1",
+                            sortedSetOf(),
+                            sortedSetOf(CopyrightFinding("copyright 3", sortedSetOf()))
+                    ),
+                    LicenseFinding(
+                            "license 2.2",
+                            sortedSetOf(),
+                            sortedSetOf(CopyrightFinding("copyright 4", sortedSetOf()))
+                    )
             ),
             mutableListOf(error21, error22)
     )

--- a/reporter-web-app/src/components/PackageScansSummary.js
+++ b/reporter-web-app/src/components/PackageScansSummary.js
@@ -59,8 +59,8 @@ const PackageScansSummary = (props) => {
                                             </dl>
                                             <dl>
                                                 {row.copyrights.map(holder => (
-                                                    <dd key={`${row.license}-holder-${holder}`}>
-                                                        {holder}
+                                                    <dd key={`${row.license}-holder-${holder.statement}`}>
+                                                        {holder.statement}
                                                     </dd>
                                                 ))}
                                             </dl>

--- a/reporter/src/main/kotlin/reporters/NoticeReporter.kt
+++ b/reporter/src/main/kotlin/reporters/NoticeReporter.kt
@@ -131,7 +131,7 @@ class NoticeReporter : Reporter() {
             if (excludes?.isExcluded(container.id, analyzerResult) != true) {
                 container.results.forEach { result ->
                     result.summary.licenseFindingsMap.forEach { (license, copyrights) ->
-                        licenseFindings.getOrPut(license) { mutableSetOf() } += copyrights
+                        licenseFindings.getOrPut(license) { mutableSetOf() } += copyrights.map { it.statement }
                     }
                 }
             }

--- a/scanner/src/test/kotlin/ScanCodeTest.kt
+++ b/scanner/src/test/kotlin/ScanCodeTest.kt
@@ -19,6 +19,7 @@
 
 package com.here.ort.scanner
 
+import com.here.ort.model.CopyrightFinding
 import com.here.ort.model.LicenseFinding
 import com.here.ort.model.TextLocation
 import com.here.ort.model.config.ScannerConfiguration
@@ -138,27 +139,46 @@ class ScanCodeTest : WordSpec({
         "properly return closest jquery copyright statements" {
             val resultFile = File("src/test/assets/esprima-2.7.3_scancode-2.2.1.json")
             val result = jsonMapper.readTree(resultFile)
+            val path = "test/3rdparty/jquery-1.9.1.js"
             val copyrights = result["files"].find {
-                it["path"].asText() == "test/3rdparty/jquery-1.9.1.js"
+                it["path"].asText() == path
             }!!.get("copyrights")
 
-            scanner.getClosestCopyrightStatements(copyrights, 5) shouldBe
-                    sortedSetOf("Copyright 2005, 2012 jQuery Foundation, Inc.")
-            scanner.getClosestCopyrightStatements(copyrights, 3690) shouldBe
-                    sortedSetOf("Copyright 2012 jQuery Foundation")
+            scanner.getClosestCopyrightStatements(path, copyrights, 5) shouldBe sortedSetOf(
+                    CopyrightFinding(
+                            "Copyright 2005, 2012 jQuery Foundation, Inc.",
+                            sortedSetOf(TextLocation(path, 8, 10))
+                    )
+            )
+            scanner.getClosestCopyrightStatements(path, copyrights, 3690) shouldBe sortedSetOf(
+                    CopyrightFinding(
+                            "Copyright 2012 jQuery Foundation",
+                            sortedSetOf(TextLocation(path, 3688, 3691))
+                    )
+            )
         }
 
         "properly return closest mootools copyright statements" {
             val resultFile = File("src/test/assets/esprima-2.7.3_scancode-2.2.1.json")
             val result = jsonMapper.readTree(resultFile)
+            val path = "test/3rdparty/mootools-1.4.5.js"
             val copyrights = result["files"].find {
-                it["path"].asText() == "test/3rdparty/mootools-1.4.5.js"
+                it["path"].asText() == path
             }!!.get("copyrights")
 
-            scanner.getClosestCopyrightStatements(copyrights, 28) shouldBe sortedSetOf(
-                    "Copyright (c) 2005-2007 Sam Stephenson",
-                    "Copyright (c) 2006 Dean Edwards, GNU Lesser General Public",
-                    "Copyright (c) 2006-2012 Valerio Proietti"
+            scanner.getClosestCopyrightStatements(path, copyrights, 28) shouldBe sortedSetOf(
+                    CopyrightFinding(
+                            "Copyright (c) 2005-2007 Sam Stephenson",
+                            sortedSetOf(TextLocation(path, 27, 29))
+                    ),
+                    CopyrightFinding(
+                            "Copyright (c) 2006 Dean Edwards, GNU Lesser General Public",
+                            sortedSetOf(TextLocation(path, 27, 29))
+                    ),
+                    CopyrightFinding(
+                            "Copyright (c) 2006-2012 Valerio Proietti",
+                            sortedSetOf(TextLocation(path, 23, 23))
+                    )
             )
         }
     }
@@ -172,7 +192,10 @@ class ScanCodeTest : WordSpec({
                     LicenseFinding(
                             "Apache-2.0",
                             sortedSetOf(TextLocation("LICENSE", 1, 201)),
-                            sortedSetOf("Copyright (C) 2017-2019 HERE Europe B.V.")
+                            sortedSetOf(CopyrightFinding(
+                                    "Copyright (C) 2017-2019 HERE Europe B.V.",
+                                    sortedSetOf(TextLocation("README.md", 162, 162))
+                            ))
                     )
             )
         }
@@ -181,151 +204,275 @@ class ScanCodeTest : WordSpec({
             val resultFile = File("src/test/assets/esprima-2.7.3_scancode-2.2.1.json")
             val result = scanner.getResult(resultFile)
 
-            val expectedFindings = sortedSetOf(
-                    LicenseFinding(
-                            "BSD-2-Clause",
-                            sortedSetOf(
-                                    TextLocation("esprima.js", 4, 22),
-                                    TextLocation("LICENSE.BSD", 3, 21),
-                                    TextLocation("bin/esvalidate.js", 5, 23),
-                                    TextLocation("bin/esparse.js", 5, 23),
-                                    TextLocation("tools/generate-fixtures.js", 3, 19),
-                                    TextLocation("test/check-complexity.js", 4, 22),
-                                    TextLocation("test/regression-tests.js", 4, 22),
-                                    TextLocation("test/downstream.js", 4, 22),
-                                    TextLocation("test/browser-tests.js", 4, 22),
-                                    TextLocation("test/profile.js", 4, 22),
-                                    TextLocation("test/unit-tests.js", 4, 22),
-                                    TextLocation("test/check-version.js", 6, 24),
-                                    TextLocation("test/grammar-tests.js", 4, 22),
-                                    TextLocation("test/benchmarks.js", 4, 22),
-                                    TextLocation("test/utils/evaluate-testcase.js", 4, 22),
-                                    TextLocation("test/utils/create-testcases.js", 4, 22),
-                                    TextLocation("test/utils/error-to-object.js", 4, 22)
-                            ),
-                            sortedSetOf(
-                                    "Copyright (c) jQuery Foundation, Inc. and Contributors"
-                            )
+            val expectedFindingBsd2 = LicenseFinding(
+                    "BSD-2-Clause",
+                    sortedSetOf(
+                            TextLocation("esprima.js", 4, 22),
+                            TextLocation("LICENSE.BSD", 3, 21),
+                            TextLocation("bin/esvalidate.js", 5, 23),
+                            TextLocation("bin/esparse.js", 5, 23),
+                            TextLocation("tools/generate-fixtures.js", 3, 19),
+                            TextLocation("test/check-complexity.js", 4, 22),
+                            TextLocation("test/regression-tests.js", 4, 22),
+                            TextLocation("test/downstream.js", 4, 22),
+                            TextLocation("test/browser-tests.js", 4, 22),
+                            TextLocation("test/profile.js", 4, 22),
+                            TextLocation("test/unit-tests.js", 4, 22),
+                            TextLocation("test/check-version.js", 6, 24),
+                            TextLocation("test/grammar-tests.js", 4, 22),
+                            TextLocation("test/benchmarks.js", 4, 22),
+                            TextLocation("test/utils/evaluate-testcase.js", 4, 22),
+                            TextLocation("test/utils/create-testcases.js", 4, 22),
+                            TextLocation("test/utils/error-to-object.js", 4, 22)
                     ),
-                    LicenseFinding(
-                            "BSD-3-Clause",
-                            sortedSetOf(
-                                    TextLocation("package.json", 37, 37),
-                                    TextLocation("bower.json", 20, 20),
-                                    TextLocation("test/3rdparty/yui-3.12.0.js", 4, 4),
-                                    TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 1910, 1910)
-                            ),
-                            sortedSetOf(
-                                    "copyright (c) 2012 Scott Jehl, Paul Irish, Nicholas Zakas.",
-                                    "Copyright 2013 Yahoo! Inc."
-                            )
-                    ),
-                    LicenseFinding(
-                            "GPL-1.0+",
-                            sortedSetOf(
-                                    TextLocation("test/3rdparty/jquery-1.9.1.js", 10, 10),
-                                    TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 8, 8),
-                                    TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 233, 233),
-                                    TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 832, 832),
-                                    TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 1522, 1523),
-                                    TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 1538, 1539),
-                                    TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 14001, 14001)
-                            ),
-                            sortedSetOf(
-                                    "Copyright (c) 2010 Cowboy Ben Alman",
-                                    "Copyright 2005, 2012 jQuery Foundation, Inc.",
-                                    "Copyright 2010, 2014 jQuery Foundation, Inc.",
-                                    "Copyright 2013 jQuery Foundation"
-                            )
-                    ),
-                    LicenseFinding(
-                            "LGPL-2.0+",
-                            sortedSetOf(
-                                    TextLocation("test/3rdparty/mootools-1.4.5.js", 28, 28),
-                                    TextLocation("test/3rdparty/mootools-1.4.5.js", 4718, 4718)
-                            ),
-                            sortedSetOf(
-                                    "Copyright (c) 2005-2007 Sam Stephenson",
-                                    "Copyright (c) 2006 Dean Edwards, GNU Lesser General Public",
-                                    "Copyright (c) 2006-2012 Valerio Proietti"
-                            )
-                    ),
-                    LicenseFinding(
-                            "MIT",
-                            sortedSetOf(
-                                    TextLocation("test/3rdparty/benchmark.js", 6, 6),
-                                    TextLocation("test/3rdparty/mootools-1.4.5.js", 21, 21),
-                                    TextLocation("test/3rdparty/mootools-1.4.5.js", 29, 29),
-                                    TextLocation("test/3rdparty/mootools-1.4.5.js", 542, 542),
-                                    TextLocation("test/3rdparty/mootools-1.4.5.js", 723, 723),
-                                    TextLocation("test/3rdparty/mootools-1.4.5.js", 807, 807),
-                                    TextLocation("test/3rdparty/mootools-1.4.5.js", 861, 861),
-                                    TextLocation("test/3rdparty/mootools-1.4.5.js", 991, 991),
-                                    TextLocation("test/3rdparty/mootools-1.4.5.js", 1202, 1202),
-                                    TextLocation("test/3rdparty/mootools-1.4.5.js", 1457, 1457),
-                                    TextLocation("test/3rdparty/mootools-1.4.5.js", 1584, 1584),
-                                    TextLocation("test/3rdparty/mootools-1.4.5.js", 1701, 1701),
-                                    TextLocation("test/3rdparty/mootools-1.4.5.js", 1881, 1881),
-                                    TextLocation("test/3rdparty/mootools-1.4.5.js", 3043, 3043),
-                                    TextLocation("test/3rdparty/mootools-1.4.5.js", 4103, 4103),
-                                    TextLocation("test/3rdparty/mootools-1.4.5.js", 4322, 4322),
-                                    TextLocation("test/3rdparty/mootools-1.4.5.js", 4514, 4514),
-                                    TextLocation("test/3rdparty/mootools-1.4.5.js", 4715, 4715),
-                                    TextLocation("test/3rdparty/mootools-1.4.5.js", 4999, 4999),
-                                    TextLocation("test/3rdparty/mootools-1.4.5.js", 5180, 5180),
-                                    TextLocation("test/3rdparty/mootools-1.4.5.js", 5350, 5350),
-                                    TextLocation("test/3rdparty/mootools-1.4.5.js", 5463, 5463),
-                                    TextLocation("test/3rdparty/mootools-1.4.5.js", 5542, 5542),
-                                    TextLocation("test/3rdparty/mootools-1.4.5.js", 5657, 5657),
-                                    TextLocation("test/3rdparty/mootools-1.4.5.js", 5937, 5937),
-                                    TextLocation("test/3rdparty/mootools-1.4.5.js", 6027, 6027),
-                                    TextLocation("test/3rdparty/mootools-1.4.5.js", 6110, 6110),
-                                    TextLocation("test/3rdparty/mootools-1.4.5.js", 6158, 6158),
-                                    TextLocation("test/3rdparty/mootools-1.4.5.js", 6234, 6234),
-                                    TextLocation("test/3rdparty/mootools-1.4.5.js", 6341, 6341),
-                                    TextLocation("test/3rdparty/angular-1.2.5.js", 4, 4),
-                                    TextLocation("test/3rdparty/jquery-1.9.1.js", 9, 9),
-                                    TextLocation("test/3rdparty/jquery-1.9.1.js", 10, 10),
-                                    TextLocation("test/3rdparty/jquery-1.9.1.js", 3690, 3690),
-                                    TextLocation("test/3rdparty/underscore-1.5.2.js", 4, 4),
-                                    TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 7, 7),
-                                    TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 8, 8),
-                                    TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 232, 232),
-                                    TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 233, 233),
-                                    TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 831, 831),
-                                    TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 832, 832),
-                                    TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 1522, 1523),
-                                    TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 1538, 1539),
-                                    TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 1910, 1910),
-                                    TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 14000, 14000),
-                                    TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 14001, 14001),
-                                    TextLocation("test/3rdparty/backbone-1.1.0.js", 5, 5)
-                            ),
-                            sortedSetOf(
-                                    "(c) 2007-2008 Steven Levithan",
-                                    "(c) 2009-2013 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & " +
-                                            "Editors Underscore",
-                                    "(c) 2010-2011 Jeremy Ashkenas, DocumentCloud Inc.",
-                                    "(c) 2010-2014 Google, Inc. http://angularjs.org",
-                                    "(c) 2011-2013 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & " +
-                                            "Editors Backbone",
-                                    "Copyright (c) 2005-2007 Sam Stephenson",
-                                    "Copyright (c) 2006 Dean Edwards, GNU Lesser General Public",
-                                    "Copyright (c) 2006-2012 Valerio Proietti",
-                                    "Copyright (c) 2010 Cowboy Ben Alman",
-                                    "copyright (c) 2012 Scott Jehl, Paul Irish, Nicholas Zakas.",
-                                    "Copyright 2005, 2012 jQuery Foundation, Inc.",
-                                    "Copyright 2010, 2014 jQuery Foundation, Inc.",
-                                    "Copyright 2010-2012 Mathias Bynens",
-                                    "Copyright 2012 jQuery Foundation",
-                                    "Copyright 2013 jQuery Foundation",
-                                    "copyright Robert Kieffer"
+                    sortedSetOf(
+                            CopyrightFinding(
+                                    "Copyright (c) jQuery Foundation, Inc. and Contributors",
+                                    sortedSetOf(
+                                            TextLocation("LICENSE.BSD", 1, 1),
+                                            TextLocation("bin/esparse.js", 3, 3),
+                                            TextLocation("bin/esvalidate.js", 3, 3),
+                                            TextLocation("esprima.js", 2, 2),
+                                            TextLocation("test/benchmarks.js", 2, 2),
+                                            TextLocation("test/browser-tests.js", 2, 2),
+                                            TextLocation("test/check-complexity.js", 2, 2),
+                                            TextLocation("test/check-version.js", 4, 4),
+                                            TextLocation("test/downstream.js", 2, 2),
+                                            TextLocation("test/grammar-tests.js", 2, 2),
+                                            TextLocation("test/profile.js", 2, 2),
+                                            TextLocation("test/regression-tests.js", 2, 2),
+                                            TextLocation("test/unit-tests.js", 2, 2),
+                                            TextLocation("test/utils/create-testcases.js", 2, 2),
+                                            TextLocation("test/utils/error-to-object.js", 2, 2),
+                                            TextLocation("test/utils/evaluate-testcase.js", 2, 2),
+                                            TextLocation("tools/generate-fixtures.js", 2, 2)
+                                    )
                             )
                     )
             )
+
+            val expectedFindingBsd3 = LicenseFinding(
+                    "BSD-3-Clause",
+                    sortedSetOf(
+                            TextLocation("package.json", 37, 37),
+                            TextLocation("bower.json", 20, 20),
+                            TextLocation("test/3rdparty/yui-3.12.0.js", 4, 4),
+                            TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 1910, 1910)
+                    ),
+                    sortedSetOf(
+                            CopyrightFinding(
+                                    "copyright (c) 2012 Scott Jehl, Paul Irish, Nicholas Zakas.",
+                                    sortedSetOf(TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 1910, 1911))
+                            ),
+                            CopyrightFinding(
+                                    "Copyright 2013 Yahoo! Inc.",
+                                    sortedSetOf(TextLocation("test/3rdparty/yui-3.12.0.js", 2, 3))
+                            )
+                    )
+            )
+
+            val expectedFindingGpl1 = LicenseFinding(
+                    "GPL-1.0+",
+                    sortedSetOf(
+                            TextLocation("test/3rdparty/jquery-1.9.1.js", 10, 10),
+                            TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 8, 8),
+                            TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 233, 233),
+                            TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 832, 832),
+                            TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 1522, 1523),
+                            TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 1538, 1539),
+                            TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 14001, 14001)
+                    ),
+                    sortedSetOf(
+                            CopyrightFinding(
+                                    "Copyright (c) 2010 Cowboy Ben Alman",
+                                    sortedSetOf(
+                                            TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 1521, 1523),
+                                            TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 1537, 1539)
+                                    )
+                            ),
+                            CopyrightFinding(
+                                    "Copyright 2005, 2012 jQuery Foundation, Inc.",
+                                    sortedSetOf(
+                                            TextLocation("test/3rdparty/jquery-1.9.1.js", 8, 10)
+                                    )
+                            ),
+                            CopyrightFinding(
+                                    "Copyright 2010, 2014 jQuery Foundation, Inc.",
+                                    sortedSetOf(
+                                            TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 6, 8)
+                                    )
+                            ),
+                            CopyrightFinding(
+                                    "Copyright 2013 jQuery Foundation",
+                                    sortedSetOf(
+                                            TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 231, 233),
+                                            TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 830, 832),
+                                            TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 13999, 14001)
+                                    )
+                            )
+                    )
+            )
+
+            val expectedFindingLgpl2 = LicenseFinding(
+                    "LGPL-2.0+",
+                    sortedSetOf(
+                            TextLocation("test/3rdparty/mootools-1.4.5.js", 28, 28),
+                            TextLocation("test/3rdparty/mootools-1.4.5.js", 4718, 4718)
+                    ),
+                    sortedSetOf(
+                            CopyrightFinding(
+                                    "Copyright (c) 2005-2007 Sam Stephenson",
+                                    sortedSetOf(TextLocation("test/3rdparty/mootools-1.4.5.js", 27, 29))
+                            ),
+                            CopyrightFinding(
+                                    "Copyright (c) 2006 Dean Edwards, GNU Lesser General Public",
+                                    sortedSetOf(TextLocation("test/3rdparty/mootools-1.4.5.js", 27, 29))
+                            ),
+                            CopyrightFinding(
+                                    "Copyright (c) 2006-2012 Valerio Proietti",
+                                    sortedSetOf(TextLocation("test/3rdparty/mootools-1.4.5.js", 23, 23))
+                            )
+                    )
+            )
+
+            val expectedFindingMit = LicenseFinding(
+                    "MIT",
+                    sortedSetOf(
+                            TextLocation("test/3rdparty/benchmark.js", 6, 6),
+                            TextLocation("test/3rdparty/mootools-1.4.5.js", 21, 21),
+                            TextLocation("test/3rdparty/mootools-1.4.5.js", 29, 29),
+                            TextLocation("test/3rdparty/mootools-1.4.5.js", 542, 542),
+                            TextLocation("test/3rdparty/mootools-1.4.5.js", 723, 723),
+                            TextLocation("test/3rdparty/mootools-1.4.5.js", 807, 807),
+                            TextLocation("test/3rdparty/mootools-1.4.5.js", 861, 861),
+                            TextLocation("test/3rdparty/mootools-1.4.5.js", 991, 991),
+                            TextLocation("test/3rdparty/mootools-1.4.5.js", 1202, 1202),
+                            TextLocation("test/3rdparty/mootools-1.4.5.js", 1457, 1457),
+                            TextLocation("test/3rdparty/mootools-1.4.5.js", 1584, 1584),
+                            TextLocation("test/3rdparty/mootools-1.4.5.js", 1701, 1701),
+                            TextLocation("test/3rdparty/mootools-1.4.5.js", 1881, 1881),
+                            TextLocation("test/3rdparty/mootools-1.4.5.js", 3043, 3043),
+                            TextLocation("test/3rdparty/mootools-1.4.5.js", 4103, 4103),
+                            TextLocation("test/3rdparty/mootools-1.4.5.js", 4322, 4322),
+                            TextLocation("test/3rdparty/mootools-1.4.5.js", 4514, 4514),
+                            TextLocation("test/3rdparty/mootools-1.4.5.js", 4715, 4715),
+                            TextLocation("test/3rdparty/mootools-1.4.5.js", 4999, 4999),
+                            TextLocation("test/3rdparty/mootools-1.4.5.js", 5180, 5180),
+                            TextLocation("test/3rdparty/mootools-1.4.5.js", 5350, 5350),
+                            TextLocation("test/3rdparty/mootools-1.4.5.js", 5463, 5463),
+                            TextLocation("test/3rdparty/mootools-1.4.5.js", 5542, 5542),
+                            TextLocation("test/3rdparty/mootools-1.4.5.js", 5657, 5657),
+                            TextLocation("test/3rdparty/mootools-1.4.5.js", 5937, 5937),
+                            TextLocation("test/3rdparty/mootools-1.4.5.js", 6027, 6027),
+                            TextLocation("test/3rdparty/mootools-1.4.5.js", 6110, 6110),
+                            TextLocation("test/3rdparty/mootools-1.4.5.js", 6158, 6158),
+                            TextLocation("test/3rdparty/mootools-1.4.5.js", 6234, 6234),
+                            TextLocation("test/3rdparty/mootools-1.4.5.js", 6341, 6341),
+                            TextLocation("test/3rdparty/angular-1.2.5.js", 4, 4),
+                            TextLocation("test/3rdparty/jquery-1.9.1.js", 9, 9),
+                            TextLocation("test/3rdparty/jquery-1.9.1.js", 10, 10),
+                            TextLocation("test/3rdparty/jquery-1.9.1.js", 3690, 3690),
+                            TextLocation("test/3rdparty/underscore-1.5.2.js", 4, 4),
+                            TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 7, 7),
+                            TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 8, 8),
+                            TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 232, 232),
+                            TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 233, 233),
+                            TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 831, 831),
+                            TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 832, 832),
+                            TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 1522, 1523),
+                            TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 1538, 1539),
+                            TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 1910, 1910),
+                            TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 14000, 14000),
+                            TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 14001, 14001),
+                            TextLocation("test/3rdparty/backbone-1.1.0.js", 5, 5)
+                    ),
+                    sortedSetOf(
+                            CopyrightFinding(
+                                    "(c) 2007-2008 Steven Levithan",
+                                    sortedSetOf(TextLocation("test/3rdparty/mootools-1.4.5.js", 1881, 1883))
+                            ),
+                            CopyrightFinding(
+                                    "(c) 2009-2013 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & " +
+                                            "Editors Underscore",
+                                    sortedSetOf(TextLocation("test/3rdparty/underscore-1.5.2.js", 2, 4))
+                            ),
+                            CopyrightFinding(
+                                    "(c) 2010-2011 Jeremy Ashkenas, DocumentCloud Inc.",
+                                    sortedSetOf(TextLocation("test/3rdparty/backbone-1.1.0.js", 3, 6))
+                            ),
+                            CopyrightFinding(
+                                    "(c) 2010-2014 Google, Inc. http://angularjs.org",
+                                    sortedSetOf(TextLocation("test/3rdparty/angular-1.2.5.js", 2, 4))
+                            ),
+                            CopyrightFinding(
+                                    "(c) 2011-2013 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & " +
+                                            "Editors Backbone",
+                                    sortedSetOf(TextLocation("test/3rdparty/backbone-1.1.0.js", 3, 6))
+                            ),
+                            CopyrightFinding(
+                                    "Copyright (c) 2005-2007 Sam Stephenson",
+                                    sortedSetOf(TextLocation("test/3rdparty/mootools-1.4.5.js", 27, 29))
+                            ),
+                            CopyrightFinding(
+                                    "Copyright (c) 2006 Dean Edwards, GNU Lesser General Public",
+                                    sortedSetOf(TextLocation("test/3rdparty/mootools-1.4.5.js", 27, 29))
+                            ),
+                            CopyrightFinding(
+                                    "Copyright (c) 2006-2012 Valerio Proietti",
+                                    sortedSetOf(TextLocation("test/3rdparty/mootools-1.4.5.js", 23, 23))
+                            ),
+                            CopyrightFinding(
+                                    "Copyright (c) 2010 Cowboy Ben Alman",
+                                    sortedSetOf(
+                                            TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 1521, 1523),
+                                            TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 1537, 1539)
+                                    )
+                            ),
+                            CopyrightFinding(
+                                    "Copyright 2005, 2012 jQuery Foundation, Inc.",
+                                    sortedSetOf(TextLocation("test/3rdparty/jquery-1.9.1.js", 8, 10))
+                            ),
+                            CopyrightFinding(
+                                    "Copyright 2010, 2014 jQuery Foundation, Inc.",
+                                    sortedSetOf(TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 6, 8))
+                            ),
+                            CopyrightFinding(
+                                    "Copyright 2010-2012 Mathias Bynens",
+                                    sortedSetOf(TextLocation("test/3rdparty/benchmark.js", 2, 6))
+                            ),
+                            CopyrightFinding(
+                                    "Copyright 2012 jQuery Foundation",
+                                    sortedSetOf(TextLocation("test/3rdparty/jquery-1.9.1.js", 3688, 3691))
+                            ),
+                            CopyrightFinding(
+                                    "Copyright 2013 jQuery Foundation",
+                                    sortedSetOf(
+                                            TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 231, 233),
+                                            TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 830, 832),
+                                            TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 13999, 14001)
+                                    )
+                            ),
+                            CopyrightFinding(
+                                    "copyright (c) 2012 Scott Jehl, Paul Irish, Nicholas Zakas.",
+                                    sortedSetOf(TextLocation("test/3rdparty/jquery.mobile-1.4.2.js", 1910, 1911))
+                            ),
+                            CopyrightFinding(
+                                    "copyright Robert Kieffer",
+                                    sortedSetOf(TextLocation("test/3rdparty/benchmark.js", 2, 6))
+                            )
+                    )
+            )
+
             val actualFindings = scanner.associateFindings(result)
 
-            actualFindings shouldBe expectedFindings
+            actualFindings.map { it.license } shouldBe
+                    listOf("BSD-2-Clause", "BSD-3-Clause", "GPL-1.0+", "LGPL-2.0+", "MIT")
+
+            actualFindings.find { it.license == "BSD-2-Clause" } shouldBe expectedFindingBsd2
+            actualFindings.find { it.license == "BSD-3-Clause" } shouldBe expectedFindingBsd3
+            actualFindings.find { it.license == "GPL-1.0+" } shouldBe expectedFindingGpl1
+            actualFindings.find { it.license == "LGPL-2.0+" } shouldBe expectedFindingLgpl2
+            actualFindings.find { it.license == "MIT" } shouldBe expectedFindingMit
         }
 
         "properly associate licenses to locations and copyrights for the new output format" {
@@ -354,7 +501,7 @@ class ScanCodeTest : WordSpec({
                     TextLocation("com/amazonaws/ClientConfigurationFactory.java", 4, 13)
             )
 
-            finding.copyrights shouldBe sortedSetOf(
+            finding.copyrights.map { it.statement } shouldBe listOf(
                     "Copyright (c) 2016 Amazon.com, Inc.",
                     "Copyright (c) 2016. Amazon.com, Inc.",
                     "Copyright 2010-2017 Amazon.com, Inc.",

--- a/utils/src/main/kotlin/Extensions.kt
+++ b/utils/src/main/kotlin/Extensions.kt
@@ -20,6 +20,8 @@
 package com.here.ort.utils
 
 import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.type.CollectionType
+import com.fasterxml.jackson.databind.type.TypeFactory
 import com.fasterxml.jackson.databind.util.ClassUtil
 
 import com.vdurmont.semver4j.Semver
@@ -36,6 +38,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.SimpleFileVisitor
 import java.nio.file.attribute.BasicFileAttributes
+import java.util.TreeSet
 
 import org.apache.commons.codec.digest.DigestUtils
 
@@ -276,6 +279,12 @@ fun Throwable.showStackTrace() {
     // https://discuss.kotlinlang.org/t/if-operator-in-function-expression/7227.
     if (printStackTrace) printStackTrace()
 }
+
+/**
+ * Function for constructing a [TreeSet] [CollectionType].
+ */
+fun TypeFactory.constructTreeSetType(elementClass: Class<*>): CollectionType =
+        constructCollectionType(TreeSet::class.java, elementClass)
 
 /**
  * Check whether the URI has a fragment that looks like a VCS revision.


### PR DESCRIPTION
Storing the file and line numbers where the copyrights associated to a
license were detected is a precondition for implementing file based
excludes. Otherwise it would not be possible to remove only the copyrights
found in a certain file.

Note that some refactorings in `ScanCode` and `ScanCodeTest` will happen in a separate PR to not make this one bigger as necessary. Also `LicenseFindingsMap` will be removed in another PR as it is not required anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1221)
<!-- Reviewable:end -->
