### PR TITLE
Support Ivy version patterns in curation data

### DIFF
--- a/analyzer/src/main/kotlin/PackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/PackageCurationProvider.kt
@@ -27,7 +27,7 @@ import com.here.ort.model.PackageCuration
  */
 interface PackageCurationProvider {
     /**
-     * Get all available [PackageCuration]s for the provided [Identifier].
+     * Get all available [PackageCuration]s for the provided [pkgId].
      */
-    fun getCurationsFor(identifier: Identifier): List<PackageCuration>
+    fun getCurationsFor(pkgId: Identifier): List<PackageCuration>
 }

--- a/analyzer/src/main/kotlin/YamlFilePackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/YamlFilePackageCurationProvider.kt
@@ -35,5 +35,5 @@ class YamlFilePackageCurationProvider(
         curationFile.readValue<List<PackageCuration>>()
     }
 
-    override fun getCurationsFor(identifier: Identifier) = packageCurations.filter { it.id.matches(identifier) }
+    override fun getCurationsFor(pkgId: Identifier) = packageCurations.filter { it.isApplicable(pkgId) }
 }

--- a/analyzer/src/test/assets/package-curations.yml
+++ b/analyzer/src/test/assets/package-curations.yml
@@ -37,3 +37,6 @@
 - id: "Maven:org.apache::"
   curations:
     homepage_url: "http://home.page"
+- id: "NPM::ramda:[0.21.0,0.25.0]"
+  curations:
+    concluded_license: "MIT"

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -252,20 +252,21 @@ location of source artifacts. The structure of the curations file is:
 
 # A few examples:
 
-# Repository moved to https://gitlab.ow2.org.
 - id: "Maven:asm:asm" # No version means the curation will be applied to all versions of the package.
   curations:
+    comment: "Repository moved to https://gitlab.ow2.org."
     vcs:
       type: "git"
       url: "https://gitlab.ow2.org/asm/asm.git"
 
-# Revisions found by comparing NPM packages with the sources from https://github.com/olov/ast-traverse.
 - id: "NPM::ast-traverse:0.1.0"
   curations:
+    comment: "Revision found by comparing NPM packages with the sources from https://github.com/olov/ast-traverse."
     vcs:
       revision: "f864d24ba07cde4b79f16999b1c99bfb240a441e"
 - id: "NPM::ast-traverse:0.1.1"
   curations:
+    comment: "Revision found by comparing NPM packages with the sources from https://github.com/olov/ast-traverse."
     vcs:
       revision: "73f2b3c319af82fd8e490d40dd89a15951069b0d"
 ```

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -269,6 +269,13 @@ location of source artifacts. The structure of the curations file is:
     comment: "Revision found by comparing NPM packages with the sources from https://github.com/olov/ast-traverse."
     vcs:
       revision: "73f2b3c319af82fd8e490d40dd89a15951069b0d"
+
+- id: "NPM::ramda:[0.21.0,0.25.0]" # Ivy-style version matchers are supported.
+  curations:
+    comment: "The package is licensed under MIT per `LICENSE` and `dist/ramda.js`. The project logo is CC-BY-NC-SA-3.0 \
+      but it is not part of the distributed .tar.gz package, see the `README.md` which says: \
+      Ramda logo artwork © 2014 J. C. Phillipps. Licensed Creative Commons CC BY-NC-SA 3.0"
+    concluded_license: "MIT"
 ```
 
 To use the curations file pass it to the `--package-curations-file` option of the `analyzer`:

--- a/model/src/main/kotlin/Identifier.kt
+++ b/model/src/main/kotlin/Identifier.kt
@@ -104,34 +104,6 @@ data class Identifier(
     }
 
     /**
-     * Return true if this matches the other identifier. To match, both identifiers need to have the same [type] and
-     * [namespace], and the [name] and [version] must be either equal or empty for at least one of them.
-     *
-     * Examples for matching identifiers:
-     * * "maven:org.hamcrest:hamcrest-core:1.3" <-> "maven:org.hamcrest:hamcrest-core:"
-     * * "maven:org.hamcrest:hamcrest-core:1.3" <-> "maven:org.hamcrest::1.3"
-     * * "maven:org.hamcrest:hamcrest-core:1.3" <-> "maven:org.hamcrest::"
-     *
-     * Examples for not matching identifiers:
-     * * "maven:org.hamcrest:hamcrest-core:1.3" <-> "maven:org.hamcrest:hamcrest-core:1.2"
-     * * "maven:org.hamcrest:hamcrest-core:" <-> "maven:org.hamcrest:hamcrest-library:"
-     */
-    fun matches(other: Identifier): Boolean {
-        if (!type.equals(other.type, true)) {
-            return false
-        }
-
-        if (namespace != other.namespace) {
-            return false
-        }
-
-        val nameMatches = name == other.name || name.isBlank() || other.name.isBlank()
-        val versionMatches = version == other.version || version.isBlank() || other.version.isBlank()
-
-        return nameMatches && versionMatches
-    }
-
-    /**
      * Create Maven-like coordinates based on the properties of the [Identifier].
      */
     // TODO: We probably want to already sanitize the individual properties, also in other classes, but Kotlin does not

--- a/model/src/test/kotlin/IdentifierTest.kt
+++ b/model/src/test/kotlin/IdentifierTest.kt
@@ -61,40 +61,6 @@ class IdentifierTest : StringSpec() {
             }
         }
 
-        "Identifiers match correctly" {
-            val matching = mapOf(
-                "maven:org.hamcrest:hamcrest-core:1.3"
-                        to "maven:org.hamcrest:hamcrest-core:1.3",
-                "maven:org.hamcrest:hamcrest-core:1.3"
-                        to "maven:org.hamcrest:hamcrest-core:",
-                "maven:org.hamcrest:hamcrest-core:1.3"
-                        to "maven:org.hamcrest::1.3",
-                "maven:org.hamcrest:hamcrest-core:1.3"
-                        to "maven:org.hamcrest::"
-            )
-
-            val nonMatching = mapOf(
-                "maven:org.hamcrest:hamcrest-core:1.3"
-                        to "maven:org.hamcrest:hamcrest-core:1.2",
-                "maven:org.hamcrest:hamcrest-core:1.3"
-                        to "maven:org.hamcrest:hamcrest-library:",
-                "maven:org.hamcrest:hamcrest-core:"
-                        to "maven:org.hamcrest:hamcrest-library:",
-                "maven:org.hamcrest::"
-                        to "maven:org.apache::",
-                "maven:org.hamcrest::"
-                        to "gradle:org.hamcrest::"
-            )
-
-            matching.forEach { id1, id2 ->
-                Identifier(id1).matches(Identifier(id2)) shouldBe true
-            }
-
-            nonMatching.forEach { id1, id2 ->
-                Identifier(id1).matches(Identifier(id2)) shouldBe false
-            }
-        }
-
         "Identifier is serialized to String" {
             val id = Identifier("type", "namespace", "name", "version")
 


### PR DESCRIPTION
This allows to create a single curation that matches multiple versions
of the same package. For Ivy version specifiers see

http://ant.apache.org/ivy/history/2.4.0/settings/version-matchers.html

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1445)
<!-- Reviewable:end -->
