### PR TITLE
analyzer: Store the analyzer root already at the PackageManager level

### DIFF
--- a/analyzer/src/funTest/kotlin/BabelTest.kt
+++ b/analyzer/src/funTest/kotlin/BabelTest.kt
@@ -67,12 +67,13 @@ class BabelTest : WordSpec() {
                     url = normalizeVcsUrl(vcsUrl),
                     revision = vcsRevision
                 )
-                val actualResult = createNPM().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+                val actualResult = createNPM().resolveDependencies(listOf(packageFile))[packageFile]
 
                 patchActualResult(yamlMapper.writeValueAsString(actualResult)) shouldBe expectedResult
             }
         }
     }
 
-    private fun createNPM() = NPM("NPM", DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
+    private fun createNPM() =
+        NPM("NPM", USER_DIR, DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/funTest/kotlin/BowerTest.kt
+++ b/analyzer/src/funTest/kotlin/BowerTest.kt
@@ -54,7 +54,7 @@ class BowerTest : StringSpec() {
                 url = normalizeVcsUrl(vcsUrl)
             )
 
-            val result = createBower().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val result = createBower().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors should beEmpty()
@@ -62,5 +62,6 @@ class BowerTest : StringSpec() {
         }
     }
 
-    private fun createBower() = Bower("Bower", DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
+    private fun createBower() =
+        Bower("Bower", USER_DIR, DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/funTest/kotlin/BundlerTest.kt
+++ b/analyzer/src/funTest/kotlin/BundlerTest.kt
@@ -49,8 +49,7 @@ class BundlerTest : WordSpec() {
                 val definitionFile = File(projectsDir, "lockfile/Gemfile")
 
                 try {
-                    val actualResult = createBundler()
-                        .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+                    val actualResult = createBundler().resolveDependencies(listOf(definitionFile))[definitionFile]
                     val expectedResult = patchExpectedResult(
                         File(projectsDir.parentFile, "bundler-expected-output-lockfile.yml"),
                         url = normalizeVcsUrl(vcsUrl),
@@ -66,7 +65,7 @@ class BundlerTest : WordSpec() {
 
             "show error if no lockfile is present" {
                 val definitionFile = File(projectsDir, "no-lockfile/Gemfile")
-                val actualResult = createBundler().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+                val actualResult = createBundler().resolveDependencies(listOf(definitionFile))[definitionFile]
 
                 actualResult shouldNotBe null
                 actualResult!!.project.id shouldBe
@@ -82,8 +81,7 @@ class BundlerTest : WordSpec() {
                 val definitionFile = File(projectsDir, "gemspec/Gemfile")
 
                 try {
-                    val actualResult = createBundler()
-                        .resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+                    val actualResult = createBundler().resolveDependencies(listOf(definitionFile))[definitionFile]
                     val expectedResult = patchExpectedResult(
                         File(projectsDir.parentFile, "bundler-expected-output-gemspec.yml"),
                         url = normalizeVcsUrl(vcsUrl),
@@ -99,5 +97,6 @@ class BundlerTest : WordSpec() {
         }
     }
 
-    private fun createBundler() = Bundler("Bundler", DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
+    private fun createBundler() =
+        Bundler("Bundler", USER_DIR, DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/funTest/kotlin/DotNetTest.kt
+++ b/analyzer/src/funTest/kotlin/DotNetTest.kt
@@ -60,8 +60,7 @@ class DotNetTest : StringSpec() {
                 revision = vcsRevision,
                 path = "$vcsPath/subProjectTest"
             )
-            val result = DotNet("DotNet", DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val result = createDotNet().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors should beEmpty()
@@ -77,4 +76,7 @@ class DotNetTest : StringSpec() {
             result[1].packageReference?.size shouldBe 2
         }
     }
+
+    private fun createDotNet() =
+        DotNet("DotNet", USER_DIR, DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/funTest/kotlin/GoDepTest.kt
+++ b/analyzer/src/funTest/kotlin/GoDepTest.kt
@@ -44,7 +44,7 @@ class GoDepTest : WordSpec() {
         "GoDep" should {
             "resolve dependencies from a lockfile correctly" {
                 val manifestFile = File(projectsDir, "external/qmstr/Gopkg.toml")
-                val result = createGoDep().resolveDependencies(USER_DIR, listOf(manifestFile))[manifestFile]
+                val result = createGoDep().resolveDependencies(listOf(manifestFile))[manifestFile]
                 val expectedResult = File(projectsDir, "external/qmstr-expected-output.yml").readText()
 
                 yamlMapper.writeValueAsString(result) shouldBe expectedResult
@@ -52,7 +52,7 @@ class GoDepTest : WordSpec() {
 
             "show error if no lockfile is present" {
                 val manifestFile = File(projectsDir, "synthetic/godep/no-lockfile/Gopkg.toml")
-                val result = createGoDep().resolveDependencies(USER_DIR, listOf(manifestFile))[manifestFile]
+                val result = createGoDep().resolveDependencies(listOf(manifestFile))[manifestFile]
 
                 result shouldNotBe null
                 result!!.project.id shouldBe
@@ -67,7 +67,7 @@ class GoDepTest : WordSpec() {
             "invoke the dependency solver if no lockfile is present and allowDynamicVersions is set" {
                 val manifestFile = File(projectsDir, "synthetic/godep/no-lockfile/Gopkg.toml")
                 val config = AnalyzerConfiguration(ignoreToolVersions = false, allowDynamicVersions = true)
-                val result = createGoDep(config).resolveDependencies(USER_DIR, listOf(manifestFile))[manifestFile]
+                val result = createGoDep(config).resolveDependencies(listOf(manifestFile))[manifestFile]
 
                 result shouldNotBe null
                 result!!.project shouldNotBe Project.EMPTY
@@ -77,7 +77,7 @@ class GoDepTest : WordSpec() {
 
             "import dependencies from Glide" {
                 val manifestFile = File(projectsDir, "external/sprig/glide.yaml")
-                val result = createGoDep().resolveDependencies(USER_DIR, listOf(manifestFile))[manifestFile]
+                val result = createGoDep().resolveDependencies(listOf(manifestFile))[manifestFile]
                 val expectedResult = File(projectsDir, "external/sprig-expected-output.yml").readText()
 
                 yamlMapper.writeValueAsString(result) shouldBe expectedResult
@@ -85,7 +85,7 @@ class GoDepTest : WordSpec() {
 
             "import dependencies from godeps" {
                 val manifestFile = File(projectsDir, "external/godep/Godeps/Godeps.json")
-                val result = createGoDep().resolveDependencies(USER_DIR, listOf(manifestFile))[manifestFile]
+                val result = createGoDep().resolveDependencies(listOf(manifestFile))[manifestFile]
                 val expectedResult = File(projectsDir, "external/godep-expected-output.yml").readText()
 
                 yamlMapper.writeValueAsString(result) shouldBe expectedResult
@@ -114,5 +114,5 @@ class GoDepTest : WordSpec() {
     }
 
     private fun createGoDep(config: AnalyzerConfiguration = DEFAULT_ANALYZER_CONFIGURATION) =
-        GoDep("GoDep", config, DEFAULT_REPOSITORY_CONFIGURATION)
+        GoDep("GoDep", USER_DIR, config, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/funTest/kotlin/GradleAndroidTest.kt
+++ b/analyzer/src/funTest/kotlin/GradleAndroidTest.kt
@@ -50,7 +50,7 @@ class GradleAndroidTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val result = createGradle().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -65,7 +65,7 @@ class GradleAndroidTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val result = createGradle().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -80,7 +80,7 @@ class GradleAndroidTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val result = createGradle().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -88,5 +88,6 @@ class GradleAndroidTest : StringSpec() {
         }
     }
 
-    private fun createGradle() = Gradle("Gradle", DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
+    private fun createGradle() =
+        Gradle("Gradle", USER_DIR, DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/funTest/kotlin/GradleKotlinScriptTest.kt
+++ b/analyzer/src/funTest/kotlin/GradleKotlinScriptTest.kt
@@ -49,7 +49,7 @@ class GradleKotlinScriptTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val result = createGradle().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -64,7 +64,7 @@ class GradleKotlinScriptTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val result = createGradle().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -79,7 +79,7 @@ class GradleKotlinScriptTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val result = createGradle().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -87,5 +87,6 @@ class GradleKotlinScriptTest : StringSpec() {
         }
     }
 
-    private fun createGradle() = Gradle("Gradle", DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
+    private fun createGradle() =
+        Gradle("Gradle", USER_DIR, DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/funTest/kotlin/GradleLibraryTest.kt
+++ b/analyzer/src/funTest/kotlin/GradleLibraryTest.kt
@@ -49,7 +49,7 @@ class GradleLibraryTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val result = createGradle().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -64,7 +64,7 @@ class GradleLibraryTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val result = createGradle().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -79,7 +79,7 @@ class GradleLibraryTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val result = createGradle().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -87,5 +87,6 @@ class GradleLibraryTest : StringSpec() {
         }
     }
 
-    private fun createGradle() = Gradle("Gradle", DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
+    private fun createGradle() =
+        Gradle("Gradle", USER_DIR, DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/funTest/kotlin/GradleTest.kt
+++ b/analyzer/src/funTest/kotlin/GradleTest.kt
@@ -66,7 +66,7 @@ class GradleTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val result = createGradle().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -81,7 +81,7 @@ class GradleTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val result = createGradle().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -96,7 +96,7 @@ class GradleTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val result = createGradle().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -111,7 +111,7 @@ class GradleTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val result = createGradle().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors shouldBe emptyList()
@@ -126,7 +126,7 @@ class GradleTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val result = createGradle().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
@@ -182,7 +182,7 @@ class GradleTest : StringSpec() {
                     revision = vcsRevision
                 )
 
-                val result = createGradle().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+                val result = createGradle().resolveDependencies(listOf(packageFile))[packageFile]
 
                 result shouldNotBe null
                 result!!.errors shouldBe emptyList()
@@ -208,5 +208,6 @@ class GradleTest : StringSpec() {
             .requireSuccess()
     }
 
-    private fun createGradle() = Gradle("Gradle", DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
+    private fun createGradle() =
+        Gradle("Gradle", USER_DIR, DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/funTest/kotlin/MavenTest.kt
+++ b/analyzer/src/funTest/kotlin/MavenTest.kt
@@ -47,7 +47,7 @@ class MavenTest : StringSpec() {
             val pomFile = File(projectDir, "pom.xml")
             val expectedResult = File(projectDir.parentFile, "jgnash-expected-output.yml").readText()
 
-            val result = createMaven().resolveDependencies(USER_DIR, listOf(pomFile))[pomFile]
+            val result = createMaven().resolveDependencies(listOf(pomFile))[pomFile]
 
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
@@ -63,7 +63,7 @@ class MavenTest : StringSpec() {
             // jgnash-core depends on jgnash-resources, so we also have to pass the pom.xml of jgnash-resources to
             // resolveDependencies so that it is available in the Maven.projectsByIdentifier cache. Otherwise resolution
             // of transitive dependencies would not work.
-            val result = createMaven().resolveDependencies(USER_DIR, listOf(pomFileCore, pomFileResources))[pomFileCore]
+            val result = createMaven().resolveDependencies(listOf(pomFileCore, pomFileResources))[pomFileCore]
 
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
@@ -76,7 +76,7 @@ class MavenTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createMaven().resolveDependencies(USER_DIR, listOf(pomFile))[pomFile]
+            val result = createMaven().resolveDependencies(listOf(pomFile))[pomFile]
 
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
@@ -93,7 +93,7 @@ class MavenTest : StringSpec() {
             // app depends on lib, so we also have to pass the pom.xml of lib to resolveDependencies so that it is
             // available in the Maven.projectsByIdentifier cache. Otherwise resolution of transitive dependencies would
             // not work.
-            val result = createMaven().resolveDependencies(USER_DIR, listOf(pomFileApp, pomFileLib))[pomFileApp]
+            val result = createMaven().resolveDependencies(listOf(pomFileApp, pomFileLib))[pomFileApp]
 
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
@@ -106,7 +106,7 @@ class MavenTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createMaven().resolveDependencies(USER_DIR, listOf(pomFile))[pomFile]
+            val result = createMaven().resolveDependencies(listOf(pomFile))[pomFile]
 
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
@@ -125,11 +125,12 @@ class MavenTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createMaven().resolveDependencies(USER_DIR, listOf(pomFile))[pomFile]
+            val result = createMaven().resolveDependencies(listOf(pomFile))[pomFile]
 
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
     }
 
-    private fun createMaven() = Maven("Maven", DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
+    private fun createMaven() =
+        Maven("Maven", USER_DIR, DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/funTest/kotlin/NpmTest.kt
+++ b/analyzer/src/funTest/kotlin/NpmTest.kt
@@ -63,7 +63,7 @@ class NpmTest : WordSpec() {
                 val workingDir = File(projectsDir, "shrinkwrap")
                 val packageFile = File(workingDir, "package.json")
 
-                val result = createNPM().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+                val result = createNPM().resolveDependencies(listOf(packageFile))[packageFile]
                 val vcsPath = vcsDir.getPathToRoot(workingDir)
                 val expectedResult = patchExpectedResult(
                     File(projectsDir.parentFile, "npm-expected-output.yml"),
@@ -81,7 +81,7 @@ class NpmTest : WordSpec() {
                 val workingDir = File(projectsDir, "package-lock")
                 val packageFile = File(workingDir, "package.json")
 
-                val result = createNPM().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+                val result = createNPM().resolveDependencies(listOf(packageFile))[packageFile]
                 val vcsPath = vcsDir.getPathToRoot(workingDir)
                 val expectedResult = patchExpectedResult(
                     File(projectsDir.parentFile, "npm-expected-output.yml"),
@@ -99,7 +99,7 @@ class NpmTest : WordSpec() {
                 val workingDir = File(projectsDir, "no-lockfile")
                 val packageFile = File(workingDir, "package.json")
 
-                val result = createNPM().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+                val result = createNPM().resolveDependencies(listOf(packageFile))[packageFile]
                 val vcsPath = vcsDir.getPathToRoot(workingDir)
                 val expectedResult = patchExpectedResult(
                     File(projectsDir.parentFile, "npm-expected-output-no-lockfile.yml"),
@@ -117,7 +117,7 @@ class NpmTest : WordSpec() {
                 val workingDir = File(projectsDir, "node-modules")
                 val packageFile = File(workingDir, "package.json")
 
-                val result = createNPM().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+                val result = createNPM().resolveDependencies(listOf(packageFile))[packageFile]
                 val vcsPath = vcsDir.getPathToRoot(workingDir)
                 val expectedResult = patchExpectedResult(
                     File(projectsDir.parentFile, "npm-expected-output.yml"),
@@ -133,5 +133,6 @@ class NpmTest : WordSpec() {
         }
     }
 
-    private fun createNPM() = NPM("NPM", DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
+    private fun createNPM() =
+        NPM("NPM", USER_DIR, DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/funTest/kotlin/NpmVersionUrlTest.kt
+++ b/analyzer/src/funTest/kotlin/NpmVersionUrlTest.kt
@@ -59,7 +59,7 @@ class NpmVersionUrlTest : WordSpec() {
                 val packageFile = File(projectDir, "package.json")
 
                 val config = AnalyzerConfiguration(ignoreToolVersions = false, allowDynamicVersions = true)
-                val result = createNPM(config).resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+                val result = createNPM(config).resolveDependencies(listOf(packageFile))[packageFile]
                 val vcsPath = vcsDir.getPathToRoot(projectDir)
                 val expectedResult = patchExpectedResult(
                     File(projectDir.parentFile, "npm-version-urls-expected-output.yml"),
@@ -75,5 +75,5 @@ class NpmVersionUrlTest : WordSpec() {
     }
 
     private fun createNPM(config: AnalyzerConfiguration = DEFAULT_ANALYZER_CONFIGURATION) =
-        NPM("NPM", config, DEFAULT_REPOSITORY_CONFIGURATION)
+        NPM("NPM", USER_DIR, config, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/funTest/kotlin/NuGetTest.kt
+++ b/analyzer/src/funTest/kotlin/NuGetTest.kt
@@ -60,8 +60,7 @@ class NuGetTest : StringSpec() {
                 revision = vcsRevision,
                 path = vcsPath
             )
-            val result = NuGet("NuGet", DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                .resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+            val result = createNuGet().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
             result!!.errors should beEmpty()
@@ -77,4 +76,7 @@ class NuGetTest : StringSpec() {
             result.packages?.size shouldBe 2
         }
     }
+
+    private fun createNuGet() =
+        NuGet("NuGet", USER_DIR, DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/funTest/kotlin/PhpComposerTest.kt
+++ b/analyzer/src/funTest/kotlin/PhpComposerTest.kt
@@ -47,7 +47,7 @@ class PhpComposerTest : StringSpec() {
         "Project dependencies are detected correctly" {
             val definitionFile = File(projectsDir, "lockfile/composer.json")
 
-            val result = createPhpComposer().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+            val result = createPhpComposer().resolveDependencies(listOf(definitionFile))[definitionFile]
             val expectedResults = patchExpectedResult(
                 File(projectsDir.parentFile, "php-composer-expected-output.yml"),
                 url = normalizeVcsUrl(vcsUrl),
@@ -60,7 +60,7 @@ class PhpComposerTest : StringSpec() {
 
         "Error is shown when no lock file is present" {
             val definitionFile = File(projectsDir, "no-lockfile/composer.json")
-            val result = createPhpComposer().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+            val result = createPhpComposer().resolveDependencies(listOf(definitionFile))[definitionFile]
 
             result shouldNotBe null
             result!!.project.id shouldBe Identifier(
@@ -77,7 +77,7 @@ class PhpComposerTest : StringSpec() {
         "No composer.lock is required for projects without dependencies" {
             val definitionFile = File(projectsDir, "no-deps/composer.json")
 
-            val result = createPhpComposer().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+            val result = createPhpComposer().resolveDependencies(listOf(definitionFile))[definitionFile]
             val expectedResults = patchExpectedResult(
                 File(projectsDir.parentFile, "php-composer-expected-output-no-deps.yml"),
                 definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
@@ -92,7 +92,7 @@ class PhpComposerTest : StringSpec() {
         "No composer.lock is required for projects with empty dependencies" {
             val definitionFile = File(projectsDir, "empty-deps/composer.json")
 
-            val result = createPhpComposer().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+            val result = createPhpComposer().resolveDependencies(listOf(definitionFile))[definitionFile]
             val expectedResults = patchExpectedResult(
                 File(projectsDir.parentFile, "php-composer-expected-output-no-deps.yml"),
                 definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
@@ -107,7 +107,7 @@ class PhpComposerTest : StringSpec() {
         "Packages defined as provided are not reported as missing" {
             val definitionFile = File(projectsDir, "with-provide/composer.json")
 
-            val result = createPhpComposer().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+            val result = createPhpComposer().resolveDependencies(listOf(definitionFile))[definitionFile]
             val expectedResults = patchExpectedResult(
                 File(projectsDir.parentFile, "php-composer-expected-output-with-provide.yml"),
                 url = normalizeVcsUrl(vcsUrl),
@@ -121,7 +121,7 @@ class PhpComposerTest : StringSpec() {
         "Packages defined as replaced are not reported as missing" {
             val definitionFile = File(projectsDir, "with-replace/composer.json")
 
-            val result = createPhpComposer().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+            val result = createPhpComposer().resolveDependencies(listOf(definitionFile))[definitionFile]
             val expectedResults = patchExpectedResult(
                 File(projectsDir.parentFile, "php-composer-expected-output-with-replace.yml"),
                 url = normalizeVcsUrl(vcsUrl),
@@ -134,5 +134,5 @@ class PhpComposerTest : StringSpec() {
     }
 
     private fun createPhpComposer() =
-        PhpComposer("PhpComposer", DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
+        PhpComposer("PhpComposer", USER_DIR, DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/funTest/kotlin/PipTest.kt
+++ b/analyzer/src/funTest/kotlin/PipTest.kt
@@ -44,7 +44,7 @@ class PipTest : WordSpec() {
             "resolve setup.py dependencies correctly for spdx-tools-python" {
                 val definitionFile = File(projectsDir, "external/spdx-tools-python/setup.py")
 
-                val result = createPIP().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+                val result = createPIP().resolveDependencies(listOf(definitionFile))[definitionFile]
                 val expectedResult = File(projectsDir, "external/spdx-tools-python-expected-output.yml").readText()
 
                 yamlMapper.writeValueAsString(result) shouldBe expectedResult
@@ -53,7 +53,7 @@ class PipTest : WordSpec() {
             "resolve requirements.txt dependencies correctly for example-python-flask" {
                 val definitionFile = File(projectsDir, "external/example-python-flask/requirements.txt")
 
-                val result = createPIP().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+                val result = createPIP().resolveDependencies(listOf(definitionFile))[definitionFile]
                 val expectedResult = File(projectsDir, "external/example-python-flask-expected-output.yml").readText()
 
                 yamlMapper.writeValueAsString(result) shouldBe expectedResult
@@ -70,7 +70,7 @@ class PipTest : WordSpec() {
                     path = vcsPath
                 )
 
-                val result = createPIP().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+                val result = createPIP().resolveDependencies(listOf(definitionFile))[definitionFile]
 
                 yamlMapper.writeValueAsString(result) shouldBe expectedResult
             }
@@ -81,7 +81,7 @@ class PipTest : WordSpec() {
                 val definitionFile = File(projectsDir, "synthetic/python3-django/requirements.txt")
                 val vcsPath = vcsDir.getPathToRoot(definitionFile.parentFile)
 
-                val result = createPIP().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+                val result = createPIP().resolveDependencies(listOf(definitionFile))[definitionFile]
                 val expectedResultFile = File(projectsDir, "synthetic/python3-django-expected-output.yml")
                 val expectedResult = patchExpectedResult(
                     expectedResultFile,
@@ -95,5 +95,6 @@ class PipTest : WordSpec() {
         }
     }
 
-    private fun createPIP() = PIP("PIP", DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
+    private fun createPIP() =
+        PIP("PIP", USER_DIR, DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/funTest/kotlin/StackTest.kt
+++ b/analyzer/src/funTest/kotlin/StackTest.kt
@@ -63,7 +63,7 @@ class StackTest : StringSpec() {
         "Dependencies should be resolved correctly for quickcheck-state-machine" {
             val definitionFile = File(projectsDir, "external/quickcheck-state-machine/stack.yaml")
 
-            val result = createStack().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+            val result = createStack().resolveDependencies(listOf(definitionFile))[definitionFile]
             val expectedOutput = if (OS.isWindows) {
                 "external/quickcheck-state-machine-expected-output-win32.yml"
             } else {
@@ -78,7 +78,7 @@ class StackTest : StringSpec() {
         "Dependencies should be resolved correctly for quickcheck-state-machine-example" {
             val definitionFile = File(projectsDir, "external/quickcheck-state-machine/example/stack.yaml")
 
-            val result = createStack().resolveDependencies(USER_DIR, listOf(definitionFile))[definitionFile]
+            val result = createStack().resolveDependencies(listOf(definitionFile))[definitionFile]
             val expectedOutput = if (OS.isWindows) {
                 "external/quickcheck-state-machine-example-expected-output-win32.yml"
             } else {
@@ -91,5 +91,6 @@ class StackTest : StringSpec() {
         }
     }
 
-    private fun createStack() = Stack("Stack", DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
+    private fun createStack() =
+        Stack("Stack", USER_DIR, DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/funTest/kotlin/YarnTest.kt
+++ b/analyzer/src/funTest/kotlin/YarnTest.kt
@@ -60,7 +60,7 @@ class YarnTest : WordSpec() {
         "yarn" should {
             "resolve dependencies correctly" {
                 val packageFile = File(projectDir, "package.json")
-                val result = createYarn().resolveDependencies(USER_DIR, listOf(packageFile))[packageFile]
+                val result = createYarn().resolveDependencies(listOf(packageFile))[packageFile]
                 val vcsPath = vcsDir.getPathToRoot(projectDir)
                 val expectedResult = patchExpectedResult(
                     File(projectDir.parentFile, "yarn-expected-output.yml"),
@@ -75,5 +75,6 @@ class YarnTest : WordSpec() {
         }
     }
 
-    private fun createYarn() = Yarn("Yarn", DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
+    private fun createYarn() =
+        Yarn("Yarn", USER_DIR, DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/funTest/kotlin/integration/AbstractIntegrationSpec.kt
+++ b/analyzer/src/funTest/kotlin/integration/AbstractIntegrationSpec.kt
@@ -116,8 +116,8 @@ abstract class AbstractIntegrationSpec : StringSpec() {
         "Analyzer creates one non-empty result per definition file".config(tags = setOf(ExpensiveTag)) {
             managedFilesForTest.forEach { manager, files ->
                 println("Resolving $manager dependencies in $files.")
-                val results = manager.create(DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
-                    .resolveDependencies(USER_DIR, files)
+                val results = manager.create(USER_DIR, DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
+                    .resolveDependencies(files)
 
                 results.size shouldBe files.size
                 results.values.forEach { result ->

--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -87,7 +87,7 @@ class Analyzer(private val config: AnalyzerConfiguration) {
         }
 
         val managedFiles = factoryFiles.mapNotNull { (factory, files) ->
-            val manager = factory.create(config, repositoryConfiguration)
+            val manager = factory.create(absoluteProjectPath, config, repositoryConfiguration)
             val mappedFiles = manager.mapDefinitionFiles(files)
             Pair(manager, mappedFiles).takeIf { mappedFiles.isNotEmpty() }
         }.toMap()
@@ -107,7 +107,7 @@ class Analyzer(private val config: AnalyzerConfiguration) {
 
         // Resolve dependencies per package manager.
         managedFiles.forEach { manager, files ->
-            val results = manager.resolveDependencies(absoluteProjectPath, files)
+            val results = manager.resolveDependencies(files)
 
             val curatedResults = packageCurationsFile?.let {
                 val provider = FilePackageCurationProvider(it)

--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -52,11 +52,13 @@ typealias ResolutionResult = MutableMap<File, ProjectAnalyzerResult>
  * A class representing a package manager that handles software dependencies.
  *
  * @param managerName The package manager's name.
+ * @param analyzerRoot The root directory of the analysis.
  * @param analyzerConfig The configuration of the analyzer to use.
  * @param repoConfig The configuration of the repository to use.
  */
 abstract class PackageManager(
     val managerName: String,
+    protected val analyzerRoot: File,
     protected val analyzerConfig: AnalyzerConfiguration,
     protected val repoConfig: RepositoryConfiguration
 ) {
@@ -187,7 +189,7 @@ abstract class PackageManager(
      * Return a tree of resolved dependencies (not necessarily declared dependencies, in case conflicts were resolved)
      * for all [definitionFiles] which were found by searching the [analyzerRoot] directory.
      */
-    open fun resolveDependencies(analyzerRoot: File, definitionFiles: List<File>): ResolutionResult {
+    open fun resolveDependencies(definitionFiles: List<File>): ResolutionResult {
         val result = mutableMapOf<File, ProjectAnalyzerResult>()
 
         prepareResolution(definitionFiles)

--- a/analyzer/src/main/kotlin/PackageManagerFactory.kt
+++ b/analyzer/src/main/kotlin/PackageManagerFactory.kt
@@ -22,6 +22,7 @@ package com.here.ort.analyzer
 import com.here.ort.model.config.AnalyzerConfiguration
 import com.here.ort.model.config.RepositoryConfiguration
 
+import java.io.File
 import java.nio.file.FileSystems
 import java.nio.file.PathMatcher
 import java.util.ServiceLoader
@@ -41,9 +42,14 @@ interface PackageManagerFactory {
     val matchersForDefinitionFiles: List<PathMatcher>
 
     /**
-     * Create a [PackageManager] using the specified [analyzerConfig] and [repoConfig].
+     * Create a [PackageManager] for analyzing the [analyzerRoot] directory using the specified [analyzerConfig] and
+     * [repoConfig].
      */
-    fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration): PackageManager
+    fun create(
+        analyzerRoot: File,
+        analyzerConfig: AnalyzerConfiguration,
+        repoConfig: RepositoryConfiguration
+    ): PackageManager
 }
 
 /**
@@ -64,7 +70,11 @@ abstract class AbstractPackageManagerFactory<out T : PackageManager>(
         }
     }
 
-    abstract override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration): T
+    abstract override fun create(
+        analyzerRoot: File,
+        analyzerConfig: AnalyzerConfiguration,
+        repoConfig: RepositoryConfiguration
+    ): T
 
     /**
      * Return the package manager's name here to allow JCommander to display something meaningful when listing the

--- a/analyzer/src/main/kotlin/managers/Bower.kt
+++ b/analyzer/src/main/kotlin/managers/Bower.kt
@@ -54,8 +54,13 @@ import java.util.Stack
 /**
  * The [Bower](https://bower.io/) package manager for JavaScript.
  */
-class Bower(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
-    PackageManager(name, analyzerConfig, repoConfig), CommandLineTool {
+class Bower(
+    name: String,
+    analyzerRoot: File,
+    analyzerConfig: AnalyzerConfiguration,
+    repoConfig: RepositoryConfiguration
+) :
+    PackageManager(name, analyzerRoot, analyzerConfig, repoConfig), CommandLineTool {
     companion object {
         // We do not actually depend on any features specific to this Bower version, but we still want to
         // stick to fixed versions to be sure to get consistent results.
@@ -204,8 +209,12 @@ class Bower(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: Rep
     class Factory : AbstractPackageManagerFactory<Bower>("Bower") {
         override val globsForDefinitionFiles = listOf("bower.json")
 
-        override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
-            Bower(managerName, analyzerConfig, repoConfig)
+        override fun create(
+            analyzerRoot: File,
+            analyzerConfig: AnalyzerConfiguration,
+            repoConfig: RepositoryConfiguration
+        ) =
+            Bower(managerName, analyzerRoot, analyzerConfig, repoConfig)
     }
 
     override fun command(workingDir: File?) = if (OS.isWindows) "bower.cmd" else "bower"

--- a/analyzer/src/main/kotlin/managers/Bundler.kt
+++ b/analyzer/src/main/kotlin/managers/Bundler.kt
@@ -65,13 +65,22 @@ import okhttp3.Request
  *
  * [1]: http://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/
  */
-class Bundler(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
-    PackageManager(name, analyzerConfig, repoConfig), CommandLineTool {
+class Bundler(
+    name: String,
+    analyzerRoot: File,
+    analyzerConfig: AnalyzerConfiguration,
+    repoConfig: RepositoryConfiguration
+) :
+    PackageManager(name, analyzerRoot, analyzerConfig, repoConfig), CommandLineTool {
     class Factory : AbstractPackageManagerFactory<Bundler>("Bundler") {
         override val globsForDefinitionFiles = listOf("Gemfile")
 
-        override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
-            Bundler(managerName, analyzerConfig, repoConfig)
+        override fun create(
+            analyzerRoot: File,
+            analyzerConfig: AnalyzerConfiguration,
+            repoConfig: RepositoryConfiguration
+        ) =
+            Bundler(managerName, analyzerRoot, analyzerConfig, repoConfig)
     }
 
     override fun command(workingDir: File?) = if (OS.isWindows) "bundle.bat" else "bundle"

--- a/analyzer/src/main/kotlin/managers/CocoaPods.kt
+++ b/analyzer/src/main/kotlin/managers/CocoaPods.kt
@@ -30,13 +30,22 @@ import java.io.File
 /**
  * The [CocoaPods](https://cocoapods.org/) package manager for Objective-C.
  */
-class CocoaPods(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
-    PackageManager(name, analyzerConfig, repoConfig) {
+class CocoaPods(
+    name: String,
+    analyzerRoot: File,
+    analyzerConfig: AnalyzerConfiguration,
+    repoConfig: RepositoryConfiguration
+) :
+    PackageManager(name, analyzerRoot, analyzerConfig, repoConfig) {
     class Factory : AbstractPackageManagerFactory<CocoaPods>("CocoaPods") {
         override val globsForDefinitionFiles = listOf("Podfile.lock", "Podfile")
 
-        override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
-            CocoaPods(managerName, analyzerConfig, repoConfig)
+        override fun create(
+            analyzerRoot: File,
+            analyzerConfig: AnalyzerConfiguration,
+            repoConfig: RepositoryConfiguration
+        ) =
+            CocoaPods(managerName, analyzerRoot, analyzerConfig, repoConfig)
     }
 
     override fun resolveDependencies(definitionFile: File): ProjectAnalyzerResult? {

--- a/analyzer/src/main/kotlin/managers/DotNet.kt
+++ b/analyzer/src/main/kotlin/managers/DotNet.kt
@@ -44,8 +44,13 @@ import java.io.File
 /**
  * The [DotNet](https://docs.microsoft.com/en-us/dotnet/core/tools/) package manager for .NET.
  */
-class DotNet(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
-    PackageManager(name, analyzerConfig, repoConfig) {
+class DotNet(
+    name: String,
+    analyzerRoot: File,
+    analyzerConfig: AnalyzerConfiguration,
+    repoConfig: RepositoryConfiguration
+) :
+    PackageManager(name, analyzerRoot, analyzerConfig, repoConfig) {
     companion object {
         fun mapPackageReferences(workingDir: File): Map<String, String> {
             val map = mutableMapOf<String, String>()
@@ -84,8 +89,12 @@ class DotNet(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: Re
     class Factory : AbstractPackageManagerFactory<DotNet>("DotNet") {
         override val globsForDefinitionFiles = listOf("*.csproj")
 
-        override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
-            DotNet(managerName, analyzerConfig, repoConfig)
+        override fun create(
+            analyzerRoot: File,
+            analyzerConfig: AnalyzerConfiguration,
+            repoConfig: RepositoryConfiguration
+        ) =
+            DotNet(managerName, analyzerRoot, analyzerConfig, repoConfig)
     }
 
     override fun resolveDependencies(definitionFile: File): ProjectAnalyzerResult? {

--- a/analyzer/src/main/kotlin/managers/GoDep.kt
+++ b/analyzer/src/main/kotlin/managers/GoDep.kt
@@ -63,13 +63,22 @@ val GO_LEGACY_MANIFESTS = mapOf(
 /**
  * The [Dep](https://golang.github.io/dep/) package manager for Go.
  */
-class GoDep(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
-    PackageManager(name, analyzerConfig, repoConfig), CommandLineTool {
+class GoDep(
+    name: String,
+    analyzerRoot: File,
+    analyzerConfig: AnalyzerConfiguration,
+    repoConfig: RepositoryConfiguration
+) :
+    PackageManager(name, analyzerRoot, analyzerConfig, repoConfig), CommandLineTool {
     class Factory : AbstractPackageManagerFactory<GoDep>("GoDep") {
         override val globsForDefinitionFiles = listOf("Gopkg.toml", *GO_LEGACY_MANIFESTS.keys.toTypedArray())
 
-        override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
-            GoDep(managerName, analyzerConfig, repoConfig)
+        override fun create(
+            analyzerRoot: File,
+            analyzerConfig: AnalyzerConfiguration,
+            repoConfig: RepositoryConfiguration
+        ) =
+            GoDep(managerName, analyzerRoot, analyzerConfig, repoConfig)
     }
 
     override fun command(workingDir: File?) = "dep"

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -61,8 +61,13 @@ import org.gradle.tooling.GradleConnector
 /**
  * The [Gradle](https://gradle.org/) package manager for Java.
  */
-class Gradle(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
-    PackageManager(name, analyzerConfig, repoConfig) {
+class Gradle(
+    name: String,
+    analyzerRoot: File,
+    analyzerConfig: AnalyzerConfiguration,
+    repoConfig: RepositoryConfiguration
+) :
+    PackageManager(name, analyzerRoot, analyzerConfig, repoConfig) {
     class Factory : AbstractPackageManagerFactory<Gradle>("Gradle") {
         // Gradle prefers Groovy ".gradle" files over Kotlin ".gradle.kts" files, but "build" files have to come before
         // "settings" files as we should consider "settings" files only if the same directory does not also contain a
@@ -72,8 +77,12 @@ class Gradle(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: Re
             "settings.gradle", "settings.gradle.kts"
         )
 
-        override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
-            Gradle(managerName, analyzerConfig, repoConfig)
+        override fun create(
+            analyzerRoot: File,
+            analyzerConfig: AnalyzerConfiguration,
+            repoConfig: RepositoryConfiguration
+        ) =
+            Gradle(managerName, analyzerRoot, analyzerConfig, repoConfig)
     }
 
     /**

--- a/analyzer/src/main/kotlin/managers/Maven.kt
+++ b/analyzer/src/main/kotlin/managers/Maven.kt
@@ -55,13 +55,22 @@ import org.eclipse.aether.repository.WorkspaceRepository
 /**
  * The [Maven](https://maven.apache.org/) package manager for Java.
  */
-class Maven(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
-    PackageManager(name, analyzerConfig, repoConfig) {
+class Maven(
+    name: String,
+    analyzerRoot: File,
+    analyzerConfig: AnalyzerConfiguration,
+    repoConfig: RepositoryConfiguration
+) :
+    PackageManager(name, analyzerRoot, analyzerConfig, repoConfig) {
     class Factory : AbstractPackageManagerFactory<Maven>("Maven") {
         override val globsForDefinitionFiles = listOf("pom.xml")
 
-        override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
-            Maven(managerName, analyzerConfig, repoConfig)
+        override fun create(
+            analyzerRoot: File,
+            analyzerConfig: AnalyzerConfiguration,
+            repoConfig: RepositoryConfiguration
+        ) =
+            Maven(managerName, analyzerRoot, analyzerConfig, repoConfig)
     }
 
     private inner class LocalProjectWorkspaceReader : WorkspaceReader {

--- a/analyzer/src/main/kotlin/managers/NPM.kt
+++ b/analyzer/src/main/kotlin/managers/NPM.kt
@@ -67,8 +67,13 @@ import okhttp3.Request
 /**
  * The [Node package manager](https://www.npmjs.com/) for JavaScript.
  */
-open class NPM(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
-    PackageManager(name, analyzerConfig, repoConfig), CommandLineTool {
+open class NPM(
+    name: String,
+    analyzerRoot: File,
+    analyzerConfig: AnalyzerConfiguration,
+    repoConfig: RepositoryConfiguration
+) :
+    PackageManager(name, analyzerRoot, analyzerConfig, repoConfig), CommandLineTool {
     companion object {
         /**
          * Expand NPM shortcuts for URLs to hosting sites to full URLs so that they can be used in a regular way.
@@ -113,8 +118,12 @@ open class NPM(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: 
     class Factory : AbstractPackageManagerFactory<NPM>("NPM") {
         override val globsForDefinitionFiles = listOf("package.json")
 
-        override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
-            NPM(managerName, analyzerConfig, repoConfig)
+        override fun create(
+            analyzerRoot: File,
+            analyzerConfig: AnalyzerConfiguration,
+            repoConfig: RepositoryConfiguration
+        ) =
+            NPM(managerName, analyzerRoot, analyzerConfig, repoConfig)
     }
 
     /**

--- a/analyzer/src/main/kotlin/managers/NuGet.kt
+++ b/analyzer/src/main/kotlin/managers/NuGet.kt
@@ -44,8 +44,13 @@ import java.io.File
 /**
  * The [NuGet](https://www.nuget.org/) package manager for .NET.
  */
-class NuGet(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
-    PackageManager(name, analyzerConfig, repoConfig) {
+class NuGet(
+    name: String,
+    analyzerRoot: File,
+    analyzerConfig: AnalyzerConfiguration,
+    repoConfig: RepositoryConfiguration
+) :
+    PackageManager(name, analyzerRoot, analyzerConfig, repoConfig) {
     companion object {
         fun mapPackageReferences(workingDir: File): Map<String, String> {
             val map = mutableMapOf<String, String>()
@@ -78,8 +83,12 @@ class NuGet(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: Rep
     class Factory : AbstractPackageManagerFactory<NuGet>("NuGet") {
         override val globsForDefinitionFiles = listOf("packages.config")
 
-        override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
-            NuGet(managerName, analyzerConfig, repoConfig)
+        override fun create(
+            analyzerRoot: File,
+            analyzerConfig: AnalyzerConfiguration,
+            repoConfig: RepositoryConfiguration
+        ) =
+            NuGet(managerName, analyzerRoot, analyzerConfig, repoConfig)
     }
 
     override fun resolveDependencies(definitionFile: File): ProjectAnalyzerResult? {

--- a/analyzer/src/main/kotlin/managers/PIP.kt
+++ b/analyzer/src/main/kotlin/managers/PIP.kt
@@ -134,13 +134,22 @@ object PythonVersion : CommandLineTool {
  * [install_requires vs requirements files](https://packaging.python.org/discussions/install-requires-vs-requirements/)
  * and [setup.py vs. requirements.txt](https://caremad.io/posts/2013/07/setup-vs-requirement/).
  */
-class PIP(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
-    PackageManager(name, analyzerConfig, repoConfig), CommandLineTool {
+class PIP(
+    name: String,
+    analyzerRoot: File,
+    analyzerConfig: AnalyzerConfiguration,
+    repoConfig: RepositoryConfiguration
+) :
+    PackageManager(name, analyzerRoot, analyzerConfig, repoConfig), CommandLineTool {
     class Factory : AbstractPackageManagerFactory<PIP>("PIP") {
         override val globsForDefinitionFiles = listOf("requirements*.txt", "setup.py")
 
-        override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
-            PIP(managerName, analyzerConfig, repoConfig)
+        override fun create(
+            analyzerRoot: File,
+            analyzerConfig: AnalyzerConfiguration,
+            repoConfig: RepositoryConfiguration
+        ) =
+            PIP(managerName, analyzerRoot, analyzerConfig, repoConfig)
     }
 
     companion object {

--- a/analyzer/src/main/kotlin/managers/PhpComposer.kt
+++ b/analyzer/src/main/kotlin/managers/PhpComposer.kt
@@ -61,13 +61,22 @@ const val COMPOSER_LOCK_FILE = "composer.lock"
 /**
  * The [Composer](https://getcomposer.org/) package manager for PHP.
  */
-class PhpComposer(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
-    PackageManager(name, analyzerConfig, repoConfig), CommandLineTool {
+class PhpComposer(
+    name: String,
+    analyzerRoot: File,
+    analyzerConfig: AnalyzerConfiguration,
+    repoConfig: RepositoryConfiguration
+) :
+    PackageManager(name, analyzerRoot, analyzerConfig, repoConfig), CommandLineTool {
     class Factory : AbstractPackageManagerFactory<PhpComposer>("PhpComposer") {
         override val globsForDefinitionFiles = listOf("composer.json")
 
-        override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
-            PhpComposer(managerName, analyzerConfig, repoConfig)
+        override fun create(
+            analyzerRoot: File,
+            analyzerConfig: AnalyzerConfiguration,
+            repoConfig: RepositoryConfiguration
+        ) =
+            PhpComposer(managerName, analyzerRoot, analyzerConfig, repoConfig)
     }
 
     override fun command(workingDir: File?) =

--- a/analyzer/src/main/kotlin/managers/SBT.kt
+++ b/analyzer/src/main/kotlin/managers/SBT.kt
@@ -41,8 +41,13 @@ import java.util.Properties
 /**
  * The [SBT](https://www.scala-sbt.org/) package manager for Scala.
  */
-class SBT(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
-    PackageManager(name, analyzerConfig, repoConfig), CommandLineTool {
+class SBT(
+    name: String,
+    analyzerRoot: File,
+    analyzerConfig: AnalyzerConfiguration,
+    repoConfig: RepositoryConfiguration
+) :
+    PackageManager(name, analyzerRoot, analyzerConfig, repoConfig), CommandLineTool {
     companion object {
         private val VERSION_REGEX = Regex("\\[info]\\s+(\\d+\\.\\d+\\.[^\\s]+)")
         private val PROJECT_REGEX = Regex("\\[info] \t [ *] (.+)")
@@ -65,8 +70,12 @@ class SBT(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: Repos
     class Factory : AbstractPackageManagerFactory<SBT>("SBT") {
         override val globsForDefinitionFiles = listOf("build.sbt", "build.scala")
 
-        override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
-            SBT(managerName, analyzerConfig, repoConfig)
+        override fun create(
+            analyzerRoot: File,
+            analyzerConfig: AnalyzerConfiguration,
+            repoConfig: RepositoryConfiguration
+        ) =
+            SBT(managerName, analyzerRoot, analyzerConfig, repoConfig)
     }
 
     override fun command(workingDir: File?) = if (OS.isWindows) "sbt.bat" else "sbt"
@@ -180,11 +189,11 @@ class SBT(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: Repos
         }
     }
 
-    override fun resolveDependencies(analyzerRoot: File, definitionFiles: List<File>) =
+    override fun resolveDependencies(definitionFiles: List<File>) =
     // Simply pass on the list of POM files to Maven, ignoring the SBT build files here.
-        Maven(managerName, analyzerConfig, repoConfig)
+        Maven(managerName, analyzerRoot, analyzerConfig, repoConfig)
             .enableSbtMode()
-            .resolveDependencies(analyzerRoot, definitionFiles)
+            .resolveDependencies(definitionFiles)
 
     override fun resolveDependencies(definitionFile: File) =
     // This is not implemented in favor over overriding [resolveDependencies].

--- a/analyzer/src/main/kotlin/managers/Stack.kt
+++ b/analyzer/src/main/kotlin/managers/Stack.kt
@@ -56,13 +56,22 @@ import okhttp3.Request
 /**
  * The [Stack](https://haskellstack.org/) package manager for Haskell.
  */
-class Stack(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
-    PackageManager(name, analyzerConfig, repoConfig), CommandLineTool {
+class Stack(
+    name: String,
+    analyzerRoot: File,
+    analyzerConfig: AnalyzerConfiguration,
+    repoConfig: RepositoryConfiguration
+) :
+    PackageManager(name, analyzerRoot, analyzerConfig, repoConfig), CommandLineTool {
     class Factory : AbstractPackageManagerFactory<Stack>("Stack") {
         override val globsForDefinitionFiles = listOf("stack.yaml")
 
-        override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
-            Stack(managerName, analyzerConfig, repoConfig)
+        override fun create(
+            analyzerRoot: File,
+            analyzerConfig: AnalyzerConfiguration,
+            repoConfig: RepositoryConfiguration
+        ) =
+            Stack(managerName, analyzerRoot, analyzerConfig, repoConfig)
     }
 
     override fun command(workingDir: File?) = "stack"

--- a/analyzer/src/main/kotlin/managers/Unmanaged.kt
+++ b/analyzer/src/main/kotlin/managers/Unmanaged.kt
@@ -37,13 +37,22 @@ import java.io.File
 /**
  * A fake [PackageManager] for projects that do not use any of the known package managers.
  */
-class Unmanaged(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
-    PackageManager(name, analyzerConfig, repoConfig) {
+class Unmanaged(
+    name: String,
+    analyzerRoot: File,
+    analyzerConfig: AnalyzerConfiguration,
+    repoConfig: RepositoryConfiguration
+) :
+    PackageManager(name, analyzerRoot, analyzerConfig, repoConfig) {
     class Factory : AbstractPackageManagerFactory<Unmanaged>("Unmanaged") {
         override val globsForDefinitionFiles = emptyList<String>()
 
-        override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
-            Unmanaged(managerName, analyzerConfig, repoConfig)
+        override fun create(
+            analyzerRoot: File,
+            analyzerConfig: AnalyzerConfiguration,
+            repoConfig: RepositoryConfiguration
+        ) =
+            Unmanaged(managerName, analyzerRoot, analyzerConfig, repoConfig)
     }
 
     /**

--- a/analyzer/src/main/kotlin/managers/Yarn.kt
+++ b/analyzer/src/main/kotlin/managers/Yarn.kt
@@ -32,13 +32,22 @@ import java.io.File
 /**
  * The [Yarn](https://www.yarnpkg.com/) package manager for JavaScript.
  */
-class Yarn(name: String, analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) :
-    NPM(name, analyzerConfig, repoConfig) {
+class Yarn(
+    name: String,
+    analyzerRoot: File,
+    analyzerConfig: AnalyzerConfiguration,
+    repoConfig: RepositoryConfiguration
+) :
+    NPM(name, analyzerRoot, analyzerConfig, repoConfig) {
     class Factory : AbstractPackageManagerFactory<Yarn>("Yarn") {
         override val globsForDefinitionFiles = listOf("package.json")
 
-        override fun create(analyzerConfig: AnalyzerConfiguration, repoConfig: RepositoryConfiguration) =
-            Yarn(managerName, analyzerConfig, repoConfig)
+        override fun create(
+            analyzerRoot: File,
+            analyzerConfig: AnalyzerConfiguration,
+            repoConfig: RepositoryConfiguration
+        ) =
+            Yarn(managerName, analyzerRoot, analyzerConfig, repoConfig)
     }
 
     override val installParameters = arrayOf("--ignore-scripts", "--ignore-engines")


### PR DESCRIPTION
The analyzer root is useful to know to create relative paths inside a
package manager implementation. Avoid passing it on as a function
parameter of resolveDependencies() by storing it as a class property
inside the PackageManager.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1472)
<!-- Reviewable:end -->
