### PR TITLE
analyzer: Add `--ignore-engines` option to `yarn install`

### DIFF
--- a/analyzer/src/main/kotlin/managers/NPM.kt
+++ b/analyzer/src/main/kotlin/managers/NPM.kt
@@ -117,6 +117,11 @@ open class NPM(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: 
                 NPM(managerName, analyzerConfig, repoConfig)
     }
 
+    /**
+     * Array of parameters passed to the install command when installing dependencies.
+     */
+    protected open val installParameters = arrayOf("--ignore-scripts")
+
     protected open fun hasLockFile(projectDir: File) = PackageJsonUtils.hasNpmLockFile(projectDir)
 
     override fun command(workingDir: File?) = if (OS.isWindows) "npm.cmd" else "npm"
@@ -491,7 +496,7 @@ open class NPM(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: 
         if (hasLockFile(workingDir) && this::class.java == NPM::class.java) {
             run(workingDir, "ci")
         } else {
-            run(workingDir, "install", "--ignore-scripts")
+            run(workingDir, "install", *installParameters)
         }
 
         // TODO: capture warnings from npm output, e.g. "Unsupported platform" which happens for fsevents on all

--- a/analyzer/src/main/kotlin/managers/Yarn.kt
+++ b/analyzer/src/main/kotlin/managers/Yarn.kt
@@ -41,6 +41,8 @@ class Yarn(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: Repo
                 Yarn(managerName, analyzerConfig, repoConfig)
     }
 
+    override val installParameters = arrayOf("--ignore-scripts", "--ignore-engines")
+
     override fun hasLockFile(projectDir: File) = PackageJsonUtils.hasYarnLockFile(projectDir)
 
     override fun command(workingDir: File?) = if (OS.isWindows) "yarn.cmd" else "yarn"


### PR DESCRIPTION
As ORT does not actually run the Yarn package we should not fail if a
dependency is not compatible with the installed node version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1352)
<!-- Reviewable:end -->
