### PR TITLE
Allow patchActualResult() to also patch the download time

### DIFF
--- a/scanner/src/funTest/kotlin/scanners/FileCounterTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/FileCounterTest.kt
@@ -24,6 +24,7 @@ import com.here.ort.model.config.ScannerConfiguration
 import com.here.ort.model.yamlMapper
 import com.here.ort.scanner.ScanResultsCache
 import com.here.ort.utils.safeDeleteRecursively
+import com.here.ort.utils.test.patchActualResult
 import com.here.ort.utils.test.patchExpectedResult
 
 import io.kotlintest.TestCase
@@ -32,7 +33,6 @@ import io.kotlintest.shouldBe
 import io.kotlintest.specs.StringSpec
 
 import java.io.File
-import java.time.Instant
 
 class FileCounterTest : StringSpec() {
     private val assetsDir = File("src/funTest/assets")
@@ -50,11 +50,6 @@ class FileCounterTest : StringSpec() {
         ScanResultsCache.stats = CacheStatistics()
     }
 
-    private val timeRegex = Regex("((download|end|start)_time|timestamp): \".*\"")
-
-    private fun patchActualResult(result: String) = result
-            .replace(timeRegex) { "${it.groupValues[1]}: \"${Instant.EPOCH}\"" }
-
     init {
         "Gradle project scan results for a given analyzer result are correct" {
             val analyzerResultFile = File(assetsDir, "analyzer-result.yml")
@@ -65,7 +60,7 @@ class FileCounterTest : StringSpec() {
                     outputDir.resolve("downloads"))
             val result = yamlMapper.writeValueAsString(ortResult)
 
-            patchActualResult(result) shouldBe expectedResult
+            patchActualResult(result, patchDownloadTime = true, patchStartAndEndTime = true) shouldBe expectedResult
         }
     }
 }

--- a/test-utils/src/main/kotlin/Utils.kt
+++ b/test-utils/src/main/kotlin/Utils.kt
@@ -30,6 +30,7 @@ val DEFAULT_REPOSITORY_CONFIGURATION = RepositoryConfiguration()
 
 val USER_DIR = File(System.getProperty("user.dir"))
 
+private val DOWNLOAD_TIME_REGEX = Regex("(download_time): \".*\"")
 private val START_AND_END_TIME_REGEX = Regex("((start|end)_time): \".*\"")
 private val TIMESTAMP_REGEX = Regex("(timestamp): \".*\"")
 
@@ -51,10 +52,13 @@ fun patchExpectedResult(result: File, custom: Pair<String, String>? = null, defi
             .replaceIfNotNull("<REPLACE_URL_PROCESSED>", urlProcessed)
 }
 
-fun patchActualResult(result: String, patchStartAndEndTime: Boolean = false): String {
+fun patchActualResult(result: String, patchDownloadTime: Boolean = false, patchStartAndEndTime: Boolean = false)
+        : String {
     fun String.replaceIf(condition: Boolean, regex: Regex, transform: (MatchResult) -> CharSequence) =
             if (condition) replace(regex, transform) else this
 
-    return result.replace(TIMESTAMP_REGEX) { "${it.groupValues[1]}: \"${Instant.EPOCH}\"" }
+    return result
+            .replace(TIMESTAMP_REGEX) { "${it.groupValues[1]}: \"${Instant.EPOCH}\"" }
+            .replaceIf(patchDownloadTime, DOWNLOAD_TIME_REGEX) { "${it.groupValues[1]}: \"${Instant.EPOCH}\"" }
             .replaceIf(patchStartAndEndTime, START_AND_END_TIME_REGEX) { "${it.groupValues[1]}: \"${Instant.EPOCH}\"" }
 }

--- a/test-utils/src/main/kotlin/Utils.kt
+++ b/test-utils/src/main/kotlin/Utils.kt
@@ -30,7 +30,7 @@ val DEFAULT_REPOSITORY_CONFIGURATION = RepositoryConfiguration()
 
 val USER_DIR = File(System.getProperty("user.dir"))
 
-private val START_AND_END_TIME_REGEX = Regex("(start_time|end_time): \".*\"")
+private val START_AND_END_TIME_REGEX = Regex("((start|end)_time): \".*\"")
 private val TIMESTAMP_REGEX = Regex("(timestamp): \".*\"")
 
 fun patchExpectedResult(result: File, custom: Pair<String, String>? = null, definitionFilePath: String? = null,

--- a/test-utils/src/main/kotlin/Utils.kt
+++ b/test-utils/src/main/kotlin/Utils.kt
@@ -28,9 +28,10 @@ import java.time.Instant
 val DEFAULT_ANALYZER_CONFIGURATION = AnalyzerConfiguration(false, false)
 val DEFAULT_REPOSITORY_CONFIGURATION = RepositoryConfiguration()
 
-val START_AND_END_TIME_REGEX = Regex("(start_time|end_time): \".*\"")
-val TIMESTAMP_REGEX = Regex("(timestamp): \".*\"")
 val USER_DIR = File(System.getProperty("user.dir"))
+
+private val START_AND_END_TIME_REGEX = Regex("(start_time|end_time): \".*\"")
+private val TIMESTAMP_REGEX = Regex("(timestamp): \".*\"")
 
 fun patchExpectedResult(result: File, custom: Pair<String, String>? = null, definitionFilePath: String? = null,
                         url: String? = null, revision: String? = null, path: String? = null,


### PR DESCRIPTION
This way we can also use it in FileCounterTest and get rid of its custom
patch function.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1237)
<!-- Reviewable:end -->
