### PR TITLE
[RFC] MavenSupport: Use a URL suffix created by Maven as the VcsInfo path

### DIFF
--- a/analyzer/src/main/kotlin/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/MavenSupport.kt
@@ -184,7 +184,15 @@ class MavenSupport(workspaceReader: WorkspaceReader) {
                 parent = parent.parent
             }
 
-            return parseScm(scm)
+            val projectVcsInfo = parseScm(mavenProject.scm)
+            val applicableVcsInfo = parseScm(scm)
+
+            // If we stripped a path from the URL, use that path as part of the VcsInfo.
+            return if (applicableVcsInfo.url != projectVcsInfo.url && applicableVcsInfo.path.isEmpty()) {
+                applicableVcsInfo.copy(path = projectVcsInfo.url.removePrefix("${applicableVcsInfo.url}/"))
+            } else {
+                applicableVcsInfo
+            }
         }
     }
 


### PR DESCRIPTION
Instead of ignoring any path-suffix in the URL completely, use it as
the VcsInfo path along with the base-URL to allow performing a sparse
checkout on that path.

This only works, though, if the path in the directory is indeed named
after the artifact it creates, which is what Maven assumes, but is not
always the case.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1253)
<!-- Reviewable:end -->
