### PR TITLE
GitRepo: Do not use latest master on Windows anymore

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,8 +39,7 @@ install:
   - set PATH=%PATH%;C:\msys64\usr\bin # For CVS.
   - set PATH=C:\Ruby25\bin;%PATH% # For licensee.
   # Install git-repo.
-  - ps: Start-FileDownload 'https://gerrit.googlesource.com/git-repo/+archive/refs/heads/master.tar.gz'
-  - 7z x -so master.tar.gz | 7z x -o"%PROGRAMFILES%\Git\usr\bin" -si -ttar -y -i!repo
+  - ps: Start-FileDownload 'https://storage.googleapis.com/git-repo-downloads/repo' -FileName "$env:PROGRAMFILES\Git\usr\bin\repo"
   # Install the Android SDK.
   - ps: Start-FileDownload 'https://dl.google.com/android/repository/sdk-tools-windows-3859397.zip'
   - 7z x sdk-tools-windows-3859397.zip -o%ANDROID_HOME% > nul

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -62,7 +62,7 @@ artifacts:
 
 on_finish:
   - ps: |
-      $url = "https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)"
+      $url = "https://ci.appveyor.com/api/testresults/junit/$env:APPVEYOR_JOB_ID"
       $pattern = '**\build\test-results\**\TEST-*.xml'
       foreach ($file in (Resolve-Path $pattern)) {
         (New-Object 'System.Net.WebClient').UploadFile($url, $file)

--- a/downloader/src/main/kotlin/vcs/GitRepo.kt
+++ b/downloader/src/main/kotlin/vcs/GitRepo.kt
@@ -119,25 +119,19 @@ class GitRepo : GitBase() {
 
     private fun runRepoCommand(targetDir: File, vararg args: String): ProcessCapture {
         val patchedArgs = if (args.first() == "init") {
-            if (OS.isWindows) {
-                // The current "stable" release of "repo" still does not support Windows officially, so get the latest
-                // code from the "master" branch instead.
-                listOf(args.first(), "--groups=all", "--no-clone-bundle", "--no-repo-verify", "--repo-branch=master") +
-                        args.drop(1)
-            } else {
-                listOf(args.first(), "--groups=all") + args.drop(1)
-            }
+            // Clone all projects instead of only those in the "default" group until we support specifying groups.
+            arrayOf(args.first(), "--groups=all") + args.drop(1)
         } else {
-            args.toList()
+            args
         }
 
         return if (OS.isWindows) {
             val repo = getPathFromEnvironment("repo") ?: throw IOException("'repo' not found in PATH.")
 
             // On Windows, the script itself is not executable, so we need to wrap the call by "python".
-            ProcessCapture(targetDir, "python", repo.absolutePath, *patchedArgs.toTypedArray()).requireSuccess()
+            ProcessCapture(targetDir, "python", repo.absolutePath, *patchedArgs).requireSuccess()
         } else {
-            ProcessCapture(targetDir, "repo", *patchedArgs.toTypedArray()).requireSuccess()
+            ProcessCapture(targetDir, "repo", *patchedArgs).requireSuccess()
         }
     }
 }


### PR DESCRIPTION
The current stable release 1.13.2 of git-repo now has all Windows patches
included [1], so use that one instead of latest master.

[1] https://groups.google.com/d/topic/repo-discuss/0V4RSOD3QCc/discussion

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1341)
<!-- Reviewable:end -->
