### PR TITLE
Upgrade ScanCode to version 3.0.2

### DIFF
--- a/scanner/src/main/kotlin/scanners/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/ScanCode.kt
@@ -207,7 +207,7 @@ class ScanCode(name: String, config: ScannerConfiguration) : LocalScanner(name, 
         }
     }
 
-    override val scannerVersion = "2.9.7"
+    override val scannerVersion = "3.0.2"
     override val resultFileExt = "json"
 
     private val scanCodeConfiguration = config.scanner?.get("ScanCode") ?: emptyMap()
@@ -343,8 +343,20 @@ class ScanCode(name: String, config: ScannerConfiguration) : LocalScanner(name, 
             EMPTY_JSON_NODE
         }
 
+    private fun getFileCount(result: JsonNode): Int {
+        // Handling for ScanCode 2.9.8 and above.
+        result["headers"]?.forEach { header ->
+            header["extra_data"]?.get("files_count")?.let {
+                return it.intValue()
+            }
+        }
+
+        // Handling for ScanCode 2.9.7 and below.
+        return result["files_count"].intValue()
+    }
+
     override fun generateSummary(startTime: Instant, endTime: Instant, result: JsonNode): ScanSummary {
-        val fileCount = result["files_count"].intValue()
+        val fileCount = getFileCount(result)
         val findings = associateFindings(result)
         val errors = mutableListOf<OrtIssue>()
 


### PR DESCRIPTION
See https://github.com/nexB/scancode-toolkit/releases/tag/v3.0.2

The ScanCode result JSON format was changed a bit: a json array
named `headers` has been added and the `files_count` node has been
moved underneath it. Adding a fallback to compute that value based
on the distinct paths keeps backwards compatibility.

Signed-off-by: Frank Viernau <frank.viernau@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1467)
<!-- Reviewable:end -->
