### PR TITLE
evaluator: Add a DSL for writing rules

### DIFF
--- a/evaluator/src/main/kotlin/DependencyRule.kt
+++ b/evaluator/src/main/kotlin/DependencyRule.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.evaluator
+
+import com.here.ort.model.Identifier
+import com.here.ort.model.LicenseFinding
+import com.here.ort.model.Package
+import com.here.ort.model.PackageLinkage
+import com.here.ort.model.PackageReference
+import com.here.ort.model.Project
+import com.here.ort.model.Scope
+import com.here.ort.spdx.enumSetOf
+
+/**
+ * A [Rule] to check a single [dependency][PackageReference].
+ */
+class DependencyRule(
+    ruleSet: RuleSet,
+    name: String,
+    pkg: Package,
+    detectedLicenses: List<LicenseFinding>,
+
+    /**
+     * The [dependency][PackageReference] to check.
+     */
+    val dependency: PackageReference,
+
+    /**
+     * The ancestors of the [dependency] in the dependency tree. The first entry is the root of the tree, the last entry
+     * (at [level] - 1) is the direct parent.
+     */
+    val ancestors: List<PackageReference>,
+
+    /**
+     * The level of the [dependency] inside the dependency tree. Starts with 0 for root level entries.
+     */
+    val level: Int,
+
+    /**
+     * The [Scope] that contains the [dependency].
+     */
+    val scope: Scope,
+
+    /**
+     * The [Project] that contains the [dependency].
+     */
+    val project: Project
+) : PackageRule(ruleSet, name, pkg, detectedLicenses) {
+    override val description =
+        "Evaluating rule '$name' for dependency '${dependency.id.toCoordinates()}' " +
+                "(project=${project.id.toCoordinates()}, scope=${scope.name}, level=$level)."
+
+    override fun errorSource() =
+        "$name - ${pkg.id.toCoordinates()} (dependency of ${project.id.toCoordinates()} in scope ${scope.name})"
+
+    /**
+     * A [RuleMatcher] that checks if the level of the [dependency] inside the dependency tree equals [level].
+     */
+    fun isAtTreeLevel(level: Int) =
+        object : RuleMatcher {
+            override val description = "isAtTreeLevel($level)"
+
+            override fun matches() = this@DependencyRule.level == level
+        }
+
+    /**
+     * A [RuleMatcher] that checks if the [identifier][Project.id] of the [project] belongs to one of the provided
+     * [orgs][Identifier.isFromOrg].
+     */
+    fun isProjectFromOrg(vararg names: String) =
+        object : RuleMatcher {
+            override val description = "isProjectFromOrg(${names.joinToString()})"
+
+            override fun matches() = project.id.isFromOrg(*names)
+        }
+
+    /**
+     * A [RuleMatcher] that checks if the [dependency] is [statically linked][PackageLinkage].
+     */
+    fun isStaticallyLinked() =
+        object : RuleMatcher {
+            override val description = "isStaticallyLinked()"
+
+            override fun matches() =
+                dependency.linkage in enumSetOf(PackageLinkage.STATIC, PackageLinkage.PROJECT_STATIC)
+        }
+}

--- a/evaluator/src/main/kotlin/LicenseSource.kt
+++ b/evaluator/src/main/kotlin/LicenseSource.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.evaluator
+
+import com.here.ort.model.Package
+
+/**
+ * The source where a license originates from.
+ */
+enum class LicenseSource {
+    /**
+     * Licenses which are part of the [concluded license][Package.concludedLicense] of a [Package].
+     */
+    CONCLUDED,
+
+    /**
+     * Licenses which are part of the [(processed)][Package.declaredLicensesProcessed]
+     * [declared licenses][Package.declaredLicenses] of a [Package].
+     */
+    DECLARED,
+
+    /**
+     * Licenses which were detected by a license scanner.
+     */
+    DETECTED
+}

--- a/evaluator/src/main/kotlin/LicenseView.kt
+++ b/evaluator/src/main/kotlin/LicenseView.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.evaluator
+
+import com.here.ort.model.Package
+
+/**
+ * A [LicenseView] provides a custom view on the licenses that belong to a [Package]. It can be used to filter the
+ * relevant licenses by [source][LicenseSource] for a [Rule].
+ */
+sealed class LicenseView {
+    abstract fun licenses(pkg: Package, detectedLicenses: List<String>): List<Pair<String, LicenseSource>>
+
+    /**
+     * Return all licenses.
+     */
+    object All : LicenseView() {
+        override fun licenses(pkg: Package, detectedLicenses: List<String>): List<Pair<String, LicenseSource>> {
+            val concluded = pkg.concludedLicense?.licenses()?.map { license ->
+                Pair(license, LicenseSource.CONCLUDED)
+            }.orEmpty()
+
+            val declared =
+                pkg.declaredLicensesProcessed.spdxExpression?.licenses()?.map { Pair(it, LicenseSource.DECLARED) }
+                    .orEmpty()
+
+            val detected = detectedLicenses.map { Pair(it, LicenseSource.DETECTED) }
+
+            return concluded + declared + detected
+        }
+    }
+
+    /**
+     * Return only the concluded licenses if they exist, otherwise return declared and detected licenses.
+     */
+    object ConcludedOrRest : LicenseView() {
+        override fun licenses(pkg: Package, detectedLicenses: List<String>): List<Pair<String, LicenseSource>> {
+            pkg.concludedLicense?.licenses()?.let {
+                return it.map { license -> Pair(license, LicenseSource.CONCLUDED) }
+            }
+
+            val declared =
+                pkg.declaredLicensesProcessed.spdxExpression?.licenses()?.map { Pair(it, LicenseSource.DECLARED) }
+                    .orEmpty()
+
+            val detected = detectedLicenses.map { Pair(it, LicenseSource.DETECTED) }
+
+            return declared + detected
+        }
+    }
+
+    /**
+     * Return only the concluded licenses if they exist, or return only the declared licenses if they exist, or return
+     * the detected licenses.
+     */
+    object ConcludedOrDeclaredOrDetected : LicenseView() {
+        override fun licenses(pkg: Package, detectedLicenses: List<String>): List<Pair<String, LicenseSource>> {
+            pkg.concludedLicense?.licenses()?.let {
+                return it.map { license -> Pair(license, LicenseSource.CONCLUDED) }
+            }
+
+            pkg.declaredLicensesProcessed.spdxExpression?.licenses()?.let {
+                return it.map { license -> Pair(license, LicenseSource.DECLARED) }
+            }
+
+            return detectedLicenses.map { Pair(it, LicenseSource.DETECTED) }
+        }
+    }
+}

--- a/evaluator/src/main/kotlin/PackageRule.kt
+++ b/evaluator/src/main/kotlin/PackageRule.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.evaluator
+
+import com.here.ort.model.Identifier
+import com.here.ort.model.LicenseFinding
+import com.here.ort.model.Package
+import com.here.ort.model.config.Excludes
+import com.here.ort.model.config.PathExclude
+import com.here.ort.spdx.SpdxLicense
+
+/**
+ * A [Rule] to check a single [Package].
+ */
+open class PackageRule(
+    ruleSet: RuleSet,
+    name: String,
+
+    /**
+     * The [Package] to check.
+     */
+    val pkg: Package,
+
+    /**
+     * The detected licenses for the [Package].
+     */
+    val detectedLicenses: List<LicenseFinding>
+) : Rule(ruleSet, name) {
+    private val licenseRules = mutableListOf<LicenseRule>()
+
+    override val description = "Evaluating rule '$name' for package '${pkg.id.toCoordinates()}'."
+
+    override fun errorSource() = "$name - ${pkg.id.toCoordinates()}"
+
+    override fun runInternal() {
+        licenseRules.forEach { it.run() }
+    }
+
+    /**
+     * A [RuleMatcher] that checks if the [package][pkg] has any concluded, declared, or detected license.
+     */
+    fun hasLicense() =
+        object : RuleMatcher {
+            override val description = "hasLicense()"
+
+            override fun matches() =
+                pkg.concludedLicense?.licenses()?.isNotEmpty() == true
+                        || pkg.declaredLicenses.isNotEmpty()
+                        || detectedLicenses.isNotEmpty()
+        }
+
+    /**
+     * A [RuleMatcher] that checks if the [package][pkg] is [excluded][Excludes].
+     */
+    fun isExcluded() =
+        object : RuleMatcher {
+            override val description = "isExcluded()"
+
+            override fun matches() = ruleSet.ortResult.isExcluded(pkg.id)
+        }
+
+    /**
+     * A [RuleMatcher] that checks if the [identifier][Package.id] of the [package][pkg] belongs to one of the provided
+     * [orgs][Identifier.isFromOrg].
+     */
+    fun isFromOrg(vararg names: String) =
+        object : RuleMatcher {
+            override val description = "isFromOrg(${names.joinToString()})"
+
+            override fun matches() = pkg.id.isFromOrg(*names)
+        }
+
+    /**
+     * A [RuleMatcher] that checks if the [identifier type][Identifier.type] of the [package][pkg] equals [type].
+     */
+    fun isType(type: String) =
+        object : RuleMatcher {
+            override val description = "isType($type)"
+
+            override fun matches() = pkg.id.type == type
+        }
+
+    /**
+     * A DSL function to configure a [LicenseRule] and add it to this rule.
+     */
+    fun licenseRule(name: String, licenseView: LicenseView, block: LicenseRule.() -> Unit) {
+        val licenses = licenseView.licenses(pkg, detectedLicenses.map { it.license })
+
+        licenses.forEach { (license, licenseSource) ->
+            val findings = if (licenseSource == LicenseSource.DETECTED) {
+                ruleSet.ortResult.collectLicenseFindings()[pkg.id].orEmpty()
+            } else {
+                emptyMap()
+            }
+
+            licenseRules += LicenseRule(name, license, licenseSource, findings).apply(block)
+        }
+    }
+
+    /**
+     * A [Rule] to check a single license of the [package][pkg].
+     */
+    inner class LicenseRule(
+        name: String,
+
+        /**
+         * The license to check.
+         */
+        val license: String,
+
+        /**
+         * The source of the license.
+         */
+        val licenseSource: LicenseSource,
+
+        /**
+         * The associated [LicenseFinding]s. Only used if [licenseSource] is [LicenseSource.DETECTED].
+         */
+        val licenseFindings: Map<LicenseFinding, List<PathExclude>> = emptyMap()
+    ) : Rule(ruleSet, name) {
+        override val description = "\tEvaluating license rule '$name' for $licenseSource license '$license'."
+
+        override fun errorSource() = "$name - $license ($licenseSource)"
+
+        /**
+         * A [RuleMatcher] that checks if the [license] is a valid [SpdxLicense].
+         */
+        fun isSpdxLicense() =
+            object : RuleMatcher {
+                override val description = "isSpdxLicense($license)"
+
+                override fun matches() = SpdxLicense.forId(license) != null
+            }
+    }
+}

--- a/evaluator/src/main/kotlin/Rule.kt
+++ b/evaluator/src/main/kotlin/Rule.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.evaluator
+
+import ch.frankel.slf4k.*
+
+import com.here.ort.model.OrtIssue
+import com.here.ort.model.Severity
+import com.here.ort.utils.log
+
+/**
+ * The base class for an evaluator rule. Rules use a set of matchers to determine if they apply, and create a list of
+ * issues which are added to the [ruleSet].
+ */
+abstract class Rule(
+    /**
+     * The [RuleSet] this rule belongs to.
+     */
+    val ruleSet: RuleSet,
+
+    /**
+     * The name of this rule.
+     */
+    val name: String
+) {
+    private val ruleMatcherManager = RuleMatcherManager()
+
+    /**
+     * The list of all matchers that need to match for this rule to apply.
+     */
+    val matchers = mutableListOf<RuleMatcher>()
+
+    /**
+     * The list of all issues created by this rule.
+     */
+    val issues = mutableListOf<OrtIssue>()
+
+    /**
+     * Return a human-readable description of this rule.
+     */
+    abstract val description: String
+
+    /**
+     * Return true if all [matchers] match.
+     */
+    private fun matches() = matchers.all { matcher ->
+        matcher.matches().also { matches ->
+            log.info { "\t${matcher.description} == $matches" }
+            if (!matches) log.info { "\tRule skipped." }
+        }
+    }
+
+    /**
+     * Run this rule by checking if all matchers apply. If this is the case all [issues] configured in this rule are
+     * added to the [ruleSet]. To add custom behavior if the rule matches override [runInternal].
+     */
+    fun run() {
+        log.info { description }
+
+        if (matches()) {
+            ruleSet.issues += issues
+
+            if (issues.isNotEmpty()) {
+                log.info { "\tFound issues:\n\t\t${issues.joinToString("\n\t\t") { "${it.severity}: ${it.message}" }}" }
+            }
+
+            runInternal()
+        }
+    }
+
+    /**
+     * Can be overridden to implement custom behavior, executed if a rule [matches].
+     */
+    open fun runInternal() {}
+
+    /**
+     * DSL function to configure [RuleMatcher]s using a [RuleMatcherManager].
+     */
+    fun require(block: RuleMatcherManager.() -> Unit) {
+        ruleMatcherManager.block()
+    }
+
+    /**
+     * Return a string to be used as [source][OrtIssue.source] for issues generated in [hint], [warning], and [error].
+     */
+    abstract fun errorSource(): String
+
+    /**
+     * Add a [hint][Severity.HINT] to the list of [issues].
+     */
+    fun hint(message: String) {
+        issues += OrtIssue(source = errorSource(), severity = Severity.HINT, message = message)
+    }
+
+    /**
+     * Add a [warning][Severity.WARNING] to the list of [issues].
+     */
+    fun warning(message: String) {
+        issues += OrtIssue(source = errorSource(), severity = Severity.WARNING, message = message)
+    }
+
+    /**
+     * Add an [error][Severity.ERROR] to the list of [issues].
+     */
+    fun error(message: String) {
+        issues += OrtIssue(source = errorSource(), severity = Severity.ERROR, message = message)
+    }
+
+    /**
+     * A DSL helper class, providing convenience functions for adding [RuleMatcher]s to this rule.
+     */
+    inner class RuleMatcherManager {
+        /**
+         * Add a [RuleMatcher] to this rule.
+         */
+        operator fun RuleMatcher.unaryPlus() {
+            matchers += this
+        }
+
+        /**
+         * Add the negation of a [RuleMatcher] to this rule.
+         */
+        operator fun RuleMatcher.unaryMinus() {
+            matchers += Not(this)
+        }
+    }
+}

--- a/evaluator/src/main/kotlin/RuleMatcher.kt
+++ b/evaluator/src/main/kotlin/RuleMatcher.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.evaluator
+
+/**
+ * A rule matcher, used to determine if a [Rule] applies.
+ */
+interface RuleMatcher {
+    /**
+     * A string describing this matcher.
+     */
+    val description: String
+
+    /**
+     * Return true if the rule applies, false otherwise.
+     */
+    fun matches(): Boolean
+}
+
+/**
+ * A [RuleMatcher] that requires all of the provided [matchers] to match.
+ */
+class AllOf(vararg val matchers: RuleMatcher) : RuleMatcher {
+    override val description = "(${matchers.joinToString(" && ") { it.description }})"
+
+    override fun matches() = matchers.all { it.matches() }
+}
+
+/**
+ * A [RuleMatcher] that requires at least one of the provided [matchers] to match.
+ */
+class AnyOf(vararg val matchers: RuleMatcher) : RuleMatcher {
+    override val description = "(${matchers.joinToString(" || ") { it.description }})"
+
+    override fun matches() = matchers.any { it.matches() }
+}
+
+/**
+ * A [RuleMatcher] that inverts the result of the provided [matcher].
+ */
+class Not(val matcher: RuleMatcher) : RuleMatcher {
+    override val description = "!(${matcher.description})"
+
+    override fun matches() = !matcher.matches()
+}

--- a/evaluator/src/main/kotlin/RuleSet.kt
+++ b/evaluator/src/main/kotlin/RuleSet.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.evaluator
+
+import com.here.ort.model.OrtIssue
+import com.here.ort.model.OrtResult
+import com.here.ort.model.Package
+import com.here.ort.model.PackageReference
+import com.here.ort.model.Project
+import com.here.ort.model.Scope
+
+/**
+ * A set of evaluator [Rule]s, using an [ortResult] as input.
+ */
+class RuleSet(val ortResult: OrtResult) {
+    /**
+     * The list of all issues created by the rules of this [RuleSet].
+     */
+    val issues = mutableSetOf<OrtIssue>()
+
+    /**
+     * A DSL function to configure a [PackageRule]. The rule is applied to each [Package] and [Project] contained in
+     * [ortResult].
+     */
+    fun packageRule(name: String, configure: PackageRule.() -> Unit) {
+        val packages = ortResult.analyzer?.result?.let { analyzerResult ->
+            analyzerResult.projects.map { it.toPackage() } + analyzerResult.packages.map { it.pkg }
+        }.orEmpty()
+
+        packages.forEach { pkg ->
+            val licenseFindings = ortResult.collectLicenseFindings()[pkg.id].orEmpty().keys.toList()
+            PackageRule(this, name, pkg, licenseFindings).apply {
+                configure()
+                run()
+            }
+        }
+    }
+
+    /**
+     * A DSL function to configure a [DependencyRule]. The rule is applied to each [PackageReference] from the
+     * dependency trees contained in [ortResult]. If the same dependency appears multiple times in the dependency tree,
+     * the rule will be applied on each occurrence.
+     */
+    fun dependencyRule(name: String, configure: DependencyRule.() -> Unit) {
+        fun traverse(
+            pkgRef: PackageReference,
+            ancestors: List<PackageReference>,
+            level: Int,
+            scope: Scope,
+            project: Project
+        ) {
+            val pkg = ortResult.analyzer?.result?.packages?.find { it.pkg.id == pkgRef.id }?.pkg!!
+            val detectedLicenses = ortResult.collectLicenseFindings()[pkg.id].orEmpty().keys.toList()
+
+            DependencyRule(this, name, pkg, detectedLicenses, pkgRef, ancestors, level, scope, project).apply {
+                configure()
+                run()
+            }
+
+            pkgRef.dependencies.forEach { dependency ->
+                traverse(dependency, listOf(pkgRef) + ancestors, level + 1, scope, project)
+            }
+        }
+
+        ortResult.analyzer?.result?.projects?.forEach { project ->
+            project.scopes.forEach { scope ->
+                scope.dependencies.forEach { pkgRef ->
+                    traverse(pkgRef, emptyList(), 0, scope, project)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * A DSL function to configure a [RuleSet].
+ */
+fun ruleSet(ortResult: OrtResult, configure: RuleSet.() -> Unit) = RuleSet(ortResult).apply(configure)


### PR DESCRIPTION
Add a DSL for describing evaluator rules. This is the first iteration
that likely needs more refactoring in the near future. Documentation
will be added later, once it reaches a stable state.

This is just the API, integration with the evaluator will happen separately.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1452)
<!-- Reviewable:end -->
