### PR TITLE
Path excludes projects

### DIFF
--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -71,7 +71,7 @@ data class OrtResult(
                 val excludes = repository.config.excludes.takeIf { omitExcluded }
 
                 analyzer?.result?.let { result ->
-                    result.packages.filter { excludes?.isPackageExcluded(it.pkg.id, result) != true }
+                    result.packages.filter { excludes?.isPackageExcluded(it.pkg.id, this) != true }
                             .associateTo(licenses) { it.pkg.id to it.pkg.concludedLicense }
                 }
             }
@@ -87,7 +87,7 @@ data class OrtResult(
 
                 analyzer?.result?.let { result ->
                     result.projects.forEach { project ->
-                        if (excludes?.isProjectExcluded(project) != true) {
+                        if (excludes?.isProjectExcluded(project, this) != true) {
                             project.declaredLicenses.forEach { license ->
                                 licenses.getOrPut(license) { sortedSetOf() } += project.id
                             }
@@ -95,7 +95,7 @@ data class OrtResult(
                     }
 
                     result.packages.forEach { (pkg, _) ->
-                        if (excludes?.isPackageExcluded(pkg.id, analyzer.result) != true) {
+                        if (excludes?.isPackageExcluded(pkg.id, this) != true) {
                             pkg.declaredLicenses.forEach { license ->
                                 licenses.getOrPut(license) { sortedSetOf() } += pkg.id
                             }
@@ -117,7 +117,7 @@ data class OrtResult(
 
                 scanner?.results?.scanResults?.forEach { result ->
                     // At this point we know that analyzer != null if excludes != null.
-                    if (excludes?.isPackageExcluded(result.id, analyzer!!.result) != true) {
+                    if (excludes?.isPackageExcluded(result.id, this) != true) {
                         result.getAllDetectedLicenses().forEach { license ->
                             licenses.getOrPut(license) { sortedSetOf() } += result.id
                         }
@@ -222,13 +222,13 @@ data class OrtResult(
 
         analyzer?.result?.apply {
             projects.filter {
-                it.id.isFromOrg(*names) && excludes?.isProjectExcluded(it) != true
+                it.id.isFromOrg(*names) && excludes?.isProjectExcluded(it, this@OrtResult) != true
             }.mapTo(vendorPackages) {
                 it.toPackage()
             }
 
             packages.filter { (pkg, _) ->
-                pkg.id.isFromOrg(*names) && excludes?.isPackageExcluded(pkg.id, analyzer.result) != true
+                pkg.id.isFromOrg(*names) && excludes?.isPackageExcluded(pkg.id, this@OrtResult) != true
             }.mapTo(vendorPackages) {
                 it.pkg
             }
@@ -263,7 +263,7 @@ data class OrtResult(
      */
     @Suppress("UNUSED") // This is intended to be mostly used via scripting.
     fun isExcluded(id: Identifier) =
-            analyzer?.result?.let { repository.config.excludes?.isExcluded(id, it) } == true
+            analyzer?.result?.let { repository.config.excludes?.isExcluded(id, this) } == true
 
     /**
      * Return a copy of this [OrtResult] with the [Repository.config] replaced by [config].

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -242,7 +242,15 @@ data class OrtResult(
      * checked out from a VCS the analyzer root is the root of the working tree, if the project was not checked out from
      * a VCS the analyzer root is the input directory of the analyzer.
      */
-    fun getDefinitionFilePathRelativeToAnalyzerRoot(project: Project): String {
+    fun getDefinitionFilePathRelativeToAnalyzerRoot(project: Project) =
+            getFilePathRelativeToAnalyzerRoot(project, project.definitionFilePath)
+
+    /**
+     * Returns the path of a file contained in [project], relative to the analyzer root. If the project was checked out
+     * from a VCS the analyzer root is the root of the working tree, if the project was not checked out from a VCS the
+     * analyzer root is the input directory of the analyzer.
+     */
+    fun getFilePathRelativeToAnalyzerRoot(project: Project, path: String): String {
         val vcsPath = repository.getRelativePath(project.vcsProcessed)
 
         requireNotNull(vcsPath) {
@@ -254,7 +262,7 @@ data class OrtResult(
                 append(vcsPath)
                 append("/")
             }
-            append(project.definitionFilePath)
+            append(path)
         }
     }
 

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -238,9 +238,9 @@ data class OrtResult(
     }
 
     /**
-     * Returns the path of the folder that contains the definition file of the [project], relative to the analyzer root.
-     * If the project was checked out from a VCS the analyzer root is the root of the working tree, if the project was
-     * not checked out from a VCS the analyzer root is the input directory of the analyzer.
+     * Returns the path of the definition file of the [project], relative to the analyzer root. If the project was
+     * checked out from a VCS the analyzer root is the root of the working tree, if the project was not checked out from
+     * a VCS the analyzer root is the input directory of the analyzer.
      */
     fun getDefinitionFilePathRelativeToAnalyzerRoot(project: Project): String {
         val vcsPath = repository.getRelativePath(project.vcsProcessed)

--- a/model/src/main/kotlin/Repository.kt
+++ b/model/src/main/kotlin/Repository.kt
@@ -49,6 +49,19 @@ data class Repository(
          */
         val config: RepositoryConfiguration
 ) {
+    companion object {
+        /**
+         * A constant for a [Repository] where all properties are empty strings.
+         */
+        @JvmField
+        val EMPTY = Repository(
+                vcs = VcsInfo.EMPTY,
+                vcsProcessed = VcsInfo.EMPTY,
+                nestedRepositories = emptyMap(),
+                config = RepositoryConfiguration()
+        )
+    }
+
     /**
      * Return the path of [vcs] relative to [Repository.vcs], or null if [vcs] is neither [Repository.vcs] nor contained
      * in [nestedRepositories].

--- a/model/src/main/kotlin/config/Excludes.kt
+++ b/model/src/main/kotlin/config/Excludes.kt
@@ -31,6 +31,12 @@ import com.here.ort.model.Scope
  */
 data class Excludes(
         /**
+         * Path excludes.
+         */
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        val paths: List<PathExclude> = emptyList(),
+
+        /**
          * Project specific excludes.
          */
         @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/model/src/main/kotlin/config/Excludes.kt
+++ b/model/src/main/kotlin/config/Excludes.kt
@@ -21,8 +21,8 @@ package com.here.ort.model.config
 
 import com.fasterxml.jackson.annotation.JsonInclude
 
-import com.here.ort.model.AnalyzerResult
 import com.here.ort.model.Identifier
+import com.here.ort.model.OrtResult
 import com.here.ort.model.Project
 import com.here.ort.model.Scope
 
@@ -49,6 +49,17 @@ data class Excludes(
         val scopes: List<ScopeExclude> = emptyList()
 ) {
     /**
+     * Return the [PathExclude]s matching the provided [path].
+     */
+    fun findPathExcludes(path: String) = paths.filter { it.matches(path) }
+
+    /**
+     * Return the [PathExclude]s matching the [definitionFilePath][Project.definitionFilePath].
+     */
+    fun findPathExcludes(project: Project, ortResult: OrtResult) =
+            paths.filter { it.matches(ortResult.getDefinitionFilePathRelativeToAnalyzerRoot(project)) }
+
+    /**
      * Return the [ProjectExclude] for the provided [project], or null if there is none.
      */
     fun findProjectExclude(project: Project) = projects.find { it.matches(project.definitionFilePath) }
@@ -66,30 +77,34 @@ data class Excludes(
      * excluded. If the [id] references a [Project] it checks if the [Project] is excluded and if the [id] does not
      * appear as a dependency of another non-excluded [Project].
      */
-    fun isExcluded(id: Identifier, analyzerResult: AnalyzerResult) =
-            analyzerResult.projects.find { it.id == id }?.let {
+    fun isExcluded(id: Identifier, ortResult: OrtResult) =
+            ortResult.analyzer?.result?.projects?.find { it.id == id }?.let {
                 // An excluded project could still be included as a dependency of another non-excluded project.
-                isProjectExcluded(it) && isPackageExcluded(id, analyzerResult)
-            } ?: isPackageExcluded(id, analyzerResult)
+                isProjectExcluded(it, ortResult) && isPackageExcluded(id, ortResult)
+            } ?: isPackageExcluded(id, ortResult)
 
     /**
-     * True if all occurrences of the package identified by [id] in the [analyzerResult] are excluded by this [Excludes]
+     * True if all occurrences of the package identified by [id] in the [ortResult] are excluded by this [Excludes]
      * configuration.
      */
-    fun isPackageExcluded(id: Identifier, analyzerResult: AnalyzerResult) =
-            analyzerResult.projects.all { project ->
-                isProjectExcluded(project) || project.scopes.all { scope ->
+    fun isPackageExcluded(id: Identifier, ortResult: OrtResult) =
+            ortResult.analyzer?.result?.projects?.all { project ->
+                isProjectExcluded(project, ortResult) || project.scopes.all { scope ->
                     isScopeExcluded(scope, project) || !scope.contains(id)
                 }
-            }
+            } ?: false
+
+    /**
+     * True if any [path exclude][paths] matches [path].
+     */
+    fun isPathExcluded(path: String) = paths.any { it.matches(path) }
 
     /**
      * True if the [project] is excluded by this [Excludes] configuration.
      */
-    fun isProjectExcluded(project: Project) =
-            projects.any {
-                it.matches(project.definitionFilePath) && it.isWholeProjectExcluded
-            }
+    fun isProjectExcluded(project: Project, ortResult: OrtResult) =
+            projects.any { it.matches(project.definitionFilePath) && it.isWholeProjectExcluded }
+                    || paths.any { it.matches(ortResult.getDefinitionFilePathRelativeToAnalyzerRoot(project)) }
 
     /**
      * True if the [scope] is excluded in [project] by this [Excludes] configuration.

--- a/model/src/main/kotlin/config/PathExclude.kt
+++ b/model/src/main/kotlin/config/PathExclude.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.model.config
+
+import java.nio.file.FileSystems
+import java.nio.file.Paths
+
+/**
+ * Defines paths which should be excluded. Each file that is matched by the [glob][pattern] is marked as excluded. If a
+ * project definition file is matched by the [pattern] the whole project is excluded. For details about the glob syntax
+ * see the [official documentation][https://docs.oracle.com/javase/tutorial/essential/io/fileOps.html#glob].
+ */
+data class PathExclude(
+        /**
+         * A glob to match the path of the project definition file, relative to the root of the repository.
+         */
+        val pattern: String,
+
+        /**
+         * The reason why the project is excluded, out of a predefined choice.
+         */
+        val reason: PathExcludeReason,
+
+        /**
+         * A comment to further explain why the [reason] is applicable here.
+         */
+        val comment: String
+) {
+    private val pathMatcher by lazy { FileSystems.getDefault().getPathMatcher("glob:$pattern") }
+
+    fun matches(path: String) = pathMatcher.matches(Paths.get(path))
+}

--- a/model/src/main/kotlin/config/PathExcludeReason.kt
+++ b/model/src/main/kotlin/config/PathExcludeReason.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.model.config
+
+/**
+ * Possible reasons for excluding a path.
+ */
+enum class PathExcludeReason {
+    /**
+     * The project only contains tools used for building source code which are not included in distributed build
+     * artifacts.
+     */
+    BUILD_TOOL_OF,
+
+    /**
+     * The project only contains data files such as fonts or images which are not included in distributed build
+     * artifacts.
+     */
+    DATA_FILE_OF,
+
+    /**
+     * The project only contains documentation which is not included in distributed build artifacts.
+     */
+    DOCUMENTATION_OF,
+
+    /**
+     * The project only contains source code examples which are not included in distributed build artifacts.
+     */
+    EXAMPLE_OF,
+
+    /**
+     * The project only contains optional components for the code that is built which are not included in distributed
+     * build artifacts.
+     */
+    OPTIONAL_COMPONENT_OF,
+
+    /**
+     * The project only contains tools used for testing source code which are not included in distributed build
+     * artifacts.
+     */
+    TEST_TOOL_OF
+}

--- a/model/src/test/kotlin/config/ExcludesTest.kt
+++ b/model/src/test/kotlin/config/ExcludesTest.kt
@@ -20,13 +20,18 @@
 package com.here.ort.model.config
 
 import com.here.ort.model.AnalyzerResult
+import com.here.ort.model.AnalyzerRun
+import com.here.ort.model.Environment
 import com.here.ort.model.Identifier
+import com.here.ort.model.OrtResult
 import com.here.ort.model.PackageReference
 import com.here.ort.model.Project
+import com.here.ort.model.Repository
 import com.here.ort.model.Scope
 
 import io.kotlintest.matchers.beEmpty
 import io.kotlintest.matchers.collections.contain
+import io.kotlintest.matchers.collections.containExactly
 import io.kotlintest.matchers.collections.containOnlyNulls
 import io.kotlintest.matchers.containAll
 import io.kotlintest.matchers.haveSize
@@ -50,6 +55,11 @@ class ExcludesTest : WordSpec() {
         val projectExclude2 = ProjectExclude("path2", ProjectExcludeReason.BUILD_TOOL_OF, "")
         val projectExclude3 = ProjectExclude("path3", ProjectExcludeReason.BUILD_TOOL_OF, "")
 
+        val pathExclude1 = PathExclude("path1", PathExcludeReason.BUILD_TOOL_OF, "")
+        val pathExclude2 = PathExclude("path2", PathExcludeReason.BUILD_TOOL_OF, "")
+        val pathExclude3 = PathExclude("**.ext", PathExcludeReason.BUILD_TOOL_OF, "")
+        val pathExclude4 = PathExclude("**/file.ext", PathExcludeReason.BUILD_TOOL_OF, "")
+
         val scope1 = Scope("scope1", sortedSetOf(PackageReference(id)))
         val scope2 = Scope("scope2", sortedSetOf(PackageReference(id)))
 
@@ -58,6 +68,30 @@ class ExcludesTest : WordSpec() {
 
         val projectExcludeWithScopes1 = ProjectExclude("path1", scopes = listOf(scopeExclude1))
         val projectExcludeWithScopes2 = ProjectExclude("path2", scopes = listOf(scopeExclude2))
+
+        "findPathExcludes" should {
+            "find the correct path excludes for a path" {
+                val excludes = Excludes(paths = listOf(pathExclude1, pathExclude2, pathExclude3, pathExclude4))
+
+                excludes.findPathExcludes("") should beEmpty()
+                excludes.findPathExcludes("path1") should containExactly(pathExclude1)
+                excludes.findPathExcludes("path2") should containExactly(pathExclude2)
+                excludes.findPathExcludes("test.ext") should containExactly(pathExclude3)
+                excludes.findPathExcludes("directory/test.ext") should containExactly(pathExclude3)
+                excludes.findPathExcludes("directory/file.ext") should containExactly(pathExclude3, pathExclude4)
+            }
+
+            "find the correct path excludes for a project" {
+                val excludes = Excludes(paths = listOf(pathExclude1, pathExclude2, pathExclude3, pathExclude4))
+
+                val analyzerResult = AnalyzerResult.EMPTY.copy(projects = sortedSetOf(project1, project2, project3))
+                val ortResult = createOrtResult(analyzerResult)
+
+                excludes.findPathExcludes(project1, ortResult) should containExactly(pathExclude1)
+                excludes.findPathExcludes(project2, ortResult) should containExactly(pathExclude2)
+                excludes.findPathExcludes(project3, ortResult) should beEmpty()
+            }
+        }
 
         "findProjectExclude" should {
             "return null if there is no matching project exclude" {
@@ -108,7 +142,7 @@ class ExcludesTest : WordSpec() {
 
         "isPackageExcluded" should {
             "return true if the package does not appear in the analyzer result" {
-                Excludes().isPackageExcluded(id, AnalyzerResult.EMPTY) shouldBe true
+                Excludes().isPackageExcluded(id, createOrtResult(AnalyzerResult.EMPTY)) shouldBe true
             }
 
             "return true if all occurrences of the package are excluded" {
@@ -124,7 +158,7 @@ class ExcludesTest : WordSpec() {
                         )
                 )
 
-                excludes.isPackageExcluded(id, analyzerResult) shouldBe true
+                excludes.isPackageExcluded(id, createOrtResult(analyzerResult)) shouldBe true
             }
 
             "return false if not all occurrences of the package are excluded" {
@@ -140,7 +174,7 @@ class ExcludesTest : WordSpec() {
                         )
                 )
 
-                excludes.isPackageExcluded(id, analyzerResult) shouldBe false
+                excludes.isPackageExcluded(id, createOrtResult(analyzerResult)) shouldBe false
             }
 
             "return false if no occurrences of the package are excluded" {
@@ -153,7 +187,30 @@ class ExcludesTest : WordSpec() {
                         )
                 )
 
-                excludes.isPackageExcluded(id, analyzerResult) shouldBe false
+                excludes.isPackageExcluded(id, createOrtResult(analyzerResult)) shouldBe false
+            }
+        }
+
+        "isPathExcluded" should {
+            "return true if any path exclude matches a file" {
+                val excludes = Excludes(paths = listOf(pathExclude1, pathExclude2))
+
+                excludes.isPathExcluded("path1") shouldBe true
+                excludes.isPathExcluded("path2") shouldBe true
+            }
+
+            "return false if no path exclude matches a file" {
+                val excludes = Excludes(paths = listOf(pathExclude1, pathExclude2))
+
+                excludes.isPathExcluded("") shouldBe false
+                excludes.isPathExcluded("path1/file") shouldBe false
+                excludes.isPathExcluded("path3") shouldBe false
+            }
+
+            "return false if no path exclude is defined" {
+                val excludes = Excludes()
+
+                excludes.isPathExcluded("path") shouldBe false
             }
         }
 
@@ -161,19 +218,25 @@ class ExcludesTest : WordSpec() {
             "return true if the project is completely excluded" {
                 val excludes = Excludes(projects = listOf(projectExclude1))
 
-                excludes.isProjectExcluded(project1) shouldBe true
+                excludes.isProjectExcluded(project1, createOrtResult(AnalyzerResult.EMPTY)) shouldBe true
+            }
+
+            "return true if the definition file of the project is excluded by a path exclude" {
+                val excludes = Excludes(paths = listOf(pathExclude1))
+
+                excludes.isProjectExcluded(project1, createOrtResult(AnalyzerResult.EMPTY)) shouldBe true
             }
 
             "return false if only scopes of the project are excluded" {
                 val excludes = Excludes(projects = listOf(projectExcludeWithScopes1))
 
-                excludes.isProjectExcluded(project1) shouldBe false
+                excludes.isProjectExcluded(project1, createOrtResult(AnalyzerResult.EMPTY)) shouldBe false
             }
 
             "return false if the project is not in the list of project excludes" {
                 val excludes = Excludes()
 
-                excludes.isProjectExcluded(project1) shouldBe false
+                excludes.isProjectExcluded(project1, createOrtResult(AnalyzerResult.EMPTY)) shouldBe false
             }
         }
 
@@ -288,4 +351,14 @@ class ExcludesTest : WordSpec() {
             }
         }
     }
+
+    private fun createOrtResult(analyzerResult: AnalyzerResult) =
+            OrtResult(
+                    repository = Repository.EMPTY,
+                    analyzer = AnalyzerRun(
+                            environment = Environment(),
+                            config = AnalyzerConfiguration(ignoreToolVersions = false, allowDynamicVersions = false),
+                            result = analyzerResult
+                    )
+            )
 }

--- a/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
+++ b/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
@@ -72,6 +72,14 @@ ul {
   filter: opacity(50%);
 }
 
+.ort-reason {
+    border-radius: 3px;
+    background: #EEE;
+    padding: 2px;
+    font-size: 12px;
+    display: inline;
+}
+
 table.ort-excluded tr.ort-excluded {
   filter: opacity(100%);
 }
@@ -156,14 +164,6 @@ table.ort-excluded tr.ort-excluded td li.ort-excluded {
   overflow: hidden;
   text-overflow: ellipsis;
   word-wrap: break-word;
-}
-
-.ort-report-table td li div.ort-reason {
-    border-radius: 3px;
-    background: #EEE;
-    padding: 2px;
-    font-size: 12px;
-    display: inline;
 }
 
 .ort-report-table td:last-child {
@@ -274,7 +274,8 @@ table.ort-excluded tr.ort-excluded td li.ort-excluded {
           <a href="#Gradle:com.here.ort.gradle.example:lib:1.0.0">Gradle:com.here.ort.gradle.example:lib:1.0.0</a>
         </li>
         <li>
-          <a href="#Gradle:com.here:nested-test-project:1.0.0">Gradle:com.here:nested-test-project:1.0.0</a>
+          <a href="#Gradle:com.here:nested-test-project:1.0.0">Gradle:com.here:nested-test-project:1.0.0 <div class="ort-reason">Excluded: EXAMPLE_OF - The project is an example.</div>
+          </a>
         </li>
       </ul>
       <h2 id="rule-violation-summary">Rule Violation Summary (1 errors, 1 warnings, 1 hints)</h2>
@@ -433,8 +434,13 @@ table.ort-excluded tr.ort-excluded td li.ort-excluded {
         </tbody>
       </table>
       <h2 id="Gradle:com.here:nested-test-project:1.0.0">Gradle:com.here:nested-test-project:1.0.0 (sub/module/project/build.gradle)</h2>
-      <h3 class="">VCS Information</h3>
-      <table class="ort-report-metadata ">
+      <h3>Project is Excluded</h3>
+      <p>The project is excluded for the following reason(s):</p>
+      <p>
+        <div class="ort-reason">EXAMPLE_OF - The project is an example.</div>
+      </p>
+      <h3 class="ort-excluded">VCS Information</h3>
+      <table class="ort-report-metadata ort-excluded">
         <tbody>
           <tr>
             <td>Type</td><td>git</td>
@@ -450,8 +456,8 @@ table.ort-excluded tr.ort-excluded td li.ort-excluded {
           </tr>
         </tbody>
       </table>
-      <h3 class="">Packages</h3>
-      <table class="ort-report-table ort-packages ">
+      <h3 class="ort-excluded">Packages</h3>
+      <table class="ort-report-table ort-packages ort-excluded">
         <thead>
           <tr>
             <th>#</th><th>Package</th><th>Scopes</th><th>Licenses</th><th>Analyzer Issues</th><th>Scanner Issues</th>

--- a/reporter/src/funTest/assets/static-html-reporter-test-input.yml
+++ b/reporter/src/funTest/assets/static-html-reporter-test-input.yml
@@ -16,7 +16,12 @@ repository:
       url: "https://example.com/git"
       revision: ""
       path: ""
-  config: {}
+  config:
+    excludes:
+      paths:
+      - pattern: "sub/module/project/build.gradle"
+        reason: "EXAMPLE_OF"
+        comment: "The project is an example."
 analyzer:
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"

--- a/reporter/src/main/kotlin/reporters/ExcelReporter.kt
+++ b/reporter/src/main/kotlin/reporters/ExcelReporter.kt
@@ -288,11 +288,11 @@ class ExcelReporter : Reporter() {
 
         val sheet = workbook.createSheet(sheetName)
 
-        val headerRows = createHeader(sheet, name, table.exclude, file, vcsInfo, extraColumns)
+        val headerRows = createHeader(sheet, name, table.projectExclude, file, vcsInfo, extraColumns)
         var currentRow = headerRows
 
         table.rows.forEach { row ->
-            val isExcluded = table.exclude != null
+            val isExcluded = table.isExcluded()
                     || (row.scopes.values.let { it.isNotEmpty() && it.all { it.isNotEmpty() } })
 
             val font = if (isExcluded) excludedFont else defaultFont

--- a/reporter/src/main/kotlin/reporters/NoticeReporter.kt
+++ b/reporter/src/main/kotlin/reporters/NoticeReporter.kt
@@ -124,13 +124,12 @@ class NoticeReporter : Reporter() {
 
     private fun getLicenseFindings(ortResult: OrtResult): LicenseFindingsMap {
         val excludes = ortResult.repository.config.excludes
-        val analyzerResult = ortResult.analyzer!!.result
         val scanRecord = ortResult.scanner!!.results
 
         val licenseFindings = sortedMapOf<String, MutableSet<String>>()
 
         scanRecord.scanResults.forEach { container ->
-            if (excludes?.isExcluded(container.id, analyzerResult) != true) {
+            if (excludes?.isExcluded(container.id, ortResult) != true) {
                 container.results.forEach { result ->
                     result.summary.licenseFindingsMap.forEach { (license, copyrights) ->
                         licenseFindings.getOrPut(license) { mutableSetOf() } += copyrights.map { it.statement }

--- a/reporter/src/main/kotlin/reporters/ReportTableModel.kt
+++ b/reporter/src/main/kotlin/reporters/ReportTableModel.kt
@@ -25,6 +25,7 @@ import com.here.ort.model.Project
 import com.here.ort.model.ScanResult
 import com.here.ort.model.Severity
 import com.here.ort.model.VcsInfo
+import com.here.ort.model.config.PathExclude
 import com.here.ort.model.config.ProjectExclude
 import com.here.ort.model.config.ScopeExclude
 import com.here.ort.spdx.SpdxExpression
@@ -87,10 +88,17 @@ data class ReportTableModel(
             val fullDefinitionFilePath: String,
 
             /**
-             * Information about if and why the project is excluded.
+             * Information about if and why the project is excluded by a [ProjectExclude].
              */
-            val exclude: ProjectExclude? = null
-    )
+            val projectExclude: ProjectExclude?,
+
+            /**
+             * Information about if and why the project is excluded by [PathExclude]s.
+             */
+            val pathExcludes: List<PathExclude>
+    ) {
+        fun isExcluded() = projectExclude != null || pathExcludes.isNotEmpty()
+    }
 
     data class DependencyRow(
             /**

--- a/reporter/src/main/kotlin/reporters/ReportTableModelMapper.kt
+++ b/reporter/src/main/kotlin/reporters/ReportTableModelMapper.kt
@@ -98,6 +98,8 @@ class ReportTableModelMapper(private val resolutionProvider: ResolutionProvider)
                 exclude.takeIf { it.isWholeProjectExcluded }
             }
 
+            val pathExcludes = ortResult.repository.config.excludes?.findPathExcludes(project, ortResult).orEmpty()
+
             val allIds = sortedSetOf(project.id)
             project.collectDependencies().mapTo(allIds) { it.id }
 
@@ -170,7 +172,12 @@ class ReportTableModelMapper(private val resolutionProvider: ResolutionProvider)
                 }
             }
 
-            ProjectTable(tableRows, ortResult.getDefinitionFilePathRelativeToAnalyzerRoot(project), projectExclude)
+            ProjectTable(
+                    tableRows,
+                    ortResult.getDefinitionFilePathRelativeToAnalyzerRoot(project),
+                    projectExclude,
+                    pathExcludes
+            )
         }.toSortedMap()
 
         val issueSummaryTable = IssueTable(issueSummaryRows.values.toList().sortedBy { it.id })

--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -108,6 +108,14 @@ class StaticHtmlReporter : Reporter() {
           filter: opacity(50%);
         }
 
+        .ort-reason {
+            border-radius: 3px;
+            background: #EEE;
+            padding: 2px;
+            font-size: 12px;
+            display: inline;
+        }
+
         table.ort-excluded tr.ort-excluded {
           filter: opacity(100%);
         }
@@ -192,14 +200,6 @@ class StaticHtmlReporter : Reporter() {
           overflow: hidden;
           text-overflow: ellipsis;
           word-wrap: break-word;
-        }
-
-        .ort-report-table td li div.ort-reason {
-            border-radius: 3px;
-            background: #EEE;
-            padding: 2px;
-            font-size: 12px;
-            display: inline;
         }
 
         .ort-report-table td:last-child {
@@ -407,9 +407,15 @@ class StaticHtmlReporter : Reporter() {
                     a("#${project.id.toCoordinates()}") {
                         +project.id.toCoordinates()
 
-                        projectTable.exclude?.let { exclude ->
-                            +" "
-                            div("ort-reason") { +"Excluded: ${exclude.reason} - ${exclude.comment}" }
+                        if (projectTable.isExcluded()) {
+                            projectTable.projectExclude?.let { exclude ->
+                                +" "
+                                div("ort-reason") { +"Excluded: ${exclude.reason} - ${exclude.comment}" }
+                            }
+                            projectTable.pathExcludes.forEach { exclude ->
+                                +" "
+                                div("ort-reason") { +"Excluded: ${exclude.reason} - ${exclude.comment}" }
+                            }
                         }
                     }
                 }
@@ -570,19 +576,27 @@ class StaticHtmlReporter : Reporter() {
     }
 
     private fun DIV.projectTable(project: Project, table: ProjectTable) {
-        val excludedClass = if (table.exclude != null) "ort-excluded" else ""
+        val excludedClass = if (table.isExcluded()) "ort-excluded" else ""
 
         h2 {
             id = project.id.toCoordinates()
             +"${project.id.toCoordinates()} (${table.fullDefinitionFilePath})"
         }
 
-        table.exclude?.let { exclude ->
+        if (table.isExcluded()) {
             h3 { +"Project is Excluded" }
+            p { +"The project is excluded for the following reason(s):" }
+        }
+
+        table.projectExclude?.let { exclude ->
             p {
-                +"The project is excluded for the following reason:"
-                br
-                div("reason") { +"${exclude.reason} - ${exclude.comment}" }
+                div("ort-reason") { +"${exclude.reason} - ${exclude.comment}" }
+            }
+        }
+
+        table.pathExcludes.forEach { exclude ->
+            p {
+                div("ort-reason") { +"${exclude.reason} - ${exclude.comment}" }
             }
         }
 


### PR DESCRIPTION
Add path excludes and use them to exclude projects. Using path excludes for excluding files from the license scan results ẃill be implemented in a separate PR. See the commit messages for details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1360)
<!-- Reviewable:end -->
