### PR TITLE
VCS: Introduce a priority for probing

### DIFF
--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -45,7 +45,7 @@ abstract class VersionControlSystem {
         /**
          * The (prioritized) list of all available Version Control Systems in the classpath.
          */
-        val ALL by lazy { LOADER.iterator().asSequence().toList() }
+        val ALL by lazy { LOADER.iterator().asSequence().toList().sortedByDescending { it.priority } }
 
         /**
          * Return the applicable VCS for the given [vcsType], or null if none is applicable.
@@ -246,6 +246,11 @@ abstract class VersionControlSystem {
      * A list of alternative names for the VCS, for example "hg" for Mercurial.
      */
     protected open val aliases = emptyList<String>()
+
+    /**
+     * The priority in which this VCS should be probed. A higher value means a higher priority.
+     */
+    protected open val priority: Int = 0
 
     /**
      * A list of symbolic names that point to the latest revision.

--- a/downloader/src/main/kotlin/vcs/Git.kt
+++ b/downloader/src/main/kotlin/vcs/Git.kt
@@ -40,6 +40,8 @@ import java.io.IOException
 const val GIT_HISTORY_DEPTH = 50
 
 class Git : GitBase() {
+    override val priority: Int = 100
+
     override fun isApplicableUrlInternal(vcsUrl: String) =
             ProcessCapture("git", "ls-remote", vcsUrl).isSuccess
 

--- a/downloader/src/main/kotlin/vcs/GitRepo.kt
+++ b/downloader/src/main/kotlin/vcs/GitRepo.kt
@@ -37,6 +37,7 @@ import java.io.IOException
 
 class GitRepo : GitBase() {
     override val aliases = listOf("git-repo", "repo")
+    override val priority: Int = 50
 
     override fun getWorkingTree(vcsDirectory: File): WorkingTree {
         val repoRoot = vcsDirectory.searchUpwardsForSubdirectory(".repo")

--- a/downloader/src/main/kotlin/vcs/Mercurial.kt
+++ b/downloader/src/main/kotlin/vcs/Mercurial.kt
@@ -41,6 +41,7 @@ class Mercurial : VersionControlSystem(), CommandLineTool {
     private val versionRegex = Pattern.compile("Mercurial .*\\([Vv]ersion (?<version>[\\d.]+)\\)")
 
     override val aliases = listOf("hg")
+    override val priority: Int = 20
     override val latestRevisionNames = listOf("tip")
 
     override fun command(workingDir: File?) = "hg"

--- a/downloader/src/main/kotlin/vcs/Subversion.kt
+++ b/downloader/src/main/kotlin/vcs/Subversion.kt
@@ -94,6 +94,7 @@ class Subversion : VersionControlSystem(), CommandLineTool {
     private val versionRegex = Pattern.compile("svn, [Vv]ersion (?<version>[\\d.]+) \\(r\\d+\\)")
 
     override val aliases = listOf("svn")
+    override val priority: Int = 10
     override val latestRevisionNames = listOf("HEAD")
 
     override fun command(workingDir: File?) = "svn"


### PR DESCRIPTION
For VCS, 35af37f was wrong saying we would "not really care about the
order of instantiation", because probing a VCS (e.g. from a URL) might
take a few seconds, so we want to probe more likely VCS first. Instead
of relying on the declaration order in the services file, which is
error-prone at the latest when loading VCS plugins provided by
third-parties on the classpath, introduce a dedicated priority.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1358)
<!-- Reviewable:end -->
