### PR TITLE
reporter: Respect path excludes in error summary

### DIFF
--- a/reporter/src/main/kotlin/reporters/ReportTableModelMapper.kt
+++ b/reporter/src/main/kotlin/reporters/ReportTableModelMapper.kt
@@ -134,7 +134,7 @@ class ReportTableModelMapper(private val resolutionProvider: ResolutionProvider)
                         analyzerIssues = analyzerIssues.map { it.toResolvableIssue() },
                         scanIssues = scanIssues.map { it.toResolvableIssue() }
                 ).also { row ->
-                    val isRowExcluded = projectExclude != null
+                    val isRowExcluded = pathExcludes.isNotEmpty() || projectExclude != null
                             || (scopes.isNotEmpty() && scopes.all { it.value.isNotEmpty() })
 
                     val nonExcludedAnalyzerIssues = if (isRowExcluded) emptyList() else row.analyzerIssues


### PR DESCRIPTION
If a project is excluded using a path exclude, do not add analyzer or
scanner issues of the project to the error summary, like it is already
done for projects excluded by project excludes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1379)
<!-- Reviewable:end -->
