### PR TITLE
spdx-utils: Disambiguate parser rules for ids and exceptions

### DIFF
--- a/spdx-utils/src/main/antlr/com/here/ort/spdx/SpdxExpression.g4
+++ b/spdx-utils/src/main/antlr/com/here/ort/spdx/SpdxExpression.g4
@@ -31,20 +31,20 @@ package com.here.ort.spdx;
  * Parser Rules
  */
 
-licenseReferenceExpression
-    :
-    LICENSEREFERENCE
-    ;
-
-licenseExceptionExpression
-    :
-    IDSTRING
-    ;
-
 licenseIdExpression
     :
     IDSTRING
     PLUS?
+    ;
+
+licenseExceptionExpression
+    :
+    LICENSE_EXCEPTION
+    ;
+
+licenseReferenceExpression
+    :
+    LICENSE_REFERENCE
     ;
 
 simpleExpression
@@ -83,7 +83,8 @@ OPEN  : '(' ;
 CLOSE : ')' ;
 PLUS  : '+' ;
 
-LICENSEREFERENCE : ('DocumentRef-' IDSTRING ':')? 'LicenseRef-' IDSTRING ;
-IDSTRING         : (ALPHA | DIGIT)(ALPHA | DIGIT | '-' | '.')* ;
+IDSTRING          : (ALPHA | DIGIT)(ALPHA | DIGIT | '-' | '.')* ;
+LICENSE_EXCEPTION : (IDSTRING '-exception' | IDSTRING '-exception-' IDSTRING) ;
+LICENSE_REFERENCE : ('DocumentRef-' IDSTRING ':')? 'LicenseRef-' IDSTRING ;
 
 WHITESPACE : ' ' -> skip ;

--- a/spdx-utils/src/test/kotlin/SpdxExpressionParserTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxExpressionParserTest.kt
@@ -171,7 +171,7 @@ class SpdxExpressionParserTest : WordSpec() {
                     SpdxExpression.parse("license WITH exception+")
                 }
 
-                exception.message shouldBe "SpdxExpression has invalid amount of children: '3'"
+                exception.message shouldBe "SpdxLicenseExceptionExpression has invalid amount of children: '2'"
             }
 
             "fail if a compound expression is used before WITH" {


### PR DESCRIPTION
Previously, an id without the optional "+" was the same as an exception,
and only the rule order determined that an exception was given precedence.
Now, require an exception to actually require the word "exception" as
specified at

https://spdx.github.io/spdx-spec/appendix-I-SPDX-license-list/#i2-exceptions-list

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1498)
<!-- Reviewable:end -->
