### PR TITLE
reporter: Do not override toString() for the reporter name

### DIFF
--- a/cli/src/main/kotlin/commands/ReporterCommand.kt
+++ b/cli/src/main/kotlin/commands/ReporterCommand.kt
@@ -47,8 +47,8 @@ import java.io.File
 object ReporterCommand : CommandWithHelp() {
     private class ReporterConverter : IStringConverter<Reporter> {
         companion object {
-            // Map upper-cased reporter names without the "Reporter" suffix names to their instances.
-            val REPORTERS = Reporter.ALL.associateBy { it.toString().removeSuffix("Reporter").toUpperCase() }
+            // Map upper-cased reporter names to their instances.
+            val REPORTERS = Reporter.ALL.associateBy { it.reporterName.toUpperCase() }
         }
 
         override fun convert(name: String): Reporter {
@@ -127,8 +127,6 @@ object ReporterCommand : CommandWithHelp() {
         absoluteOutputDir.safeMkdirs()
 
         reports.forEach { reporter, file ->
-            val name = reporter.toString().removeSuffix("Reporter")
-
             try {
                 reporter.generateReport(
                         ortResult,
@@ -138,11 +136,11 @@ object ReporterCommand : CommandWithHelp() {
                         postProcessingScript?.readText()
                 )
 
-                println("Created '$name' report:\n\t$file")
+                println("Created '${reporter.reporterName}' report:\n\t$file")
             } catch (e: Exception) {
                 e.showStackTrace()
 
-                log.error { "Could not create '$name' report: ${e.message}" }
+                log.error { "Could not create '${reporter.reporterName}' report: ${e.message}" }
 
                 exitCode = 1
             }

--- a/reporter/src/main/kotlin/Reporter.kt
+++ b/reporter/src/main/kotlin/Reporter.kt
@@ -42,14 +42,14 @@ abstract class Reporter {
     }
 
     /**
+     * The name to use to refer to the reporter.
+     */
+    abstract val reporterName: String
+
+    /**
      * The default output filename to use with this reporter format.
      */
     abstract val defaultFilename: String
-
-    /**
-     * Return the Java class name as a simple way to refer to the [Reporter].
-     */
-    override fun toString(): String = javaClass.simpleName
 
     /**
      * Generate a report for the [ortResult], taking into account any issue resolutions provided by [resolutionProvider]

--- a/reporter/src/main/kotlin/reporters/ExcelReporter.kt
+++ b/reporter/src/main/kotlin/reporters/ExcelReporter.kt
@@ -80,6 +80,7 @@ class ExcelReporter : Reporter() {
 
     private lateinit var creationHelper: CreationHelper
 
+    override val reporterName = "Excel"
     override val defaultFilename = "scan-report.xlsx"
 
     override fun generateReport(

--- a/reporter/src/main/kotlin/reporters/NoticeReporter.kt
+++ b/reporter/src/main/kotlin/reporters/NoticeReporter.kt
@@ -83,6 +83,7 @@ class NoticeReporter : Reporter() {
         override fun run(script: String): NoticeReport = super.run(script) as NoticeReport
     }
 
+    override val reporterName = "Notice"
     override val defaultFilename = "NOTICE"
 
     override fun generateReport(

--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -296,6 +296,7 @@ class StaticHtmlReporter : Reporter() {
 
         """.trimIndent()
 
+    override val reporterName = "StaticHtml"
     override val defaultFilename = "scan-report.html"
 
     override fun generateReport(

--- a/reporter/src/main/kotlin/reporters/WebAppReporter.kt
+++ b/reporter/src/main/kotlin/reporters/WebAppReporter.kt
@@ -28,6 +28,7 @@ import com.here.ort.reporter.ResolutionProvider
 import java.io.OutputStream
 
 class WebAppReporter : Reporter() {
+    override val reporterName = "WebApp"
     override val defaultFilename = "scan-report-web-app.html"
 
     override fun generateReport(


### PR DESCRIPTION
Similar to like we did for the package managers and scanners before.

The implementation is slightly simpler in this case as for the reporter
no factory class is required because the base class already has a
constructor with no arguments that can be used directly with
ServiceLoader.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1262)
<!-- Reviewable:end -->
