### PR TITLE
AppVeyor: Ensure  %HOME%\.gradle exists

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -55,7 +55,7 @@ test_script:
   - if "%APPVEYOR_SCHEDULED_BUILD%"=="True" (
       gradlew --stacktrace dokkaJar check
     ) else (
-      gradlew --scan --stacktrace -Dkotlintest.tags.exclude=ExpensiveTag check
+      gradlew --stacktrace -Dkotlintest.tags.exclude=ExpensiveTag check
     )
 
 on_finish:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -47,6 +47,7 @@ install:
 
 # Do something useful here to override the default MSBuild (which would fail otherwise).
 build_script:
+  - if not exist %HOME%\.gradle mkdir %HOME%\.gradle
   - echo org.gradle.daemon=false>>%HOME%\.gradle\gradle.properties
   - echo org.gradle.java.home=C:/Program Files/Java/jdk9>>%HOME%\.gradle\gradle.properties
 


### PR DESCRIPTION
E.g. after clearing the build cache the directory may not exist yet.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1414)
<!-- Reviewable:end -->
