### PR TITLE
Maven: Minor code simplification regarding SBT mode

### DIFF
--- a/analyzer/src/main/kotlin/managers/Maven.kt
+++ b/analyzer/src/main/kotlin/managers/Maven.kt
@@ -149,7 +149,7 @@ class Maven(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: Rep
 
         val project = Project(
                 id = Identifier(
-                        type = if (sbtMode) "SBT" else managerName,
+                        type = managerName,
                         namespace = mavenProject.groupId,
                         name = mavenProject.artifactId,
                         version = mavenProject.version


### PR DESCRIPTION
In SBT mode, i.e. if the Maven class was instanciated by the SBT class,
"managerName" is already set to "SBT", so this condition can be removed.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1297)
<!-- Reviewable:end -->
