### PR TITLE
Rename all upper-case acrynom classes to camel-case

### DIFF
--- a/analyzer/src/funTest/kotlin/BabelTest.kt
+++ b/analyzer/src/funTest/kotlin/BabelTest.kt
@@ -19,7 +19,7 @@
 
 package com.here.ort.analyzer
 
-import com.here.ort.analyzer.managers.NPM
+import com.here.ort.analyzer.managers.Npm
 import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
@@ -75,5 +75,5 @@ class BabelTest : WordSpec() {
     }
 
     private fun createNPM() =
-        NPM("NPM", USER_DIR, DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
+        Npm("NPM", USER_DIR, DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/funTest/kotlin/GradleTest.kt
+++ b/analyzer/src/funTest/kotlin/GradleTest.kt
@@ -23,7 +23,7 @@ import com.here.ort.analyzer.managers.Gradle
 import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.downloader.vcs.Git
 import com.here.ort.model.yamlMapper
-import com.here.ort.utils.OS
+import com.here.ort.utils.Os
 import com.here.ort.utils.ProcessCapture
 import com.here.ort.utils.normalizeVcsUrl
 import com.here.ort.utils.test.DEFAULT_ANALYZER_CONFIGURATION
@@ -199,7 +199,7 @@ class GradleTest : StringSpec() {
     private fun installGradleWrapper(version: String) {
         println("Installing Gradle wrapper version $version.")
 
-        val (gradle, wrapper) = if (OS.isWindows) {
+        val (gradle, wrapper) = if (Os.isWindows) {
             Pair("gradle.bat", projectDir.resolve("gradlew.bat"))
         } else {
             Pair("gradle", projectDir.resolve("gradlew"))

--- a/analyzer/src/funTest/kotlin/NpmTest.kt
+++ b/analyzer/src/funTest/kotlin/NpmTest.kt
@@ -19,7 +19,7 @@
 
 package com.here.ort.analyzer
 
-import com.here.ort.analyzer.managers.NPM
+import com.here.ort.analyzer.managers.Npm
 import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
@@ -134,5 +134,5 @@ class NpmTest : WordSpec() {
     }
 
     private fun createNPM() =
-        NPM("NPM", USER_DIR, DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
+        Npm("NPM", USER_DIR, DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/funTest/kotlin/NpmVersionUrlTest.kt
+++ b/analyzer/src/funTest/kotlin/NpmVersionUrlTest.kt
@@ -19,7 +19,7 @@
 
 package com.here.ort.analyzer
 
-import com.here.ort.analyzer.managers.NPM
+import com.here.ort.analyzer.managers.Npm
 import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.config.AnalyzerConfiguration
 import com.here.ort.model.yamlMapper
@@ -75,5 +75,5 @@ class NpmVersionUrlTest : WordSpec() {
     }
 
     private fun createNPM(config: AnalyzerConfiguration = DEFAULT_ANALYZER_CONFIGURATION) =
-        NPM("NPM", USER_DIR, config, DEFAULT_REPOSITORY_CONFIGURATION)
+        Npm("NPM", USER_DIR, config, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/funTest/kotlin/PipTest.kt
+++ b/analyzer/src/funTest/kotlin/PipTest.kt
@@ -19,7 +19,7 @@
 
 package com.here.ort.analyzer
 
-import com.here.ort.analyzer.managers.PIP
+import com.here.ort.analyzer.managers.Pip
 import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.normalizeVcsUrl
@@ -96,5 +96,5 @@ class PipTest : WordSpec() {
     }
 
     private fun createPIP() =
-        PIP("PIP", USER_DIR, DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
+        Pip("PIP", USER_DIR, DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
 }

--- a/analyzer/src/funTest/kotlin/SbtTest.kt
+++ b/analyzer/src/funTest/kotlin/SbtTest.kt
@@ -19,7 +19,7 @@
 
 package com.here.ort.analyzer
 
-import com.here.ort.analyzer.managers.SBT
+import com.here.ort.analyzer.managers.Sbt
 import com.here.ort.downloader.vcs.Git
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.test.DEFAULT_ANALYZER_CONFIGURATION
@@ -40,7 +40,7 @@ class SbtTest : StringSpec({
         // Clean any previously generated POM files / target directories.
         Git().run(projectDir, "clean", "-fd")
 
-        val ortResult = Analyzer(DEFAULT_ANALYZER_CONFIGURATION).analyze(projectDir, listOf(SBT.Factory()))
+        val ortResult = Analyzer(DEFAULT_ANALYZER_CONFIGURATION).analyze(projectDir, listOf(Sbt.Factory()))
 
         val actualResult = yamlMapper.writeValueAsString(ortResult)
         val expectedResult = patchExpectedResult(expectedOutputFile)
@@ -56,7 +56,7 @@ class SbtTest : StringSpec({
         // Clean any previously generated POM files / target directories.
         Git().run(projectDir, "clean", "-fd")
 
-        val ortResult = Analyzer(DEFAULT_ANALYZER_CONFIGURATION).analyze(projectDir, listOf(SBT.Factory()))
+        val ortResult = Analyzer(DEFAULT_ANALYZER_CONFIGURATION).analyze(projectDir, listOf(Sbt.Factory()))
 
         val actualResult = yamlMapper.writeValueAsString(ortResult)
         val expectedResult = patchExpectedResult(expectedOutputFile)

--- a/analyzer/src/funTest/kotlin/StackTest.kt
+++ b/analyzer/src/funTest/kotlin/StackTest.kt
@@ -21,8 +21,8 @@ package com.here.ort.analyzer
 
 import com.here.ort.analyzer.managers.Stack
 import com.here.ort.model.yamlMapper
-import com.here.ort.utils.CI
-import com.here.ort.utils.OS
+import com.here.ort.utils.Ci
+import com.here.ort.utils.Os
 import com.here.ort.utils.ProcessCapture
 import com.here.ort.utils.getPathFromEnvironment
 import com.here.ort.utils.test.DEFAULT_ANALYZER_CONFIGURATION
@@ -44,12 +44,12 @@ class StackTest : StringSpec() {
         // Only install GHC, which takes along time, if we really are running this test until
         // https://github.com/commercialhaskell/stack/issues/4390 is resolved.
         if (getPathFromEnvironment("stack") == null) {
-            if (CI.isAppVeyor) {
+            if (Ci.isAppVeyor) {
                 ProcessCapture("cinst", "haskell-stack", "--version", "1.7.1", "-y").requireSuccess()
 
                 // This installs the whole GHC to an isolated location!
                 ProcessCapture("stack", "setup").requireSuccess()
-            } else if (CI.isTravis) {
+            } else if (Ci.isTravis) {
                 val getStack = ProcessCapture("curl", "-sSL", "https://get.haskellstack.org/").requireSuccess()
                 ProcessCapture("sh", getStack.stdoutFile.absolutePath).requireSuccess()
 
@@ -64,7 +64,7 @@ class StackTest : StringSpec() {
             val definitionFile = File(projectsDir, "external/quickcheck-state-machine/stack.yaml")
 
             val result = createStack().resolveDependencies(listOf(definitionFile))[definitionFile]
-            val expectedOutput = if (OS.isWindows) {
+            val expectedOutput = if (Os.isWindows) {
                 "external/quickcheck-state-machine-expected-output-win32.yml"
             } else {
                 "external/quickcheck-state-machine-expected-output.yml"
@@ -79,7 +79,7 @@ class StackTest : StringSpec() {
             val definitionFile = File(projectsDir, "external/quickcheck-state-machine/example/stack.yaml")
 
             val result = createStack().resolveDependencies(listOf(definitionFile))[definitionFile]
-            val expectedOutput = if (OS.isWindows) {
+            val expectedOutput = if (Os.isWindows) {
                 "external/quickcheck-state-machine-example-expected-output-win32.yml"
             } else {
                 "external/quickcheck-state-machine-example-expected-output.yml"

--- a/analyzer/src/funTest/kotlin/integration/DrupalIntegrationTest.kt
+++ b/analyzer/src/funTest/kotlin/integration/DrupalIntegrationTest.kt
@@ -20,7 +20,7 @@
 package com.here.ort.analyzer.integration
 
 import com.here.ort.analyzer.PackageManagerFactory
-import com.here.ort.analyzer.managers.NPM
+import com.here.ort.analyzer.managers.Npm
 import com.here.ort.analyzer.managers.PhpComposer
 import com.here.ort.analyzer.managers.Yarn
 import com.here.ort.model.Identifier
@@ -82,7 +82,7 @@ class DrupalIntegrationTest : AbstractIntegrationSpec() {
                 File(downloadDir, "core/composer.json"),
                 File(downloadDir, "composer.json")
             ),
-            NPM.Factory() as PackageManagerFactory to listOf(
+            Npm.Factory() as PackageManagerFactory to listOf(
                 File(downloadDir, "core/package.json"),
                 File(downloadDir, "core/assets/vendor/jquery.ui/package.json")
             ),

--- a/analyzer/src/funTest/kotlin/integration/PolymerIntegrationTest.kt
+++ b/analyzer/src/funTest/kotlin/integration/PolymerIntegrationTest.kt
@@ -21,7 +21,7 @@ package com.here.ort.analyzer.integration
 
 import com.here.ort.analyzer.PackageManagerFactory
 import com.here.ort.analyzer.managers.Bower
-import com.here.ort.analyzer.managers.NPM
+import com.here.ort.analyzer.managers.Npm
 import com.here.ort.analyzer.managers.Yarn
 import com.here.ort.model.Identifier
 import com.here.ort.model.Package
@@ -59,7 +59,7 @@ class PolymerIntegrationTest : AbstractIntegrationSpec() {
 
         mapOf(
             Bower.Factory() as PackageManagerFactory to bowerJsonFiles,
-            NPM.Factory() as PackageManagerFactory to packageJsonFiles,
+            Npm.Factory() as PackageManagerFactory to packageJsonFiles,
             Yarn.Factory() as PackageManagerFactory to packageJsonFiles
         )
     }
@@ -68,7 +68,7 @@ class PolymerIntegrationTest : AbstractIntegrationSpec() {
         mapOf(
             Bower.Factory() as PackageManagerFactory to
                     listOf(File(downloadResult.downloadDirectory, "bower.json")),
-            NPM.Factory() as PackageManagerFactory to
+            Npm.Factory() as PackageManagerFactory to
                     listOf(File(downloadResult.downloadDirectory, "package.json"))
         )
     }

--- a/analyzer/src/funTest/kotlin/integration/VueJsIntegrationTest.kt
+++ b/analyzer/src/funTest/kotlin/integration/VueJsIntegrationTest.kt
@@ -20,7 +20,7 @@
 package com.here.ort.analyzer.integration
 
 import com.here.ort.analyzer.PackageManagerFactory
-import com.here.ort.analyzer.managers.NPM
+import com.here.ort.analyzer.managers.Npm
 import com.here.ort.analyzer.managers.Yarn
 import com.here.ort.model.Identifier
 import com.here.ort.model.Package
@@ -52,7 +52,7 @@ class VueJsIntegrationTest : AbstractIntegrationSpec() {
     override val expectedManagedFiles by lazy {
         val downloadDir = downloadResult.downloadDirectory
         mapOf(
-            NPM.Factory() as PackageManagerFactory to listOf(
+            Npm.Factory() as PackageManagerFactory to listOf(
                 File(downloadDir, "package.json"),
                 File(downloadDir, "packages/vue-server-renderer/package.json"),
                 File(downloadDir, "packages/vue-template-compiler/package.json"),
@@ -71,7 +71,7 @@ class VueJsIntegrationTest : AbstractIntegrationSpec() {
 
     override val managedFilesForTest by lazy {
         mapOf(
-            NPM.Factory() as PackageManagerFactory to
+            Npm.Factory() as PackageManagerFactory to
                     listOf(File(downloadResult.downloadDirectory, "package.json"))
         )
     }

--- a/analyzer/src/main/kotlin/managers/Bower.kt
+++ b/analyzer/src/main/kotlin/managers/Bower.kt
@@ -38,7 +38,7 @@ import com.here.ort.model.config.AnalyzerConfiguration
 import com.here.ort.model.config.RepositoryConfiguration
 import com.here.ort.model.jsonMapper
 import com.here.ort.utils.CommandLineTool
-import com.here.ort.utils.OS
+import com.here.ort.utils.Os
 import com.here.ort.utils.fieldNamesOrEmpty
 import com.here.ort.utils.fieldsOrEmpty
 import com.here.ort.utils.log
@@ -216,7 +216,7 @@ class Bower(
             Bower(managerName, analyzerRoot, analyzerConfig, repoConfig)
     }
 
-    override fun command(workingDir: File?) = if (OS.isWindows) "bower.cmd" else "bower"
+    override fun command(workingDir: File?) = if (Os.isWindows) "bower.cmd" else "bower"
 
     override fun getVersionRequirement(): Requirement = Requirement.buildStrict(REQUIRED_BOWER_VERSION)
 

--- a/analyzer/src/main/kotlin/managers/Bundler.kt
+++ b/analyzer/src/main/kotlin/managers/Bundler.kt
@@ -42,7 +42,7 @@ import com.here.ort.model.config.RepositoryConfiguration
 import com.here.ort.model.jsonMapper
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.CommandLineTool
-import com.here.ort.utils.OS
+import com.here.ort.utils.Os
 import com.here.ort.utils.OkHttpClientHelper
 import com.here.ort.utils.collectMessagesAsString
 import com.here.ort.utils.log
@@ -82,7 +82,7 @@ class Bundler(
             Bundler(managerName, analyzerRoot, analyzerConfig, repoConfig)
     }
 
-    override fun command(workingDir: File?) = if (OS.isWindows) "bundle.bat" else "bundle"
+    override fun command(workingDir: File?) = if (Os.isWindows) "bundle.bat" else "bundle"
 
     override fun getVersionRequirement(): Requirement = Requirement.buildIvy("[1.16,2.1[")
 

--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -44,7 +44,7 @@ import com.here.ort.model.config.RepositoryConfiguration
 import com.here.ort.model.jsonMapper
 import com.here.ort.model.readValue
 import com.here.ort.utils.CommandLineTool
-import com.here.ort.utils.OS
+import com.here.ort.utils.Os
 import com.here.ort.utils.OkHttpClientHelper
 import com.here.ort.utils.hasFragmentRevision
 import com.here.ort.utils.log
@@ -67,7 +67,7 @@ import okhttp3.Request
 /**
  * The [Node package manager](https://www.npmjs.com/) for JavaScript.
  */
-open class NPM(
+open class Npm(
     name: String,
     analyzerRoot: File,
     analyzerConfig: AnalyzerConfiguration,
@@ -114,7 +114,7 @@ open class NPM(
         }
     }
 
-    class Factory : AbstractPackageManagerFactory<NPM>("NPM") {
+    class Factory : AbstractPackageManagerFactory<Npm>("NPM") {
         override val globsForDefinitionFiles = listOf("package.json")
 
         override fun create(
@@ -122,7 +122,7 @@ open class NPM(
             analyzerConfig: AnalyzerConfiguration,
             repoConfig: RepositoryConfiguration
         ) =
-            NPM(managerName, analyzerRoot, analyzerConfig, repoConfig)
+            Npm(managerName, analyzerRoot, analyzerConfig, repoConfig)
     }
 
     /**
@@ -132,7 +132,7 @@ open class NPM(
 
     protected open fun hasLockFile(projectDir: File) = PackageJsonUtils.hasNpmLockFile(projectDir)
 
-    override fun command(workingDir: File?) = if (OS.isWindows) "npm.cmd" else "npm"
+    override fun command(workingDir: File?) = if (Os.isWindows) "npm.cmd" else "npm"
 
     override fun getVersionRequirement(): Requirement = Requirement.buildNPM("5.7.* - 6.4.*")
 
@@ -509,7 +509,7 @@ open class NPM(
         }
 
         // Install all NPM dependencies to enable NPM to list dependencies.
-        if (hasLockFile(workingDir) && this::class.java == NPM::class.java) {
+        if (hasLockFile(workingDir) && this::class.java == Npm::class.java) {
             run(workingDir, "ci")
         } else {
             run(workingDir, "install", *installParameters)

--- a/analyzer/src/main/kotlin/managers/PhpComposer.kt
+++ b/analyzer/src/main/kotlin/managers/PhpComposer.kt
@@ -41,7 +41,7 @@ import com.here.ort.model.config.AnalyzerConfiguration
 import com.here.ort.model.config.RepositoryConfiguration
 import com.here.ort.model.jsonMapper
 import com.here.ort.utils.CommandLineTool
-import com.here.ort.utils.OS
+import com.here.ort.utils.Os
 import com.here.ort.utils.ProcessCapture
 import com.here.ort.utils.collectMessagesAsString
 import com.here.ort.utils.log
@@ -82,7 +82,7 @@ class PhpComposer(
         if (workingDir?.resolve(COMPOSER_PHAR_BINARY)?.isFile == true) {
             "php $COMPOSER_PHAR_BINARY"
         } else {
-            if (OS.isWindows) {
+            if (Os.isWindows) {
                 "composer.bat"
             } else {
                 "composer"

--- a/analyzer/src/main/kotlin/managers/Sbt.kt
+++ b/analyzer/src/main/kotlin/managers/Sbt.kt
@@ -26,7 +26,7 @@ import com.here.ort.analyzer.PackageManager
 import com.here.ort.model.config.AnalyzerConfiguration
 import com.here.ort.model.config.RepositoryConfiguration
 import com.here.ort.utils.CommandLineTool
-import com.here.ort.utils.OS
+import com.here.ort.utils.Os
 import com.here.ort.utils.getCommonFileParent
 import com.here.ort.utils.log
 import com.here.ort.utils.suppressInput
@@ -41,7 +41,7 @@ import java.util.Properties
 /**
  * The [SBT](https://www.scala-sbt.org/) package manager for Scala.
  */
-class SBT(
+class Sbt(
     name: String,
     analyzerRoot: File,
     analyzerConfig: AnalyzerConfiguration,
@@ -54,11 +54,11 @@ class SBT(
 
         // Batch mode (which suppresses interactive prompts) is only supported on non-Windows, see
         // https://github.com/sbt/sbt-launcher-package/blob/d251388/src/universal/bin/sbt#L86.
-        private val BATCH_MODE = if (!OS.isWindows) "-batch" else ""
+        private val BATCH_MODE = if (!Os.isWindows) "-batch" else ""
 
         // See https://github.com/sbt/sbt/issues/2695.
         private val LOG_NO_FORMAT = "-Dsbt.log.noformat=true".let {
-            if (OS.isWindows) {
+            if (Os.isWindows) {
                 "\"$it\""
             } else {
                 it
@@ -66,7 +66,7 @@ class SBT(
         }
     }
 
-    class Factory : AbstractPackageManagerFactory<SBT>("SBT") {
+    class Factory : AbstractPackageManagerFactory<Sbt>("SBT") {
         override val globsForDefinitionFiles = listOf("build.sbt", "build.scala")
 
         override fun create(
@@ -74,10 +74,10 @@ class SBT(
             analyzerConfig: AnalyzerConfiguration,
             repoConfig: RepositoryConfiguration
         ) =
-            SBT(managerName, analyzerRoot, analyzerConfig, repoConfig)
+            Sbt(managerName, analyzerRoot, analyzerConfig, repoConfig)
     }
 
-    override fun command(workingDir: File?) = if (OS.isWindows) "sbt.bat" else "sbt"
+    override fun command(workingDir: File?) = if (Os.isWindows) "sbt.bat" else "sbt"
 
     override fun getVersionRequirement(): Requirement =
         // We need at least sbt version 0.13.0 to be able to use "makePom" instead of the deprecated hyphenated

--- a/analyzer/src/main/kotlin/managers/Yarn.kt
+++ b/analyzer/src/main/kotlin/managers/Yarn.kt
@@ -23,7 +23,7 @@ import com.here.ort.analyzer.AbstractPackageManagerFactory
 import com.here.ort.analyzer.PackageJsonUtils
 import com.here.ort.model.config.AnalyzerConfiguration
 import com.here.ort.model.config.RepositoryConfiguration
-import com.here.ort.utils.OS
+import com.here.ort.utils.Os
 
 import com.vdurmont.semver4j.Requirement
 
@@ -37,7 +37,7 @@ class Yarn(
     analyzerRoot: File,
     analyzerConfig: AnalyzerConfiguration,
     repoConfig: RepositoryConfiguration
-) : NPM(name, analyzerRoot, analyzerConfig, repoConfig) {
+) : Npm(name, analyzerRoot, analyzerConfig, repoConfig) {
     class Factory : AbstractPackageManagerFactory<Yarn>("Yarn") {
         override val globsForDefinitionFiles = listOf("package.json")
 
@@ -53,7 +53,7 @@ class Yarn(
 
     override fun hasLockFile(projectDir: File) = PackageJsonUtils.hasYarnLockFile(projectDir)
 
-    override fun command(workingDir: File?) = if (OS.isWindows) "yarn.cmd" else "yarn"
+    override fun command(workingDir: File?) = if (Os.isWindows) "yarn.cmd" else "yarn"
 
     override fun getVersionRequirement(): Requirement = Requirement.buildNPM("1.3.* - 1.13.*")
 

--- a/analyzer/src/main/resources/META-INF/services/com.here.ort.analyzer.PackageManagerFactory
+++ b/analyzer/src/main/resources/META-INF/services/com.here.ort.analyzer.PackageManagerFactory
@@ -4,10 +4,10 @@ com.here.ort.analyzer.managers.DotNet$Factory
 com.here.ort.analyzer.managers.GoDep$Factory
 com.here.ort.analyzer.managers.Gradle$Factory
 com.here.ort.analyzer.managers.Maven$Factory
-com.here.ort.analyzer.managers.NPM$Factory
+com.here.ort.analyzer.managers.Npm$Factory
 com.here.ort.analyzer.managers.NuGet$Factory
 com.here.ort.analyzer.managers.PhpComposer$Factory
-com.here.ort.analyzer.managers.PIP$Factory
-com.here.ort.analyzer.managers.SBT$Factory
+com.here.ort.analyzer.managers.Pip$Factory
+com.here.ort.analyzer.managers.Sbt$Factory
 com.here.ort.analyzer.managers.Stack$Factory
 com.here.ort.analyzer.managers.Yarn$Factory

--- a/analyzer/src/test/kotlin/NpmTest.kt
+++ b/analyzer/src/test/kotlin/NpmTest.kt
@@ -19,7 +19,7 @@
 
 package com.here.ort.analyzer
 
-import com.here.ort.analyzer.managers.NPM
+import com.here.ort.analyzer.managers.Npm
 
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.WordSpec
@@ -27,7 +27,7 @@ import io.kotlintest.specs.WordSpec
 class NpmTest : WordSpec({
     "expandShortcutURL" should {
         "do nothing for empty URLs" {
-            NPM.expandShortcutURL("") shouldBe ""
+            Npm.expandShortcutURL("") shouldBe ""
         }
 
         "properly handle NPM shortcut URLs" {
@@ -47,7 +47,7 @@ class NpmTest : WordSpec({
             )
 
             packages.forEach { (actualUrl, expectedUrl) ->
-                NPM.expandShortcutURL(actualUrl) shouldBe expectedUrl
+                Npm.expandShortcutURL(actualUrl) shouldBe expectedUrl
             }
         }
 
@@ -62,7 +62,7 @@ class NpmTest : WordSpec({
             )
 
             packages.forEach { (actualUrl, expectedUrl) ->
-                NPM.expandShortcutURL(actualUrl) shouldBe expectedUrl
+                Npm.expandShortcutURL(actualUrl) shouldBe expectedUrl
             }
         }
     }

--- a/analyzer/src/test/kotlin/PackageManagerTest.kt
+++ b/analyzer/src/test/kotlin/PackageManagerTest.kt
@@ -62,7 +62,7 @@ class PackageManagerTest : WordSpec({
         "find only files for active package managers" {
             val managedFiles = PackageManager.findManagedFiles(
                 projectDir,
-                listOf(Gradle.Factory(), PIP.Factory(), SBT.Factory())
+                listOf(Gradle.Factory(), Pip.Factory(), Sbt.Factory())
             )
 
             managedFiles.size shouldBe 3

--- a/downloader/src/main/kotlin/vcs/Git.kt
+++ b/downloader/src/main/kotlin/vcs/Git.kt
@@ -25,7 +25,7 @@ import com.here.ort.downloader.DownloadException
 import com.here.ort.downloader.WorkingTree
 import com.here.ort.model.Package
 import com.here.ort.spdx.LICENSE_FILE_NAMES
-import com.here.ort.utils.OS
+import com.here.ort.utils.Os
 import com.here.ort.utils.ProcessCapture
 import com.here.ort.utils.log
 import com.here.ort.utils.safeMkdirs
@@ -85,7 +85,7 @@ class Git : GitBase() {
             run(targetDir, "config", "protocol.version", "2")
         }
 
-        if (OS.isWindows) {
+        if (Os.isWindows) {
             run(targetDir, "config", "core.longpaths", "true")
         }
 

--- a/downloader/src/main/kotlin/vcs/GitRepo.kt
+++ b/downloader/src/main/kotlin/vcs/GitRepo.kt
@@ -25,7 +25,7 @@ import com.here.ort.downloader.DownloadException
 import com.here.ort.downloader.WorkingTree
 import com.here.ort.model.Package
 import com.here.ort.model.VcsInfo
-import com.here.ort.utils.OS
+import com.here.ort.utils.Os
 import com.here.ort.utils.ProcessCapture
 import com.here.ort.utils.getPathFromEnvironment
 import com.here.ort.utils.log
@@ -140,7 +140,7 @@ class GitRepo : GitBase() {
     }
 
     private fun runRepoCommand(targetDir: File, vararg args: String) =
-        if (OS.isWindows) {
+        if (Os.isWindows) {
             val repo = getPathFromEnvironment("repo") ?: throw IOException("'repo' not found in PATH.")
 
             // On Windows, the script itself is not executable, so we need to wrap the call by "python".

--- a/downloader/src/test/kotlin/GitTest.kt
+++ b/downloader/src/test/kotlin/GitTest.kt
@@ -20,7 +20,7 @@
 package com.here.ort.downloader.vcs
 
 import com.here.ort.downloader.VersionControlSystem
-import com.here.ort.utils.OS
+import com.here.ort.utils.Os
 import com.here.ort.utils.getUserOrtDirectory
 import com.here.ort.utils.safeDeleteRecursively
 import com.here.ort.utils.unpack
@@ -67,7 +67,7 @@ class GitTest : StringSpec() {
             git.isApplicableUrl("https://bitbucket.org/paniq/masagin") shouldBe false
         }
 
-        "Git does not prompt for credentials for non-existing repositories".config(enabled = !OS.isWindows) {
+        "Git does not prompt for credentials for non-existing repositories".config(enabled = !Os.isWindows) {
             git.isApplicableUrl("https://github.com/heremaps/foobar.git") shouldBe false
         }
 

--- a/model/src/main/kotlin/Environment.kt
+++ b/model/src/main/kotlin/Environment.kt
@@ -19,7 +19,7 @@
 
 package com.here.ort.model
 
-import com.here.ort.utils.OS
+import com.here.ort.utils.Os
 
 /**
  * A description of the environment that ORT was executed in.
@@ -33,7 +33,7 @@ data class Environment(
     /**
      * Name of the operating system, defaults to [OS.name].
      */
-    val os: String = OS.name,
+    val os: String = Os.name,
 
     /**
      * Map of selected environment variables that might be relevant for debugging.

--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -43,7 +43,7 @@ import com.here.ort.model.ScannerRun
 import com.here.ort.model.config.ScannerConfiguration
 import com.here.ort.model.mapper
 import com.here.ort.utils.CommandLineTool
-import com.here.ort.utils.OS
+import com.here.ort.utils.Os
 import com.here.ort.utils.collectMessagesAsString
 import com.here.ort.utils.fileSystemEncode
 import com.here.ort.utils.getPathFromEnvironment
@@ -355,7 +355,7 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
 
         // There is no package id for arbitrary paths so create a fake one, ensuring that no ":" is contained.
         val id = Identifier(
-            OS.name.fileSystemEncode(), absoluteInputPath.parent.fileSystemEncode(),
+            Os.name.fileSystemEncode(), absoluteInputPath.parent.fileSystemEncode(),
             inputPath.name.fileSystemEncode(), ""
         )
 

--- a/scanner/src/main/kotlin/scanners/Askalono.kt
+++ b/scanner/src/main/kotlin/scanners/Askalono.kt
@@ -35,7 +35,7 @@ import com.here.ort.scanner.HTTP_CACHE_PATH
 import com.here.ort.scanner.LocalScanner
 import com.here.ort.scanner.ScanException
 import com.here.ort.utils.CommandLineTool
-import com.here.ort.utils.OS
+import com.here.ort.utils.Os
 import com.here.ort.utils.OkHttpClientHelper
 import com.here.ort.utils.ProcessCapture
 import com.here.ort.utils.log
@@ -59,9 +59,9 @@ class Askalono(name: String, config: ScannerConfiguration) : LocalScanner(name, 
 
     override fun command(workingDir: File?): String {
         val extension = when {
-            OS.isLinux -> "linux"
-            OS.isMac -> "osx"
-            OS.isWindows -> "exe"
+            Os.isLinux -> "linux"
+            Os.isMac -> "osx"
+            Os.isWindows -> "exe"
             else -> throw IllegalArgumentException("Unsupported operating system.")
         }
 
@@ -105,7 +105,7 @@ class Askalono(name: String, config: ScannerConfiguration) : LocalScanner(name, 
             val scannerFile = File(scannerDir, scannerExe)
             Okio.buffer(Okio.sink(scannerFile)).use { it.writeAll(body.source()) }
 
-            if (!OS.isWindows) {
+            if (!Os.isWindows) {
                 // Ensure the executable Unix mode bit to be set.
                 scannerFile.setExecutable(true)
             }

--- a/scanner/src/main/kotlin/scanners/BoyterLc.kt
+++ b/scanner/src/main/kotlin/scanners/BoyterLc.kt
@@ -35,7 +35,7 @@ import com.here.ort.scanner.HTTP_CACHE_PATH
 import com.here.ort.scanner.LocalScanner
 import com.here.ort.scanner.ScanException
 import com.here.ort.utils.CommandLineTool
-import com.here.ort.utils.OS
+import com.here.ort.utils.Os
 import com.here.ort.utils.OkHttpClientHelper
 import com.here.ort.utils.ProcessCapture
 import com.here.ort.utils.log
@@ -65,7 +65,7 @@ class BoyterLc(name: String, config: ScannerConfiguration) : LocalScanner(name, 
     override val scannerVersion = "1.3.1"
     override val resultFileExt = "json"
 
-    override fun command(workingDir: File?) = if (OS.isWindows) "lc.exe" else "lc"
+    override fun command(workingDir: File?) = if (Os.isWindows) "lc.exe" else "lc"
 
     override fun getVersion(dir: File): String {
         // Create a temporary tool to get its version from the installation in a specific directory.
@@ -82,9 +82,9 @@ class BoyterLc(name: String, config: ScannerConfiguration) : LocalScanner(name, 
 
     override fun bootstrap(): File {
         val platform = when {
-            OS.isLinux -> "x86_64-unknown-linux"
-            OS.isMac -> "x86_64-apple-darwin"
-            OS.isWindows -> "x86_64-pc-windows"
+            Os.isLinux -> "x86_64-unknown-linux"
+            Os.isMac -> "x86_64-apple-darwin"
+            Os.isWindows -> "x86_64-pc-windows"
             else -> throw IllegalArgumentException("Unsupported operating system.")
         }
 
@@ -116,7 +116,7 @@ class BoyterLc(name: String, config: ScannerConfiguration) : LocalScanner(name, 
                 log.warn { "Unable to delete temporary file '$scannerArchive'." }
             }
 
-            if (!OS.isWindows) {
+            if (!Os.isWindows) {
                 // The Linux version is distributed as a ZIP, but without having the Unix executable mode bits stored.
                 File(unpackDir, command()).setExecutable(true)
             }

--- a/scanner/src/main/kotlin/scanners/Licensee.kt
+++ b/scanner/src/main/kotlin/scanners/Licensee.kt
@@ -33,9 +33,9 @@ import com.here.ort.model.jsonMapper
 import com.here.ort.scanner.AbstractScannerFactory
 import com.here.ort.scanner.LocalScanner
 import com.here.ort.scanner.ScanException
-import com.here.ort.utils.CI
+import com.here.ort.utils.Ci
 import com.here.ort.utils.CommandLineTool
-import com.here.ort.utils.OS
+import com.here.ort.utils.Os
 import com.here.ort.utils.ProcessCapture
 import com.here.ort.utils.getPathFromEnvironment
 import com.here.ort.utils.log
@@ -56,7 +56,7 @@ class Licensee(name: String, config: ScannerConfiguration) : LocalScanner(name, 
     override val scannerVersion = "9.11.0"
     override val resultFileExt = "json"
 
-    override fun command(workingDir: File?) = if (OS.isWindows) "licensee.bat" else "licensee"
+    override fun command(workingDir: File?) = if (Os.isWindows) "licensee.bat" else "licensee"
 
     override fun getVersion(dir: File): String {
         // Create a temporary tool to get its version from the installation in a specific directory.
@@ -69,11 +69,11 @@ class Licensee(name: String, config: ScannerConfiguration) : LocalScanner(name, 
     }
 
     override fun bootstrap(): File {
-        val gem = if (OS.isWindows) "gem.cmd" else "gem"
+        val gem = if (Os.isWindows) "gem.cmd" else "gem"
 
         // Work around Travis CI not being able to handle gem user installs, see
         // https://github.com/travis-ci/travis-ci/issues/9412.
-        return if (CI.isTravis) {
+        return if (Ci.isTravis) {
             ProcessCapture(gem, "install", "licensee", "-v", scannerVersion).requireSuccess()
             getPathFromEnvironment(command())?.parentFile
                 ?: throw IOException("Install directory for licensee not found.")

--- a/scanner/src/main/kotlin/scanners/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/ScanCode.kt
@@ -44,7 +44,7 @@ import com.here.ort.spdx.LICENSE_FILE_NAMES
 import com.here.ort.spdx.NON_LICENSE_FILENAMES
 import com.here.ort.utils.CommandLineTool
 import com.here.ort.utils.ORT_CONFIG_FILENAME
-import com.here.ort.utils.OS
+import com.here.ort.utils.Os
 import com.here.ort.utils.OkHttpClientHelper
 import com.here.ort.utils.ProcessCapture
 import com.here.ort.utils.log
@@ -168,7 +168,7 @@ class ScanCode(name: String, config: ScannerConfiguration) : LocalScanner(name, 
         }.toList()
     }
 
-    override fun command(workingDir: File?) = if (OS.isWindows) "scancode.bat" else "scancode"
+    override fun command(workingDir: File?) = if (Os.isWindows) "scancode.bat" else "scancode"
 
     override fun getVersion(dir: File): String {
         // Create a temporary tool to get its version from the installation in a specific directory.
@@ -188,7 +188,7 @@ class ScanCode(name: String, config: ScannerConfiguration) : LocalScanner(name, 
         val archive = when {
             // Use the .zip file despite it being slightly larger than the .tar.gz file here as the latter for some
             // reason does not complete to unpack on Windows.
-            OS.isWindows -> "v$scannerVersion.zip"
+            Os.isWindows -> "v$scannerVersion.zip"
             else -> "v$scannerVersion.tar.gz"
         }
 

--- a/utils/src/main/kotlin/ArchiveUtils.kt
+++ b/utils/src/main/kotlin/ArchiveUtils.kt
@@ -85,7 +85,7 @@ fun File.unpackTar(targetDirectory: File) {
                 it.copyTo(output)
             }
 
-            if (!OS.isWindows) {
+            if (!Os.isWindows) {
                 // Note: In contrast to Java, Kotlin does not support octal literals, see
                 // https://kotlinlang.org/docs/reference/basic-types.html#literal-constants.
                 // The bit-triplets from left to right stand for user, groups, other, respectively.
@@ -119,7 +119,7 @@ fun File.unpackZip(targetDirectory: File) {
                 it.copyTo(output)
             }
 
-            if (!OS.isWindows) {
+            if (!Os.isWindows) {
                 // Note: In contrast to Java, Kotlin does not support octal literals, see
                 // https://kotlinlang.org/docs/reference/basic-types.html#literal-constants.
                 // The bit-triplets from left to right stand for user, groups, other, respectively.

--- a/utils/src/main/kotlin/Ci.kt
+++ b/utils/src/main/kotlin/Ci.kt
@@ -20,13 +20,9 @@
 package com.here.ort.utils
 
 /**
- * Operating-System-specific utility functions.
+ * Continuous-Integration-specific utility functions.
  */
-object OS {
-    val name = System.getProperty("os.name") ?: ""
-    private val nameLowerCase = name.toLowerCase()
-
-    val isLinux = "linux" in nameLowerCase
-    val isMac = "mac" in nameLowerCase
-    val isWindows = "windows" in nameLowerCase
+object Ci {
+    val isAppVeyor = listOf("APPVEYOR", "CI").all { System.getenv(it)?.toBoolean() == true }
+    val isTravis = listOf("TRAVIS", "CI").all { System.getenv(it)?.toBoolean() == true }
 }

--- a/utils/src/main/kotlin/Extensions.kt
+++ b/utils/src/main/kotlin/Extensions.kt
@@ -86,7 +86,7 @@ fun File.safeCopyRecursively(target: File, overwrite: Boolean = false) {
     // FileVisitOption.FOLLOW_LINKS is not used, so symbolic links are not followed.
     Files.walkFileTree(sourcePath, object : SimpleFileVisitor<Path>() {
         override fun preVisitDirectory(dir: Path, attrs: BasicFileAttributes): FileVisitResult {
-            if ((!OS.isWindows && attrs.isSymbolicLink) || (OS.isWindows && attrs.isOther)) {
+            if ((!Os.isWindows && attrs.isSymbolicLink) || (Os.isWindows && attrs.isOther)) {
                 // Do not follow symbolic links or junctions.
                 return FileVisitResult.SKIP_SUBTREE
             }
@@ -121,7 +121,7 @@ fun File.safeDeleteRecursively(force: Boolean = false) {
     // FileVisitOption.FOLLOW_LINKS is not used, so symbolic links are not followed.
     Files.walkFileTree(toPath(), object : SimpleFileVisitor<Path>() {
         override fun preVisitDirectory(dir: Path, attrs: BasicFileAttributes): FileVisitResult {
-            if (OS.isWindows && attrs.isOther) {
+            if (Os.isWindows && attrs.isOther) {
                 // delete() actually works to delete only the junction and not the directory it points to.
                 dir.toFile().delete()
                 return FileVisitResult.SKIP_SUBTREE

--- a/utils/src/main/kotlin/Os.kt
+++ b/utils/src/main/kotlin/Os.kt
@@ -20,9 +20,13 @@
 package com.here.ort.utils
 
 /**
- * Continuous-Integration-specific utility functions.
+ * Operating-System-specific utility functions.
  */
-object CI {
-    val isAppVeyor = listOf("APPVEYOR", "CI").all { System.getenv(it)?.toBoolean() == true }
-    val isTravis = listOf("TRAVIS", "CI").all { System.getenv(it)?.toBoolean() == true }
+object Os {
+    val name = System.getProperty("os.name") ?: ""
+    private val nameLowerCase = name.toLowerCase()
+
+    val isLinux = "linux" in nameLowerCase
+    val isMac = "mac" in nameLowerCase
+    val isWindows = "windows" in nameLowerCase
 }

--- a/utils/src/main/kotlin/Redirection.kt
+++ b/utils/src/main/kotlin/Redirection.kt
@@ -55,7 +55,7 @@ fun redirectStdout(block: () -> Unit) = redirectOutput(System.out, System::setOu
 fun <T> suppressInput(block: () -> T): T {
     val originalInput = System.`in`
 
-    val nullDevice = FileInputStream(if (OS.isWindows) "NUL" else "/dev/null")
+    val nullDevice = FileInputStream(if (Os.isWindows) "NUL" else "/dev/null")
     System.setIn(nullDevice)
 
     return try {

--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -163,7 +163,7 @@ fun getCommonFileParent(files: Collection<File>) =
 fun getPathFromEnvironment(executable: String): File? {
     val paths = System.getenv("PATH")?.splitToSequence(File.pathSeparatorChar) ?: emptySequence()
 
-    val executables = if (OS.isWindows) {
+    val executables = if (Os.isWindows) {
         // Get the list of executable file extensions without the leading dot each.
         val pathExt = System.getenv("PATHEXT")?.let {
             it.split(File.pathSeparatorChar).map { ext -> ext.toLowerCase().removePrefix(".") }

--- a/utils/src/test/kotlin/ExtensionsTest.kt
+++ b/utils/src/test/kotlin/ExtensionsTest.kt
@@ -35,11 +35,11 @@ class ExtensionsTest : WordSpec({
     }
 
     "File.expandTilde" should {
-        "only make the path absolute on Windows".config(enabled = OS.isWindows) {
+        "only make the path absolute on Windows".config(enabled = Os.isWindows) {
             File("~/Desktop").expandTilde() shouldBe File("~/Desktop").absoluteFile
         }
 
-        "expand the path on Unix".config(enabled = !OS.isWindows) {
+        "expand the path on Unix".config(enabled = !Os.isWindows) {
             File("~/Desktop").expandTilde() shouldBe getUserHomeDirectory().resolve("Desktop")
         }
     }

--- a/utils/src/test/kotlin/ProcessCaptureTest.kt
+++ b/utils/src/test/kotlin/ProcessCaptureTest.kt
@@ -25,7 +25,7 @@ import io.kotlintest.specs.StringSpec
 class ProcessCaptureTest : StringSpec({
     "Environment variables should be passed correctly" {
         val env = mapOf("PREFIX" to "This is some path: ", "SOME_PATH" to "/foo/bar")
-        val proc = if (OS.isWindows) {
+        val proc = if (Os.isWindows) {
             ProcessCapture("cmd.exe", "/c", "echo %PREFIX%%SOME_PATH%", environment = env)
         } else {
             ProcessCapture("sh", "-c", "echo \$PREFIX\$SOME_PATH", environment = env)

--- a/utils/src/test/kotlin/UtilsTest.kt
+++ b/utils/src/test/kotlin/UtilsTest.kt
@@ -214,7 +214,7 @@ class UtilsTest : WordSpec({
     }
 
     "getPathFromEnvironment" should {
-        "find system executables on Windows".config(enabled = OS.isWindows) {
+        "find system executables on Windows".config(enabled = Os.isWindows) {
             val winverPath = File(System.getenv("SYSTEMROOT"), "system32/winver.exe")
 
             getPathFromEnvironment("winver") shouldNotBe null
@@ -228,7 +228,7 @@ class UtilsTest : WordSpec({
             getPathFromEnvironment("nul") shouldBe null
         }
 
-        "find system executables on non-Windows".config(enabled = !OS.isWindows) {
+        "find system executables on non-Windows".config(enabled = !Os.isWindows) {
             getPathFromEnvironment("sh") shouldNotBe null
             getPathFromEnvironment("sh") shouldBe File("/bin/sh")
 


### PR DESCRIPTION
To follow Java naming conventions. Still keep them all upper-case in
user-facing output, though.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1496)
<!-- Reviewable:end -->
