### PR TITLE
DotNet/NuGet: Fix test projects to use an existing jQuery version

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/dotnet/subProjectTest/test.csproj
+++ b/analyzer/src/funTest/assets/projects/synthetic/dotnet/subProjectTest/test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="jQuery" Version="1.3.2"/>
+    <PackageReference Include="jQuery" Version="3.3.1"/>
     <PackageReference Include="WebGrease" Version="1.5.2"/>
   </ItemGroup>
 

--- a/analyzer/src/funTest/assets/projects/synthetic/nuget/packages.config
+++ b/analyzer/src/funTest/assets/projects/synthetic/nuget/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="jQuery" version="1.3.2" targetFramework="net462" />
+  <package id="jQuery" version="3.3.1" targetFramework="net462" />
   <package id="WebGrease" version="1.5.2" targetFramework="net462" />
 </packages>

--- a/analyzer/src/funTest/kotlin/DotNetSupportTest.kt
+++ b/analyzer/src/funTest/kotlin/DotNetSupportTest.kt
@@ -25,8 +25,6 @@ import com.here.ort.model.OrtIssue
 import com.here.ort.model.PackageReference
 import com.here.ort.model.Scope
 
-import io.kotlintest.matchers.beEmpty
-import io.kotlintest.should
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.StringSpec
 
@@ -37,26 +35,6 @@ class DotNetSupportTest : StringSpec() {
     private val projectDir = File("src/funTest/assets/projects/synthetic/dotnet").absoluteFile
 
     init {
-        "non-existing version is mapped to most recent version" {
-            val testPackage = Pair("jQuery", "1.3.2")
-            val dotNetSupport = DotNetSupport(mapOf(testPackage), projectDir)
-            val resultScope = Scope(
-                "dependencies", sortedSetOf(
-                    PackageReference(
-                        Identifier(
-                            type = "nuget",
-                            namespace = "",
-                            name = "jQuery",
-                            version = "3.3.1"
-                        )
-                    )
-                )
-            )
-
-            dotNetSupport.scope shouldBe resultScope
-            dotNetSupport.errors should beEmpty()
-        }
-
         "non-existing project gets registered as error and is not added to scope" {
             val testPackage = Pair("trifj", "2.0.0")
             val testPackage2 = Pair("tffrifj", "2.0.0")


### PR DESCRIPTION
DotNet/NuGet: Fix test projects to use an existing jQuery version

If a non-existing version is used, NuGet falls back to using the most
recent version. Using such non-existing versions in test is undesirable
as it requires to update the tests whenever a new version is released.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1504)
<!-- Reviewable:end -->
