### PR TITLE
Extensions: Make isLicenseRefTo() stricter

### DIFF
--- a/spdx-utils/src/main/kotlin/Extensions.kt
+++ b/spdx-utils/src/main/kotlin/Extensions.kt
@@ -68,14 +68,25 @@ fun SpdxLicenseException.toExpression() = SpdxLicenseExceptionExpression(id)
  * Return whether this [String] is a LicenseRef to [name], by default [ignoring case][ignoreCase]. Any possible
  * (scanner-specific) namespaces are ignored.
  */
-fun String.isLicenseRefTo(name: String, ignoreCase: Boolean = true): Boolean {
-    if (name.isBlank()) return false
+fun String.isLicenseRefTo(
+        name: String,
+        ignoreCase: Boolean = true,
+        namespaces: List<String> = listOf("ORT", "Askalono", "BoyterLc", "Licensee", "scancode")
+): Boolean {
+    if (name.isBlank() || name.startsWith("-") || name.endsWith("-")) return false
 
+    // Check that the string changes when removing the prefix, otherwise it did not contain the prefix.
     val withoutPrefix = removePrefix("LicenseRef-")
     if (withoutPrefix == this) return false
 
+    // Check that the string contains the name as the suffix.
     if (!withoutPrefix.endsWith(name, ignoreCase)) return false
     val infix = withoutPrefix.dropLast(name.length)
+    if (infix.isEmpty()) return true
 
-    return infix.indexOf('-') == infix.length - 1
+    // Check that the string changes when removing the suffix, otherwise it did not contain the suffix.
+    val namespace = infix.removeSuffix("-")
+    if (namespace == infix) return false
+
+    return namespaces.any { it.equals(namespace, ignoreCase) }
 }

--- a/spdx-utils/src/test/kotlin/ExtensionsTest.kt
+++ b/spdx-utils/src/test/kotlin/ExtensionsTest.kt
@@ -55,8 +55,17 @@ class ExtensionsTest : WordSpec({
             assertSoftly {
                 "LicenseRef".isLicenseRefTo("") shouldBe false
                 "LicenseRef-".isLicenseRefTo("") shouldBe false
+                "LicenseRef--".isLicenseRefTo("-") shouldBe false
+                "LicenseRef--foo".isLicenseRefTo("-foo") shouldBe false
+                "LicenseRef--foo".isLicenseRefTo("foo") shouldBe false
                 "public-domain".isLicenseRefTo("public-domain") shouldBe false
+                "".isLicenseRefTo("") shouldBe false
+                "-".isLicenseRefTo("public-domain") shouldBe false
             }
+        }
+
+        "return false if the namespace is not known" {
+            "LicenseRef-no-public-domain".isLicenseRefTo("public-domain") shouldBe false
         }
     }
 })


### PR DESCRIPTION
Allow only infixes which we know to be namespaces. This prevents e.g.
"LicenseRef-no-public-domain" to be regarded as "public domain" in the
"no" namespace.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1314)
<!-- Reviewable:end -->
