### PR TITLE
Fix passing on OrtResult meta-data when amending results

### DIFF
--- a/cli/src/main/kotlin/commands/EvaluatorCommand.kt
+++ b/cli/src/main/kotlin/commands/EvaluatorCommand.kt
@@ -141,7 +141,9 @@ object EvaluatorCommand : CommandWithHelp() {
 
         if (absoluteOutputDir != null) {
             // Note: This overwrites any existing EvaluatorRun from the input file.
-            val ortResultOutput = ortResultInput.copy(evaluator = evaluatorRun)
+            val ortResultOutput = ortResultInput.copy(evaluator = evaluatorRun).apply {
+                data += ortResultInput.data
+            }
 
             absoluteOutputDir.safeMkdirs()
 

--- a/model/src/main/kotlin/Model.kt
+++ b/model/src/main/kotlin/Model.kt
@@ -19,4 +19,4 @@
 
 package com.here.ort.model
 
-typealias CustomData = Map<String, Any>
+typealias CustomData = MutableMap<String, Any>

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -154,6 +154,8 @@ abstract class Scanner(val scannerName: String, protected val config: ScannerCon
         val scannerRun = ScannerRun(startTime, endTime, Environment(), config, scanRecord)
 
         // Note: This overwrites any existing ScannerRun from the input file.
-        return ortResult.copy(scanner = scannerRun)
+        return ortResult.copy(scanner = scannerRun).apply {
+            data += ortResult.data
+        }
     }
 }


### PR DESCRIPTION
This was broken as of d824a74 because copy() does not include "data"
anymore.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1417)
<!-- Reviewable:end -->
