### PR TITLE
analyzer: Do not override toString() for the package manager name

### DIFF
--- a/analyzer/src/funTest/kotlin/BabelTest.kt
+++ b/analyzer/src/funTest/kotlin/BabelTest.kt
@@ -60,7 +60,6 @@ class BabelTest : WordSpec() {
     init {
         "Babel dependencies" should {
             "be correctly analyzed" {
-                val npm = NPM(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                 val packageFile = File(projectDir, "package.json")
 
                 val expectedResult = patchExpectedResult(
@@ -68,10 +67,12 @@ class BabelTest : WordSpec() {
                         url = normalizeVcsUrl(vcsUrl),
                         revision = vcsRevision
                 )
-                val actualResult = npm.resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+                val actualResult = createNPM().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
                 patchActualResult(yamlMapper.writeValueAsString(actualResult)) shouldBe expectedResult
             }
         }
     }
+
+    private fun createNPM() = NPM("NPM", DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/funTest/kotlin/BowerTest.kt
+++ b/analyzer/src/funTest/kotlin/BowerTest.kt
@@ -52,12 +52,13 @@ class BowerTest : StringSpec() {
                     revision = vcsRevision,
                     url = normalizeVcsUrl(vcsUrl))
 
-            val result = Bower(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val result = createBower().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors should beEmpty()
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
     }
+
+    private fun createBower() = Bower("Bower", DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/funTest/kotlin/BundlerTest.kt
+++ b/analyzer/src/funTest/kotlin/BundlerTest.kt
@@ -49,7 +49,7 @@ class BundlerTest : WordSpec() {
                 val definitionFile = File(projectsDir, "lockfile/Gemfile")
 
                 try {
-                    val actualResult = Bundler(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
+                    val actualResult = createBundler()
                             .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
                     val expectedResult = patchExpectedResult(
                             File(projectsDir.parentFile, "bundler-expected-output-lockfile.yml"),
@@ -66,9 +66,7 @@ class BundlerTest : WordSpec() {
 
             "show error if no lockfile is present" {
                 val definitionFile = File(projectsDir, "no-lockfile/Gemfile")
-
-                val actualResult = Bundler(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                        .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+                val actualResult = createBundler().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
 
                 actualResult shouldNotBe null
                 actualResult!!.project.id shouldBe
@@ -84,7 +82,7 @@ class BundlerTest : WordSpec() {
                 val definitionFile = File(projectsDir, "gemspec/Gemfile")
 
                 try {
-                    val actualResult = Bundler(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
+                    val actualResult = createBundler()
                             .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
                     val expectedResult = patchExpectedResult(
                             File(projectsDir.parentFile, "bundler-expected-output-gemspec.yml"),
@@ -100,4 +98,6 @@ class BundlerTest : WordSpec() {
             }
         }
     }
+
+    private fun createBundler() = Bundler("Bundler", DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/funTest/kotlin/GradleAndroidTest.kt
+++ b/analyzer/src/funTest/kotlin/GradleAndroidTest.kt
@@ -50,8 +50,7 @@ class GradleAndroidTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val result = createGradle().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -66,8 +65,7 @@ class GradleAndroidTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val result = createGradle().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -82,12 +80,13 @@ class GradleAndroidTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val result = createGradle().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
     }
+
+    private fun createGradle() = Gradle("Gradle", DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/funTest/kotlin/GradleKotlinScriptTest.kt
+++ b/analyzer/src/funTest/kotlin/GradleKotlinScriptTest.kt
@@ -49,8 +49,7 @@ class GradleKotlinScriptTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val result = createGradle().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -65,8 +64,7 @@ class GradleKotlinScriptTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val result = createGradle().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -81,12 +79,13 @@ class GradleKotlinScriptTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val result = createGradle().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
     }
+
+    private fun createGradle() = Gradle("Gradle", DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/funTest/kotlin/GradleLibraryTest.kt
+++ b/analyzer/src/funTest/kotlin/GradleLibraryTest.kt
@@ -49,8 +49,7 @@ class GradleLibraryTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val result = createGradle().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -65,8 +64,7 @@ class GradleLibraryTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val result = createGradle().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -81,12 +79,13 @@ class GradleLibraryTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val result = createGradle().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
     }
+
+    private fun createGradle() = Gradle("Gradle", DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/funTest/kotlin/GradleTest.kt
+++ b/analyzer/src/funTest/kotlin/GradleTest.kt
@@ -66,8 +66,7 @@ class GradleTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val result = createGradle().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -82,8 +81,7 @@ class GradleTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val result = createGradle().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -98,8 +96,7 @@ class GradleTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val result = createGradle().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -114,8 +111,7 @@ class GradleTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val result = createGradle().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -130,8 +126,7 @@ class GradleTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Gradle(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val result = createGradle().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
@@ -187,8 +182,7 @@ class GradleTest : StringSpec() {
                         revision = vcsRevision
                 )
 
-                val result = Gradle(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                        .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+                val result = createGradle().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
 
                 result shouldNotBe null
                 result!!.errors shouldBe emptyList()
@@ -213,4 +207,6 @@ class GradleTest : StringSpec() {
         ProcessCapture(projectDir, File(command).absolutePath, "--no-daemon", "wrapper", "--gradle-version", version)
                 .requireSuccess()
     }
+
+    private fun createGradle() = Gradle("Gradle", DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/funTest/kotlin/MavenTest.kt
+++ b/analyzer/src/funTest/kotlin/MavenTest.kt
@@ -47,8 +47,7 @@ class MavenTest : StringSpec() {
             val pomFile = File(projectDir, "pom.xml")
             val expectedResult = File(projectDir.parentFile, "jgnash-expected-output.yml").readText()
 
-            val result = Maven(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, listOf(pomFile))[pomFile]
+            val result = createMaven().resolveDependencies(USER_DIR, listOf(pomFile))[pomFile]
 
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
@@ -64,8 +63,7 @@ class MavenTest : StringSpec() {
             // jgnash-core depends on jgnash-resources, so we also have to pass the pom.xml of jgnash-resources to
             // resolveDependencies so that it is available in the Maven.projectsByIdentifier cache. Otherwise resolution
             // of transitive dependencies would not work.
-            val result = Maven(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, listOf(pomFileCore, pomFileResources))[pomFileCore]
+            val result = createMaven().resolveDependencies(USER_DIR, listOf(pomFileCore, pomFileResources))[pomFileCore]
 
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
@@ -78,8 +76,7 @@ class MavenTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Maven(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, listOf(pomFile))[pomFile]
+            val result = createMaven().resolveDependencies(USER_DIR, listOf(pomFile))[pomFile]
 
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
@@ -96,8 +93,7 @@ class MavenTest : StringSpec() {
             // app depends on lib, so we also have to pass the pom.xml of lib to resolveDependencies so that it is
             // available in the Maven.projectsByIdentifier cache. Otherwise resolution of transitive dependencies would
             // not work.
-            val result = Maven(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, listOf(pomFileApp, pomFileLib))[pomFileApp]
+            val result = createMaven().resolveDependencies(USER_DIR, listOf(pomFileApp, pomFileLib))[pomFileApp]
 
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
@@ -110,8 +106,7 @@ class MavenTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Maven(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, listOf(pomFile))[pomFile]
+            val result = createMaven().resolveDependencies(USER_DIR, listOf(pomFile))[pomFile]
 
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
@@ -130,10 +125,11 @@ class MavenTest : StringSpec() {
                     revision = vcsRevision
             )
 
-            val result = Maven(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, listOf(pomFile))[pomFile]
+            val result = createMaven().resolveDependencies(USER_DIR, listOf(pomFile))[pomFile]
 
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
     }
+
+    private fun createMaven() = Maven("Maven", DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/funTest/kotlin/NpmTest.kt
+++ b/analyzer/src/funTest/kotlin/NpmTest.kt
@@ -63,8 +63,7 @@ class NpmTest : WordSpec() {
                 val workingDir = File(projectsDir, "shrinkwrap")
                 val packageFile = File(workingDir, "package.json")
 
-                val result = NPM(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                        .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+                val result = createNPM().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
                 val vcsPath = vcsDir.getPathToRoot(workingDir)
                 val expectedResult = patchExpectedResult(
                         File(projectsDir.parentFile, "npm-expected-output.yml"),
@@ -82,8 +81,7 @@ class NpmTest : WordSpec() {
                 val workingDir = File(projectsDir, "package-lock")
                 val packageFile = File(workingDir, "package.json")
 
-                val result = NPM(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                        .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+                val result = createNPM().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
                 val vcsPath = vcsDir.getPathToRoot(workingDir)
                 val expectedResult = patchExpectedResult(
                         File(projectsDir.parentFile, "npm-expected-output.yml"),
@@ -101,8 +99,7 @@ class NpmTest : WordSpec() {
                 val workingDir = File(projectsDir, "no-lockfile")
                 val packageFile = File(workingDir, "package.json")
 
-                val result = NPM(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                        .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+                val result = createNPM().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
                 val vcsPath = vcsDir.getPathToRoot(workingDir)
                 val expectedResult = patchExpectedResult(
                         File(projectsDir.parentFile, "npm-expected-output-no-lockfile.yml"),
@@ -120,8 +117,7 @@ class NpmTest : WordSpec() {
                 val workingDir = File(projectsDir, "node-modules")
                 val packageFile = File(workingDir, "package.json")
 
-                val result = NPM(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                        .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+                val result = createNPM().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
                 val vcsPath = vcsDir.getPathToRoot(workingDir)
                 val expectedResult = patchExpectedResult(
                         File(projectsDir.parentFile, "npm-expected-output.yml"),
@@ -136,4 +132,6 @@ class NpmTest : WordSpec() {
             }
         }
     }
+
+    private fun createNPM() = NPM("NPM", DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/funTest/kotlin/NpmVersionUrlTest.kt
+++ b/analyzer/src/funTest/kotlin/NpmVersionUrlTest.kt
@@ -25,6 +25,7 @@ import com.here.ort.model.config.AnalyzerConfiguration
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
 import com.here.ort.utils.safeDeleteRecursively
+import com.here.ort.utils.test.DEFAULT_ANALYZER_CONFIGURATION
 import com.here.ort.utils.test.DEFAULT_REPOSITORY_CONFIGURATION
 import com.here.ort.utils.test.USER_DIR
 import com.here.ort.utils.test.patchExpectedResult
@@ -57,8 +58,8 @@ class NpmVersionUrlTest : WordSpec() {
             "resolve dependencies with URLs as versions correctly" {
                 val packageFile = File(projectDir, "package.json")
 
-                val result = NPM(AnalyzerConfiguration(false, true), DEFAULT_REPOSITORY_CONFIGURATION)
-                        .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+                val config = AnalyzerConfiguration(false, true)
+                val result = createNPM(config).resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
                 val vcsPath = vcsDir.getPathToRoot(projectDir)
                 val expectedResult = patchExpectedResult(
                         File(projectDir.parentFile, "npm-version-urls-expected-output.yml"),
@@ -72,4 +73,7 @@ class NpmVersionUrlTest : WordSpec() {
             }
         }
     }
+
+    private fun createNPM(config: AnalyzerConfiguration = DEFAULT_ANALYZER_CONFIGURATION) =
+            NPM("NPM", config, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/funTest/kotlin/PhpComposerTest.kt
+++ b/analyzer/src/funTest/kotlin/PhpComposerTest.kt
@@ -47,8 +47,7 @@ class PhpComposerTest : StringSpec() {
         "Project dependencies are detected correctly" {
             val definitionFile = File(projectsDir, "lockfile/composer.json")
 
-            val result = PhpComposer(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+            val result = createPhpComposer().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
             val expectedResults = patchExpectedResult(
                     File(projectsDir.parentFile, "php-composer-expected-output.yml"),
                     url = normalizeVcsUrl(vcsUrl),
@@ -61,9 +60,7 @@ class PhpComposerTest : StringSpec() {
 
         "Error is shown when no lock file is present" {
             val definitionFile = File(projectsDir, "no-lockfile/composer.json")
-
-            val result = PhpComposer(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+            val result = createPhpComposer().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
 
             result shouldNotBe null
             result!!.project.id shouldBe Identifier("PhpComposer::src/funTest/assets/projects/synthetic/" +
@@ -78,8 +75,7 @@ class PhpComposerTest : StringSpec() {
         "No composer.lock is required for projects without dependencies" {
             val definitionFile = File(projectsDir, "no-deps/composer.json")
 
-            val result = PhpComposer(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+            val result = createPhpComposer().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
             val expectedResults = patchExpectedResult(
                     File(projectsDir.parentFile, "php-composer-expected-output-no-deps.yml"),
                     definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
@@ -94,8 +90,7 @@ class PhpComposerTest : StringSpec() {
         "No composer.lock is required for projects with empty dependencies" {
             val definitionFile = File(projectsDir, "empty-deps/composer.json")
 
-            val result = PhpComposer(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+            val result = createPhpComposer().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
             val expectedResults = patchExpectedResult(
                     File(projectsDir.parentFile, "php-composer-expected-output-no-deps.yml"),
                     definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
@@ -110,8 +105,7 @@ class PhpComposerTest : StringSpec() {
         "Packages defined as provided are not reported as missing" {
             val definitionFile = File(projectsDir, "with-provide/composer.json")
 
-            val result = PhpComposer(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+            val result = createPhpComposer().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
             val expectedResults = patchExpectedResult(
                     File(projectsDir.parentFile, "php-composer-expected-output-with-provide.yml"),
                     url = normalizeVcsUrl(vcsUrl),
@@ -125,8 +119,7 @@ class PhpComposerTest : StringSpec() {
         "Packages defined as replaced are not reported as missing" {
             val definitionFile = File(projectsDir, "with-replace/composer.json")
 
-            val result = PhpComposer(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+            val result = createPhpComposer().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
             val expectedResults = patchExpectedResult(
                     File(projectsDir.parentFile, "php-composer-expected-output-with-replace.yml"),
                     url = normalizeVcsUrl(vcsUrl),
@@ -137,4 +130,7 @@ class PhpComposerTest : StringSpec() {
             yamlMapper.writeValueAsString(result) shouldBe expectedResults
         }
     }
+
+    private fun createPhpComposer() =
+            PhpComposer("PhpComposer", DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/funTest/kotlin/PipTest.kt
+++ b/analyzer/src/funTest/kotlin/PipTest.kt
@@ -33,62 +33,63 @@ import io.kotlintest.specs.WordSpec
 
 import java.io.File
 
-class PipTest : WordSpec({
-    val projectsDir = File("src/funTest/assets/projects")
-    val vcsDir = VersionControlSystem.forDirectory(projectsDir)!!
-    val vcsUrl = vcsDir.getRemoteUrl()
-    val vcsRevision = vcsDir.getRevision()
+class PipTest : WordSpec() {
+    private val projectsDir = File("src/funTest/assets/projects")
+    private val vcsDir = VersionControlSystem.forDirectory(projectsDir)!!
+    private val vcsUrl = vcsDir.getRemoteUrl()
+    private val vcsRevision = vcsDir.getRevision()
 
-    "Python 2" should {
-        "resolve setup.py dependencies correctly for spdx-tools-python" {
-            val definitionFile = File(projectsDir, "external/spdx-tools-python/setup.py")
+    init {
+        "Python 2" should {
+            "resolve setup.py dependencies correctly for spdx-tools-python" {
+                val definitionFile = File(projectsDir, "external/spdx-tools-python/setup.py")
 
-            val result = PIP(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
-            val expectedResult = File(projectsDir, "external/spdx-tools-python-expected-output.yml").readText()
+                val result = createPIP().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+                val expectedResult = File(projectsDir, "external/spdx-tools-python-expected-output.yml").readText()
 
-            yamlMapper.writeValueAsString(result) shouldBe expectedResult
+                yamlMapper.writeValueAsString(result) shouldBe expectedResult
+            }
+
+            "resolve requirements.txt dependencies correctly for example-python-flask" {
+                val definitionFile = File(projectsDir, "external/example-python-flask/requirements.txt")
+
+                val result = createPIP().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+                val expectedResult = File(projectsDir, "external/example-python-flask-expected-output.yml").readText()
+
+                yamlMapper.writeValueAsString(result) shouldBe expectedResult
+            }
+
+            "capture metadata from setup.py even if requirements.txt is present" {
+                val definitionFile = File(projectsDir, "synthetic/pip/requirements.txt")
+                val vcsPath = vcsDir.getPathToRoot(definitionFile.parentFile)
+
+                val expectedResult = patchExpectedResult(File(projectsDir, "synthetic/pip-expected-output.yml"),
+                        url = normalizeVcsUrl(vcsUrl),
+                        revision = vcsRevision,
+                        path = vcsPath)
+
+                val result = createPIP().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+
+                yamlMapper.writeValueAsString(result) shouldBe expectedResult
+            }
         }
 
-        "resolve requirements.txt dependencies correctly for example-python-flask" {
-            val definitionFile = File(projectsDir, "external/example-python-flask/requirements.txt")
+        "Python 3" should {
+            "resolve dependencies correctly for python-django" {
+                val definitionFile = File(projectsDir, "synthetic/python3-django/requirements.txt")
+                val vcsPath = vcsDir.getPathToRoot(definitionFile.parentFile)
 
-            val result = PIP(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
-            val expectedResult = File(projectsDir, "external/example-python-flask-expected-output.yml").readText()
+                val result = createPIP().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+                val expectedResultFile = File(projectsDir, "synthetic/python3-django-expected-output.yml")
+                val expectedResult = patchExpectedResult(expectedResultFile,
+                        url = normalizeVcsUrl(vcsUrl),
+                        revision = vcsRevision,
+                        path = vcsPath)
 
-            yamlMapper.writeValueAsString(result) shouldBe expectedResult
-        }
-
-        "capture metadata from setup.py even if requirements.txt is present" {
-            val definitionFile = File(projectsDir, "synthetic/pip/requirements.txt")
-            val vcsPath = vcsDir.getPathToRoot(definitionFile.parentFile)
-
-            val expectedResult = patchExpectedResult(File(projectsDir, "synthetic/pip-expected-output.yml"),
-                    url = normalizeVcsUrl(vcsUrl),
-                    revision = vcsRevision,
-                    path = vcsPath)
-
-            val result = PIP(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
-
-            yamlMapper.writeValueAsString(result) shouldBe expectedResult
+                yamlMapper.writeValueAsString(result) shouldBe expectedResult
+            }
         }
     }
 
-    "Python 3" should {
-        "resolve dependencies correctly for python-django" {
-            val definitionFile = File(projectsDir, "synthetic/python3-django/requirements.txt")
-            val vcsPath = vcsDir.getPathToRoot(definitionFile.parentFile)
-
-            val result = PIP(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
-            val expectedResult = patchExpectedResult(File(projectsDir, "synthetic/python3-django-expected-output.yml"),
-                    url = normalizeVcsUrl(vcsUrl),
-                    revision = vcsRevision,
-                    path = vcsPath)
-
-            yamlMapper.writeValueAsString(result) shouldBe expectedResult
-        }
-    }
-})
+    private fun createPIP() = PIP("PIP", DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
+}

--- a/analyzer/src/funTest/kotlin/StackTest.kt
+++ b/analyzer/src/funTest/kotlin/StackTest.kt
@@ -63,8 +63,7 @@ class StackTest : StringSpec() {
         "Dependencies should be resolved correctly for quickcheck-state-machine" {
             val definitionFile = File(projectsDir, "external/quickcheck-state-machine/stack.yaml")
 
-            val result = Stack(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+            val result = createStack().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
             val expectedOutput = if (OS.isWindows) {
                 "external/quickcheck-state-machine-expected-output-win32.yml"
             } else {
@@ -79,8 +78,7 @@ class StackTest : StringSpec() {
         "Dependencies should be resolved correctly for quickcheck-state-machine-example" {
             val definitionFile = File(projectsDir, "external/quickcheck-state-machine/example/stack.yaml")
 
-            val result = Stack(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+            val result = createStack().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
             val expectedOutput = if (OS.isWindows) {
                 "external/quickcheck-state-machine-example-expected-output-win32.yml"
             } else {
@@ -92,4 +90,6 @@ class StackTest : StringSpec() {
             actualResult shouldBe expectedResult
         }
     }
+
+    private fun createStack() = Stack("Stack", DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/funTest/kotlin/YarnTest.kt
+++ b/analyzer/src/funTest/kotlin/YarnTest.kt
@@ -60,8 +60,7 @@ class YarnTest : WordSpec() {
         "yarn" should {
             "resolve dependencies correctly" {
                 val packageFile = File(projectDir, "package.json")
-                val result = Yarn(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                        .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+                val result = createYarn().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
                 val vcsPath = vcsDir.getPathToRoot(projectDir)
                 val expectedResult = patchExpectedResult(
                         File(projectDir.parentFile, "yarn-expected-output.yml"),
@@ -75,4 +74,6 @@ class YarnTest : WordSpec() {
             }
         }
     }
+
+    private fun createYarn() = Yarn("Yarn", DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -51,10 +51,12 @@ typealias ResolutionResult = MutableMap<File, ProjectAnalyzerResult>
 /**
  * A class representing a package manager that handles software dependencies.
  *
+ * @param managerName The package manager's name.
  * @param analyzerConfig The configuration of the analyzer to use.
  * @param repoConfig The configuration of the repository to use.
  */
 abstract class PackageManager(
+        val managerName: String,
         protected val analyzerConfig: AnalyzerConfiguration,
         protected val repoConfig: RepositoryConfiguration
 ) {

--- a/analyzer/src/main/kotlin/PackageManagerFactory.kt
+++ b/analyzer/src/main/kotlin/PackageManagerFactory.kt
@@ -30,6 +30,11 @@ import java.nio.file.PathMatcher
  */
 interface PackageManagerFactory {
     /**
+     * The name to use to refer to the package manager.
+     */
+    val managerName: String
+
+    /**
      * The glob matchers for all definition files.
      */
     val matchersForDefinitionFiles: List<PathMatcher>
@@ -43,7 +48,9 @@ interface PackageManagerFactory {
 /**
  * A generic factory class for a [PackageManager].
  */
-abstract class AbstractPackageManagerFactory<out T : PackageManager> : PackageManagerFactory {
+abstract class AbstractPackageManagerFactory<out T : PackageManager>(
+        override val managerName: String
+) : PackageManagerFactory {
     /**
      * The prioritized list of glob patterns of definition files supported by this package manager. Only all matches of
      * the first glob having any matches are considered.
@@ -59,8 +66,8 @@ abstract class AbstractPackageManagerFactory<out T : PackageManager> : PackageMa
     abstract override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration): T
 
     /**
-     * Return the Java class name as a simple way to refer to the [AbstractPackageManagerFactory]. As factories are
-     * supposed to be implemented as inner classes we need to manually strip unwanted parts of the fully qualified name.
+     * Return the package manager's name here to allow JCommander to display something meaningful when listing the
+     * package managers which are enabled by default via their factories.
      */
-    override fun toString() = javaClass.name.substringBefore('$').substringAfterLast('.')
+    override fun toString() = managerName
 }

--- a/analyzer/src/main/kotlin/managers/Bower.kt
+++ b/analyzer/src/main/kotlin/managers/Bower.kt
@@ -54,8 +54,8 @@ import java.util.Stack
 /**
  * The Bower package manager for JavaScript, see https://bower.io/.
  */
-class Bower(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
-        PackageManager(analyzerConfig, repoConfig), CommandLineTool {
+class Bower(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
+        PackageManager(name, analyzerConfig, repoConfig), CommandLineTool {
     companion object {
         // We do not actually depend on any features specific to this Bower version, but we still want to
         // stick to fixed versions to be sure to get consistent results.
@@ -198,11 +198,11 @@ class Bower(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfigu
         }
     }
 
-    class Factory : AbstractPackageManagerFactory<Bower>() {
+    class Factory : AbstractPackageManagerFactory<Bower>("Bower") {
         override val globsForDefinitionFiles = listOf("bower.json")
 
         override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
-                Bower(analyzerConfig, repoConfig)
+                Bower(managerName, analyzerConfig, repoConfig)
     }
 
     override fun command(workingDir: File?) = if (OS.isWindows) "bower.cmd" else "bower"

--- a/analyzer/src/main/kotlin/managers/Bundler.kt
+++ b/analyzer/src/main/kotlin/managers/Bundler.kt
@@ -63,13 +63,13 @@ import okhttp3.Request
  * The Bundler package manager for Ruby, see https://bundler.io/. Also see
  * http://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/.
  */
-class Bundler(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
-        PackageManager(analyzerConfig, repoConfig), CommandLineTool {
-    class Factory : AbstractPackageManagerFactory<Bundler>() {
+class Bundler(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
+        PackageManager(name, analyzerConfig, repoConfig), CommandLineTool {
+    class Factory : AbstractPackageManagerFactory<Bundler>("Bundler") {
         override val globsForDefinitionFiles = listOf("Gemfile")
 
         override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
-                Bundler(analyzerConfig, repoConfig)
+                Bundler(managerName, analyzerConfig, repoConfig)
     }
 
     override fun command(workingDir: File?) = if (OS.isWindows) "bundle.bat" else "bundle"
@@ -95,7 +95,7 @@ class Bundler(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfi
             installDependencies(workingDir)
 
             val (projectName, version, homepageUrl, declaredLicenses) = parseProject(workingDir)
-            val projectId = Identifier(toString(), "", projectName, version)
+            val projectId = Identifier(managerName, "", projectName, version)
             val groupedDeps = getDependencyGroups(workingDir)
 
             for ((groupName, dependencyList) in groupedDeps) {
@@ -135,7 +135,7 @@ class Bundler(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfi
 
         try {
             var gemSpec = getGemspec(gemName, workingDir)
-            val gemId = Identifier(toString(), "", gemSpec.name, gemSpec.version)
+            val gemId = Identifier(managerName, "", gemSpec.name, gemSpec.version)
 
             // The project itself can be listed as a dependency if the project is a Gem (i.e. there is a .gemspec file
             // for it, and the Gemfile refers to it). In that case, skip querying Rubygems and adding Package and
@@ -174,7 +174,7 @@ class Bundler(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfi
             val errorMsg = "Failed to parse package (gem) $gemName: ${e.collectMessagesAsString()}"
             log.error { errorMsg }
 
-            errors += OrtIssue(source = toString(), message = errorMsg)
+            errors += OrtIssue(source = managerName, message = errorMsg)
         }
     }
 

--- a/analyzer/src/main/kotlin/managers/CocoaPods.kt
+++ b/analyzer/src/main/kotlin/managers/CocoaPods.kt
@@ -30,13 +30,13 @@ import java.io.File
 /**
  * The CocoaPods package manager for Objective-C, see https://cocoapods.org/.
  */
-class CocoaPods(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
-        PackageManager(analyzerConfig, repoConfig) {
-    class Factory : AbstractPackageManagerFactory<CocoaPods>() {
+class CocoaPods(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
+        PackageManager(name, analyzerConfig, repoConfig) {
+    class Factory : AbstractPackageManagerFactory<CocoaPods>("CocoaPods") {
         override val globsForDefinitionFiles = listOf("Podfile.lock", "Podfile")
 
         override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
-                CocoaPods(analyzerConfig, repoConfig)
+                CocoaPods(managerName, analyzerConfig, repoConfig)
     }
 
     override fun resolveDependencies(definitionFile: File): ProjectAnalyzerResult? {

--- a/analyzer/src/main/kotlin/managers/Maven.kt
+++ b/analyzer/src/main/kotlin/managers/Maven.kt
@@ -54,13 +54,13 @@ import org.eclipse.aether.repository.WorkspaceRepository
 /**
  * The Maven package manager for Java, see https://maven.apache.org/.
  */
-class Maven(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
-        PackageManager(analyzerConfig, repoConfig) {
-    class Factory : AbstractPackageManagerFactory<Maven>() {
+class Maven(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
+        PackageManager(name, analyzerConfig, repoConfig) {
+    class Factory : AbstractPackageManagerFactory<Maven>("Maven") {
         override val globsForDefinitionFiles = listOf("pom.xml")
 
         override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
-                Maven(analyzerConfig, repoConfig)
+                Maven(managerName, analyzerConfig, repoConfig)
     }
 
     private inner class LocalProjectWorkspaceReader : WorkspaceReader {
@@ -189,9 +189,9 @@ class Maven(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfigu
             }
 
             return PackageReference(
-                    Identifier(toString(), node.artifact.groupId, node.artifact.artifactId, node.artifact.version),
+                    Identifier(managerName, node.artifact.groupId, node.artifact.artifactId, node.artifact.version),
                     dependencies = sortedSetOf(),
-                    errors = listOf(OrtIssue(source = toString(), message = e.collectMessagesAsString()))
+                    errors = listOf(OrtIssue(source = managerName, message = e.collectMessagesAsString()))
             )
         }
     }

--- a/analyzer/src/main/kotlin/managers/NPM.kt
+++ b/analyzer/src/main/kotlin/managers/NPM.kt
@@ -69,8 +69,8 @@ import okhttp3.Request
 /**
  * The Node package manager for JavaScript, see https://www.npmjs.com/.
  */
-open class NPM(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
-        PackageManager(analyzerConfig, repoConfig), CommandLineTool {
+open class NPM(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
+        PackageManager(name, analyzerConfig, repoConfig), CommandLineTool {
     companion object {
         /**
          * Expand NPM shortcuts for URLs to hosting sites to full URLs so that they can be used in a regular way.
@@ -112,11 +112,11 @@ open class NPM(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConf
         }
     }
 
-    class Factory : AbstractPackageManagerFactory<NPM>() {
+    class Factory : AbstractPackageManagerFactory<NPM>("NPM") {
         override val globsForDefinitionFiles = listOf("package.json")
 
         override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
-                NPM(analyzerConfig, repoConfig)
+                NPM(managerName, analyzerConfig, repoConfig)
     }
 
     protected open fun hasLockFile(projectDir: File) = PackageJsonUtils.hasNpmLockFile(projectDir)
@@ -423,8 +423,8 @@ open class NPM(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConf
                         "fine if the module was not installed because it is specific to a different platform."
             }
 
-            val id = Identifier(toString(), "", name, "")
-            val issue = OrtIssue(source = toString(), message = "Package '$name' was not installed.")
+            val id = Identifier(managerName, "", name, "")
+            val issue = OrtIssue(source = managerName, message = "Package '$name' was not installed.")
             return PackageReference(id, errors = listOf(issue))
         } else {
             // Skip the package name directory when going up.
@@ -476,7 +476,7 @@ open class NPM(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConf
 
         val project = Project(
                 id = Identifier(
-                        type = toString(),
+                        type = managerName,
                         namespace = namespace,
                         name = name,
                         version = version

--- a/analyzer/src/main/kotlin/managers/PIP.kt
+++ b/analyzer/src/main/kotlin/managers/PIP.kt
@@ -133,13 +133,13 @@ object PythonVersion : CommandLineTool {
  * https://packaging.python.org/discussions/install-requires-vs-requirements/ and
  * https://caremad.io/posts/2013/07/setup-vs-requirement/.
  */
-class PIP(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
-        PackageManager(analyzerConfig, repoConfig), CommandLineTool {
-    class Factory : AbstractPackageManagerFactory<PIP>() {
+class PIP(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
+        PackageManager(name, analyzerConfig, repoConfig), CommandLineTool {
+    class Factory : AbstractPackageManagerFactory<PIP>("PIP") {
         override val globsForDefinitionFiles = listOf("requirements*.txt", "setup.py")
 
         override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
-                PIP(analyzerConfig, repoConfig)
+                PIP(managerName, analyzerConfig, repoConfig)
     }
 
     private val INSTALL_OPTIONS = listOf(
@@ -373,7 +373,7 @@ class PIP(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfigura
 
         val project = Project(
                 id = Identifier(
-                        type = toString(),
+                        type = managerName,
                         namespace = "",
                         name = projectName,
                         version = projectVersion

--- a/analyzer/src/main/kotlin/managers/PhpComposer.kt
+++ b/analyzer/src/main/kotlin/managers/PhpComposer.kt
@@ -61,13 +61,13 @@ const val COMPOSER_LOCK_FILE = "composer.lock"
 /**
  * The Composer package manager for PHP, see https://getcomposer.org/.
  */
-class PhpComposer(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
-        PackageManager(analyzerConfig, repoConfig), CommandLineTool {
-    class Factory : AbstractPackageManagerFactory<PhpComposer>() {
+class PhpComposer(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
+        PackageManager(name, analyzerConfig, repoConfig), CommandLineTool {
+    class Factory : AbstractPackageManagerFactory<PhpComposer>("PhpComposer") {
         override val globsForDefinitionFiles = listOf("composer.json")
 
         override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
-                PhpComposer(analyzerConfig, repoConfig)
+                PhpComposer(managerName, analyzerConfig, repoConfig)
     }
 
     override fun command(workingDir: File?) =
@@ -177,7 +177,7 @@ class PhpComposer(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryC
 
                     log.error { "Could not resolve dependencies of '$packageName': ${e.collectMessagesAsString()}" }
 
-                    packageInfo.toReference(errors = listOf(OrtIssue(source = toString(),
+                    packageInfo.toReference(errors = listOf(OrtIssue(source = managerName,
                             message = e.collectMessagesAsString())))
                 }
             }
@@ -193,7 +193,7 @@ class PhpComposer(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryC
 
         return Project(
                 id = Identifier(
-                        type = toString(),
+                        type = managerName,
                         namespace = rawName.substringBefore("/"),
                         name = rawName.substringAfter("/"),
                         version = json["version"].textValueOrEmpty()
@@ -225,7 +225,7 @@ class PhpComposer(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryC
 
                 packages[rawName] = Package(
                         id = Identifier(
-                                type = toString(),
+                                type = managerName,
                                 namespace = rawName.substringBefore("/"),
                                 name = rawName.substringAfter("/"),
                                 version = version

--- a/analyzer/src/main/kotlin/managers/SBT.kt
+++ b/analyzer/src/main/kotlin/managers/SBT.kt
@@ -41,8 +41,8 @@ import java.util.Properties
 /**
  * The SBT package manager for Scala, see https://www.scala-sbt.org/.
  */
-class SBT(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
-        PackageManager(analyzerConfig, repoConfig), CommandLineTool {
+class SBT(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
+        PackageManager(name, analyzerConfig, repoConfig), CommandLineTool {
     companion object {
         private val VERSION_REGEX = Regex("\\[info]\\s+(\\d+\\.\\d+\\.[^\\s]+)")
         private val PROJECT_REGEX = Regex("\\[info] \t [ *] (.+)")
@@ -62,11 +62,11 @@ class SBT(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfigura
         }
     }
 
-    class Factory : AbstractPackageManagerFactory<SBT>() {
+    class Factory : AbstractPackageManagerFactory<SBT>("SBT") {
         override val globsForDefinitionFiles = listOf("build.sbt", "build.scala")
 
         override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
-                SBT(analyzerConfig, repoConfig)
+                SBT(managerName, analyzerConfig, repoConfig)
     }
 
     override fun command(workingDir: File?) = if (OS.isWindows) "sbt.bat" else "sbt"
@@ -100,7 +100,7 @@ class SBT(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfigura
             // project's root directory. In order to determine the root directory, use the common prefix of all
             // definition file paths.
             getCommonFilePrefix(definitionFiles).also {
-                log.info { "Determined '$it' as the ${toString()} project root directory." }
+                log.info { "Determined '$it' as the $managerName project root directory." }
             }
         } else {
             definitionFiles.first().parentFile
@@ -140,7 +140,7 @@ class SBT(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfigura
             // project's root directory. In order to determine the root directory, use the common prefix of all
             // definition file paths.
             getCommonFilePrefix(definitionFiles).also {
-                log.info { "Determined '$it' as the ${toString()} project root directory." }
+                log.info { "Determined '$it' as the $managerName project root directory." }
             }
         } else {
             definitionFiles.first().parentFile
@@ -172,7 +172,7 @@ class SBT(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfigura
             val lowestSbtVersion = checkForSameSbtVersion(versions)
 
             if (!sbtVersionRequirement.isSatisfiedBy(lowestSbtVersion)) {
-                throw IOException("Unsupported ${toString()} version $lowestSbtVersion does not fulfill " +
+                throw IOException("Unsupported $managerName version $lowestSbtVersion does not fulfill " +
                         "$sbtVersionRequirement.")
             }
         }
@@ -180,7 +180,7 @@ class SBT(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfigura
 
     override fun resolveDependencies(analyzerRoot: File, definitionFiles: List<File>) =
             // Simply pass on the list of POM files to Maven, ignoring the SBT build files here.
-            Maven(analyzerConfig, repoConfig)
+            Maven("SBT", analyzerConfig, repoConfig)
                     .enableSbtMode()
                     .resolveDependencies(analyzerRoot, definitionFiles)
 

--- a/analyzer/src/main/kotlin/managers/Stack.kt
+++ b/analyzer/src/main/kotlin/managers/Stack.kt
@@ -56,13 +56,13 @@ import java.util.SortedSet
 /**
  * The Stack package manager for Haskell, see https://haskellstack.org/.
  */
-class Stack(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
-        PackageManager(analyzerConfig, repoConfig), CommandLineTool {
-    class Factory : AbstractPackageManagerFactory<Stack>() {
+class Stack(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
+        PackageManager(name, analyzerConfig, repoConfig), CommandLineTool {
+    class Factory : AbstractPackageManagerFactory<Stack>("Stack") {
         override val globsForDefinitionFiles = listOf("stack.yaml")
 
         override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
-                Stack(analyzerConfig, repoConfig)
+                Stack(managerName, analyzerConfig, repoConfig)
     }
 
     override fun command(workingDir: File?) = "stack"
@@ -84,7 +84,7 @@ class Stack(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfigu
         }
 
         val projectPackage = parseCabalFile(cabalFile.readText())
-        val projectId = projectPackage.id.copy(type = toString())
+        val projectId = projectPackage.id.copy(type = managerName)
 
         // Parse package information from the stack.yaml file.
         fun runStack(vararg command: String): ProcessCapture {

--- a/analyzer/src/main/kotlin/managers/Unmanaged.kt
+++ b/analyzer/src/main/kotlin/managers/Unmanaged.kt
@@ -37,13 +37,13 @@ import java.io.File
 /**
  * A fake [PackageManager] for projects that do not use any of the known package managers.
  */
-class Unmanaged(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
-        PackageManager(analyzerConfig, repoConfig) {
-    class Factory : AbstractPackageManagerFactory<Unmanaged>() {
+class Unmanaged(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
+        PackageManager(name, analyzerConfig, repoConfig) {
+    class Factory : AbstractPackageManagerFactory<Unmanaged>("Unmanaged") {
         override val globsForDefinitionFiles = emptyList<String>()
 
         override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
-                Unmanaged(analyzerConfig, repoConfig)
+                Unmanaged(managerName, analyzerConfig, repoConfig)
     }
 
     /**
@@ -67,7 +67,7 @@ class Unmanaged(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryCon
                 }
 
                 Identifier(
-                        type = toString(),
+                        type = managerName,
                         namespace = "",
                         name = projectDir.name,
                         version = ""
@@ -78,7 +78,7 @@ class Unmanaged(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryCon
                 // For GitRepo looking at the URL and revision only is not enough, we also need to take the used
                 // manifest into account.
                 Identifier(
-                        type = toString(),
+                        type = managerName,
                         namespace = vcsInfo.path.substringBeforeLast('/'),
                         name = vcsInfo.path.substringAfterLast('/').removeSuffix(".xml"),
                         version = vcsInfo.revision
@@ -88,7 +88,7 @@ class Unmanaged(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryCon
             else -> {
                 // For all non-GitRepo VCSes derive the name from the VCS URL.
                 Identifier(
-                        type = toString(),
+                        type = managerName,
                         namespace = "",
                         name = vcsInfo.url.split('/').last().removeSuffix(".git"),
                         version = vcsInfo.revision

--- a/analyzer/src/main/kotlin/managers/Yarn.kt
+++ b/analyzer/src/main/kotlin/managers/Yarn.kt
@@ -32,13 +32,13 @@ import java.io.File
 /**
  * The Yarn package manager for JavaScript, see https://www.yarnpkg.com/.
  */
-class Yarn(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
-        NPM(analyzerConfig, repoConfig) {
-    class Factory : AbstractPackageManagerFactory<Yarn>() {
+class Yarn(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
+        NPM(name, analyzerConfig, repoConfig) {
+    class Factory : AbstractPackageManagerFactory<Yarn>("Yarn") {
         override val globsForDefinitionFiles = listOf("package.json")
 
         override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
-                Yarn(analyzerConfig, repoConfig)
+                Yarn(managerName, analyzerConfig, repoConfig)
     }
 
     override fun hasLockFile(projectDir: File) = PackageJsonUtils.hasYarnLockFile(projectDir)


### PR DESCRIPTION
Overriding toString() often is a bad idea to due hard-to-track
side-effects. Instead, use a dedicated "managerName" property and
explicitly define each package manager name only once for both package
manager and package manager factory classes, avoiding the name to be
deduced multiple times from the class name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1251)
<!-- Reviewable:end -->
