### PR TITLE
Main: Add an ASCII logo for ORT

### DIFF
--- a/cli/src/main/kotlin/Main.kt
+++ b/cli/src/main/kotlin/Main.kt
@@ -65,6 +65,26 @@ object Main : CommandWithHelp() {
      * Run the ORT CLI with the provided [args] and return the exit code of [CommandWithHelp.run].
      */
     fun run(args: Array<String>): Int {
+        val env = Environment()
+        val variables = env.variables.entries.map { (key, value) -> "$key = $value" }
+
+        println("""
+            ________ _____________________
+            \_____  \\______   \__    ___/ version ${env.ortVersion} running on ${env.os} with
+             /   |   \|       _/ |    |    ${variables.getOrElse(0) { "" }}
+            /    |    \    |   \ |    |    ${variables.getOrElse(1) { "" }}
+            \_______  /____|_  / |____|    ${variables.getOrElse(2) { "" }}
+                    \/       \/
+        """.trimIndent())
+
+        val moreVariables = variables.drop(3)
+        if (moreVariables.isNotEmpty()) {
+            println("More environment variables:")
+            moreVariables.forEach(::println)
+        }
+
+        println()
+
         val jc = JCommander(this).apply {
             programName = TOOL_NAME
             addCommand(AnalyzerCommand)
@@ -87,8 +107,6 @@ object Main : CommandWithHelp() {
 
         // Make the parameter globally available.
         printStackTrace = stacktrace
-
-        println("Running ORT with ${Environment()}.")
 
         // JCommander already validates the command names.
         val command = jc.commands[jc.parsedCommand]!!


### PR DESCRIPTION
Because a member of the team has a demoscene background ;-)

Generated with:

http://patorjk.com/software/taag/#p=display&f=Graffiti&t=ORT

Note that the tool versions are now not shown anymore, but so far that
map is not populated anyway.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1269)
<!-- Reviewable:end -->
