### PR TITLE
model: Allow to curate VCS information with empty properties

### DIFF
--- a/model/src/main/kotlin/Package.kt
+++ b/model/src/main/kotlin/Package.kt
@@ -144,7 +144,7 @@ data class Package(
                 homepageUrl = homepageUrl.takeIf { it != other.homepageUrl },
                 binaryArtifact = binaryArtifact.takeIf { it != other.binaryArtifact },
                 sourceArtifact = sourceArtifact.takeIf { it != other.sourceArtifact },
-                vcs = vcs.takeIf { it != other.vcs }
+                vcs = vcs.takeIf { it != other.vcs }?.toCuration()
         )
     }
 

--- a/model/src/main/kotlin/PackageCurationData.kt
+++ b/model/src/main/kotlin/PackageCurationData.kt
@@ -73,7 +73,7 @@ data class PackageCurationData(
          * VCS-related information.
          */
         @JsonInclude(JsonInclude.Include.NON_NULL)
-        val vcs: VcsInfo? = null,
+        val vcs: VcsInfoCuration? = null,
 
         /**
          * A plain-text comment about this curation. Should contain information about how and why the curation was
@@ -98,12 +98,13 @@ data class PackageCurationData(
      */
     fun apply(base: CuratedPackage): CuratedPackage {
         val curatedVcs = if (vcs != null) {
+            // Curation data for VCS information is handled specially so we can curate only individual properties.
             VcsInfo(
-                    type = vcs.type.takeUnless { it.isBlank() } ?: base.pkg.vcs.type,
-                    url = vcs.url.takeUnless { it.isBlank() } ?: base.pkg.vcs.url,
-                    revision = vcs.revision.takeUnless { it.isBlank() } ?: base.pkg.vcs.revision,
+                    type = vcs.type ?: base.pkg.vcs.type,
+                    url = vcs.url ?: base.pkg.vcs.url,
+                    revision = vcs.revision ?: base.pkg.vcs.revision,
                     resolvedRevision = vcs.resolvedRevision ?: base.pkg.vcs.resolvedRevision,
-                    path = vcs.path.takeUnless { it.isBlank() } ?: base.pkg.vcs.path
+                    path = vcs.path ?: base.pkg.vcs.path
             )
         } else {
             base.pkg.vcs

--- a/model/src/main/kotlin/VcsInfo.kt
+++ b/model/src/main/kotlin/VcsInfo.kt
@@ -125,6 +125,11 @@ data class VcsInfo(
      * [normalizeVcsUrl] to the [url].
      */
     fun normalize() = copy(type = type.toLowerCase(), url = normalizeVcsUrl(url))
+
+    /**
+     * Return a [VcsInfoCuration] with the properties from this [VcsInfo].
+     */
+    fun toCuration() = VcsInfoCuration(type, url, revision, resolvedRevision, path)
 }
 
 class VcsInfoDeserializer : StdDeserializer<VcsInfo>(VcsInfo::class.java) {

--- a/model/src/main/kotlin/VcsInfoCuration.kt
+++ b/model/src/main/kotlin/VcsInfoCuration.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.model
+
+import com.fasterxml.jackson.annotation.JsonInclude
+
+/**
+ * Bundles curation data for Version Control System information.
+ */
+data class VcsInfoCuration(
+        /**
+         * The name of the VCS type, for example Git, GitRepo, Mercurial or Subversion.
+         */
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        val type: String? = null,
+
+        /**
+         * The URL to the VCS repository.
+         */
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        val url: String? = null,
+
+        /**
+         * The VCS-specific revision (tag, branch, SHA1) that the version of the package maps to.
+         */
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        val revision: String? = null,
+
+        /**
+         * The VCS-specific revision resolved during downloading from the VCS. In contrast to [revision] this must not
+         * contain symbolic names like branches or tags.
+         */
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        val resolvedRevision: String? = null,
+
+        /**
+         * The path inside the VCS to take into account, if any. The actual meaning depends on the VCS type. For
+         * example, for Git only this subdirectory of the repository should be cloned, or for Git Repo it is
+         * interpreted as the path to the manifest file.
+         */
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        val path: String? = null
+)

--- a/model/src/test/kotlin/PackageCurationTest.kt
+++ b/model/src/test/kotlin/PackageCurationTest.kt
@@ -23,11 +23,11 @@ import com.here.ort.spdx.SpdxExpression
 
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldThrow
-import io.kotlintest.specs.StringSpec
+import io.kotlintest.specs.WordSpec
 
-class PackageCurationTest : StringSpec() {
-    init {
-        "apply overwrites the correct values" {
+class PackageCurationTest : WordSpec({
+    "Applying a single curation" should {
+        "overwrite the correct values" {
             val pkg = Package(
                     id = Identifier(
                             type = "Maven",
@@ -88,7 +88,7 @@ class PackageCurationTest : StringSpec() {
             curatedPkg.curations.first().curation shouldBe curation.data
         }
 
-        "apply changes only curated fields" {
+        "change only curated fields" {
             val pkg = Package(
                     id = Identifier(
                             type = "Maven",
@@ -144,7 +144,7 @@ class PackageCurationTest : StringSpec() {
             curatedPkg.curations.first().curation shouldBe curation.data
         }
 
-        "applying curation fails when identifiers do not match" {
+        "fail if identifiers do not match" {
             val pkg = Package(
                     id = Identifier(
                             type = "Maven",
@@ -181,8 +181,10 @@ class PackageCurationTest : StringSpec() {
                 curation.apply(pkg.toCuratedPackage())
             }
         }
+    }
 
-        "applying multiple curations in a row adds curation results to the curated package" {
+    "Applying multiple curations" should {
+        "accumulate curation results to the curated package" {
             val id = Identifier("type", "namespace", "name", "version")
             val pkg = Package.EMPTY.copy(id = id)
             val curation1 = PackageCuration(id, PackageCurationData(description = "description 1"))
@@ -215,4 +217,4 @@ class PackageCurationTest : StringSpec() {
             result3.curations[2].curation shouldBe curation3.data
         }
     }
-}
+})

--- a/model/src/test/kotlin/PackageCurationTest.kt
+++ b/model/src/test/kotlin/PackageCurationTest.kt
@@ -144,6 +144,45 @@ class PackageCurationTest : WordSpec({
             curatedPkg.curations.first().curation shouldBe curation.data
         }
 
+        "be able to empty VCS information" {
+            val pkg = Package(
+                    id = Identifier(
+                            type = "Maven",
+                            namespace = "org.hamcrest",
+                            name = "hamcrest-core",
+                            version = "1.3"
+                    ),
+                    declaredLicenses = sortedSetOf("license a", "license b"),
+                    description = "description",
+                    homepageUrl = "homepageUrl",
+                    binaryArtifact = RemoteArtifact.EMPTY,
+                    sourceArtifact = RemoteArtifact.EMPTY,
+                    vcs = VcsInfo(
+                            type = "git",
+                            url = "http://url.git",
+                            revision = "revision",
+                            path = "path"
+                    )
+            )
+
+            val curation = PackageCuration(
+                    id = pkg.id,
+                    data = PackageCurationData(
+                            vcs = VcsInfoCuration(
+                                    type = "",
+                                    url = "",
+                                    revision = "",
+                                    path = ""
+                            )
+                    )
+            )
+
+            val curatedPkg = curation.apply(pkg.toCuratedPackage())
+
+            curatedPkg.curations.size shouldBe 1
+            curatedPkg.pkg.vcs shouldBe VcsInfo.EMPTY
+        }
+
         "fail if identifiers do not match" {
             val pkg = Package(
                     id = Identifier(

--- a/model/src/test/kotlin/PackageCurationTest.kt
+++ b/model/src/test/kotlin/PackageCurationTest.kt
@@ -42,6 +42,7 @@ class PackageCurationTest : StringSpec() {
                     sourceArtifact = RemoteArtifact.EMPTY,
                     vcs = VcsInfo.EMPTY
             )
+
             val curation = PackageCuration(
                     id = pkg.id,
                     data = PackageCurationData(
@@ -59,7 +60,7 @@ class PackageCurationTest : StringSpec() {
                                     hash = "source.hash",
                                     hashAlgorithm = HashAlgorithm.UNKNOWN
                             ),
-                            vcs = VcsInfo(
+                            vcs = VcsInfoCuration(
                                     type = "git",
                                     url = "http://url.git",
                                     revision = "revision",
@@ -79,7 +80,7 @@ class PackageCurationTest : StringSpec() {
                 homepageUrl shouldBe curation.data.homepageUrl
                 binaryArtifact shouldBe curation.data.binaryArtifact
                 sourceArtifact shouldBe curation.data.sourceArtifact
-                vcs shouldBe curation.data.vcs
+                vcs.toCuration() shouldBe curation.data.vcs
             }
 
             curatedPkg.curations.size shouldBe 1
@@ -108,14 +109,13 @@ class PackageCurationTest : StringSpec() {
                             path = "path"
                     )
             )
+
             val curation = PackageCuration(
                     id = pkg.id,
                     data = PackageCurationData(
                             homepageUrl = "http://home.page",
-                            vcs = VcsInfo(
-                                    type = "",
-                                    url = "http://url.git",
-                                    revision = ""
+                            vcs = VcsInfoCuration(
+                                    url = "http://url.git"
                             )
                     )
             )
@@ -132,7 +132,7 @@ class PackageCurationTest : StringSpec() {
                 sourceArtifact shouldBe pkg.sourceArtifact
                 vcs shouldBe VcsInfo(
                         type = pkg.vcs.type,
-                        url = curation.data.vcs!!.url,
+                        url = curation.data.vcs!!.url!!,
                         revision = pkg.vcs.revision,
                         resolvedRevision = pkg.vcs.resolvedRevision,
                         path = pkg.vcs.path
@@ -159,6 +159,7 @@ class PackageCurationTest : StringSpec() {
                     sourceArtifact = RemoteArtifact.EMPTY,
                     vcs = VcsInfo.EMPTY
             )
+
             val curation = PackageCuration(
                     id = Identifier(
                             type = "",
@@ -168,7 +169,7 @@ class PackageCurationTest : StringSpec() {
                     ),
                     data = PackageCurationData(
                             homepageUrl = "http://home.page",
-                            vcs = VcsInfo(
+                            vcs = VcsInfoCuration(
                                     type = "",
                                     url = "http://url.git",
                                     revision = ""

--- a/model/src/test/kotlin/PackageTest.kt
+++ b/model/src/test/kotlin/PackageTest.kt
@@ -72,7 +72,7 @@ class PackageTest : StringSpec() {
             diff.declaredLicenses shouldBe pkg.declaredLicenses
             diff.homepageUrl shouldBe pkg.homepageUrl
             diff.sourceArtifact shouldBe pkg.sourceArtifact
-            diff.vcs shouldBe pkg.vcs
+            diff.vcs shouldBe pkg.vcs.toCuration()
         }
 
         "diff result does not contain unchanged values" {


### PR DESCRIPTION
Sometimes we need to enforce the use of a source artifact even if VCS
information is present. A convenient way to do this is to clear the VCS
URL which previously was not possible as a blank curated VCS URL triggered
the use of original VCS URL. Support blank VCS URLs in curation by
introducing a dedicated VcsInfoCuration class with nullable properties.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1367)
<!-- Reviewable:end -->
