### PR TITLE
downloader: Do not set the exception cause in `downloadPomArtifact`

### DIFF
--- a/downloader/src/main/kotlin/Downloader.kt
+++ b/downloader/src/main/kotlin/Downloader.kt
@@ -396,7 +396,7 @@ class Downloader {
 
             DownloadResult(startTime, outputDirectory, sourceArtifact = pomArtifact)
         } catch (e: IOException) {
-            throw DownloadException("Failed to download the Maven POM for '${target.id.toCoordinates()}'.", e)
+            throw DownloadException("Failed to download the Maven POM for '${target.id.toCoordinates()}': ${e.message}")
         }
     }
 }


### PR DESCRIPTION
The calling code catches the `DownloadException` and initializes its
cause which fails if the exception already has a cause.

This is a fixup for 4d01427.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1324)
<!-- Reviewable:end -->
