### PR TITLE
Capture nested repositories for Git and Git-Repo

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/grpc-bundler-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/grpc-bundler-expected-output.yml
@@ -10,6 +10,67 @@ repository:
     url: "https://github.com/heremaps/oss-review-toolkit-test-data.git"
     revision: "918bd2e8a091bf63c97729f129a5429b2ffd70ed"
     path: "git-repo/manifest.xml"
+  nested_repositories:
+    grpc:
+      type: "Git"
+      url: "https://github.com/grpc/grpc"
+      revision: "5cf4b44fff8755edc9bdc46284d6cd270bc4a162"
+      path: ""
+    grpc/third_party/benchmark:
+      type: "Git"
+      url: "https://github.com/google/benchmark"
+      revision: "44c25c892a6229b20db7cd9dc05584ea865896de"
+      path: ""
+    grpc/third_party/boringssl:
+      type: "Git"
+      url: "https://github.com/google/boringssl.git"
+      revision: "be2ee342d3781ddb954f91f8a7e660c6f59e87e5"
+      path: ""
+    grpc/third_party/boringssl-with-bazel:
+      type: "Git"
+      url: "https://boringssl.googlesource.com/boringssl"
+      revision: "886e7d75368e3f4fab3f4d0d3584e4abfc557755"
+      path: ""
+    grpc/third_party/cares/cares:
+      type: "Git"
+      url: "https://github.com/c-ares/c-ares.git"
+      revision: "3be1924221e1326df520f8498d704a5c4c8d0cce"
+      path: ""
+    grpc/third_party/gflags:
+      type: "Git"
+      url: "https://github.com/gflags/gflags.git"
+      revision: "30dbc81fb5ffdc98ea9b14b1918bfe4e8779b26e"
+      path: ""
+    grpc/third_party/gflags/doc:
+      type: "Git"
+      url: "https://github.com/gflags/gflags.git"
+      revision: "971dd2a4fadac9cdab174c523c22df79efd63aa5"
+      path: ""
+    grpc/third_party/googletest:
+      type: "Git"
+      url: "https://github.com/google/googletest.git"
+      revision: "ec44c6c1675c25b9827aacd08c02433cccde7780"
+      path: ""
+    grpc/third_party/protobuf:
+      type: "Git"
+      url: "https://github.com/google/protobuf.git"
+      revision: "80a37e0782d2d702d52234b62dd4b9ec74fd2c95"
+      path: ""
+    grpc/third_party/protobuf/third_party/benchmark:
+      type: "Git"
+      url: "https://github.com/google/benchmark.git"
+      revision: "360e66c1c4777c99402cf8cd535aa510fee16573"
+      path: ""
+    grpc/third_party/zlib:
+      type: "Git"
+      url: "https://github.com/madler/zlib"
+      revision: "cacf7f1d4e3d44d871b605da3b647f07d718623f"
+      path: ""
+    spdx-tools:
+      type: "Git"
+      url: "https://github.com/spdx/tools"
+      revision: "c4193eeb4b89c7d6266f5647e4d81e9cf0a442a1"
+      path: ""
   config: {}
 analyzer:
   start_time: "1970-01-01T00:00:00Z"

--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -98,7 +98,7 @@ class Analyzer(private val config: AnalyzerConfiguration) {
                 // No need to use curly-braces-syntax for logging here as the log level check is already done above.
                 log.info("${manager.managerName} projects found in:")
                 files.forEach { file ->
-                    log.info("\t${file.toRelativeString(absoluteProjectPath).takeIf { it.isNotEmpty() } ?: "." }")
+                    log.info("\t${file.toRelativeString(absoluteProjectPath).takeIf { it.isNotEmpty() } ?: "."}")
                 }
             }
         }

--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -30,6 +30,7 @@ import com.here.ort.model.Environment
 import com.here.ort.model.OrtResult
 import com.here.ort.model.ProjectAnalyzerResult
 import com.here.ort.model.Repository
+import com.here.ort.model.VcsInfo
 import com.here.ort.model.config.AnalyzerConfiguration
 import com.here.ort.model.config.RepositoryConfiguration
 import com.here.ort.model.readValue
@@ -133,8 +134,13 @@ class Analyzer(private val config: AnalyzerConfiguration) {
             }
         }
 
-        val vcs = VersionControlSystem.getCloneInfo(absoluteProjectPath)
-        val repository = Repository(vcs, vcs.normalize(), repositoryConfiguration)
+        val workingTree = VersionControlSystem.forDirectory(absoluteProjectPath)
+        val vcs = workingTree?.getInfo() ?: VcsInfo.EMPTY
+        val nestedVcs = workingTree?.getNested()?.filter { (path, _) ->
+            // Only include nested VCS if they are part of the analyzed directory.
+            workingTree.getRootPath().resolve(path).startsWith(absoluteProjectPath)
+        }.orEmpty()
+        val repository = Repository(vcs, vcs.normalize(), nestedVcs, repositoryConfiguration)
 
         val endTime = Instant.now()
 

--- a/downloader/src/main/kotlin/WorkingTree.kt
+++ b/downloader/src/main/kotlin/WorkingTree.kt
@@ -37,6 +37,12 @@ abstract class WorkingTree(val workingDir: File, val vcsType: String) {
     open fun getInfo() = VcsInfo(vcsType, getRemoteUrl(), getRevision(), path = getPathToRoot(workingDir))
 
     /**
+     * Return the map of nested repositories, for example Git submodules or Git-Repo modules. The key is the path to the
+     * nested repository relative to the root of this working tree.
+     */
+    open fun getNested() = emptyMap<String, VcsInfo>()
+
+    /**
      * Return true if the [workingDir] is managed by this VCS, false otherwise.
      */
     abstract fun isValid(): Boolean

--- a/downloader/src/main/kotlin/vcs/GitWorkingTree.kt
+++ b/downloader/src/main/kotlin/vcs/GitWorkingTree.kt
@@ -20,7 +20,9 @@
 package com.here.ort.downloader.vcs
 
 import com.here.ort.downloader.WorkingTree
+import com.here.ort.model.VcsInfo
 import com.here.ort.utils.ProcessCapture
+
 import java.io.File
 
 open class GitWorkingTree(workingDir: File, private val gitBase: GitBase) : WorkingTree(workingDir, gitBase.type) {
@@ -37,6 +39,14 @@ open class GitWorkingTree(workingDir: File, private val gitBase: GitBase) : Work
     override fun isShallow(): Boolean {
         val dotGitDir = gitBase.run(workingDir, "rev-parse", "--absolute-git-dir").stdout.trimEnd()
         return File(dotGitDir, "shallow").isFile
+    }
+
+    override fun getNested(): Map<String, VcsInfo> {
+        val root = getRootPath()
+        val paths = gitBase.run(root, "submodule", "--quiet", "foreach", "--recursive", "echo \$displaypath").stdout
+                .lines().filter { it.isNotBlank() }
+
+        return paths.associateWith { GitWorkingTree(root.resolve(it), gitBase).getInfo() }
     }
 
     override fun getRemoteUrl() = gitBase.run(workingDir, "remote", "get-url", getFirstRemote()).stdout.trimEnd()

--- a/downloader/src/test/kotlin/GitTest.kt
+++ b/downloader/src/test/kotlin/GitTest.kt
@@ -19,6 +19,7 @@
 
 package com.here.ort.downloader.vcs
 
+import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.utils.getUserOrtDirectory
 import com.here.ort.utils.safeDeleteRecursively
 import com.here.ort.utils.unpack
@@ -70,6 +71,7 @@ class GitTest : StringSpec() {
 
             workingTree.vcsType shouldBe "Git"
             workingTree.isValid() shouldBe true
+            workingTree.getNested() shouldBe emptyMap()
             workingTree.getRemoteUrl() shouldBe "https://github.com/naiquevin/pipdeptree.git"
             workingTree.getRevision() shouldBe "6f70dd5508331b6cfcfe3c1b626d57d9836cfd7c"
             workingTree.getRootPath() shouldBe zipContentDir
@@ -109,6 +111,23 @@ class GitTest : StringSpec() {
 
             val workingTree = git.getWorkingTree(zipContentDir)
             workingTree.listRemoteTags().joinToString("\n") shouldBe expectedTags.joinToString("\n")
+        }
+
+        "Git correctly lists submodules" {
+            val expectedSubmodules = listOf(
+                    "analyzer/src/funTest/assets/projects/external/directories",
+                    "analyzer/src/funTest/assets/projects/external/example-python-flask",
+                    "analyzer/src/funTest/assets/projects/external/godep",
+                    "analyzer/src/funTest/assets/projects/external/jgnash",
+                    "analyzer/src/funTest/assets/projects/external/qmstr",
+                    "analyzer/src/funTest/assets/projects/external/quickcheck-state-machine",
+                    "analyzer/src/funTest/assets/projects/external/sbt-multi-project-example",
+                    "analyzer/src/funTest/assets/projects/external/spdx-tools-python",
+                    "analyzer/src/funTest/assets/projects/external/sprig"
+            ).associateWith { VersionControlSystem.getPathInfo(File("../$it")) }
+
+            val workingTree = git.getWorkingTree(File(".."))
+            workingTree.getNested() shouldBe expectedSubmodules
         }
     }
 }

--- a/evaluator/src/test/kotlin/EvaluatorTest.kt
+++ b/evaluator/src/test/kotlin/EvaluatorTest.kt
@@ -32,7 +32,7 @@ import io.kotlintest.specs.WordSpec
 
 class EvaluatorTest : WordSpec() {
     init {
-        val ortResult = OrtResult(Repository(VcsInfo.EMPTY, VcsInfo.EMPTY, RepositoryConfiguration()))
+        val ortResult = OrtResult(Repository(VcsInfo.EMPTY, VcsInfo.EMPTY, emptyMap(), RepositoryConfiguration()))
 
         "checkSyntax" should {
             "succeed if the script can be compiled" {

--- a/model/src/main/kotlin/Repository.kt
+++ b/model/src/main/kotlin/Repository.kt
@@ -19,6 +19,8 @@
 
 package com.here.ort.model
 
+import com.fasterxml.jackson.annotation.JsonInclude
+
 import com.here.ort.model.config.RepositoryConfiguration
 
 /**
@@ -34,6 +36,13 @@ data class Repository(
          * The [VcsInfo] of the repository.
          */
         val vcsProcessed: VcsInfo,
+
+        /**
+         * A map of nested repositories, for example Git submodules or Git-Repo modules. The key is the path to the
+         * nested repository relative to the root of the main repository.
+         */
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        val nestedRepositories: Map<String, VcsInfo> = emptyMap(),
 
         /**
          * The configuration of the repository, parsed from the ".ort.yml" file.

--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -278,7 +278,7 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
         val scannerRun = ScannerRun(startTime, endTime, Environment(), config, scanRecord)
 
         val vcs = VersionControlSystem.getCloneInfo(inputPath)
-        val repository = Repository(vcs, vcs.normalize(), RepositoryConfiguration())
+        val repository = Repository(vcs, vcs.normalize(), emptyMap(), RepositoryConfiguration())
 
         return OrtResult(repository, scanner = scannerRun)
     }


### PR DESCRIPTION
Nested repositories are submodules for Git and projects for Git-Repo.
Capture those nested repositories and add them to the ORT result file.

This is a prerequisite to fix the issue that definition file paths of
different projects can be identical and therefore ambiguous, because
they are always relative to the nested repository, not the root
repository.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1332)
<!-- Reviewable:end -->
