### PR TITLE
Revert "Gradle: Enable parallel compilation of independent source sets"

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -32,5 +32,3 @@ xzVersion = 1.8
 org.gradle.caching=true
 org.gradle.configureondemand=true
 org.gradle.parallel=true
-
-kotlin.parallel.tasks.in.project=true


### PR DESCRIPTION
This reverts commit 5ec3169 as it seems to be causing

    Caused by: java.lang.OutOfMemoryError: Metaspace

on AppVeyor CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1228)
<!-- Reviewable:end -->
