### PR TITLE
OrtResult: Make sure replaceConfig() keeps the custom data

### DIFF
--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -328,5 +328,6 @@ data class OrtResult(
     /**
      * Return a copy of this [OrtResult] with the [Repository.config] replaced by [config].
      */
-    fun replaceConfig(config: RepositoryConfiguration) = copy(repository = repository.copy(config = config))
+    fun replaceConfig(config: RepositoryConfiguration): OrtResult =
+        copy(repository = repository.copy(config = config)).also { it.data += data }
 }


### PR DESCRIPTION
The auto-generated copy function does not adhere to the data attribute
as it is not declared via the primary constructor.
Manually copy that data in order to ensure that replaceConfig() does
nothing in addition to just replacing the config.

This fixes up d824a743.

Signed-off-by: Frank Viernau <frank.viernau@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1479)
<!-- Reviewable:end -->
