### PR TITLE
ScanCode: Raise the minimum license score to 15

### DIFF
--- a/scanner/src/main/kotlin/scanners/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/ScanCode.kt
@@ -89,6 +89,7 @@ class ScanCode(name: String, config: ScannerConfiguration) : LocalScanner(name, 
     }
 
     companion object {
+        private const val MIN_LICENSE_SCORE = 15
         private const val OUTPUT_FORMAT = "json-pp"
         private const val TIMEOUT = 300
 
@@ -98,6 +99,7 @@ class ScanCode(name: String, config: ScannerConfiguration) : LocalScanner(name, 
         private val DEFAULT_CONFIGURATION_OPTIONS = listOf(
                 "--copyright",
                 "--license",
+                "--license-score", MIN_LICENSE_SCORE.toString(),
                 "--ignore", "*$ORT_CONFIG_FILENAME",
                 "--info",
                 "--strip-root",

--- a/scanner/src/test/kotlin/ScanCodeTest.kt
+++ b/scanner/src/test/kotlin/ScanCodeTest.kt
@@ -524,8 +524,8 @@ class ScanCodeTest : WordSpec({
     "getConfiguration()" should {
         "return the default values if the scanner configuration is empty" {
             scanner.getConfiguration() shouldBe
-                    "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE " +
-                    "--ignore META-INF/DEPENDENCIES --json-pp --license-diag"
+                    "--copyright --license --license-score 15 --ignore *.ort.yml --info --strip-root --timeout 300 " +
+                    "--ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp --license-diag"
         }
 
         "return the non-config values from the scanner configuration" {
@@ -545,9 +545,9 @@ class ScanCodeTest : WordSpec({
     "commandLineOptions" should {
         "contain the default values if the scanner configuration is empty" {
             scanner.commandLineOptions.joinToString(" ") should
-                    match("--copyright --license --ignore \\*.ort.yml --info --strip-root --timeout 300 " +
-                            "--ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --processes \\d+ --license-diag " +
-                            "--verbose")
+                    match("--copyright --license --license-score 15 --ignore \\*.ort.yml --info --strip-root " +
+                            "--timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --processes \\d+ " +
+                            "--license-diag --verbose")
         }
 
         "contain the values from the scanner configuration" {


### PR DESCRIPTION
The score ranges from 0 (default) to 100 and somewhat resembles a
"percentage of confidence" of a license finding. Use a new minimum score
of 15 get rid of false-positives we currently see at about a score of 11.

Note that this change also changes the provenance information and thus
invalidates the scan result storage.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1349)
<!-- Reviewable:end -->
