### PR TITLE
GitRepo: Remove a superfluous info log statement

### DIFF
--- a/downloader/src/main/kotlin/vcs/GitRepo.kt
+++ b/downloader/src/main/kotlin/vcs/GitRepo.kt
@@ -85,8 +85,6 @@ class GitRepo : GitBase() {
             }
             runRepoCommand(targetDir, "init", "-b", revision, "-u", pkg.vcsProcessed.url, "-m", manifestPath)
 
-            log.info { "Starting git-repo sync." }
-
             if (recursive) {
                 runRepoCommand(targetDir, "sync", "-c", "--fetch-submodules")
             } else {


### PR DESCRIPTION
Running "sync" itself already creates an info log entry.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1322)
<!-- Reviewable:end -->
