### PR TITLE
Introduce a NONE hash to distinguish from UNKNOWN

### DIFF
--- a/analyzer/src/main/kotlin/managers/Stack.kt
+++ b/analyzer/src/main/kotlin/managers/Stack.kt
@@ -25,7 +25,6 @@ import com.here.ort.analyzer.AbstractPackageManagerFactory
 import com.here.ort.analyzer.HTTP_CACHE_PATH
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.downloader.VersionControlSystem
-import com.here.ort.model.Hash
 import com.here.ort.model.Identifier
 import com.here.ort.model.Package
 import com.here.ort.model.PackageReference
@@ -331,10 +330,8 @@ class Stack(
             version = map["version"].orEmpty()
         )
 
-        val artifact = RemoteArtifact(
-            url = "${getPackageUrl(id.name, id.version)}/${id.name}-${id.version}.tar.gz",
-            hash = Hash.UNKNOWN.value,
-            hashAlgorithm = Hash.UNKNOWN.algorithm
+        val artifact = RemoteArtifact.EMPTY.copy(
+            url = "${getPackageUrl(id.name, id.version)}/${id.name}-${id.version}.tar.gz"
         )
 
         val vcs = VcsInfo(

--- a/cli/src/main/kotlin/commands/DownloaderCommand.kt
+++ b/cli/src/main/kotlin/commands/DownloaderCommand.kt
@@ -28,7 +28,6 @@ import com.beust.jcommander.Parameters
 import com.here.ort.CommandWithHelp
 import com.here.ort.downloader.DownloadException
 import com.here.ort.downloader.Downloader
-import com.here.ort.model.Hash
 import com.here.ort.model.Identifier
 import com.here.ort.model.OrtResult
 import com.here.ort.model.Package
@@ -167,14 +166,7 @@ object DownloaderCommand : CommandWithHelp() {
 
             val dummyId = Identifier("Downloader::$projectName:")
             val dummyPackage = if (ARCHIVE_EXTENSIONS.any { projectFile.name.endsWith(it) }) {
-                Package.EMPTY.copy(
-                    id = dummyId,
-                    sourceArtifact = RemoteArtifact(
-                        url = projectUrl!!,
-                        hash = Hash.UNKNOWN.value,
-                        hashAlgorithm = Hash.UNKNOWN.algorithm
-                    )
-                )
+                Package.EMPTY.copy(id = dummyId, sourceArtifact = RemoteArtifact.EMPTY.copy(url = projectUrl!!))
             } else {
                 val vcs = VcsInfo(type = vcsType, url = projectUrl!!, revision = vcsRevision, path = vcsPath)
                 Package.EMPTY.copy(id = dummyId, vcs = vcs, vcsProcessed = vcs.normalize())

--- a/model/src/main/kotlin/Hash.kt
+++ b/model/src/main/kotlin/Hash.kt
@@ -41,9 +41,20 @@ data class Hash(
 ) {
     companion object {
         /**
-         * A constant to specify an unknown hash.
+         * A constant to specify that no hash value (and thus also no hash algorithm) is provided.
          */
-        val UNKNOWN = Hash(HashAlgorithm.UNKNOWN, HashAlgorithm.UNKNOWN.toString())
+        val NONE = Hash(HashAlgorithm.NONE, HashAlgorithm.NONE.toString())
+
+
+        /**
+         * The set of algorithms that cannot be verified.
+         */
+        val UNVERIFIABLE = setOf(HashAlgorithm.NONE, HashAlgorithm.UNKNOWN)
+
+        /**
+         * The list of algorithms that can be verified.
+         */
+        val VERIFIABLE = enumValues<HashAlgorithm>().toSet() - UNVERIFIABLE
 
         /**
          * Create a hash from it a [value].
@@ -67,8 +78,8 @@ data class Hash(
      * Verify that the [file] matches this hash.
      */
     fun verify(file: File): Boolean {
-        require(algorithm != HashAlgorithm.UNKNOWN) {
-            "Cannot verify an unknown hash algorithm."
+        require(algorithm in VERIFIABLE) {
+            "Cannot verify algorithm '$algorithm'. Supported algorithms are $VERIFIABLE."
         }
 
         return file.hash(algorithm.toString()) == value

--- a/model/src/main/kotlin/HashAlgorithm.kt
+++ b/model/src/main/kotlin/HashAlgorithm.kt
@@ -28,9 +28,14 @@ import com.fasterxml.jackson.annotation.JsonValue
  */
 enum class HashAlgorithm(private vararg val aliases: String) {
     /**
+     * No hash algorithm.
+     */
+    NONE(""),
+
+    /**
      * An unknown hash algorithm.
      */
-    UNKNOWN("", "UNKNOWN"),
+    UNKNOWN("UNKNOWN"),
 
     /**
      * The Message-Digest 5 hash algorithm, see [MD5](http://en.wikipedia.org/wiki/MD5).
@@ -72,7 +77,7 @@ enum class HashAlgorithm(private vararg val aliases: String) {
          * Create a hash algorithm from a hash [value].
          */
         fun fromHash(value: String): HashAlgorithm {
-            if (value.isBlank()) return UNKNOWN
+            if (value.isBlank()) return NONE
 
             return when (value.length) {
                 128 -> SHA512

--- a/model/src/main/kotlin/Provenance.kt
+++ b/model/src/main/kotlin/Provenance.kt
@@ -74,9 +74,9 @@ data class Provenance(
     fun matches(pkg: Package): Boolean {
         // If the scanned source code came from a source artifact, it has to match the package's source artifact.
         if (sourceArtifact != null) {
-            // If the (non-empty) hashes match, we do not need to compare the other properties like the URL. Only
-            // support this for a known algorithm whose hash we were able to verify as otherwise the hash could be fake.
-            if (sourceArtifact.hash.isNotEmpty() && sourceArtifact.hashAlgorithm != HashAlgorithm.UNKNOWN) {
+            // If the (non-blank) hash values match, we do not need to compare the other properties like the URL. Only
+            // support this for known algorithms which we are able to verify as otherwise the hash could be fake.
+            if (sourceArtifact.hash.isNotBlank() && sourceArtifact.hashAlgorithm in Hash.VERIFIABLE) {
                 return sourceArtifact.hash == pkg.sourceArtifact.hash
                         && sourceArtifact.hashAlgorithm == pkg.sourceArtifact.hashAlgorithm
             }

--- a/model/src/main/kotlin/RemoteArtifact.kt
+++ b/model/src/main/kotlin/RemoteArtifact.kt
@@ -45,8 +45,8 @@ data class RemoteArtifact(
         @JvmField
         val EMPTY = RemoteArtifact(
             url = "",
-            hash = Hash.UNKNOWN.value,
-            hashAlgorithm = Hash.UNKNOWN.algorithm
+            hash = Hash.NONE.value,
+            hashAlgorithm = Hash.NONE.algorithm
         )
     }
 }

--- a/model/src/test/assets/deprecated-errors-scan-results.yml
+++ b/model/src/test/assets/deprecated-errors-scan-results.yml
@@ -6,7 +6,7 @@ results:
     source_artifact:
       url: "url"
       hash: "hash"
-      hash_algorithm: "SHA-1"
+      hash_algorithm: "UNKNOWN"
   scanner:
     name: "name 1"
     version: "version 1"

--- a/model/src/test/assets/deprecated-licenses-scan-results.yml
+++ b/model/src/test/assets/deprecated-licenses-scan-results.yml
@@ -6,7 +6,7 @@ results:
     source_artifact:
       url: "url"
       hash: "hash"
-      hash_algorithm: "SHA-1"
+      hash_algorithm: "UNKNOWN"
   scanner:
     name: "name 1"
     version: "version 1"

--- a/model/src/test/assets/expected-scan-results.yml
+++ b/model/src/test/assets/expected-scan-results.yml
@@ -6,7 +6,7 @@ results:
     source_artifact:
       url: "url"
       hash: "hash"
-      hash_algorithm: ""
+      hash_algorithm: "UNKNOWN"
   scanner:
     name: "name 1"
     version: "version 1"


### PR DESCRIPTION
Previously, UNKNOWN was used for two cases:

1) An existing hash value of an unknown hash algorithm.
2) A non-existing hash value of no hash algorithm.

However, for case 1) we can still compare actual and expected hash
values by string even without knowing the algorithm. Because of this it
makes sense to distinguish these two cases by introducing NONE for case
2) and keeping UNKNOWN for case 1).

Also fix test data accordingly so that only empty hash values use NONE.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1509)
<!-- Reviewable:end -->
