### PR TITLE
PackageManager: Use {} for an empty function body

### DIFF
--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -181,7 +181,7 @@ abstract class PackageManager(
     /**
      * Optional preparation step for dependency resolution, like checking for prerequisites.
      */
-    protected open fun prepareResolution(definitionFiles: List<File>) = Unit
+    protected open fun prepareResolution(definitionFiles: List<File>) {}
 
     /**
      * Return a tree of resolved dependencies (not necessarily declared dependencies, in case conflicts were resolved)


### PR DESCRIPTION
Because Martin likes that better than "= Unit" :-)

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1458)
<!-- Reviewable:end -->
