### PR TITLE
Gradle: Enable parallel compilation of independent source sets

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -53,9 +53,9 @@ build_script:
 
 test_script:
   - if "%APPVEYOR_SCHEDULED_BUILD%"=="True" (
-      gradlew --stacktrace dokkaJar check
+      gradlew --stacktrace -Pkotlin.parallel.tasks.in.project=false dokkaJar check
     ) else (
-      gradlew -Dkotlintest.tags.exclude=ExpensiveTag --stacktrace dokkaJar check
+      gradlew --stacktrace -Pkotlin.parallel.tasks.in.project=false -Dkotlintest.tags.exclude=ExpensiveTag dokkaJar check
     )
 
 artifacts:

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,3 +32,5 @@ xzVersion = 1.8
 org.gradle.caching=true
 org.gradle.configureondemand=true
 org.gradle.parallel=true
+
+kotlin.parallel.tasks.in.project=true


### PR DESCRIPTION
This is a new feature in Kotlin 1.3.20. Do not enable that feature on
AppVeyor CI, though, as we otherwise get

    Caused by: java.lang.OutOfMemoryError: Metaspace

over there.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1229)
<!-- Reviewable:end -->
