### PR TITLE
StaticHtmlReporter: Do not hard-code issue rows to error color

### DIFF
--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -490,7 +490,23 @@ class StaticHtmlReporter : Reporter() {
     private fun TBODY.issueRow(rowIndex: Int, row: ReportTableModel.IssueRow) {
         val rowId = "issue-$rowIndex"
 
-        tr("ort-error") {
+        val worstSeverity = row.analyzerIssues.flatMap { it.value }.map { it.severity }.min() ?: Severity.ERROR
+
+        val areAllResolved = row.analyzerIssues.isNotEmpty() && row.analyzerIssues.all { (_, issues) ->
+            issues.all { it.isResolved }
+        }
+
+        val cssClass = if (areAllResolved) {
+            "ort-resolved"
+        } else {
+            when (worstSeverity) {
+                Severity.ERROR -> "ort-error"
+                Severity.WARNING -> "ort-warning"
+                Severity.HINT -> "ort-hint"
+            }
+        }
+
+        tr(cssClass) {
             id = rowId
             td {
                 a  {


### PR DESCRIPTION
Unfortunately, we display multiple issues with potentially different
severities in a single row, so there is no single correct color.
However, hard-coding the error color is not the best we can do. Instead,
use the color for the worst severity, and also take resolutions into
account.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1294)
<!-- Reviewable:end -->
