### PR TITLE
reporter: Show full path to definition file in static HTML report

### DIFF
--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -238,6 +238,27 @@ data class OrtResult(
     }
 
     /**
+     * Returns the path of the folder that contains the definition file of the [project], relative to the analyzer root.
+     * If the project was checked out from a VCS the analyzer root is the root of the working tree, if the project was
+     * not checked out from a VCS the analyzer root is the input directory of the analyzer.
+     */
+    fun getDefinitionFilePathRelativeToAnalyzerRoot(project: Project): String {
+        val vcsPath = repository.getRelativePath(project.vcsProcessed)
+
+        requireNotNull(vcsPath) {
+            "The ${project.vcs} of project '${project.id.toCoordinates()}' cannot be found in $repository."
+        }
+
+        return buildString {
+            if (vcsPath.isNotEmpty()) {
+                append(vcsPath)
+                append("/")
+            }
+            append(project.definitionFilePath)
+        }
+    }
+
+    /**
      * Return true if the project or package with the given identifier is excluded.
      */
     @Suppress("UNUSED") // This is intended to be mostly used via scripting.

--- a/model/src/main/kotlin/Repository.kt
+++ b/model/src/main/kotlin/Repository.kt
@@ -48,4 +48,19 @@ data class Repository(
          * The configuration of the repository, parsed from the ".ort.yml" file.
          */
         val config: RepositoryConfiguration
-)
+) {
+    /**
+     * Return the path of [vcs] relative to [Repository.vcs], or null if [vcs] is neither [Repository.vcs] nor contained
+     * in [nestedRepositories].
+     */
+    fun getRelativePath(vcs: VcsInfo): String? {
+        fun VcsInfo.matches(other: VcsInfo) =
+                other.type == other.type && url == other.url && revision == other.revision
+
+        val normalizedVcs = vcs.normalize()
+
+        if (vcsProcessed.matches(normalizedVcs)) return ""
+
+        return nestedRepositories.entries.find { (_, nestedVcs) -> nestedVcs.matches(normalizedVcs) }?.key
+    }
+}

--- a/model/src/test/kotlin/OrtResultTest.kt
+++ b/model/src/test/kotlin/OrtResultTest.kt
@@ -19,12 +19,18 @@
 
 package com.here.ort.model
 
+import com.here.ort.model.config.AnalyzerConfiguration
+import com.here.ort.model.config.RepositoryConfiguration
+
 import io.kotlintest.matchers.haveSize
+import io.kotlintest.matchers.match
 import io.kotlintest.should
 import io.kotlintest.shouldBe
+import io.kotlintest.shouldThrow
 import io.kotlintest.specs.WordSpec
 
 import java.io.File
+import java.lang.IllegalArgumentException
 
 class OrtResultTest : WordSpec({
     "collectDependencies" should {
@@ -60,6 +66,85 @@ class OrtResultTest : WordSpec({
             idsWithoutSubProjects should haveSize(8)
 
             actualIds shouldBe expectedIds
+        }
+    }
+
+    "getDefinitionFilePathRelativeToAnalyzerRoot" should {
+        "use the correct vcs" {
+            val vcs = VcsInfo(type = "Git", url = "https://example.com/git", revision = "")
+            val nestedVcs1 = VcsInfo(type = "Git", url = "https://example.com/git1", revision = "")
+            val nestedVcs2 = VcsInfo(type = "Git", url = "https://example.com/git2", revision = "")
+            val project1 = Project.EMPTY.copy(
+                    id = Identifier("Gradle:com.here:project1:1.0"),
+                    definitionFilePath = "project1/build.gradle",
+                    vcs = vcs,
+                    vcsProcessed = vcs.normalize()
+            )
+            val project2 = Project.EMPTY.copy(
+                    id = Identifier("Gradle:com.here:project1:1.0"),
+                    definitionFilePath = "project2/build.gradle",
+                    vcs = nestedVcs1,
+                    vcsProcessed = nestedVcs1.normalize()
+            )
+            val project3 = Project.EMPTY.copy(
+                    id = Identifier("Gradle:com.here:project1:1.0"),
+                    definitionFilePath = "project3/build.gradle",
+                    vcs = nestedVcs2,
+                    vcsProcessed = nestedVcs2.normalize()
+            )
+            val ortResult = OrtResult(
+                    Repository(
+                            vcs = vcs,
+                            vcsProcessed = vcs.normalize(),
+                            nestedRepositories = mapOf(
+                                    "path/1" to nestedVcs1,
+                                    "path/2" to nestedVcs2
+                            ),
+                            config = RepositoryConfiguration()
+                    ),
+                    AnalyzerRun(
+                            environment = Environment(),
+                            config = AnalyzerConfiguration(ignoreToolVersions = true, allowDynamicVersions = true),
+                            result = AnalyzerResult.EMPTY
+                    )
+            )
+
+            ortResult.getDefinitionFilePathRelativeToAnalyzerRoot(project1) shouldBe "project1/build.gradle"
+            ortResult.getDefinitionFilePathRelativeToAnalyzerRoot(project2) shouldBe "path/1/project2/build.gradle"
+            ortResult.getDefinitionFilePathRelativeToAnalyzerRoot(project3) shouldBe "path/2/project3/build.gradle"
+        }
+
+        "fail if no vcs matches" {
+            val vcs = VcsInfo(type = "Git", url = "https://example.com/git", revision = "")
+            val nestedVcs1 = VcsInfo(type = "Git", url = "https://example.com/git1", revision = "")
+            val nestedVcs2 = VcsInfo(type = "Git", url = "https://example.com/git2", revision = "")
+            val project = Project.EMPTY.copy(
+                    id = Identifier("Gradle:com.here:project1:1.0"),
+                    definitionFilePath = "build.gradle",
+                    vcs = nestedVcs2,
+                    vcsProcessed = nestedVcs2.normalize()
+            )
+            val ortResult = OrtResult(
+                    Repository(
+                            vcs = vcs,
+                            vcsProcessed = vcs.normalize(),
+                            nestedRepositories = mapOf(
+                                    "path/1" to nestedVcs1
+                            ),
+                            config = RepositoryConfiguration()
+                    ),
+                    AnalyzerRun(
+                            environment = Environment(),
+                            config = AnalyzerConfiguration(ignoreToolVersions = true, allowDynamicVersions = true),
+                            result = AnalyzerResult.EMPTY
+                    )
+            )
+
+            val e = shouldThrow<IllegalArgumentException> {
+                ortResult.getDefinitionFilePathRelativeToAnalyzerRoot(project) shouldBe "project1/build.gradle"
+            }
+
+            e.message should match("The .* of project .* cannot be found in .*")
         }
     }
 })

--- a/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
+++ b/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
@@ -273,6 +273,9 @@ table.ort-excluded tr.ort-excluded td li.ort-excluded {
         <li>
           <a href="#Gradle:com.here.ort.gradle.example:lib:1.0.0">Gradle:com.here.ort.gradle.example:lib:1.0.0</a>
         </li>
+        <li>
+          <a href="#Gradle:com.here:nested-test-project:1.0.0">Gradle:com.here:nested-test-project:1.0.0</a>
+        </li>
       </ul>
       <h2 id="rule-violation-summary">Rule Violation Summary (1 errors, 1 warnings, 1 hints)</h2>
       <table class="ort-report-table ort-violations">
@@ -422,6 +425,41 @@ table.ort-excluded tr.ort-excluded td li.ort-excluded {
                 <dd>New BSD License</dd>
               </dl>
             </td><td>
+              <ul></ul>
+            </td><td>
+              <ul></ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <h2 id="Gradle:com.here:nested-test-project:1.0.0">Gradle:com.here:nested-test-project:1.0.0 (sub/module/project/build.gradle)</h2>
+      <h3 class="">VCS Information</h3>
+      <table class="ort-report-metadata ">
+        <tbody>
+          <tr>
+            <td>Type</td><td>git</td>
+          </tr>
+          <tr>
+            <td>URL</td><td>https://example.com/git</td>
+          </tr>
+          <tr>
+            <td>Path</td><td>project</td>
+          </tr>
+          <tr>
+            <td>Revision</td><td></td>
+          </tr>
+        </tbody>
+      </table>
+      <h3 class="">Packages</h3>
+      <table class="ort-report-table ort-packages ">
+        <thead>
+          <tr>
+            <th>#</th><th>Package</th><th>Scopes</th><th>Licenses</th><th>Analyzer Issues</th><th>Scanner Issues</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="ort-warning " id="Gradle:com.here:nested-test-project:1.0.0-pkg-1">
+            <td><a href="#Gradle:com.here:nested-test-project:1.0.0-pkg-1">1</a></td><td>Gradle:com.here:nested-test-project:1.0.0</td><td></td><td></td><td>
               <ul></ul>
             </td><td>
               <ul></ul>

--- a/reporter/src/funTest/assets/static-html-reporter-test-input.yml
+++ b/reporter/src/funTest/assets/static-html-reporter-test-input.yml
@@ -10,6 +10,12 @@ repository:
     url: ""
     revision: ""
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
+  nested_repositories:
+    sub/module:
+      type: "git"
+      url: "https://example.com/git"
+      revision: ""
+      path: ""
   config: {}
 analyzer:
   start_time: "1970-01-01T00:00:00Z"
@@ -52,6 +58,21 @@ analyzer:
         - id: "Maven:org.apache.commons:commons-text:1.1"
           dependencies:
           - id: "Maven:org.apache.commons:commons-lang3:3.5"
+    - id: "Gradle:com.here:nested-test-project:1.0.0"
+      definition_file_path: "project/build.gradle"
+      declared_licenses: []
+      vcs:
+        type: ""
+        url: ""
+        revision: ""
+        path: ""
+      vcs_processed:
+        type: "git"
+        url: "https://example.com/git"
+        revision: ""
+        path: "project"
+      homepage_url: ""
+      scopes: []
     packages:
     - package:
         id: "Maven:junit:junit:4.12"

--- a/reporter/src/main/kotlin/reporters/ReportTableModel.kt
+++ b/reporter/src/main/kotlin/reporters/ReportTableModel.kt
@@ -81,6 +81,12 @@ data class ReportTableModel(
             val rows: List<DependencyRow>,
 
             /**
+             * The path to the directory containing the definition file of the project, relative to the analyzer root,
+             * see [OrtResult.getDefinitionFilePathRelativeToAnalyzerRoot].
+             */
+            val fullDefinitionFilePath: String,
+
+            /**
              * Information about if and why the project is excluded.
              */
             val exclude: ProjectExclude? = null

--- a/reporter/src/main/kotlin/reporters/ReportTableModelMapper.kt
+++ b/reporter/src/main/kotlin/reporters/ReportTableModelMapper.kt
@@ -170,7 +170,7 @@ class ReportTableModelMapper(private val resolutionProvider: ResolutionProvider)
                 }
             }
 
-            ProjectTable(tableRows, projectExclude)
+            ProjectTable(tableRows, ortResult.getDefinitionFilePathRelativeToAnalyzerRoot(project), projectExclude)
         }.toSortedMap()
 
         val issueSummaryTable = IssueTable(issueSummaryRows.values.toList().sortedBy { it.id })

--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -574,7 +574,7 @@ class StaticHtmlReporter : Reporter() {
 
         h2 {
             id = project.id.toCoordinates()
-            +"${project.id.toCoordinates()} (${project.definitionFilePath})"
+            +"${project.id.toCoordinates()} (${table.fullDefinitionFilePath})"
         }
 
         table.exclude?.let { exclude ->


### PR DESCRIPTION
Use the recently added information about nested VCS in the OrtResult to
determine the full path to the definition file of a project. This is
different to `Project.definitionFilePath` if the project is located
inside a nested VCS, because the definition file path is always relative
to the VCS that contains the file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1350)
<!-- Reviewable:end -->
