### PR TITLE
cli: Normalize paths in potentially user-facing output

### DIFF
--- a/cli/src/main/kotlin/commands/AnalyzerCommand.kt
+++ b/cli/src/main/kotlin/commands/AnalyzerCommand.kt
@@ -105,7 +105,7 @@ object AnalyzerCommand : CommandWithHelp() {
     private var repositoryConfigurationFile: File? = null
 
     override fun runCommand(jc: JCommander): Int {
-        val absoluteOutputDir = outputDir.absoluteFile
+        val absoluteOutputDir = outputDir.absoluteFile.normalize()
 
         val outputFiles = outputFormats.distinct().map { format ->
             File(absoluteOutputDir, "analyzer-result.${format.fileExtension}")
@@ -131,12 +131,12 @@ object AnalyzerCommand : CommandWithHelp() {
         println("The following package managers are activated:")
         println("\t" + packageManagers.joinToString(", "))
 
-        val absoluteProjectPath = inputDir.absoluteFile
-        println("Scanning project path:\n\t$absoluteProjectPath")
+        val absoluteInputDir = inputDir.absoluteFile.normalize()
+        println("Scanning project path:\n\t$absoluteInputDir")
 
         val config = AnalyzerConfiguration(ignoreToolVersions, allowDynamicVersions)
         val analyzer = Analyzer(config)
-        val ortResult = analyzer.analyze(absoluteProjectPath, packageManagers, packageCurationsFile,
+        val ortResult = analyzer.analyze(absoluteInputDir, packageManagers, packageCurationsFile,
                 repositoryConfigurationFile)
 
         println("Found ${ortResult.analyzer?.result?.projects.orEmpty().size} project(s) in total.")

--- a/cli/src/main/kotlin/commands/EvaluatorCommand.kt
+++ b/cli/src/main/kotlin/commands/EvaluatorCommand.kt
@@ -99,7 +99,7 @@ object EvaluatorCommand : CommandWithHelp() {
 
         val evaluatorRun = evaluator.run(script)
 
-        outputDir?.absoluteFile?.let { absoluteOutputDir ->
+        outputDir?.absoluteFile?.normalize()?.let { absoluteOutputDir ->
             val outputFiles = outputFormats.distinct().map { format ->
                 File(absoluteOutputDir, "evaluation-result.${format.fileExtension}")
             }

--- a/cli/src/main/kotlin/commands/ReporterCommand.kt
+++ b/cli/src/main/kotlin/commands/ReporterCommand.kt
@@ -99,7 +99,7 @@ object ReporterCommand : CommandWithHelp() {
     private var repositoryConfigurationFile: File? = null
 
     override fun runCommand(jc: JCommander): Int {
-        val absoluteOutputDir = outputDir.absoluteFile
+        val absoluteOutputDir = outputDir.absoluteFile.normalize()
 
         val reports = reporters.associateWith { reporter ->
             File(absoluteOutputDir, reporter.defaultFilename)


### PR DESCRIPTION
Using an absolute path is not enough to get rid of e.g. the trailing "."
in

    /Users/d029788/src/go/src/github.com/gardener/gardener/.

so normalize, too.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1234)
<!-- Reviewable:end -->
