### PR TITLE
Gradle: Enable the build scan plugin for (non-scheduled) CI builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -55,7 +55,7 @@ test_script:
   - if "%APPVEYOR_SCHEDULED_BUILD%"=="True" (
       gradlew --stacktrace dokkaJar check
     ) else (
-      gradlew -Dkotlintest.tags.exclude=ExpensiveTag --stacktrace dokkaJar check
+      gradlew --scan --stacktrace -Dkotlintest.tags.exclude=ExpensiveTag dokkaJar check
     )
 
 artifacts:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ script:
       ./gradlew --no-daemon --stacktrace :cli:dockerBuildImage;
       ./gradlew --no-daemon --stacktrace -Dkotlintest.tags.exclude=ScanCodeTag check jacocoReport | tee log.txt;
     else
-      ./gradlew --no-daemon --stacktrace -Dkotlintest.tags.exclude=ExpensiveTag check jacocoReport | tee log.txt;
+      ./gradlew --no-daemon --scan --stacktrace -Dkotlintest.tags.exclude=ExpensiveTag check jacocoReport | tee log.txt;
     fi
   - if grep -A1 ".+Test.+STARTED$" log.txt | grep -q "^:"; then
       echo "Some tests seemingly have been aborted.";

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,11 @@ plugins {
     id 'org.jetbrains.gradle.plugin.idea-ext'
 }
 
+buildScan {
+    termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+    termsOfServiceAgree = 'yes'
+}
+
 dependencyUpdates.resolutionStrategy = {
     componentSelection { rules ->
         rules.all { ComponentSelection selection ->


### PR DESCRIPTION
See https://guides.gradle.org/creating-build-scans/.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1325)
<!-- Reviewable:end -->
