### PR TITLE
Bundler: Retry when RubyGems reports "bad gateway"

### DIFF
--- a/analyzer/src/main/kotlin/managers/Bundler.kt
+++ b/analyzer/src/main/kotlin/managers/Bundler.kt
@@ -219,7 +219,7 @@ class Bundler(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: R
         run(workingDir, "install", "--path", "vendor/bundle")
     }
 
-    private fun queryRubygems(name: String, version: String): GemSpec? {
+    private fun queryRubygems(name: String, version: String, retryCount: Int = 3): GemSpec? {
         // See http://guides.rubygems.org/rubygems-org-api-v2/.
         val request = Request.Builder()
                 .get()
@@ -244,6 +244,12 @@ class Bundler(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: R
                 }
 
                 else -> {
+                    if (retryCount > 0 && code == HttpURLConnection.HTTP_BAD_GATEWAY) {
+                        // We see a lot of sporadic "bad gateway" responses that disappear when trying again.
+                        Thread.sleep(100)
+                        return queryRubygems(name, version, retryCount - 1)
+                    }
+
                     throw IOException("RubyGems reported unhandled HTTP code $code when requesting meta-data for " +
                             "gem '$name'.")
                 }


### PR DESCRIPTION
While OkHttp as a built-in retry mechanism [1] it does not kick in on
"bad gateway" responses.

[1] https://square.github.io/okhttp/3.x/okhttp/okhttp3/OkHttpClient.Builder.html#retryOnConnectionFailure-boolean-

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1355)
<!-- Reviewable:end -->
