### PR TITLE
downloader: Improve exception handling in `downloadPomArtifact()`

### DIFF
--- a/downloader/src/main/kotlin/Downloader.kt
+++ b/downloader/src/main/kotlin/Downloader.kt
@@ -37,9 +37,7 @@ import com.here.ort.utils.stripCredentialsFromUrl
 import com.here.ort.utils.unpack
 
 import java.io.File
-import java.io.FileNotFoundException
 import java.io.IOException
-import java.net.MalformedURLException
 import java.net.URI
 import java.net.URL
 import java.time.Instant
@@ -374,6 +372,12 @@ class Downloader {
         val pomFilename = "${target.id.name}-${target.id.version}.pom"
         val pomUrl = target.binaryArtifact.url.replaceAfterLast('/', pomFilename)
 
+        if (pomUrl.isEmpty()) {
+            // TODO: Investigate why the binary artifact URL is actually empty and update the implementation according
+            // to root cause.
+            throw DownloadException("Binary artifact URL for '${target.id.toCoordinates()}' is empty.")
+        }
+
         log.info {
             "Trying to download POM artifact for '${target.id.toCoordinates()}' from $pomUrl..."
         }
@@ -391,12 +395,8 @@ class Downloader {
             )
 
             DownloadResult(startTime, outputDirectory, sourceArtifact = pomArtifact)
-        } catch (e: FileNotFoundException) {
-            throw DownloadException("Failed to download the Maven POM for '${target.id.toCoordinates()}'.")
-        } catch (e: MalformedURLException) {
-            // TODO: Investigate why the binary artifact URL is actually empty and update
-            // the implementation according to root cause.
-            throw DownloadException("Failed to download the Maven POM for '${target.id.toCoordinates()}'.")
+        } catch (e: IOException) {
+            throw DownloadException("Failed to download the Maven POM for '${target.id.toCoordinates()}'.", e)
         }
     }
 }


### PR DESCRIPTION
`URL.readBytes()` can throw an `IOException`, so instead of catching the
specific `FileNotFoundExceptoin` and `MalformedURLException` catch their
parent `IOException`. Also check if the POM URL is empty before trying
to download it to use a more precise exception message in this case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1320)
<!-- Reviewable:end -->
