### PR TITLE
downloader: Skip verification if a source artifact has no hash

### DIFF
--- a/downloader/src/main/kotlin/Downloader.kt
+++ b/downloader/src/main/kotlin/Downloader.kt
@@ -334,7 +334,9 @@ class Downloader {
             }
         }
 
-        if (!Hash(target.sourceArtifact.hashAlgorithm, target.sourceArtifact.hash).verify(sourceArchive)) {
+        if (target.sourceArtifact.hash.isEmpty()) {
+            log.warn { "Source artifact has no hash, skipping verification." }
+        } else if (!Hash(target.sourceArtifact.hashAlgorithm, target.sourceArtifact.hash).verify(sourceArchive)) {
             throw DownloadException("Source artifact does not match expected ${target.sourceArtifact.hashAlgorithm} " +
                     "hash '${target.sourceArtifact.hash}'.")
         }


### PR DESCRIPTION
If a source artifact has no hash to verify, skip the verification and
print a warning instead of aborting the downloader with an exception.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1366)
<!-- Reviewable:end -->
