### PR TITLE
Sort contents of services files alphabetically

### DIFF
--- a/analyzer/src/main/resources/META-INF/services/com.here.ort.analyzer.PackageManagerFactory
+++ b/analyzer/src/main/resources/META-INF/services/com.here.ort.analyzer.PackageManagerFactory
@@ -1,11 +1,11 @@
 com.here.ort.analyzer.managers.Bower$Factory
+com.here.ort.analyzer.managers.Bundler$Factory
+com.here.ort.analyzer.managers.GoDep$Factory
 com.here.ort.analyzer.managers.Gradle$Factory
 com.here.ort.analyzer.managers.Maven$Factory
-com.here.ort.analyzer.managers.SBT$Factory
 com.here.ort.analyzer.managers.NPM$Factory
-com.here.ort.analyzer.managers.Yarn$Factory
-com.here.ort.analyzer.managers.GoDep$Factory
-com.here.ort.analyzer.managers.PIP$Factory
-com.here.ort.analyzer.managers.Bundler$Factory
 com.here.ort.analyzer.managers.PhpComposer$Factory
+com.here.ort.analyzer.managers.PIP$Factory
+com.here.ort.analyzer.managers.SBT$Factory
 com.here.ort.analyzer.managers.Stack$Factory
+com.here.ort.analyzer.managers.Yarn$Factory

--- a/downloader/src/main/resources/META-INF/services/com.here.ort.downloader.VersionControlSystem
+++ b/downloader/src/main/resources/META-INF/services/com.here.ort.downloader.VersionControlSystem
@@ -1,5 +1,5 @@
+com.here.ort.downloader.vcs.Cvs
 com.here.ort.downloader.vcs.Git
 com.here.ort.downloader.vcs.GitRepo
 com.here.ort.downloader.vcs.Mercurial
 com.here.ort.downloader.vcs.Subversion
-com.here.ort.downloader.vcs.Cvs


### PR DESCRIPTION
While the order in these files determines the order in which classes are
instantiated, we do not really care about the order of instantiation and
having a defined order makes maintenance easier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1347)
<!-- Reviewable:end -->
