### PR TITLE
SpdxExpression: Remove the default ConsoleErrorListener

### DIFF
--- a/spdx-utils/src/main/kotlin/SpdxErrorListener.kt
+++ b/spdx-utils/src/main/kotlin/SpdxErrorListener.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.spdx
+
+import org.antlr.v4.runtime.BaseErrorListener
+import org.antlr.v4.runtime.RecognitionException
+import org.antlr.v4.runtime.Recognizer
+
+/**
+ * An ANTLR error listener that throws an [SpdxException].
+ */
+class SpdxErrorListener : BaseErrorListener() {
+    override fun syntaxError(
+        recognizer: Recognizer<*, *>?,
+        offendingSymbol: Any?,
+        line: Int,
+        charPositionInLine: Int,
+        msg: String?,
+        e: RecognitionException?
+    ) {
+        throw SpdxException(msg)
+    }
+}

--- a/spdx-utils/src/main/kotlin/SpdxExpression.kt
+++ b/spdx-utils/src/main/kotlin/SpdxExpression.kt
@@ -25,11 +25,8 @@ import com.fasterxml.jackson.databind.ser.std.ToStringSerializer
 
 import java.util.EnumSet
 
-import org.antlr.v4.runtime.BaseErrorListener
 import org.antlr.v4.runtime.CharStreams
 import org.antlr.v4.runtime.CommonTokenStream
-import org.antlr.v4.runtime.RecognitionException
-import org.antlr.v4.runtime.Recognizer
 
 /**
  * An SPDX expression as defined by version 2.1 of the [SPDX specification, appendix IV][1].
@@ -78,18 +75,8 @@ sealed class SpdxExpression {
             val charStream = CharStreams.fromString(expression)
             val lexer = SpdxExpressionLexer(charStream)
 
-            lexer.addErrorListener(object : BaseErrorListener() {
-                override fun syntaxError(
-                    recognizer: Recognizer<*, *>?,
-                    offendingSymbol: Any?,
-                    line: Int,
-                    charPositionInLine: Int,
-                    msg: String?,
-                    e: RecognitionException?
-                ) {
-                    throw SpdxException(msg)
-                }
-            })
+            lexer.removeErrorListeners()
+            lexer.addErrorListener(SpdxErrorListener())
 
             val tokenStream = CommonTokenStream(lexer)
             val parser = SpdxExpressionParser(tokenStream)

--- a/spdx-utils/src/test/kotlin/SpdxExpressionLexerTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxExpressionLexerTest.kt
@@ -23,10 +23,7 @@ import io.kotlintest.shouldBe
 import io.kotlintest.shouldThrow
 import io.kotlintest.specs.WordSpec
 
-import org.antlr.v4.runtime.BaseErrorListener
 import org.antlr.v4.runtime.CharStreams
-import org.antlr.v4.runtime.RecognitionException
-import org.antlr.v4.runtime.Recognizer
 
 class SpdxExpressionLexerTest : WordSpec() {
     init {
@@ -72,19 +69,9 @@ class SpdxExpressionLexerTest : WordSpec() {
     private fun getTokensByTypeForExpression(expression: String): List<Pair<Int, String>> {
         val charStream = CharStreams.fromString(expression)
         val lexer = SpdxExpressionLexer(charStream)
+
         lexer.removeErrorListeners()
-        lexer.addErrorListener(object : BaseErrorListener() {
-            override fun syntaxError(
-                recognizer: Recognizer<*, *>?,
-                offendingSymbol: Any?,
-                line: Int,
-                charPositionInLine: Int,
-                msg: String?,
-                e: RecognitionException?
-            ) {
-                throw SpdxException(msg)
-            }
-        })
+        lexer.addErrorListener(SpdxErrorListener())
 
         return lexer.allTokens.map { it.type to it.text }
     }


### PR DESCRIPTION
Ensure that always only our custom error listener is set to avoid errors
being written to the console. This e.g. avoids

    line 1:4 token recognition error at: ':'

being written to stderr when parsing the URL

    http://jquery.org/license

as an SpdxExpression.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1429)
<!-- Reviewable:end -->
