### PR TITLE
GitRepo: Re-introduce "--no-repo-verify" to avoid the dependency on GPG

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
@@ -36,6 +36,11 @@ repository:
       url: "https://github.com/fb55/entities.git"
       revision: "54a5717d85d886c4aafa2ac5ff83d8d3d730337c"
       path: ""
+    submodules/test-data-npm/long.js:
+      type: "Git"
+      url: "https://github.com/dcodeIO/long.js.git"
+      revision: "941c5c62471168b5d18153755c2a7b38d2560e58"
+      path: ""
   config: {}
 analyzer:
   start_time: "1970-01-01T00:00:00Z"
@@ -50,6 +55,29 @@ analyzer:
     allow_dynamic_versions: false
   result:
     projects:
+    - id: "Bower::long:4.0.0"
+      purl: "pkg://Bower//long@4.0.0"
+      definition_file_path: "bower.json"
+      declared_licenses:
+      - "Apache-2.0"
+      declared_licenses_processed:
+        spdx_expression: "Apache-2.0"
+      vcs:
+        type: ""
+        url: ""
+        revision: ""
+        path: ""
+      vcs_processed:
+        type: "git"
+        url: "https://github.com/dcodeIO/long.js.git"
+        revision: "941c5c62471168b5d18153755c2a7b38d2560e58"
+        path: ""
+      homepage_url: ""
+      scopes:
+      - name: "dependencies"
+        dependencies: []
+      - name: "devDependencies"
+        dependencies: []
     - id: "Maven:org.apache.commons:commons-text:1.6"
       purl: "pkg://Maven/org.apache.commons/commons-text@1.6"
       definition_file_path: "pom.xml"
@@ -874,6 +902,23 @@ analyzer:
             dependencies:
             - id: "NPM::editions:1.3.4"
             - id: "NPM::graceful-fs:4.1.15"
+    - id: "NPM::submodules/test-data-npm/long.js/package.json:"
+      purl: "pkg://NPM//submodules%2Ftest-data-npm%2Flong.js%2Fpackage.json@"
+      definition_file_path: "package.json"
+      declared_licenses: []
+      declared_licenses_processed: {}
+      vcs:
+        type: ""
+        url: ""
+        revision: ""
+        path: ""
+      vcs_processed:
+        type: "git"
+        url: "https://github.com/dcodeIO/long.js.git"
+        revision: "941c5c62471168b5d18153755c2a7b38d2560e58"
+        path: ""
+      homepage_url: ""
+      scopes: []
     - id: "Unmanaged:manifest.xml:manifest:<REPLACE_REVISION>"
       purl: "pkg://Unmanaged/manifest.xml/manifest@<REPLACE_REVISION>"
       definition_file_path: ""
@@ -8339,6 +8384,14 @@ analyzer:
           revision: ""
           path: "types/node"
       curations: []
-    has_errors: false
+    errors:
+      'NPM::submodules/test-data-npm/long.js/package.json:':
+      - timestamp: "1970-01-01T00:00:00Z"
+        source: "NPM"
+        message: "IllegalArgumentException: No lockfile found in 'submodules/test-data-npm/long.js'.\
+          \ This potentially results in unstable versions of dependencies. To allow\
+          \ this, enable support for dynamic versions."
+        severity: "ERROR"
+    has_errors: true
 scanner: null
 evaluator: null

--- a/analyzer/src/funTest/kotlin/vcs/GitRepoTest.kt
+++ b/analyzer/src/funTest/kotlin/vcs/GitRepoTest.kt
@@ -70,14 +70,13 @@ class GitRepoTest : StringSpec() {
         }
 
         "GitRepo correctly lists submodules" {
-            // TODO: The list below should also contain "submodules/test-data-npm/long.js", but it is not correctly
-            //       cloned by git-repo.
             val expectedSubmodules = listOf(
                 "spdx-tools",
                 "submodules",
                 "submodules/commons-text",
                 "submodules/test-data-npm",
-                "submodules/test-data-npm/entities"
+                "submodules/test-data-npm/entities",
+                "submodules/test-data-npm/long.js"
             ).associateWith { VersionControlSystem.getPathInfo(File(outputDir, it)) }
 
             val workingTree = GitRepo().getWorkingTree(outputDir)

--- a/downloader/src/main/kotlin/vcs/GitRepo.kt
+++ b/downloader/src/main/kotlin/vcs/GitRepo.kt
@@ -107,8 +107,8 @@ class GitRepo : GitBase() {
 
             // Clone all projects instead of only those in the "default" group until we support specifying groups.
             runRepoCommand(
-                targetDir, "init", "--groups=all", "-b", revision, "-u", pkg.vcsProcessed.url,
-                "-m", manifestPath
+                targetDir, "init", "--groups=all", "--no-repo-verify", "-b", revision,
+                "-u", pkg.vcsProcessed.url, "-m", manifestPath
             )
 
             // Repo allows to checkout Git repositories to nested directories. If a manifest is badly configured, a

--- a/downloader/src/main/kotlin/vcs/GitRepo.kt
+++ b/downloader/src/main/kotlin/vcs/GitRepo.kt
@@ -38,7 +38,7 @@ import java.io.IOException
 /**
  * The branch of git-repo to use. This allows to override git-repo's default of using the "stable" branch.
  */
-const val GIT_REPO_BRANCH = "stable"
+const val GIT_REPO_BRANCH = "master"
 
 class GitRepo : GitBase() {
     override val aliases = listOf("git-repo", "repo")

--- a/downloader/src/main/kotlin/vcs/GitRepo.kt
+++ b/downloader/src/main/kotlin/vcs/GitRepo.kt
@@ -35,6 +35,11 @@ import com.here.ort.utils.searchUpwardsForSubdirectory
 import java.io.File
 import java.io.IOException
 
+/**
+ * The branch of git-repo to use. This allows to override git-repo's default of using the "stable" branch.
+ */
+const val GIT_REPO_BRANCH = "stable"
+
 class GitRepo : GitBase() {
     override val aliases = listOf("git-repo", "repo")
     override val priority: Int = 50
@@ -107,8 +112,12 @@ class GitRepo : GitBase() {
 
             // Clone all projects instead of only those in the "default" group until we support specifying groups.
             runRepoCommand(
-                targetDir, "init", "--groups=all", "--no-repo-verify", "-b", revision,
-                "-u", pkg.vcsProcessed.url, "-m", manifestPath
+                targetDir,
+                "init", "--groups=all", "--no-repo-verify",
+                "--no-clone-bundle", "--repo-branch=$GIT_REPO_BRANCH",
+                "-b", revision,
+                "-u", pkg.vcsProcessed.url,
+                "-m", manifestPath
             )
 
             // Repo allows to checkout Git repositories to nested directories. If a manifest is badly configured, a


### PR DESCRIPTION
This argument was accidentally removed in 8191aa8.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1469)
<!-- Reviewable:end -->
