### PR TITLE
scanner: Use multiple threads in `LocalScanner`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,6 +18,7 @@ disklrucacheVersion = 2.0.2
 jacksonVersion = 2.9.8
 jcommanderVersion = 1.74
 kotlintestVersion = 3.3.0
+kotlinxCoroutinesVersion = 1.1.1
 kotlinxHtmlVersion = 0.6.12
 logbackVersion = 1.2.3
 mavenVersion = 3.6.0

--- a/scanner/build.gradle
+++ b/scanner/build.gradle
@@ -8,4 +8,6 @@ dependencies {
 
     implementation project(':downloader')
     implementation project(':utils')
+
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion"
 }


### PR DESCRIPTION
To make better use of the resources use Kotlin coroutines to make the
local scanner multithreaded. Use separate fixed size thread pools for
scanning source code and for downloading results from the cache.

As scanning itself already uses multiple threads, at least with
ScanCode, limit the thread pool for scanning to a single thread.

Downloading cached results mainly uses network bandwidth for
transferring the results and the CPU for deserialization. To improve
throughput use a thread pool size of 5.

As this change makes it harder to read the log output add a few lines
and add the index of the package to all log statements in
`LocalScanner`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1351)
<!-- Reviewable:end -->
