### PR TITLE
StaticHtmlReporter: Improve presentation of rule violations

### DIFF
--- a/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
+++ b/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
@@ -441,19 +441,19 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
         <tbody>
           <tr class="ort-error" id="violation-1">
             <td><a href="#violation-1">1</a></td><td>GPL-1.0-only</td><td>
-              <p>2019-01-02T17:23:55.486Z [ERROR]: GPL-1.0-only - GPL 1 error</p>
+              <p>ERROR: GPL 1 error</p>
               <p></p>
             </td>
           </tr>
           <tr class="ort-warning" id="violation-2">
             <td><a href="#violation-2">2</a></td><td>GPL-2.0-only</td><td>
-              <p>2019-01-02T17:23:55.486Z [WARNING]: GPL-2.0-only - GPL 2 warning</p>
+              <p>WARNING: GPL 2 warning</p>
               <p></p>
             </td>
           </tr>
           <tr class="ort-hint" id="violation-3">
             <td><a href="#violation-3">3</a></td><td>GPL-3.0-only</td><td>
-              <p>2019-01-02T17:23:55.486Z [HINT]: GPL-3.0-only - GPL 3 hint</p>
+              <p>HINT: GPL 3 hint</p>
               <p></p>
             </td>
           </tr>

--- a/reporter/src/main/kotlin/reporters/ReportTableModelMapper.kt
+++ b/reporter/src/main/kotlin/reporters/ReportTableModelMapper.kt
@@ -60,7 +60,7 @@ class ReportTableModelMapper(private val resolutionProvider: ResolutionProvider)
         val resolutions = resolutionProvider.getRuleViolationResolutionsFor(this)
         return ResolvableIssue(
             source = this@toResolvableEvaluatorIssue.source,
-            description = this@toResolvableEvaluatorIssue.toString(),
+            description = "${this@toResolvableEvaluatorIssue.severity}: ${this@toResolvableEvaluatorIssue.message}",
             resolutionDescription = buildString {
                 if (resolutions.isNotEmpty()) {
                     append(resolutions.joinToString(


### PR DESCRIPTION
Do not repeat the source of the violation in the description field and
remove the timestamp, because it is not relevant for rule violations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1506)
<!-- Reviewable:end -->
