### PR TITLE
Provenance: Allow only source artifact hashes to match

### DIFF
--- a/model/src/main/kotlin/Provenance.kt
+++ b/model/src/main/kotlin/Provenance.kt
@@ -90,8 +90,11 @@ data class Provenance(
             return sourceArtifact.copy(data = emptyMap()) == pkg.sourceArtifact.copy(data = emptyMap())
         }
 
-        // If the VCS information does not have a resolved revision it means that there was an issue with downloading
-        // the source code.
+        // By now it is clear the scanned source code did not come from a source artifact, so try to compare the VCS
+        // information instead.
+
+        // If no VCS information is present either, or it does not have a resolved revision, there is no way of
+        // verifying matching provenance.
         if (vcsInfo?.resolvedRevision == null) {
             return false
         }

--- a/model/src/main/kotlin/Provenance.kt
+++ b/model/src/main/kotlin/Provenance.kt
@@ -78,9 +78,15 @@ data class Provenance(
      * True if this [Provenance] refers to the same source code as [pkg], assuming that it belongs to the package id.
      */
     fun matches(pkg: Package): Boolean {
-        // TODO: Only comparing the hashes of the source artifacts might be sufficient.
+        // If the scanned source code came from a source artifact, it has to match the package's source artifact.
         if (sourceArtifact != null) {
-            // Note that pkg.sourceArtifact is non-nullable.
+            // If the (non-empty) hashes match, we do not need to compare the other properties like the URL. Only
+            // support this for a known algorithm whose hash we were able to verify as otherwise the hash could be fake.
+            if (sourceArtifact.hash.isNotEmpty() && sourceArtifact.hashAlgorithm != HashAlgorithm.UNKNOWN) {
+                return sourceArtifact.hash == pkg.sourceArtifact.hash
+                        && sourceArtifact.hashAlgorithm == pkg.sourceArtifact.hashAlgorithm
+            }
+
             return sourceArtifact.copy(data = emptyMap()) == pkg.sourceArtifact.copy(data = emptyMap())
         }
 

--- a/scanner/src/funTest/kotlin/HttpStorageTest.kt
+++ b/scanner/src/funTest/kotlin/HttpStorageTest.kt
@@ -322,7 +322,7 @@ class HttpStorageTest : StringSpec() {
                 rawResultWithContent
             )
             val provenanceSourceArtifactNonMatching = provenanceWithSourceArtifact.copy(
-                sourceArtifact = sourceArtifact.copy(url = "url2")
+                sourceArtifact = sourceArtifact.copy(hash = "0123456789012345678901234567890123456789")
             )
             val scanResultSourceArtifactNonMatching = ScanResult(
                 provenanceSourceArtifactNonMatching, scannerDetails1,


### PR DESCRIPTION
If the (non-empty) hashes match, the source code is the same. This
added earlier check supports the case where the source artifact URLs
differ (e.g. because the artifact was retrieved from a cache) although
the artifacts are in fact the same.

Also add some more code comments along the way.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1395)
<!-- Reviewable:end -->
