### PR TITLE
Custom data no equals

### DIFF
--- a/model/src/main/kotlin/AnalyzerResult.kt
+++ b/model/src/main/kotlin/AnalyzerResult.kt
@@ -51,13 +51,7 @@ data class AnalyzerResult(
     // Do not serialize if empty to reduce the size of the result file. If there are no errors at all,
     // [AnalyzerResult.hasErrors] already contains that information.
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val errors: SortedMap<Identifier, List<OrtIssue>> = sortedMapOf(),
-
-    /**
-     * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.
-     */
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val data: CustomData = emptyMap()
+    val errors: SortedMap<Identifier, List<OrtIssue>> = sortedMapOf()
 ) {
     companion object {
         /**
@@ -67,8 +61,7 @@ data class AnalyzerResult(
         val EMPTY = AnalyzerResult(
             projects = sortedSetOf(),
             packages = sortedSetOf(),
-            errors = sortedMapOf(),
-            data = emptyMap()
+            errors = sortedMapOf()
         )
     }
 

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -54,13 +54,7 @@ data class OrtResult(
      * An [EvaluatorRun] containing details about the evaluation that was run using the result from [scanner] as
      * input. Can be null if no evaluation was run.
      */
-    val evaluator: EvaluatorRun? = null,
-
-    /**
-     * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.
-     */
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val data: CustomData = emptyMap()
+    val evaluator: EvaluatorRun? = null
 ) {
     companion object {
         /**
@@ -71,10 +65,15 @@ data class OrtResult(
             repository = Repository.EMPTY,
             analyzer = null,
             scanner = null,
-            evaluator = null,
-            data = emptyMap()
+            evaluator = null
         )
     }
+
+    /**
+     * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val data: CustomData = mutableMapOf()
 
     /**
      * Return the concluded licenses for each package. If [omitExcluded] is set to true, excluded packages are omitted

--- a/model/src/main/kotlin/Package.kt
+++ b/model/src/main/kotlin/Package.kt
@@ -99,13 +99,7 @@ data class Package(
     /**
      * Processed VCS-related information about the [Package] that has e.g. common mistakes corrected.
      */
-    val vcsProcessed: VcsInfo = vcs.normalize(),
-
-    /**
-     * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.
-     */
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val data: CustomData = emptyMap()
+    val vcsProcessed: VcsInfo = vcs.normalize()
 ) : Comparable<Package> {
     companion object {
         /**
@@ -123,8 +117,7 @@ data class Package(
             binaryArtifact = RemoteArtifact.EMPTY,
             sourceArtifact = RemoteArtifact.EMPTY,
             vcs = VcsInfo.EMPTY,
-            vcsProcessed = VcsInfo.EMPTY,
-            data = emptyMap()
+            vcsProcessed = VcsInfo.EMPTY
         )
     }
 

--- a/model/src/main/kotlin/PackageCurationData.kt
+++ b/model/src/main/kotlin/PackageCurationData.kt
@@ -80,13 +80,7 @@ data class PackageCurationData(
      * created.
      */
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    val comment: String? = null,
-
-    /**
-     * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.
-     */
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val data: CustomData = emptyMap()
+    val comment: String? = null
 ) {
     /**
      * Apply the curation data to the provided package, by overriding all values of the original package with non-null

--- a/model/src/main/kotlin/PackageCurationResult.kt
+++ b/model/src/main/kotlin/PackageCurationResult.kt
@@ -19,8 +19,6 @@
 
 package com.here.ort.model
 
-import com.fasterxml.jackson.annotation.JsonInclude
-
 /**
  * This class contains information about which values were changed when applying a curation.
  */
@@ -33,11 +31,5 @@ data class PackageCurationResult(
     /**
      * The curation that was applied.
      */
-    val curation: PackageCurationData,
-
-    /**
-     * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.
-     */
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val data: CustomData = emptyMap()
+    val curation: PackageCurationData
 )

--- a/model/src/main/kotlin/PackageReference.kt
+++ b/model/src/main/kotlin/PackageReference.kt
@@ -58,12 +58,7 @@ data class PackageReference(
     /**
      * A list of errors that occurred handling this [PackageReference].
      */
-    val errors: List<OrtIssue> = emptyList(),
-
-    /**
-     * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.
-     */
-    val data: CustomData = emptyMap()
+    val errors: List<OrtIssue> = emptyList()
 ) : Comparable<PackageReference> {
     /**
      * Return the set of [PackageReference]s this [PackageReference] transitively depends on, up to and including a

--- a/model/src/main/kotlin/Project.kt
+++ b/model/src/main/kotlin/Project.kt
@@ -20,7 +20,6 @@
 package com.here.ort.model
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonInclude
 
 import com.here.ort.spdx.SpdxExpression
 import com.here.ort.spdx.SpdxOperator
@@ -82,13 +81,7 @@ data class Project(
     /**
      * The dependency scopes defined by this project.
      */
-    val scopes: SortedSet<Scope>,
-
-    /**
-     * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.
-     */
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val data: CustomData = emptyMap()
+    val scopes: SortedSet<Scope>
 ) : Comparable<Project> {
     companion object {
         /**
@@ -104,8 +97,7 @@ data class Project(
             vcs = VcsInfo.EMPTY,
             vcsProcessed = VcsInfo.EMPTY,
             homepageUrl = "",
-            scopes = sortedSetOf(),
-            data = emptyMap()
+            scopes = sortedSetOf()
         )
     }
 

--- a/model/src/main/kotlin/Provenance.kt
+++ b/model/src/main/kotlin/Provenance.kt
@@ -59,13 +59,7 @@ data class Provenance(
      */
     @JsonAlias("originalVcsInfo")
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    val originalVcsInfo: VcsInfo? = null,
-
-    /**
-     * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.
-     */
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val data: CustomData = emptyMap()
+    val originalVcsInfo: VcsInfo? = null
 ) {
     init {
         require(sourceArtifact == null || vcsInfo == null) {
@@ -87,7 +81,7 @@ data class Provenance(
                         && sourceArtifact.hashAlgorithm == pkg.sourceArtifact.hashAlgorithm
             }
 
-            return sourceArtifact.copy(data = emptyMap()) == pkg.sourceArtifact.copy(data = emptyMap())
+            return sourceArtifact == pkg.sourceArtifact
         }
 
         // By now it is clear the scanned source code did not come from a source artifact, so try to compare the VCS

--- a/model/src/main/kotlin/RemoteArtifact.kt
+++ b/model/src/main/kotlin/RemoteArtifact.kt
@@ -19,8 +19,6 @@
 
 package com.here.ort.model
 
-import com.fasterxml.jackson.annotation.JsonInclude
-
 /**
  * Bundles information about a remote artifact.
  */
@@ -38,13 +36,7 @@ data class RemoteArtifact(
     /**
      * The name of the algorithm used to calculate the [hash].
      */
-    val hashAlgorithm: HashAlgorithm,
-
-    /**
-     * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.
-     */
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val data: CustomData = emptyMap()
+    val hashAlgorithm: HashAlgorithm
 ) {
     companion object {
         /**
@@ -54,8 +46,7 @@ data class RemoteArtifact(
         val EMPTY = RemoteArtifact(
             url = "",
             hash = Hash.UNKNOWN.value,
-            hashAlgorithm = Hash.UNKNOWN.algorithm,
-            data = emptyMap()
+            hashAlgorithm = Hash.UNKNOWN.algorithm
         )
     }
 }

--- a/model/src/main/kotlin/ScanRecord.kt
+++ b/model/src/main/kotlin/ScanRecord.kt
@@ -21,7 +21,6 @@ package com.here.ort.model
 
 import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonInclude
 
 import java.util.SortedSet
 
@@ -44,13 +43,7 @@ data class ScanRecord(
      * The [AccessStatistics] for the scan results storage.
      */
     @JsonAlias("cache_stats")
-    val storageStats: AccessStatistics,
-
-    /**
-     * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.
-     */
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val data: CustomData = emptyMap()
+    val storageStats: AccessStatistics
 ) {
     /**
      * Return a map of all de-duplicated errors associated by [Identifier].

--- a/model/src/main/kotlin/ScanResult.kt
+++ b/model/src/main/kotlin/ScanResult.kt
@@ -48,11 +48,5 @@ data class ScanResult(
      */
     @JsonAlias("rawResult")
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    val rawResult: JsonNode? = null,
-
-    /**
-     * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.
-     */
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val data: CustomData = emptyMap()
+    val rawResult: JsonNode? = null
 )

--- a/model/src/main/kotlin/ScanResultContainer.kt
+++ b/model/src/main/kotlin/ScanResultContainer.kt
@@ -19,8 +19,6 @@
 
 package com.here.ort.model
 
-import com.fasterxml.jackson.annotation.JsonInclude
-
 import java.util.SortedSet
 
 /**
@@ -35,13 +33,7 @@ data class ScanResultContainer(
     /**
      * The list of [ScanResult]s from potentially multiple scanners and / or with different package provenance.
      */
-    val results: List<ScanResult>,
-
-    /**
-     * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.
-     */
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val data: CustomData = emptyMap()
+    val results: List<ScanResult>
 ) : Comparable<ScanResultContainer> {
     /**
      * A comparison function to sort scan result containers by their identifier.

--- a/model/src/main/kotlin/ScannerDetails.kt
+++ b/model/src/main/kotlin/ScannerDetails.kt
@@ -19,8 +19,6 @@
 
 package com.here.ort.model
 
-import com.fasterxml.jackson.annotation.JsonInclude
-
 import com.vdurmont.semver4j.Semver
 
 import java.util.EnumSet
@@ -42,13 +40,7 @@ data class ScannerDetails(
     /**
      * The configuration of the scanner, could be command line arguments for example.
      */
-    val configuration: String,
-
-    /**
-     * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.
-     */
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val data: CustomData = emptyMap()
+    val configuration: String
 ) {
     companion object {
         private val MAJOR_MINOR = EnumSet.of(Semver.VersionDiff.MAJOR, Semver.VersionDiff.MINOR)

--- a/model/src/main/kotlin/Scope.kt
+++ b/model/src/main/kotlin/Scope.kt
@@ -20,7 +20,6 @@
 package com.here.ort.model
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonInclude
 
 import java.util.SortedSet
 
@@ -43,13 +42,7 @@ data class Scope(
      * dependencies would not be test dependencies of the test dependencies, but compile dependencies of test
      * dependencies.
      */
-    val dependencies: SortedSet<PackageReference> = sortedSetOf(),
-
-    /**
-     * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.
-     */
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val data: CustomData = emptyMap()
+    val dependencies: SortedSet<PackageReference> = sortedSetOf()
 ) : Comparable<Scope> {
     /**
      * Return the set of [PackageReference]s in this [Scope], up to and including a depth of [maxDepth] where counting

--- a/model/src/main/kotlin/VcsInfo.kt
+++ b/model/src/main/kotlin/VcsInfo.kt
@@ -63,13 +63,7 @@ data class VcsInfo(
      * example, for Git only this subdirectory of the repository should be cloned, or for Git Repo it is
      * interpreted as the path to the manifest file.
      */
-    val path: String = "",
-
-    /**
-     * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.
-     */
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val data: CustomData = emptyMap()
+    val path: String = ""
 ) {
     companion object {
         /**
@@ -81,8 +75,7 @@ data class VcsInfo(
             url = "",
             revision = "",
             resolvedRevision = null,
-            path = "",
-            data = emptyMap()
+            path = ""
         )
     }
 

--- a/model/src/test/kotlin/VcsInfoTest.kt
+++ b/model/src/test/kotlin/VcsInfoTest.kt
@@ -85,8 +85,6 @@ class VcsInfoTest : StringSpec({
                 revision: "revision"
                 resolved_revision: "resolved_revision"
                 path: "path"
-                data:
-                  key: "value"
                 unknown: "unknown"
                 """.trimIndent()
 
@@ -96,7 +94,7 @@ class VcsInfoTest : StringSpec({
 
             exception.propertyName shouldBe "unknown"
             exception.knownPropertyIds should
-                    containAll<Any>("type", "url", "revision", "resolved_revision", "path", "data")
+                    containAll<Any>("type", "url", "revision", "resolved_revision", "path")
         }
     }
 

--- a/reporter/src/main/kotlin/reporters/ReportTableModelMapper.kt
+++ b/reporter/src/main/kotlin/reporters/ReportTableModelMapper.kt
@@ -211,7 +211,7 @@ class ReportTableModelMapper(private val resolutionProvider: ResolutionProvider)
             it.entries.associateTo(metadata) { (key, value) -> key.toString() to value.toString() }
         }
 
-        val extraColumns = (scanRecord.data["excel_report_extra_columns"] as? List<*>)?.let { extraColumns ->
+        val extraColumns = (ortResult.data["excel_report_extra_columns"] as? List<*>)?.let { extraColumns ->
             extraColumns.map { it.toString() }
         }.orEmpty()
 


### PR DESCRIPTION
I'm proposing to move custom data out of the primary constructor of data classes so that the auto-generated `equals()` does not take custom data into account.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1394)
<!-- Reviewable:end -->
