### PR TITLE
PackageJsonUtils: Handle exceptions caused by invalid package.json files

### DIFF
--- a/analyzer/src/main/kotlin/PackageJsonUtils.kt
+++ b/analyzer/src/main/kotlin/PackageJsonUtils.kt
@@ -19,10 +19,15 @@
 
 package com.here.ort.analyzer
 
+import ch.frankel.slf4k.*
+
+import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.node.ArrayNode
 import com.fasterxml.jackson.databind.node.ObjectNode
 
 import com.here.ort.model.readValue
+import com.here.ort.utils.log
+import com.here.ort.utils.showStackTrace
 
 import java.io.File
 import java.nio.file.FileSystems
@@ -79,7 +84,15 @@ internal class PackageJsonUtils {
         }
 
         private fun isYarnWorkspaceRoot(definitionFile: File): Boolean {
-            return definitionFile.readValue<ObjectNode>()["workspaces"] != null
+            return try {
+                definitionFile.readValue<ObjectNode>()["workspaces"] != null
+            } catch(e: JsonProcessingException) {
+                e.showStackTrace()
+
+                log.error { "Could not parse '${definitionFile.invariantSeparatorsPath}': ${e.message}" }
+
+                false
+            }
         }
 
         private fun getYarnWorkspaceSubmodules(definitionFiles: Set<File>): Set<File> {
@@ -107,7 +120,16 @@ internal class PackageJsonUtils {
         }
 
         private fun getWorkspaceMatchers(definitionFile: File): List<PathMatcher> {
-            var workspaces = definitionFile.readValue<ObjectNode>()["workspaces"]
+            var workspaces = try {
+                definitionFile.readValue<ObjectNode>()["workspaces"]
+            } catch (e: JsonProcessingException) {
+                e.showStackTrace()
+
+                log.error { "Could not parse '${definitionFile.invariantSeparatorsPath}': ${e.message}" }
+
+                null
+            }
+
             if (workspaces != null && workspaces !is ArrayNode) {
                 workspaces = workspaces["packages"]
             }

--- a/analyzer/src/main/kotlin/PackageJsonUtils.kt
+++ b/analyzer/src/main/kotlin/PackageJsonUtils.kt
@@ -83,17 +83,16 @@ internal class PackageJsonUtils {
             }
         }
 
-        private fun isYarnWorkspaceRoot(definitionFile: File): Boolean {
-            return try {
-                definitionFile.readValue<ObjectNode>()["workspaces"] != null
-            } catch(e: JsonProcessingException) {
-                e.showStackTrace()
+        private fun isYarnWorkspaceRoot(definitionFile: File) =
+                try {
+                    definitionFile.readValue<ObjectNode>()["workspaces"] != null
+                } catch (e: JsonProcessingException) {
+                    e.showStackTrace()
 
-                log.error { "Could not parse '${definitionFile.invariantSeparatorsPath}': ${e.message}" }
+                    log.error { "Could not parse '${definitionFile.invariantSeparatorsPath}': ${e.message}" }
 
-                false
-            }
-        }
+                    false
+                }
 
         private fun getYarnWorkspaceSubmodules(definitionFiles: Set<File>): Set<File> {
             val result = mutableSetOf<File>()


### PR DESCRIPTION
If a package.json cannot be parsed, log the exception and continue with
a reasonable default value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1363)
<!-- Reviewable:end -->
