### PR TITLE
DotNet/NuGet: Decode SRI hashes

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output.yml
@@ -36,7 +36,7 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: "https://api.nuget.org/v3-flatcontainer/antlr/3.4.1.9004/antlr.3.4.1.9004.nupkg"
-      hash: "t4RqqB/yvSHU8okrySS1L2KaaPsAOCDM8NPbiOy8OJw/oiNIjjUzS5igIVJds0m5k5AmYyGWV9jBVpFQcq830w=="
+      hash: "b7846aa81ff2bd21d4f2892bc924b52f629a68fb003820ccf0d3db88ecbc389c3fa223488e35334b98a021525db349b993902663219657d8c156915072af37d3"
       hash_algorithm: "SHA-512"
     source_artifact:
       url: ""
@@ -65,7 +65,7 @@ packages:
     homepage_url: "http://james.newtonking.com/projects/json-net.aspx"
     binary_artifact:
       url: "https://api.nuget.org/v3-flatcontainer/newtonsoft.json/5.0.4/newtonsoft.json.5.0.4.nupkg"
-      hash: "dg2TSL5YEyhbitOHlaKlr+eIvN2rT3GQ7VgcbqUkwNZ6fdW91ThPGX47WljAcKtb23BEk8yOCtY6s191O21hvw=="
+      hash: "760d9348be5813285b8ad38795a2a5afe788bcddab4f7190ed581c6ea524c0d67a7dd5bdd5384f197e3b5a58c070ab5bdb704493cc8e0ad63ab35f753b6d61bf"
       hash_algorithm: "SHA-512"
     source_artifact:
       url: ""
@@ -95,7 +95,7 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: "https://api.nuget.org/v3-flatcontainer/webgrease/1.5.2/webgrease.1.5.2.nupkg"
-      hash: "RT+no0g7Qk28J/XVwHgn5lJ/qm4hyWFp7wt0I71Uw0j3SfTfOmNqPMxfedHanAjtf3dB2/0KjQ3fQkvVewsvsA=="
+      hash: "453fa7a3483b424dbc27f5d5c07827e6527faa6e21c96169ef0b7423bd54c348f749f4df3a636a3ccc5f79d1da9c08ed7f7741dbfd0a8d0ddf424bd57b0b2fb0"
       hash_algorithm: "SHA-512"
     source_artifact:
       url: ""
@@ -129,7 +129,7 @@ packages:
     homepage_url: "http://jquery.com/"
     binary_artifact:
       url: "https://api.nuget.org/v3-flatcontainer/jquery/3.3.1/jquery.3.3.1.nupkg"
-      hash: "Emsts1D6E2AgHVBm4cTD2dxoRyWVG+3zK1x8mYbf+k6aAArPTXHR2Ip++o1utlNbmYIzaPFnhGw3YDexp8PjlQ=="
+      hash: "126b2db350fa1360201d5066e1c4c3d9dc684725951bedf32b5c7c9986dffa4e9a000acf4d71d1d88a7efa8d6eb6535b99823368f167846c376037b1a7c3e395"
       hash_algorithm: "SHA-512"
     source_artifact:
       url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/nuget-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/nuget-expected-output.yml
@@ -36,7 +36,7 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: "https://api.nuget.org/v3-flatcontainer/antlr/3.4.1.9004/antlr.3.4.1.9004.nupkg"
-      hash: "t4RqqB/yvSHU8okrySS1L2KaaPsAOCDM8NPbiOy8OJw/oiNIjjUzS5igIVJds0m5k5AmYyGWV9jBVpFQcq830w=="
+      hash: "b7846aa81ff2bd21d4f2892bc924b52f629a68fb003820ccf0d3db88ecbc389c3fa223488e35334b98a021525db349b993902663219657d8c156915072af37d3"
       hash_algorithm: "SHA-512"
     source_artifact:
       url: ""
@@ -65,7 +65,7 @@ packages:
     homepage_url: "http://james.newtonking.com/projects/json-net.aspx"
     binary_artifact:
       url: "https://api.nuget.org/v3-flatcontainer/newtonsoft.json/5.0.4/newtonsoft.json.5.0.4.nupkg"
-      hash: "dg2TSL5YEyhbitOHlaKlr+eIvN2rT3GQ7VgcbqUkwNZ6fdW91ThPGX47WljAcKtb23BEk8yOCtY6s191O21hvw=="
+      hash: "760d9348be5813285b8ad38795a2a5afe788bcddab4f7190ed581c6ea524c0d67a7dd5bdd5384f197e3b5a58c070ab5bdb704493cc8e0ad63ab35f753b6d61bf"
       hash_algorithm: "SHA-512"
     source_artifact:
       url: ""
@@ -95,7 +95,7 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: "https://api.nuget.org/v3-flatcontainer/webgrease/1.5.2/webgrease.1.5.2.nupkg"
-      hash: "RT+no0g7Qk28J/XVwHgn5lJ/qm4hyWFp7wt0I71Uw0j3SfTfOmNqPMxfedHanAjtf3dB2/0KjQ3fQkvVewsvsA=="
+      hash: "453fa7a3483b424dbc27f5d5c07827e6527faa6e21c96169ef0b7423bd54c348f749f4df3a636a3ccc5f79d1da9c08ed7f7741dbfd0a8d0ddf424bd57b0b2fb0"
       hash_algorithm: "SHA-512"
     source_artifact:
       url: ""
@@ -129,7 +129,7 @@ packages:
     homepage_url: "http://jquery.com/"
     binary_artifact:
       url: "https://api.nuget.org/v3-flatcontainer/jquery/3.3.1/jquery.3.3.1.nupkg"
-      hash: "Emsts1D6E2AgHVBm4cTD2dxoRyWVG+3zK1x8mYbf+k6aAArPTXHR2Ip++o1utlNbmYIzaPFnhGw3YDexp8PjlQ=="
+      hash: "126b2db350fa1360201d5066e1c4c3d9dc684725951bedf32b5c7c9986dffa4e9a000acf4d71d1d88a7efa8d6eb6535b99823368f167846c376037b1a7c3e395"
       hash_algorithm: "SHA-512"
     source_artifact:
       url: ""

--- a/analyzer/src/main/kotlin/DotNetSupport.kt
+++ b/analyzer/src/main/kotlin/DotNetSupport.kt
@@ -23,7 +23,7 @@ package com.here.ort.analyzer
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 
-import com.here.ort.model.HashAlgorithm
+import com.here.ort.model.Hash
 import com.here.ort.model.Identifier
 import com.here.ort.model.OrtIssue
 import com.here.ort.model.Package
@@ -87,14 +87,14 @@ class DotNetSupport(
                 }
             }
 
-        private fun extractRemoteArtifact(node: JsonNode, nupkgUrl: String) =
-            RemoteArtifact(
-                url = nupkgUrl,
-                hash = node["packageHash"].textValueOrEmpty(),
-                hashAlgorithm = HashAlgorithm.fromString(
-                    node["packageHashAlgorithm"].textValueOrEmpty()
-                )
-            )
+        private fun extractRemoteArtifact(node: JsonNode, nupkgUrl: String): RemoteArtifact {
+            val encodedHash = node["packageHash"].textValueOrEmpty()
+            val hashAlgorithm = node["packageHashAlgorithm"].textValueOrEmpty()
+            val sri = hashAlgorithm.replace("-", "") + "-" + encodedHash
+            val hash = Hash.fromValue(sri)
+
+            return RemoteArtifact(nupkgUrl, hash.value, hash.algorithm)
+        }
 
         private fun getCatalogURL(registrationNode: JsonNode): String =
             registrationNode["catalogEntry"].textValueOrEmpty()


### PR DESCRIPTION
The NuGet hashes are in fact SRI-style hashes that are Base64-encoded,
so decode them.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1516)
<!-- Reviewable:end -->
