### PR TITLE
downloader: Do not enable tests depending on whether tools are installed

### DIFF
--- a/downloader/src/funTest/kotlin/BeanUtilsTest.kt
+++ b/downloader/src/funTest/kotlin/BeanUtilsTest.kt
@@ -19,7 +19,6 @@
 
 package com.here.ort.downloader
 
-import com.here.ort.downloader.vcs.Subversion
 import com.here.ort.model.Identifier
 import com.here.ort.model.Package
 import com.here.ort.model.RemoteArtifact
@@ -46,7 +45,7 @@ class BeanUtilsTest : StringSpec() {
     }
 
     init {
-        "BeanUtils SVN tag should be correctly downloaded".config(enabled = Subversion().isInPath()) {
+        "BeanUtils SVN tag should be correctly downloaded" {
             val vcsFromCuration = VcsInfo(
                 type = "svn",
                 url = "http://svn.apache.org/repos/asf/commons/proper/beanutils",

--- a/downloader/src/funTest/kotlin/CvsDownloadTest.kt
+++ b/downloader/src/funTest/kotlin/CvsDownloadTest.kt
@@ -53,7 +53,7 @@ class CvsDownloadTest : StringSpec() {
     }
 
     init {
-        "CVS can download a given revision".config(enabled = cvs.isInPath(), tags = setOf(ExpensiveTag)) {
+        "CVS can download a given revision".config(tags = setOf(ExpensiveTag)) {
             val pkg = Package.EMPTY.copy(vcsProcessed = VcsInfo("CVS", REPO_URL, REPO_REV))
             val expectedFiles = listOf(
                 "CVS",
@@ -74,7 +74,7 @@ class CvsDownloadTest : StringSpec() {
             buildXmlStatus.stdout should contain("Working revision:\t1.159")
         }
 
-        "CVS can download only a single path".config(enabled = cvs.isInPath(), tags = setOf(ExpensiveTag)) {
+        "CVS can download only a single path".config(tags = setOf(ExpensiveTag)) {
             val pkg = Package.EMPTY.copy(vcsProcessed = VcsInfo("CVS", REPO_URL, REPO_REV, path = REPO_PATH))
             val expectedFiles = listOf(
                 File(REPO_PATH, "changes.xml")
@@ -91,7 +91,7 @@ class CvsDownloadTest : StringSpec() {
             actualFiles.joinToString("\n") shouldBe expectedFiles.joinToString("\n")
         }
 
-        "CVS can download based on a version".config(enabled = cvs.isInPath(), tags = setOf(ExpensiveTag)) {
+        "CVS can download based on a version".config(tags = setOf(ExpensiveTag)) {
             val pkg = Package.EMPTY.copy(
                 id = Identifier("Test:::$REPO_VERSION"),
                 vcsProcessed = VcsInfo("CVS", REPO_URL, "")
@@ -110,7 +110,7 @@ class CvsDownloadTest : StringSpec() {
         }
 
         "CVS can download only a single path based on a version"
-            .config(enabled = cvs.isInPath(), tags = setOf(ExpensiveTag)) {
+            .config(tags = setOf(ExpensiveTag)) {
                 val pkg = Package.EMPTY.copy(
                     id = Identifier("Test:::$REPO_VERSION"),
                     vcsProcessed = VcsInfo("CVS", REPO_URL, "", path = REPO_PATH_FOR_VERSION)

--- a/downloader/src/funTest/kotlin/MercurialDownloadTest.kt
+++ b/downloader/src/funTest/kotlin/MercurialDownloadTest.kt
@@ -52,7 +52,7 @@ class MercurialDownloadTest : StringSpec() {
     }
 
     init {
-        "Mercurial can download a given revision".config(enabled = hg.isInPath(), tags = setOf(ExpensiveTag)) {
+        "Mercurial can download a given revision".config(tags = setOf(ExpensiveTag)) {
             val pkg = Package.EMPTY.copy(vcsProcessed = VcsInfo("Mercurial", REPO_URL, REPO_REV))
             val expectedFiles = listOf(
                 ".hg",
@@ -75,10 +75,7 @@ class MercurialDownloadTest : StringSpec() {
         }
 
         "Mercurial can download only a single path"
-            .config(
-                enabled = hg.isInPath() && hg.isAtLeastVersion("4.3"),
-                tags = setOf(ExpensiveTag)
-            ) {
+            .config(enabled = hg.isAtLeastVersion("4.3"), tags = setOf(ExpensiveTag)) {
                 val pkg = Package.EMPTY.copy(vcsProcessed = VcsInfo("Mercurial", REPO_URL, REPO_REV, path = REPO_PATH))
                 val expectedFiles = listOf(
                     File(".hgsub"), // We always get these configuration files, if present.
@@ -106,7 +103,7 @@ class MercurialDownloadTest : StringSpec() {
                 actualFiles.joinToString("\n") shouldBe expectedFiles.joinToString("\n")
             }
 
-        "Mercurial can download based on a version".config(enabled = hg.isInPath(), tags = setOf(ExpensiveTag)) {
+        "Mercurial can download based on a version".config(tags = setOf(ExpensiveTag)) {
             val pkg = Package.EMPTY.copy(
                 id = Identifier("Test:::$REPO_VERSION"),
                 vcsProcessed = VcsInfo("Mercurial", REPO_URL, "")
@@ -119,10 +116,7 @@ class MercurialDownloadTest : StringSpec() {
         }
 
         "Mercurial can download only a single path based on a version"
-            .config(
-                enabled = hg.isInPath() && hg.isAtLeastVersion("4.3"),
-                tags = setOf(ExpensiveTag)
-            ) {
+            .config(enabled = hg.isAtLeastVersion("4.3"), tags = setOf(ExpensiveTag)) {
                 val pkg = Package.EMPTY.copy(
                     id = Identifier("Test:::$REPO_VERSION"),
                     vcsProcessed = VcsInfo("Mercurial", REPO_URL, "", path = REPO_PATH_FOR_VERSION)

--- a/downloader/src/funTest/kotlin/SubversionDownloadTest.kt
+++ b/downloader/src/funTest/kotlin/SubversionDownloadTest.kt
@@ -54,7 +54,7 @@ class SubversionDownloadTest : StringSpec() {
     }
 
     init {
-        "Subversion can download a given revision".config(enabled = svn.isInPath(), tags = setOf(ExpensiveTag)) {
+        "Subversion can download a given revision".config(tags = setOf(ExpensiveTag)) {
             val pkg = Package.EMPTY.copy(vcsProcessed = VcsInfo("Subversion", REPO_URL, REPO_REV))
             val expectedFiles = listOf(
                 ".svn",
@@ -73,7 +73,7 @@ class SubversionDownloadTest : StringSpec() {
         }
 
         "Subversion can download only a single path"
-            .config(enabled = svn.isInPath(), tags = setOf(ExpensiveTag)) {
+            .config(tags = setOf(ExpensiveTag)) {
                 val pkg = Package.EMPTY.copy(vcsProcessed = VcsInfo("Subversion", REPO_URL, REPO_REV, path = REPO_PATH))
                 val expectedFiles = listOf(
                     "SendMessage.sln",
@@ -94,7 +94,7 @@ class SubversionDownloadTest : StringSpec() {
                 actualFiles.joinToString("\n") shouldBe expectedFiles.joinToString("\n")
             }
 
-        "Subversion can download a given tag".config(enabled = svn.isInPath(), tags = setOf(ExpensiveTag)) {
+        "Subversion can download a given tag".config(tags = setOf(ExpensiveTag)) {
             val pkg = Package.EMPTY.copy(vcsProcessed = VcsInfo("Subversion", REPO_URL, "", path = REPO_TAG))
             val expectedFiles = listOf(
                 "SendMessage.proj",
@@ -113,7 +113,7 @@ class SubversionDownloadTest : StringSpec() {
         }
 
         "Subversion can download based on a version"
-            .config(enabled = svn.isInPath(), tags = setOf(ExpensiveTag)) {
+            .config(tags = setOf(ExpensiveTag)) {
                 val pkg = Package.EMPTY.copy(
                     id = Identifier("Test:::$REPO_VERSION"),
                     vcsProcessed = VcsInfo("Subversion", REPO_URL, "")
@@ -126,7 +126,7 @@ class SubversionDownloadTest : StringSpec() {
             }
 
         "Subversion can download only a single path based on a version"
-            .config(enabled = svn.isInPath(), tags = setOf(ExpensiveTag)) {
+            .config(tags = setOf(ExpensiveTag)) {
                 val pkg = Package.EMPTY.copy(
                     id = Identifier("Test:::$REPO_VERSION"),
                     vcsProcessed = VcsInfo("Subversion", REPO_URL, "", path = REPO_PATH_FOR_VERSION)

--- a/downloader/src/test/kotlin/CvsTest.kt
+++ b/downloader/src/test/kotlin/CvsTest.kt
@@ -48,23 +48,23 @@ class CvsTest : StringSpec() {
     }
 
     init {
-        "Detected CVS version is not empty".config(enabled = cvs.isInPath()) {
+        "Detected CVS version is not empty" {
             val version = cvs.getVersion()
             println("CVS version $version detected.")
             version shouldNotBe ""
         }
 
-        "CVS detects non-working-trees".config(enabled = cvs.isInPath()) {
+        "CVS detects non-working-trees" {
             cvs.getWorkingTree(getUserOrtDirectory()).isValid() shouldBe false
         }
 
-        "CVS correctly detects URLs to remote repositories".config(enabled = cvs.isInPath() && false) {
+        "CVS correctly detects URLs to remote repositories".config(enabled = false) {
             cvs.isApplicableUrl(":pserver:anonymous@tyrex.cvs.sourceforge.net:/cvsroot/tyrex") shouldBe true
             cvs.isApplicableUrl(":ext:jrandom@cvs.foobar.com:/usr/local/cvs") shouldBe true
             cvs.isApplicableUrl("http://svn.code.sf.net/p/grepwin/code/") shouldBe false
         }
 
-        "Detected CVS working tree information is correct".config(enabled = cvs.isInPath() && false) {
+        "Detected CVS working tree information is correct".config(enabled = false) {
             val workingTree = cvs.getWorkingTree(zipContentDir)
 
             workingTree.vcsType shouldBe "Cvs"
@@ -75,7 +75,7 @@ class CvsTest : StringSpec() {
             workingTree.getPathToRoot(File(zipContentDir, "tomcat")) shouldBe "tomcat"
         }
 
-        "CVS correctly lists remote branches".config(enabled = cvs.isInPath() && false) {
+        "CVS correctly lists remote branches".config(enabled = false) {
             val expectedBranches = listOf(
                 "Exoffice"
             )
@@ -84,7 +84,7 @@ class CvsTest : StringSpec() {
             workingTree.listRemoteBranches().joinToString("\n") shouldBe expectedBranches.joinToString("\n")
         }
 
-        "CVS correctly lists remote tags".config(enabled = cvs.isInPath() && false) {
+        "CVS correctly lists remote tags".config(enabled = false) {
             val expectedTags = listOf(
                 "A02",
                 "A03",

--- a/downloader/src/test/kotlin/MercurialTest.kt
+++ b/downloader/src/test/kotlin/MercurialTest.kt
@@ -49,24 +49,24 @@ class MercurialTest : StringSpec() {
     }
 
     init {
-        "Detected Mercurial version is not empty".config(enabled = hg.isInPath()) {
+        "Detected Mercurial version is not empty" {
             val version = hg.getVersion()
             println("Mercurial version $version detected.")
             version shouldNotBe ""
         }
 
-        "Mercurial detects non-working-trees".config(enabled = hg.isInPath()) {
+        "Mercurial detects non-working-trees" {
             hg.getWorkingTree(getUserOrtDirectory()).isValid() shouldBe false
         }
 
-        "Mercurial correctly detects URLs to remote repositories".config(enabled = hg.isInPath()) {
+        "Mercurial correctly detects URLs to remote repositories" {
             hg.isApplicableUrl("https://bitbucket.org/paniq/masagin") shouldBe true
 
             // Bitbucket forwards to ".git" URLs for Git repositories, so we can omit the suffix.
             hg.isApplicableUrl("https://bitbucket.org/yevster/spdxtraxample") shouldBe false
         }
 
-        "Detected Mercurial working tree information is correct".config(enabled = hg.isInPath()) {
+        "Detected Mercurial working tree information is correct" {
             val workingTree = hg.getWorkingTree(zipContentDir)
 
             workingTree.vcsType shouldBe "Mercurial"
@@ -77,7 +77,7 @@ class MercurialTest : StringSpec() {
             workingTree.getPathToRoot(File(zipContentDir, "tests")) shouldBe "tests"
         }
 
-        "Mercurial correctly lists remote branches".config(enabled = hg.isInPath()) {
+        "Mercurial correctly lists remote branches" {
             val expectedBranches = listOf(
                 "default"
             )
@@ -86,7 +86,7 @@ class MercurialTest : StringSpec() {
             workingTree.listRemoteBranches().joinToString("\n") shouldBe expectedBranches.joinToString("\n")
         }
 
-        "Mercurial correctly lists remote tags".config(enabled = hg.isInPath()) {
+        "Mercurial correctly lists remote tags" {
             val expectedTags = listOf(
                 "1.0",
                 "1.0.1",

--- a/downloader/src/test/kotlin/SubversionTest.kt
+++ b/downloader/src/test/kotlin/SubversionTest.kt
@@ -49,22 +49,22 @@ class SubversionTest : StringSpec() {
     }
 
     init {
-        "Detected Subversion version is not empty".config(enabled = svn.isInPath()) {
+        "Detected Subversion version is not empty" {
             val version = svn.getVersion()
             println("Subversion version $version detected.")
             version shouldNotBe ""
         }
 
-        "Subversion detects non-working-trees".config(enabled = svn.isInPath()) {
+        "Subversion detects non-working-trees" {
             svn.getWorkingTree(getUserOrtDirectory()).isValid() shouldBe false
         }
 
-        "Subversion correctly detects URLs to remote repositories".config(enabled = svn.isInPath()) {
+        "Subversion correctly detects URLs to remote repositories" {
             svn.isApplicableUrl("http://svn.code.sf.net/p/grepwin/code/") shouldBe true
             svn.isApplicableUrl("https://bitbucket.org/facebook/lz4revlog") shouldBe false
         }
 
-        "Detected Subversion working tree information is correct".config(enabled = svn.isInPath()) {
+        "Detected Subversion working tree information is correct" {
             val workingTree = svn.getWorkingTree(zipContentDir)
 
             workingTree.vcsType shouldBe "Subversion"
@@ -75,7 +75,7 @@ class SubversionTest : StringSpec() {
             workingTree.getPathToRoot(File(zipContentDir, "docutils")) shouldBe "docutils"
         }
 
-        "Subversion correctly lists remote branches".config(enabled = svn.isInPath()) {
+        "Subversion correctly lists remote branches" {
             val expectedBranches = listOf(
                 "address-rendering",
                 "index-bug",
@@ -89,7 +89,7 @@ class SubversionTest : StringSpec() {
             workingTree.listRemoteBranches().joinToString("\n") shouldBe expectedBranches.joinToString("\n")
         }
 
-        "Subversion correctly lists remote tags".config(enabled = svn.isInPath()) {
+        "Subversion correctly lists remote tags" {
             val expectedTags = listOf(
                 "docutils-0.10",
                 "docutils-0.11",

--- a/downloader/src/test/kotlin/VersionControlSystemTest.kt
+++ b/downloader/src/test/kotlin/VersionControlSystemTest.kt
@@ -19,7 +19,6 @@
 
 package com.here.ort.downloader
 
-import com.here.ort.downloader.vcs.Mercurial
 import com.here.ort.model.VcsInfo
 
 import io.kotlintest.shouldBe
@@ -106,7 +105,7 @@ class VersionControlSystemTest : WordSpec({
     }
 
     "splitUrl for Bitbucket" should {
-        "not modify URLs without a path".config(enabled = Mercurial().isInPath()) {
+        "not modify URLs without a path" {
             val actual = VersionControlSystem.splitUrl(
                 "https://bitbucket.org/paniq/masagin"
             )


### PR DESCRIPTION
This potentially shadows test breakages if a developer / CI has not the
required tool installed. Better fail hard to force installation of the
respective tool to verify the test passes afterwards.

Disabling tests if a tool is not installed was an experiment based on
the discussions in issues #398 and #416, but we decided that not
shadowing any potential test breakages outweights nice looking reports
for seemingly passing test suites with skipped test cases.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1453)
<!-- Reviewable:end -->
