### PR TITLE
Upgrade Yarn to version 1.13.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,7 +22,7 @@ clone_depth: 50
 
 install:
   - git submodule update --init --recursive
-  - npm install -g bower@1.8.4 npm@6.4.0 yarn@1.12.1
+  - npm install -g bower@1.8.4 npm@6.4.0 yarn@1.13.0
   - pip install virtualenv==15.1.0
   - cinst sbt --version 1.0.2 -y
   - cinst php --version 7.2.0 -y

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
   - sudo apt install -y cvs
   - eval "$(gimme)"
   - curl https://raw.githubusercontent.com/golang/dep/7d5cd199ce454707f81c63b7ea4299151b8b981d/install.sh | sh
-  - npm install -g bower@1.8.4 npm@6.4.0 yarn@1.12.1
+  - npm install -g bower@1.8.4 npm@6.4.0 yarn@1.13.0
   - phpenv global 7.1.19
   - curl -Ls https://git.io/sbt > ~/bin/sbt
   - chmod a+x ~/bin/sbt

--- a/analyzer/src/main/kotlin/managers/Yarn.kt
+++ b/analyzer/src/main/kotlin/managers/Yarn.kt
@@ -45,7 +45,7 @@ class Yarn(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: Repo
 
     override fun command(workingDir: File?) = if (OS.isWindows) "yarn.cmd" else "yarn"
 
-    override fun getVersionRequirement(): Requirement = Requirement.buildNPM("1.3.* - 1.12.*")
+    override fun getVersionRequirement(): Requirement = Requirement.buildNPM("1.3.* - 1.13.*")
 
     override fun mapDefinitionFiles(definitionFiles: List<File>) =
             PackageJsonUtils.mapDefinitionFilesForYarn(definitionFiles).toList()

--- a/cli/docker/Dockerfile
+++ b/cli/docker/Dockerfile
@@ -53,7 +53,7 @@ RUN apt-get install -y --no-install-recommends \
         sbt=0.13.13-2 \
     && \
 
-    npm install --global bower@1.8.4 yarn@1.9.4 && \
+    npm install --global bower@1.8.4 yarn@1.13.0 && \
     pip install virtualenv==15.1.0 && \
 
     curl https://raw.githubusercontent.com/golang/dep/7d5cd199ce454707f81c63b7ea4299151b8b981d/install.sh | \


### PR DESCRIPTION
This seems to fix an issue on AppVeyor / Windows where a link to the
jsesc binary could not be created, see

https://ci.appveyor.com/project/heremaps/oss-review-toolkit/builds/22167822#L2031

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1274)
<!-- Reviewable:end -->
