### PR TITLE
NPM: Add support for the new "directory" field for a repository

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
@@ -8332,12 +8332,12 @@ analyzer:
           type: "git"
           url: "https://github.com/DefinitelyTyped/DefinitelyTyped.git"
           revision: ""
-          path: ""
+          path: "types/node"
         vcs_processed:
           type: "git"
           url: "https://github.com/DefinitelyTyped/DefinitelyTyped.git"
           revision: ""
-          path: ""
+          path: "types/node"
       curations: []
     has_errors: false
 scanner: null

--- a/analyzer/src/main/kotlin/managers/NPM.kt
+++ b/analyzer/src/main/kotlin/managers/NPM.kt
@@ -366,7 +366,8 @@ open class NPM(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: 
         return node["repository"]?.let { repo ->
             val type = repo["type"].textValueOrEmpty()
             val url = repo.textValue() ?: repo["url"].textValueOrEmpty()
-            VcsInfo(type, expandShortcutURL(url), head)
+            val path = repo["directory"].textValueOrEmpty()
+            VcsInfo(type, expandShortcutURL(url), head, path = path)
         } ?: VcsInfo("", "", head)
     }
 


### PR DESCRIPTION
See https://docs.npmjs.com/files/package.json#repository and
https://github.com/npm/cli/releases/tag/v6.8.0.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1356)
<!-- Reviewable:end -->
