### PR TITLE
LocalScanner: Quote thread names for clarity

### DIFF
--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -161,7 +161,7 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
                             val storedResults = withContext(storageDispatcher) {
                                 log.info {
                                     "Reading stored scan results for ${pkg.id.toCoordinates()} in thread " +
-                                            "${Thread.currentThread().name} $packageIndex."
+                                            "'${Thread.currentThread().name}' $packageIndex."
                                 }
 
                                 readFromStorage(scannerDetails, pkg, outputDirectory)
@@ -175,7 +175,7 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
                                 withContext(scanDispatcher) {
                                     log.info {
                                         "Scanning package ${pkg.id.toCoordinates()} in thread " +
-                                                "${Thread.currentThread().name} $packageIndex."
+                                                "'${Thread.currentThread().name}' $packageIndex."
                                     }
 
                                     listOf(


### PR DESCRIPTION
Otherwise a sentence like "Scanning [...] in thread scan" reads a bit
odd as "thread scan" sounds like a composite noun.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1362)
<!-- Reviewable:end -->
