### PR TITLE
Rename `ScanResultsCache` to `ScanResultsStorage`

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,13 +128,14 @@ This tool wraps underlying license / copyright scanners with a common API so all
 same way to easily run them and compare their results. If passed an ORT result file with an analyzer result (`-a`), the
 Scanner will automatically download the sources of the dependencies via the Downloader and scan them afterwards. In
 order to not download or scan any previously scanned sources, the Scanner can be configured (`-c`) to use a remote
-cache hosted e.g. on [Artifactory](./scanner/src/main/kotlin/ArtifactoryCache.kt) or S3 (not yet implemented, see
+storage hosted e.g. on [Artifactory](./scanner/src/main/kotlin/ArtifactoryCache.kt) or S3 (not yet implemented, see
 [#752](https://github.com/heremaps/oss-review-toolkit/issues/752)). Using the example of configuring an Artifactory
-cache, the YAML-based configuration file would look like:
+storage, the YAML-based configuration file would look like:
 
 ```yaml
-artifactory_cache:
-  url: "https://artifactory.domain.com/artifactory/generic-repository-name"
+artifactory_storage:
+  url: "https://artifactory.domain.com/artifactory"
+  repository: "generic-repository-name"
   apiToken: $ARTIFACTORY_API_KEY
 ```
 
@@ -185,9 +186,9 @@ ORT comes with some example implementations for wrappers around license / copyri
 * [Licensee](https://github.com/benbalter/licensee)
 * [ScanCode](https://github.com/nexB/scancode-toolkit)
 
-## Supported remote caches
+## Supported remote storages
 
-For reusing already known scan results, ORT can currently use one of the following backends as a remote cache:
+For reusing already known scan results, ORT can currently use one of the following backends as a remote storage:
 
 * [Artifactory](https://jfrog.com/artifactory/)
 

--- a/cli/src/main/kotlin/commands/ScannerCommand.kt
+++ b/cli/src/main/kotlin/commands/ScannerCommand.kt
@@ -33,7 +33,7 @@ import com.here.ort.model.config.ScannerConfiguration
 import com.here.ort.model.mapper
 import com.here.ort.model.readValue
 import com.here.ort.scanner.LocalScanner
-import com.here.ort.scanner.ScanResultsCache
+import com.here.ort.scanner.ScanResultsStorage
 import com.here.ort.scanner.Scanner
 import com.here.ort.scanner.ScannerFactory
 import com.here.ort.scanner.scanners.ScanCode
@@ -137,8 +137,8 @@ object ScannerCommand : CommandWithHelp() {
             it.readValue<ScannerConfiguration>()
         } ?: ScannerConfiguration()
 
-        config.artifactoryCache?.let {
-            ScanResultsCache.configure(it)
+        config.artifactoryStorage?.let {
+            ScanResultsStorage.configure(it)
         }
 
         val scanner = scannerFactory.create(config)

--- a/model/src/main/kotlin/AccessStatistics.kt
+++ b/model/src/main/kotlin/AccessStatistics.kt
@@ -17,14 +17,19 @@
  * License-Filename: LICENSE
  */
 
-package com.here.ort.model.config
+package com.here.ort.model
 
-import com.fasterxml.jackson.annotation.JsonProperty
+/**
+ * Statistics about reads and hits on a resource.
+ */
+data class AccessStatistics(
+        /**
+         * The number of read operations in the storage.
+         */
+        var numReads: Int = 0,
 
-data class ArtifactoryCacheConfiguration(
-        val url: String,
-        val repository: String,
-
-        @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
-        val apiToken: String = ""
+        /**
+         * The number of read operations that returned an entry from the storage.
+         */
+        var numHits: Int = 0
 )

--- a/model/src/main/kotlin/ScanRecord.kt
+++ b/model/src/main/kotlin/ScanRecord.kt
@@ -19,6 +19,7 @@
 
 package com.here.ort.model
 
+import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 
@@ -40,9 +41,10 @@ data class ScanRecord(
         val scanResults: SortedSet<ScanResultContainer>,
 
         /**
-         * The [CacheStatistics] for the scan results cache.
+         * The [AccessStatistics] for the scan results storage.
          */
-        val cacheStats: CacheStatistics,
+        @JsonAlias("cache_stats")
+        val storageStats: AccessStatistics,
 
         /**
          * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.

--- a/model/src/main/kotlin/config/ArtifactoryStorageConfiguration.kt
+++ b/model/src/main/kotlin/config/ArtifactoryStorageConfiguration.kt
@@ -17,19 +17,14 @@
  * License-Filename: LICENSE
  */
 
-package com.here.ort.model
+package com.here.ort.model.config
 
-/**
- * Statistics about reads and hits in a cache.
- */
-data class CacheStatistics(
-        /**
-         * The number of read operations in the cache.
-         */
-        var numReads: Int = 0,
+import com.fasterxml.jackson.annotation.JsonProperty
 
-        /**
-         * The number of read operations that returned an entry from the cache.
-         */
-        var numHits: Int = 0
+data class ArtifactoryStorageConfiguration(
+        val url: String,
+        val repository: String,
+
+        @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+        val apiToken: String = ""
 )

--- a/model/src/main/kotlin/config/ScannerConfiguration.kt
+++ b/model/src/main/kotlin/config/ScannerConfiguration.kt
@@ -19,14 +19,17 @@
 
 package com.here.ort.model.config
 
+import com.fasterxml.jackson.annotation.JsonAlias
+
 /**
  * The configuration model of the scanner.
  */
 data class ScannerConfiguration(
         /**
-         * Configuration of the scan results Artifactory cache.
+         * Configuration of the scan results Artifactory storage.
          */
-        val artifactoryCache: ArtifactoryCacheConfiguration? = null,
+        @JsonAlias("artifactory_cache")
+        val artifactoryStorage: ArtifactoryStorageConfiguration? = null,
 
         /**
          * Scanner specific configuration options. The key needs to match the name of the scanner class, e.g. "ScanCode"

--- a/model/src/test/kotlin/ScannerRunTest.kt
+++ b/model/src/test/kotlin/ScannerRunTest.kt
@@ -35,12 +35,12 @@ class ScannerRunTest : StringSpec() {
                   os: "Linux"
                   tool_versions: {}
                 config:
-                  artifactory_cache: null
+                  artifactory_storage: null
                   scanner: null
                 results:
                   scanned_scopes: []
                   scan_results: []
-                  cache_stats:
+                  storage_stats:
                     num_reads: 0
                     num_hits: 0
                   has_errors: false
@@ -61,12 +61,12 @@ class ScannerRunTest : StringSpec() {
                   os: "Linux"
                   tool_versions: {}
                 config:
-                  artifactory_cache: null
+                  artifactory_storage: null
                   scanner: null
                 results:
                   scanned_scopes: []
                   scan_results: []
-                  cache_stats:
+                  storage_stats:
                     num_reads: 0
                     num_hits: 0
                   has_errors: false

--- a/model/src/test/kotlin/config/ArtifactoryStorageConfigurationTest.kt
+++ b/model/src/test/kotlin/config/ArtifactoryStorageConfigurationTest.kt
@@ -26,9 +26,9 @@ import com.here.ort.model.yamlMapper
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.WordSpec
 
-class ArtifactoryCacheConfigurationTest : WordSpec() {
+class ArtifactoryStorageConfigurationTest : WordSpec() {
     init {
-        "ArtifactoryCacheConfiguration" should {
+        "ArtifactoryStorageConfiguration" should {
             "be deserializable" {
                 val yaml = """
                     ---
@@ -36,17 +36,17 @@ class ArtifactoryCacheConfigurationTest : WordSpec() {
                     repository: "repository"
                     api_token: "apiToken"""".trimIndent()
 
-                val artifactoryCacheConfiguration = yamlMapper.readValue<ArtifactoryCacheConfiguration>(yaml)
+                val artifactoryStorageConfiguration = yamlMapper.readValue<ArtifactoryStorageConfiguration>(yaml)
 
-                artifactoryCacheConfiguration.url shouldBe "url"
-                artifactoryCacheConfiguration.repository shouldBe "repository"
-                artifactoryCacheConfiguration.apiToken shouldBe "apiToken"
+                artifactoryStorageConfiguration.url shouldBe "url"
+                artifactoryStorageConfiguration.repository shouldBe "repository"
+                artifactoryStorageConfiguration.apiToken shouldBe "apiToken"
             }
 
             "not serialize the ApiToken" {
-                val artifactoryCacheConfiguration = ArtifactoryCacheConfiguration("url", "repository", "apiToken")
+                val artifactoryStorageConfiguration = ArtifactoryStorageConfiguration("url", "repository", "apiToken")
 
-                val yaml = yamlMapper.writeValueAsString(artifactoryCacheConfiguration).trim()
+                val yaml = yamlMapper.writeValueAsString(artifactoryStorageConfiguration).trim()
 
                 yaml shouldBe """
                     ---
@@ -62,11 +62,11 @@ class ArtifactoryCacheConfigurationTest : WordSpec() {
                     repository: "repository"
                     """.trimIndent()
 
-                val artifactoryCacheConfiguration = yamlMapper.readValue<ArtifactoryCacheConfiguration>(yaml)
+                val artifactoryStorageConfiguration = yamlMapper.readValue<ArtifactoryStorageConfiguration>(yaml)
 
-                artifactoryCacheConfiguration.url shouldBe "url"
-                artifactoryCacheConfiguration.repository shouldBe "repository"
-                artifactoryCacheConfiguration.apiToken shouldBe ""
+                artifactoryStorageConfiguration.url shouldBe "url"
+                artifactoryStorageConfiguration.repository shouldBe "repository"
+                artifactoryStorageConfiguration.apiToken shouldBe ""
             }
         }
     }

--- a/reporter/src/funTest/assets/NPM-is-windows-1.0.2-scan-result.json
+++ b/reporter/src/funTest/assets/NPM-is-windows-1.0.2-scan-result.json
@@ -6225,7 +6225,7 @@
       "tool_versions" : { }
     },
     "config" : {
-      "artifactory_cache" : null
+      "artifactory_storage" : null
     },
     "results" : {
       "scanned_scopes" : [ {
@@ -11597,7 +11597,7 @@
           }
         } ]
       } ],
-      "cache_stats" : {
+      "storage_stats" : {
         "num_reads" : 154,
         "num_hits" : 0
       },

--- a/reporter/src/funTest/assets/npm-test-with-exclude-scan-results.yml
+++ b/reporter/src/funTest/assets/npm-test-with-exclude-scan-results.yml
@@ -324,7 +324,7 @@ scanner:
     variables: {}
     tool_versions: {}
   config:
-    artifactory_cache: null
+    artifactory_storage: null
   results:
     scanned_scopes:
     - id: "NPM::npm-excludes-test-project:1.0.0"
@@ -621,7 +621,7 @@ scanner:
           - license: "MIT"
             copyrights:
             - "Copyright (c) 2011-2012 http://balupton.com' Benjamin Lupton"
-    cache_stats:
+    storage_stats:
       num_reads: 11
       num_hits: 0
     has_errors: true

--- a/reporter/src/funTest/assets/npm-test-without-exclude-scan-results.yml
+++ b/reporter/src/funTest/assets/npm-test-without-exclude-scan-results.yml
@@ -319,7 +319,7 @@ scanner:
     variables: {}
     tool_versions: {}
   config:
-    artifactory_cache: null
+    artifactory_storage: null
   results:
     scanned_scopes:
     - id: "NPM::npm-excludes-test-project:1.0.0"
@@ -616,7 +616,7 @@ scanner:
           - license: "MIT"
             copyrights:
             - "Copyright (c) 2011-2012 http://balupton.com' Benjamin Lupton"
-    cache_stats:
+    storage_stats:
       num_reads: 11
       num_hits: 0
     has_errors: true

--- a/reporter/src/funTest/assets/static-html-reporter-test-input.yml
+++ b/reporter/src/funTest/assets/static-html-reporter-test-input.yml
@@ -169,7 +169,7 @@ scanner:
     variables: {}
     tool_versions: {}
   config:
-    artifactory_cache: null
+    artifactory_storage: null
     scanner: null
   results:
     scanned_scopes:
@@ -270,7 +270,7 @@ scanner:
           end_time: "1970-01-01T00:00:00Z"
           file_count: 47
           license_findings: []
-    cache_stats:
+    storage_stats:
       num_reads: 5
       num_hits: 0
     has_errors: true

--- a/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
@@ -169,7 +169,7 @@ scanner:
     variables: {}
     tool_versions: {}
   config:
-    artifactory_cache: null
+    artifactory_storage: null
     scanner: null
   results:
     scanned_scopes:
@@ -268,7 +268,7 @@ scanner:
           end_time: "1970-01-01T00:00:00Z"
           file_count: 47
           license_findings: []
-    cache_stats:
+    storage_stats:
       num_reads: 5
       num_hits: 0
     has_errors: true

--- a/scanner/src/funTest/kotlin/HttpStorageTest.kt
+++ b/scanner/src/funTest/kotlin/HttpStorageTest.kt
@@ -52,7 +52,7 @@ import java.time.Instant
 
 import kotlin.random.Random
 
-class HttpCacheTest : StringSpec() {
+class HttpStorageTest : StringSpec() {
     private val loopback = InetAddress.getLoopbackAddress()
     private val port = Random.nextInt(1024, 49152) // See https://en.wikipedia.org/wiki/Registered_port.
 
@@ -164,81 +164,81 @@ class HttpCacheTest : StringSpec() {
         super.afterSpec(spec)
     }
 
-    private fun createCache() = ArtifactoryCache("http://${loopback.hostAddress}:$port", "repository", "apiToken")
+    private fun createStorage() = ArtifactoryStorage("http://${loopback.hostAddress}:$port", "repository", "apiToken")
 
     init {
-        "Scan result can be added to the cache" {
-            val cache = createCache()
+        "Scan result can be added to the storage" {
+            val storage = createStorage()
             val scanResult = ScanResult(provenanceWithSourceArtifact, scannerDetails1, scanSummaryWithFiles,
                     rawResultWithContent)
 
-            val result = cache.add(id, scanResult)
-            val cachedResults = cache.read(id)
+            val result = storage.add(id, scanResult)
+            val storedResults = storage.read(id)
 
             result shouldBe true
-            cachedResults.id shouldBe id
-            cachedResults.results.size shouldBe 1
-            cachedResults.results[0] shouldBe scanResult
+            storedResults.id shouldBe id
+            storedResults.results.size shouldBe 1
+            storedResults.results[0] shouldBe scanResult
         }
 
-        "Does not add scan result without raw result to cache" {
-            val cache = createCache()
+        "Does not add scan result without raw result to storage" {
+            val storage = createStorage()
             val scanResult = ScanResult(provenanceWithSourceArtifact, scannerDetails1, scanSummaryWithoutFiles)
 
-            val result = cache.add(id, scanResult)
-            val cachedResults = cache.read(id)
+            val result = storage.add(id, scanResult)
+            val storedResults = storage.read(id)
 
             result shouldBe false
-            cachedResults.id shouldBe id
-            cachedResults.results.size shouldBe 0
+            storedResults.id shouldBe id
+            storedResults.results.size shouldBe 0
         }
 
-        "Does not add scan result with fileCount 0 to cache" {
-            val cache = createCache()
+        "Does not add scan result with fileCount 0 to storage" {
+            val storage = createStorage()
             val scanResult = ScanResult(provenanceWithSourceArtifact, scannerDetails1, scanSummaryWithoutFiles,
                     rawResultWithContent)
 
-            val result = cache.add(id, scanResult)
-            val cachedResults = cache.read(id)
+            val result = storage.add(id, scanResult)
+            val storedResults = storage.read(id)
 
             result shouldBe false
-            cachedResults.id shouldBe id
-            cachedResults.results.size shouldBe 0
+            storedResults.id shouldBe id
+            storedResults.results.size shouldBe 0
         }
 
-        "Does not add scan result without provenance information to cache" {
-            val cache = createCache()
+        "Does not add scan result without provenance information to storage" {
+            val storage = createStorage()
             val scanResult = ScanResult(provenanceEmpty, scannerDetails1, scanSummaryWithFiles,
                     rawResultEmpty)
 
-            val result = cache.add(id, scanResult)
-            val cachedResults = cache.read(id)
+            val result = storage.add(id, scanResult)
+            val storedResults = storage.read(id)
 
             result shouldBe false
-            cachedResults.id shouldBe id
-            cachedResults.results.size shouldBe 0
+            storedResults.id shouldBe id
+            storedResults.results.size shouldBe 0
         }
 
-        "Can retrieve all scan results from cache" {
-            val cache = createCache()
+        "Can retrieve all scan results from storage" {
+            val storage = createStorage()
             val scanResult1 = ScanResult(provenanceWithSourceArtifact, scannerDetails1, scanSummaryWithFiles,
                     rawResultWithContent)
             val scanResult2 = ScanResult(provenanceWithSourceArtifact, scannerDetails2, scanSummaryWithFiles,
                     rawResultWithContent)
 
-            val result1 = cache.add(id, scanResult1)
-            val result2 = cache.add(id, scanResult2)
-            val cachedResults = cache.read(id)
+            val result1 = storage.add(id, scanResult1)
+            val result2 = storage.add(id, scanResult2)
+            val storedResults = storage.read(id)
 
             result1 shouldBe true
             result2 shouldBe true
-            cachedResults.results.size shouldBe 2
-            cachedResults.results should contain(scanResult1)
-            cachedResults.results should contain(scanResult2)
+            storedResults.results.size shouldBe 2
+            storedResults.results should contain(scanResult1)
+            storedResults.results should contain(scanResult2)
         }
 
-        "Can retrieve all scan results for specific scanner from cache" {
-            val cache = createCache()
+        "Can retrieve all scan results for specific scanner from storage" {
+            val storage = createStorage()
             val scanResult1 = ScanResult(provenanceWithSourceArtifact, scannerDetails1, scanSummaryWithFiles,
                     rawResultWithContent)
             val scanResult2 = ScanResult(provenanceWithVcsInfo, scannerDetails1, scanSummaryWithFiles,
@@ -246,21 +246,21 @@ class HttpCacheTest : StringSpec() {
             val scanResult3 = ScanResult(provenanceWithSourceArtifact, scannerDetails2, scanSummaryWithFiles,
                     rawResultWithContent)
 
-            val result1 = cache.add(id, scanResult1)
-            val result2 = cache.add(id, scanResult2)
-            val result3 = cache.add(id, scanResult3)
-            val cachedResults = cache.read(pkg, scannerDetails1)
+            val result1 = storage.add(id, scanResult1)
+            val result2 = storage.add(id, scanResult2)
+            val result3 = storage.add(id, scanResult3)
+            val storedResults = storage.read(pkg, scannerDetails1)
 
             result1 shouldBe true
             result2 shouldBe true
             result3 shouldBe true
-            cachedResults.results.size shouldBe 2
-            cachedResults.results should contain(scanResult1)
-            cachedResults.results should contain(scanResult2)
+            storedResults.results.size shouldBe 2
+            storedResults.results should contain(scanResult1)
+            storedResults.results should contain(scanResult2)
         }
 
-        "Can retrieve all scan results for compatible scanners from cache" {
-            val cache = createCache()
+        "Can retrieve all scan results for compatible scanners from storage" {
+            val storage = createStorage()
             val scanResult = ScanResult(provenanceWithSourceArtifact, scannerDetails1, scanSummaryWithFiles,
                     rawResultWithContent)
             val scanResultCompatible1 = ScanResult(provenanceWithSourceArtifact, scannerDetailsCompatibleVersion1,
@@ -270,24 +270,24 @@ class HttpCacheTest : StringSpec() {
             val scanResultIncompatible = ScanResult(provenanceWithSourceArtifact, scannerDetailsIncompatibleVersion,
                     scanSummaryWithFiles, rawResultWithContent)
 
-            val result = cache.add(id, scanResult)
-            val resultCompatible1 = cache.add(id, scanResultCompatible1)
-            val resultCompatible2 = cache.add(id, scanResultCompatible2)
-            val resultIncompatible = cache.add(id, scanResultIncompatible)
-            val cachedResults = cache.read(pkg, scannerDetails1)
+            val result = storage.add(id, scanResult)
+            val resultCompatible1 = storage.add(id, scanResultCompatible1)
+            val resultCompatible2 = storage.add(id, scanResultCompatible2)
+            val resultIncompatible = storage.add(id, scanResultIncompatible)
+            val storedResults = storage.read(pkg, scannerDetails1)
 
             result shouldBe true
             resultCompatible1 shouldBe true
             resultCompatible2 shouldBe true
             resultIncompatible shouldBe true
-            cachedResults.results.size shouldBe 3
-            cachedResults.results should contain(scanResult)
-            cachedResults.results should contain(scanResultCompatible1)
-            cachedResults.results should contain(scanResultCompatible2)
+            storedResults.results.size shouldBe 3
+            storedResults.results should contain(scanResult)
+            storedResults.results should contain(scanResultCompatible1)
+            storedResults.results should contain(scanResultCompatible2)
         }
 
         "Returns only packages with matching provenance" {
-            val cache = createCache()
+            val storage = createStorage()
             val scanResultSourceArtifactMatching = ScanResult(provenanceWithSourceArtifact, scannerDetails1,
                     scanSummaryWithFiles, rawResultWithContent)
             val scanResultVcsMatching = ScanResult(provenanceWithVcsInfo, scannerDetails1, scanSummaryWithFiles,
@@ -301,32 +301,32 @@ class HttpCacheTest : StringSpec() {
             val scanResultVcsInfoNonMatching = ScanResult(provenanceVcsInfoNonMatching, scannerDetails1,
                     scanSummaryWithFiles, rawResultWithContent)
 
-            val result1 = cache.add(id, scanResultSourceArtifactMatching)
-            val result2 = cache.add(id, scanResultVcsMatching)
-            val result3 = cache.add(id, scanResultSourceArtifactNonMatching)
-            val result4 = cache.add(id, scanResultVcsInfoNonMatching)
-            val cachedResults = cache.read(pkg, scannerDetails1)
+            val result1 = storage.add(id, scanResultSourceArtifactMatching)
+            val result2 = storage.add(id, scanResultVcsMatching)
+            val result3 = storage.add(id, scanResultSourceArtifactNonMatching)
+            val result4 = storage.add(id, scanResultVcsInfoNonMatching)
+            val storedResults = storage.read(pkg, scannerDetails1)
 
             result1 shouldBe true
             result2 shouldBe true
             result3 shouldBe true
             result4 shouldBe true
-            cachedResults.results.size shouldBe 2
-            cachedResults.results should contain(scanResultSourceArtifactMatching)
-            cachedResults.results should contain(scanResultVcsMatching)
+            storedResults.results.size shouldBe 2
+            storedResults.results should contain(scanResultSourceArtifactMatching)
+            storedResults.results should contain(scanResultVcsMatching)
         }
 
-        "Cached result is found if revision was detected from version" {
-            val cache = createCache()
+        "Stored result is found if revision was detected from version" {
+            val storage = createStorage()
             val scanResult = ScanResult(provenanceWithOriginalVcsInfo, scannerDetails1, scanSummaryWithFiles,
                     rawResultWithContent)
 
-            val result = cache.add(id, scanResult)
-            val cachedResults = cache.read(pkgWithoutRevision, scannerDetails1)
+            val result = storage.add(id, scanResult)
+            val storedResults = storage.read(pkgWithoutRevision, scannerDetails1)
 
             result shouldBe true
-            cachedResults.results.size shouldBe 1
-            cachedResults.results should contain(scanResult)
+            storedResults.results.size shouldBe 1
+            storedResults.results should contain(scanResult)
         }
     }
 }

--- a/scanner/src/funTest/kotlin/scanners/FileCounterTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/FileCounterTest.kt
@@ -19,10 +19,10 @@
 
 package com.here.ort.scanner.scanners
 
-import com.here.ort.model.CacheStatistics
+import com.here.ort.model.AccessStatistics
 import com.here.ort.model.config.ScannerConfiguration
 import com.here.ort.model.yamlMapper
-import com.here.ort.scanner.ScanResultsCache
+import com.here.ort.scanner.ScanResultsStorage
 import com.here.ort.utils.safeDeleteRecursively
 import com.here.ort.utils.test.patchActualResult
 import com.here.ort.utils.test.patchExpectedResult
@@ -47,7 +47,7 @@ class FileCounterTest : StringSpec() {
 
     override fun afterTest(testCase: TestCase, result: TestResult) {
         outputRootDir.safeDeleteRecursively(force = true)
-        ScanResultsCache.stats = CacheStatistics()
+        ScanResultsStorage.stats = AccessStatistics()
     }
 
     init {

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -63,8 +63,8 @@ abstract class Scanner(protected val config: ScannerConfiguration) {
     /**
      * Scan the list of [packages] and store the scan results in [outputDirectory]. The [downloadDirectory] is used to
      * download the source code to for scanning. [ScanResult]s are returned associated by the [Package]. The map may
-     * contain multiple results for the same [Package] if the cache contains more than one result for the specification
-     * of this scanner.
+     * contain multiple results for the same [Package] if the storage contains more than one result for the
+     * specification of this scanner.
      */
     protected abstract fun scanPackages(packages: List<Package>, outputDirectory: File, downloadDirectory: File)
             : Map<Package, List<ScanResult>>
@@ -138,7 +138,7 @@ abstract class Scanner(protected val config: ScannerConfiguration) {
             }
         }
 
-        val scanRecord = ScanRecord(projectScanScopes, resultContainers, ScanResultsCache.stats)
+        val scanRecord = ScanRecord(projectScanScopes, resultContainers, ScanResultsStorage.stats)
 
         val endTime = Instant.now()
 

--- a/scanner/src/main/kotlin/scanners/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/ScanCode.kt
@@ -39,7 +39,7 @@ import com.here.ort.scanner.AbstractScannerFactory
 import com.here.ort.scanner.HTTP_CACHE_PATH
 import com.here.ort.scanner.LocalScanner
 import com.here.ort.scanner.ScanException
-import com.here.ort.scanner.ScanResultsCache
+import com.here.ort.scanner.ScanResultsStorage
 import com.here.ort.spdx.LICENSE_FILE_NAMES
 import com.here.ort.utils.CommandLineTool
 import com.here.ort.utils.ORT_CONFIG_FILENAME
@@ -73,7 +73,7 @@ import kotlin.math.absoluteValue
  * configuration options:
  *
  * * **"commandLine":** Command line options that modify the result. These are added to the [ScannerDetails] when
- *   looking up results from the [ScanResultsCache]. Defaults to [DEFAULT_CONFIGURATION_OPTIONS].
+ *   looking up results from the [ScanResultsStorage]. Defaults to [DEFAULT_CONFIGURATION_OPTIONS].
  * * **"commandLineNonConfig":** Command line options that do not modify the result and should therefore not be
  *   considered in [getConfiguration], like "--processes". Defaults to [DEFAULT_NON_CONFIGURATION_OPTIONS].
  * * **"debugCommandLine":** Debug command line options that modify the result. Only used if the [log] level is set to

--- a/scanner/src/test/kotlin/ScanResultsStorageTest.kt
+++ b/scanner/src/test/kotlin/ScanResultsStorageTest.kt
@@ -19,7 +19,7 @@
 
 package com.here.ort.scanner
 
-import com.here.ort.model.config.ArtifactoryCacheConfiguration
+import com.here.ort.model.config.ArtifactoryStorageConfiguration
 
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldNotBe
@@ -27,57 +27,57 @@ import io.kotlintest.shouldThrow
 import io.kotlintest.specs.WordSpec
 
 @Suppress("UnsafeCallOnNullableType", "UnsafeCast")
-class ScanResultsCacheTest : WordSpec() {
-    private fun ArtifactoryCache.getStringField(name: String): String {
+class ScanResultsStorageTest : WordSpec() {
+    private fun ArtifactoryStorage.getStringField(name: String): String {
         javaClass.getDeclaredField(name).let {
             it.isAccessible = true
             return it.get(this) as String
         }
     }
 
-    private fun ArtifactoryCache.getApiToken() = getStringField("apiToken")
+    private fun ArtifactoryStorage.getApiToken() = getStringField("apiToken")
 
-    private fun ArtifactoryCache.getRepository() = getStringField("repository")
+    private fun ArtifactoryStorage.getRepository() = getStringField("repository")
 
-    private fun ArtifactoryCache.getUrl() = getStringField("url")
+    private fun ArtifactoryStorage.getUrl() = getStringField("url")
 
     init {
-        "ScanResultsCache.configure" should {
+        "ScanResultsStorage.configure" should {
             "fail if the Artifactory URL is empty" {
                 val exception = shouldThrow<IllegalArgumentException> {
-                    val config = ArtifactoryCacheConfiguration("", "someRepository", "someApiToken")
+                    val config = ArtifactoryStorageConfiguration("", "someRepository", "someApiToken")
 
-                    ScanResultsCache.configure(config)
+                    ScanResultsStorage.configure(config)
                 }
-                exception.message shouldBe "URL for Artifactory cache is missing."
+                exception.message shouldBe "URL for Artifactory storage is missing."
             }
 
             "fail if the Artifactory repository is empty" {
                 val exception = shouldThrow<java.lang.IllegalArgumentException> {
-                    val config = ArtifactoryCacheConfiguration("someUrl", "", "someApiToken")
+                    val config = ArtifactoryStorageConfiguration("someUrl", "", "someApiToken")
 
-                    ScanResultsCache.configure(config)
+                    ScanResultsStorage.configure(config)
                 }
-                exception.message shouldBe "Repository for Artifactory cache is missing."
+                exception.message shouldBe "Repository for Artifactory storage is missing."
             }
 
             "fail if the Artifactory apiToken is empty" {
                 val exception = shouldThrow<IllegalArgumentException> {
-                    val config = ArtifactoryCacheConfiguration("someUrl", "someRepository", "")
+                    val config = ArtifactoryStorageConfiguration("someUrl", "someRepository", "")
 
-                    ScanResultsCache.configure(config)
+                    ScanResultsStorage.configure(config)
                 }
-                exception.message shouldBe "API token for Artifactory cache is missing."
+                exception.message shouldBe "API token for Artifactory storage is missing."
             }
 
-            "configure the Artifactory cache correctly" {
-                val config = ArtifactoryCacheConfiguration("someUrl", "someRepository", "someApiToken")
+            "configure the Artifactory storage correctly" {
+                val config = ArtifactoryStorageConfiguration("someUrl", "someRepository", "someApiToken")
 
-                ScanResultsCache.configure(config)
+                ScanResultsStorage.configure(config)
 
-                ScanResultsCache.cache shouldNotBe null
-                ScanResultsCache.cache::class shouldBe ArtifactoryCache::class
-                (ScanResultsCache.cache as ArtifactoryCache).apply {
+                ScanResultsStorage.storage shouldNotBe null
+                ScanResultsStorage.storage::class shouldBe ArtifactoryStorage::class
+                (ScanResultsStorage.storage as ArtifactoryStorage).apply {
                     getUrl() shouldBe "someUrl"
                     getRepository() shouldBe "someRepository"
                     getApiToken() shouldBe "someApiToken"


### PR DESCRIPTION
The interface is not intended to be used as a temporary cache but as a
permanent storage for scan results.

Along the way rename `CacheStatistics` to `AccessStatistics` as the class
could be used also in other places than the storage and fix the README
section about storages which was not updated in 2307b72.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1247)
<!-- Reviewable:end -->
