### PR TITLE
utils: Ensure that `getCommonFilePrefix` returns a directory

### DIFF
--- a/analyzer/src/main/kotlin/managers/SBT.kt
+++ b/analyzer/src/main/kotlin/managers/SBT.kt
@@ -27,7 +27,7 @@ import com.here.ort.model.config.AnalyzerConfiguration
 import com.here.ort.model.config.RepositoryConfiguration
 import com.here.ort.utils.CommandLineTool
 import com.here.ort.utils.OS
-import com.here.ort.utils.getCommonFilePrefix
+import com.here.ort.utils.getCommonFileParent
 import com.here.ort.utils.log
 import com.here.ort.utils.suppressInput
 
@@ -99,7 +99,7 @@ class SBT(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: Repos
             // Some SBT projects do not have a build file in their root, but they still require "sbt" to be run from the
             // project's root directory. In order to determine the root directory, use the common prefix of all
             // definition file paths.
-            getCommonFilePrefix(definitionFiles).also {
+            getCommonFileParent(definitionFiles).also {
                 log.info { "Determined '$it' as the $managerName project root directory." }
             }
         } else {
@@ -139,7 +139,7 @@ class SBT(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: Repos
             // Some SBT projects do not have a build file in their root, but they still require "sbt" to be run from the
             // project's root directory. In order to determine the root directory, use the common prefix of all
             // definition file paths.
-            getCommonFilePrefix(definitionFiles).also {
+            getCommonFileParent(definitionFiles).also {
                 log.info { "Determined '$it' as the $managerName project root directory." }
             }
         } else {

--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -143,9 +143,9 @@ fun filterVersionNames(version: String, names: List<String>, project: String? = 
 }
 
 /**
- * Return the longest prefix that is common to all [files].
+ * Return the longest parent directory that is common to all [files].
  */
-fun getCommonFilePrefix(files: Collection<File>) =
+fun getCommonFileParent(files: Collection<File>) =
         files.map {
             it.normalize().absolutePath
         }.reduce { prefix, path ->

--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -151,7 +151,8 @@ fun getCommonFilePrefix(files: Collection<File>) =
         }.reduce { prefix, path ->
             prefix.commonPrefixWith(path)
         }.let {
-            File(it)
+            val commonPrefix = File(it)
+            if (commonPrefix.isDirectory) commonPrefix else commonPrefix.parentFile
         }
 
 /**


### PR DESCRIPTION
If the files passed to this function share a common prefix in the
filename part this was part of the returned prefix. For example, passing
"/dir/file-1" and "/dir/file-2" returned "/dir/file-". This was wrong
because the result is expected to be an existing directory. To fix this
ensure that the returned value is a directory and if not return the
parent file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1359)
<!-- Reviewable:end -->
