### PR TITLE
Dockerfile: Upgrade Bundler to version 1.17.3-3

### DIFF
--- a/cli/docker/Dockerfile
+++ b/cli/docker/Dockerfile
@@ -32,7 +32,7 @@ FROM openjdk:11-jre-slim-sid
 ENV \
     # Package manager versions.
     BOWER_VERSION=1.8.8 \
-    BUNDLER_VERSION=1.17.3-2 \
+    BUNDLER_VERSION=1.17.3-3 \
     COMPOSER_VERSION=1.8.4-1 \
     GO_DEP_VERSION=0.5.0-1+B10 \
     HASKELL_STACK_VERSION=1.7.1-3 \


### PR DESCRIPTION
To enable building the Docker image again as the previous version is not
available anymore in Debian Sid.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1382)
<!-- Reviewable:end -->
