### PR TITLE
Git: Suppress interactive prompts for credentials

### DIFF
--- a/downloader/src/main/kotlin/vcs/Git.kt
+++ b/downloader/src/main/kotlin/vcs/Git.kt
@@ -30,6 +30,7 @@ import com.here.ort.utils.ProcessCapture
 import com.here.ort.utils.log
 import com.here.ort.utils.safeMkdirs
 import com.here.ort.utils.showStackTrace
+import com.here.ort.utils.suppressInput
 
 import com.vdurmont.semver4j.Semver
 
@@ -43,7 +44,9 @@ class Git : GitBase() {
     override val priority: Int = 100
 
     override fun isApplicableUrlInternal(vcsUrl: String) =
-        ProcessCapture("git", "ls-remote", vcsUrl).isSuccess
+        suppressInput {
+            ProcessCapture("git", "-c", "credential.helper=", "-c", "core.askpass=", "ls-remote", vcsUrl).isSuccess
+        }
 
     override fun download(
         pkg: Package, targetDir: File, allowMovingRevisions: Boolean,

--- a/downloader/src/test/kotlin/GitTest.kt
+++ b/downloader/src/test/kotlin/GitTest.kt
@@ -20,6 +20,7 @@
 package com.here.ort.downloader.vcs
 
 import com.here.ort.downloader.VersionControlSystem
+import com.here.ort.utils.OS
 import com.here.ort.utils.getUserOrtDirectory
 import com.here.ort.utils.safeDeleteRecursively
 import com.here.ort.utils.unpack
@@ -64,6 +65,10 @@ class GitTest : StringSpec() {
             git.isApplicableUrl("https://bitbucket.org/yevster/spdxtraxample") shouldBe true
 
             git.isApplicableUrl("https://bitbucket.org/paniq/masagin") shouldBe false
+        }
+
+        "Git does not prompt for credentials for non-existing repositories".config(enabled = !OS.isWindows) {
+            git.isApplicableUrl("https://github.com/heremaps/foobar.git") shouldBe false
         }
 
         "Detected Git working tree information is correct" {


### PR DESCRIPTION
The changes are confirmed to work as expected on Linux. However, while
doing no harm on Windows compared to before, the test hangs on Windows,
so only enable it on non-Windows for now.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1402)
<!-- Reviewable:end -->
