### PR TITLE
OrtResult: Add a function to lookup `uncurated` packages

### DIFF
--- a/model/src/main/kotlin/CuratedPackage.kt
+++ b/model/src/main/kotlin/CuratedPackage.kt
@@ -41,4 +41,13 @@ data class CuratedPackage(
      * A comparison function to sort packages by their identifier.
      */
     override fun compareTo(other: CuratedPackage) = pkg.id.compareTo(other.pkg.id)
+
+    /**
+     * Returns a [Package] representing the same package as this one but which does not have any curations
+     * applied.
+     */
+    fun toUncuratedPackage() =
+        curations.reversed().fold(this) {
+            current, curation -> curation.base.apply(current)
+        }.pkg
 }

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -289,6 +289,11 @@ data class OrtResult(
         return vendorPackages
     }
 
+    @Suppress("UNUSED") // This is intended to be mostly used via scripting.
+    fun getUncuratedPackageById(id: Identifier): Package? =
+        analyzer?.result?.packages?.find { it.pkg.id == id }?.toUncuratedPackage()
+            ?: analyzer?.result?.projects?.find { it.id == id }?.toPackage()
+
     /**
      * Returns the path of the definition file of the [project], relative to the analyzer root. If the project was
      * checked out from a VCS the analyzer root is the root of the working tree, if the project was not checked out from


### PR DESCRIPTION
Sometimes it makes sense to work on not curated representations
of a package rather than on curated ones. The implementation of
policies enforcing rules on package meta data would ideally consume
not curated packages.

Add a function to support such use cases.

Signed-off-by: Frank Viernau <frank.viernau@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1497)
<!-- Reviewable:end -->
