### PR TITLE
analyzer: Remove `Yaml` from `YamlFilePackageCurationProvider`

### DIFF
--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -110,7 +110,7 @@ class Analyzer(private val config: AnalyzerConfiguration) {
             val results = manager.resolveDependencies(absoluteProjectPath, files)
 
             val curatedResults = packageCurationsFile?.let {
-                val provider = YamlFilePackageCurationProvider(it)
+                val provider = FilePackageCurationProvider(it)
                 results.mapValues { entry ->
                     ProjectAnalyzerResult(
                         project = entry.value.project,

--- a/analyzer/src/main/kotlin/FilePackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/FilePackageCurationProvider.kt
@@ -21,14 +21,16 @@ package com.here.ort.analyzer
 
 import com.here.ort.model.Identifier
 import com.here.ort.model.PackageCuration
+import com.here.ort.model.OutputFormat
 import com.here.ort.model.readValue
 
 import java.io.File
 
 /**
- * A [PackageCurationProvider] that loads [PackageCuration]s from a single YAML file.
+ * A [PackageCurationProvider] that loads [PackageCuration]s from a single file. Supports all file formats specified
+ * in [OutputFormat].
  */
-class YamlFilePackageCurationProvider(
+class FilePackageCurationProvider(
     curationFile: File
 ) : PackageCurationProvider {
     internal val packageCurations: List<PackageCuration> by lazy {

--- a/analyzer/src/test/kotlin/FilePackageCurationProviderTest.kt
+++ b/analyzer/src/test/kotlin/FilePackageCurationProviderTest.kt
@@ -29,18 +29,18 @@ import io.kotlintest.specs.StringSpec
 
 import java.io.File
 
-class YamlFilePackageCurationProviderTest : StringSpec() {
+class FilePackageCurationProviderTest : StringSpec() {
     private val curationsFile = File("src/test/assets/package-curations.yml")
 
     init {
         "Provider can read YAML file" {
-            val provider = YamlFilePackageCurationProvider(curationsFile)
+            val provider = FilePackageCurationProvider(curationsFile)
 
             provider.packageCurations should haveSize(8)
         }
 
         "Provider returns only matching curations for a fixed version" {
-            val provider = YamlFilePackageCurationProvider(curationsFile)
+            val provider = FilePackageCurationProvider(curationsFile)
 
             val identifier = Identifier("maven", "org.hamcrest", "hamcrest-core", "1.3")
             val curations = provider.getCurationsFor(identifier)
@@ -55,7 +55,7 @@ class YamlFilePackageCurationProviderTest : StringSpec() {
         }
 
         "Provider returns only matching curations for a version range" {
-            val provider = YamlFilePackageCurationProvider(curationsFile)
+            val provider = FilePackageCurationProvider(curationsFile)
 
             val idMinVersion = Identifier("npm", "", "ramda", "0.21.0")
             val idMaxVersion = Identifier("npm", "", "ramda", "0.25.0")


### PR DESCRIPTION
Rename `YamlFilePackageCurationProvider` to `FilePackageCurationProvider`,
because the provider can also read JSON and XML files, so the old name was
giving the false impression that only YAML files are supported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1454)
<!-- Reviewable:end -->
