### PR TITLE
Travis: Accept patch-level PHP version changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ env:
     - GIMME_GO_VERSION="1.10" # Used internally by Travis.
     - GO_DEP_VERSION="0.5.1"
     - NPM_VERSION="6.4.0"
-    - PHP_VERSION="7.1.19"
+    - PHP_VERSION="7.1"
     - YARN_VERSION="1.13.0"
 
 before_install:


### PR DESCRIPTION
Travis from time to time seems to silently do patch-level upgrades to
PHP, resulting in an exact version like 7.1.19 to not be found anymore.
Effectively revert 2dbe831 to again allow patch-level version changes as
Travis by now seems to have fixed the issue with the "7.1" alias from back
then.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1408)
<!-- Reviewable:end -->
