### PR TITLE
DotNet/NuGet: Make some types non-nullable

### DIFF
--- a/analyzer/src/funTest/kotlin/NuGetTest.kt
+++ b/analyzer/src/funTest/kotlin/NuGetTest.kt
@@ -73,7 +73,7 @@ class NuGetTest : StringSpec() {
 
             result shouldNotBe null
             result.packages shouldNotBe null
-            result.packages?.size shouldBe 2
+            result.packages.size shouldBe 2
         }
     }
 

--- a/analyzer/src/main/kotlin/managers/DotNet.kt
+++ b/analyzer/src/main/kotlin/managers/DotNet.kt
@@ -59,7 +59,7 @@ class DotNet(
             itemGroups.forEach { itemGroup ->
                 itemGroup.packageReference?.forEach {
                     if (!it.include.isNullOrEmpty()) {
-                        map[it.include] = it.version ?: " "
+                        map[it.include] = it.version
                     }
                 }
             }
@@ -90,9 +90,9 @@ class DotNet(
     @JsonIgnoreProperties(ignoreUnknown = true)
     data class PackageReference(
         @JacksonXmlProperty(isAttribute = true, localName = "Include")
-        val include: String?,
+        val include: String,
         @JacksonXmlProperty(isAttribute = true, localName = "Version")
-        val version: String?
+        val version: String
     )
 
     override fun resolveDependencies(definitionFile: File): ProjectAnalyzerResult? {

--- a/analyzer/src/main/kotlin/managers/NuGet.kt
+++ b/analyzer/src/main/kotlin/managers/NuGet.kt
@@ -56,7 +56,7 @@ class NuGet(
             val mapper = XmlMapper().registerKotlinModule()
             val packagesConfig = mapper.readValue<PackagesConfig>(definitionFile)
 
-            packagesConfig.packages?.forEach {
+            packagesConfig.packages.forEach {
                 map[it.id] = it.version
             }
 
@@ -80,7 +80,7 @@ class NuGet(
     data class PackagesConfig(
         @JsonProperty(value = "package")
         @JacksonXmlElementWrapper(useWrapping = false)
-        val packages: List<Package>?
+        val packages: List<Package>
     )
 
     @JsonIgnoreProperties(ignoreUnknown = true)


### PR DESCRIPTION
Because they do not have to be, which simplifies the code.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1485)
<!-- Reviewable:end -->
