### PR TITLE
model: Allow an empty downloadTime for Provenance

### DIFF
--- a/model/src/main/kotlin/Provenance.kt
+++ b/model/src/main/kotlin/Provenance.kt
@@ -30,10 +30,11 @@ import java.time.Instant
  */
 data class Provenance(
         /**
-         * The time when the source code was downloaded.
+         * The time when the source code was downloaded, or [Instant.EPOCH] if unknown (e.g. for source code that was
+         * downloaded separately from running ORT).
          */
         @JsonAlias("downloadTime")
-        val downloadTime: Instant,
+        val downloadTime: Instant = Instant.EPOCH,
 
         /**
          * The source artifact that was downloaded, or null.

--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -153,7 +153,7 @@ abstract class LocalScanner(config: ScannerConfiguration) : Scanner(config), Com
 
                 val now = Instant.now()
                 listOf(ScanResult(
-                        provenance = Provenance(now),
+                        provenance = Provenance(),
                         scanner = scannerDetails,
                         summary = ScanSummary(
                                 startTime = now,
@@ -199,7 +199,7 @@ abstract class LocalScanner(config: ScannerConfiguration) : Scanner(config), Com
             val now = Instant.now()
             val summary = ScanSummary(now, now, 0, sortedSetOf(),
                     listOf(OrtIssue(source = toString(), message = e.collectMessagesAsString())))
-            ScanResult(Provenance(now), getDetails(), summary)
+            ScanResult(Provenance(), getDetails(), summary)
         }
 
         // There is no package id for arbitrary paths so create a fake one, ensuring that no ":" is contained.
@@ -257,7 +257,7 @@ abstract class LocalScanner(config: ScannerConfiguration) : Scanner(config), Com
 
             val now = Instant.now()
             val scanResult = ScanResult(
-                    Provenance(now),
+                    Provenance(),
                     scannerDetails,
                     ScanSummary(
                             startTime = now,


### PR DESCRIPTION
To signal an unknown download time. Use this in places where the
download time actually is unknown and previously was simply set to the
start time if the scan.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1238)
<!-- Reviewable:end -->
