### PR TITLE
Bundle the hash algorithm and value into an object for (de-)serialization

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
@@ -64,12 +64,14 @@ analyzer:
         homepage_url: "http://github.com/sbt/junit-interface/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/com/novocode/junit-interface/0.11/junit-interface-0.11.jar"
-          hash: "38bb853c93abfbe14a0514016f0f70dd73422d9f"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "38bb853c93abfbe14a0514016f0f70dd73422d9f"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/com/novocode/junit-interface/0.11/junit-interface-0.11-sources.jar"
-          hash: "c7c1394bbc5718aa256557544d891b3842825a8d"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "c7c1394bbc5718aa256557544d891b3842825a8d"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git@github.com:sbt/junit-interface.git"
@@ -93,12 +95,14 @@ analyzer:
         homepage_url: "http://junit.org"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12.jar"
-          hash: "2973d150c0dc1fefe998f834810d68f278ea58ec"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "2973d150c0dc1fefe998f834810d68f278ea58ec"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
-          hash: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/junit-team/junit.git"
@@ -123,12 +127,14 @@ analyzer:
         homepage_url: "https://github.com/hamcrest/JavaHamcrest/hamcrest-core"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"
-          hash: "42a25dc3219429f0e5d060061f71acb49bf010a0"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "42a25dc3219429f0e5d060061f71acb49bf010a0"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
-          hash: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git@github.com:hamcrest/JavaHamcrest.git"
@@ -152,12 +158,14 @@ analyzer:
         homepage_url: "http://www.scala-sbt.org"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0.jar"
-          hash: "0a3f14d010c4cb32071f863d97291df31603b521"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "0a3f14d010c4cb32071f863d97291df31603b521"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0-sources.jar"
-          hash: "d44b23e9e3419ad0e00b91bba764a48d43075000"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "d44b23e9e3419ad0e00b91bba764a48d43075000"
+            algorithm: "SHA-1"
         vcs:
           type: ""
           url: ""

--- a/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
@@ -40,12 +40,14 @@ packages:
     homepage_url: "http://github.com/pallets/flask/"
     binary_artifact:
       url: "https://files.pythonhosted.org/packages/0e/e9/37ee66dde483dceefe45bb5e92b387f990d4f097df40c400cf816dcebaa4/Flask-0.12-py2.py3-none-any.whl"
-      hash: "d3351b10f54446203ac0fd8839850c62"
-      hash_algorithm: "MD5"
+      hash:
+        value: "d3351b10f54446203ac0fd8839850c62"
+        algorithm: "MD5"
     source_artifact:
       url: "https://files.pythonhosted.org/packages/4b/3a/4c20183df155dd2e39168e35d53a388efb384a512ca6c73001d8292c094a/Flask-0.12.tar.gz"
-      hash: "c1d30f51cff4a38f9454b23328a15c5a"
-      hash_algorithm: "MD5"
+      hash:
+        value: "c1d30f51cff4a38f9454b23328a15c5a"
+        algorithm: "MD5"
     vcs:
       type: ""
       url: ""
@@ -69,12 +71,14 @@ packages:
     homepage_url: "http://jinja.pocoo.org/"
     binary_artifact:
       url: "https://files.pythonhosted.org/packages/67/ea/92b1d9d8f2dc43302df7f5271b9500bbfc237386782343561a5f62beb306/Jinja2-2.8.1-py2.py3-none-any.whl"
-      hash: "7472b9df828747c2d44eb539558bbf7a"
-      hash_algorithm: "MD5"
+      hash:
+        value: "7472b9df828747c2d44eb539558bbf7a"
+        algorithm: "MD5"
     source_artifact:
       url: "https://files.pythonhosted.org/packages/5f/bd/5815d4d925a2b8cbbb4b4960f018441b0c65f24ba29f3bdcfb3c8218a307/Jinja2-2.8.1.tar.gz"
-      hash: "150a8f1c180272753cf46dd3cdd6decf"
-      hash_algorithm: "MD5"
+      hash:
+        value: "150a8f1c180272753cf46dd3cdd6decf"
+        algorithm: "MD5"
     vcs:
       type: ""
       url: ""
@@ -98,12 +102,14 @@ packages:
     homepage_url: "https://palletsprojects.com/p/markupsafe/"
     binary_artifact:
       url: "https://files.pythonhosted.org/packages/6d/d2/0ccd2c0e2cd93b35e765d9b3205cd6602e6b202b522fc7997531353715b3/MarkupSafe-1.1.1-cp27-cp27m-macosx_10_6_intel.whl"
-      hash: "c937b3654640ee5864f2917bf24a7ad2"
-      hash_algorithm: "MD5"
+      hash:
+        value: "c937b3654640ee5864f2917bf24a7ad2"
+        algorithm: "MD5"
     source_artifact:
       url: "https://files.pythonhosted.org/packages/b9/2e/64db92e53b86efccfaea71321f597fa2e1b2bd3853d8ce658568f7a13094/MarkupSafe-1.1.1.tar.gz"
-      hash: "43fd756864fe42063068e092e220c57b"
-      hash_algorithm: "MD5"
+      hash:
+        value: "43fd756864fe42063068e092e220c57b"
+        algorithm: "MD5"
     vcs:
       type: ""
       url: ""
@@ -127,12 +133,14 @@ packages:
     homepage_url: "https://palletsprojects.com/p/werkzeug/"
     binary_artifact:
       url: "https://files.pythonhosted.org/packages/9f/57/92a497e38161ce40606c27a86759c6b92dd34fcdb33f64171ec559257c02/Werkzeug-0.15.4-py2.py3-none-any.whl"
-      hash: "abd0838797100e25fc87bdd63f3c0470"
-      hash_algorithm: "MD5"
+      hash:
+        value: "abd0838797100e25fc87bdd63f3c0470"
+        algorithm: "MD5"
     source_artifact:
       url: "https://files.pythonhosted.org/packages/59/2d/b24bab64b409e22f026fee6705b035cb0698399a7b69449c49442b30af47/Werkzeug-0.15.4.tar.gz"
-      hash: "c0dfc8b685d2a9912d500d3fa8a1d60b"
-      hash_algorithm: "MD5"
+      hash:
+        value: "c0dfc8b685d2a9912d500d3fa8a1d60b"
+        algorithm: "MD5"
     vcs:
       type: ""
       url: ""
@@ -155,12 +163,14 @@ packages:
     homepage_url: "https://palletsprojects.com/p/click/"
     binary_artifact:
       url: "https://files.pythonhosted.org/packages/fa/37/45185cb5abbc30d7257104c434fe0b07e5a195a6847506c074527aa599ec/Click-7.0-py2.py3-none-any.whl"
-      hash: "4de489e31c57834a21b8be7111dab613"
-      hash_algorithm: "MD5"
+      hash:
+        value: "4de489e31c57834a21b8be7111dab613"
+        algorithm: "MD5"
     source_artifact:
       url: "https://files.pythonhosted.org/packages/f8/5c/f60e9d8a1e77005f664b76ff8aeaee5bc05d0a91798afd7f53fc998dbc47/Click-7.0.tar.gz"
-      hash: "7f53d50f7b7373ebc7963f9ff697450a"
-      hash_algorithm: "MD5"
+      hash:
+        value: "7f53d50f7b7373ebc7963f9ff697450a"
+        algorithm: "MD5"
     vcs:
       type: ""
       url: ""
@@ -183,12 +193,14 @@ packages:
     homepage_url: "http://gunicorn.org"
     binary_artifact:
       url: "https://files.pythonhosted.org/packages/72/de/ec28a64885e0b390063379cca601b60b1f9e51367e0c76030ac8a5cddd5e/gunicorn-19.6.0-py2.py3-none-any.whl"
-      hash: "ab69dff52e2e0bccb25bf1e3a82e1448"
-      hash_algorithm: "MD5"
+      hash:
+        value: "ab69dff52e2e0bccb25bf1e3a82e1448"
+        algorithm: "MD5"
     source_artifact:
       url: "https://files.pythonhosted.org/packages/84/ce/7ea5396efad1cef682bbc4068e72a0276341d9d9d0f501da609fab9fcb80/gunicorn-19.6.0.tar.gz"
-      hash: "338e5e8a83ea0f0625f768dba4597530"
-      hash_algorithm: "MD5"
+      hash:
+        value: "338e5e8a83ea0f0625f768dba4597530"
+        algorithm: "MD5"
     vcs:
       type: ""
       url: ""
@@ -211,12 +223,14 @@ packages:
     homepage_url: "https://palletsprojects.com/p/itsdangerous/"
     binary_artifact:
       url: "https://files.pythonhosted.org/packages/76/ae/44b03b253d6fade317f32c24d100b3b35c2239807046a4c953c7b89fa49e/itsdangerous-1.1.0-py2.py3-none-any.whl"
-      hash: "55179072b7f84ae38f16b3fdca33aa4f"
-      hash_algorithm: "MD5"
+      hash:
+        value: "55179072b7f84ae38f16b3fdca33aa4f"
+        algorithm: "MD5"
     source_artifact:
       url: "https://files.pythonhosted.org/packages/68/1a/f27de07a8a304ad5fa817bbe383d1238ac4396da447fa11ed937039fa04b/itsdangerous-1.1.0.tar.gz"
-      hash: "9b7f5afa7f1e3acfb7786eeca3d99307"
-      hash_algorithm: "MD5"
+      hash:
+        value: "9b7f5afa7f1e3acfb7786eeca3d99307"
+        algorithm: "MD5"
     vcs:
       type: ""
       url: ""

--- a/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
@@ -951,12 +951,14 @@ analyzer:
         homepage_url: "http://www.antlr.org/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/antlr/antlr/2.7.7/antlr-2.7.7.jar"
-          hash: "83cd2cd674a217ade95a4bb83a8a14f351f48bd0"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "83cd2cd674a217ade95a4bb83a8a14f351f48bd0"
+            algorithm: "SHA-1"
         source_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         vcs:
           type: ""
           url: ""
@@ -980,12 +982,14 @@ analyzer:
         homepage_url: "http://github.com/FasterXML/jackson"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.9.0/jackson-annotations-2.9.0.jar"
-          hash: "07c10d545325e3a6e72e06381afe469fd40eb701"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "07c10d545325e3a6e72e06381afe469fd40eb701"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.9.0/jackson-annotations-2.9.0-sources.jar"
-          hash: "a0ad4e203304ccab7e01266fa814115850edb8a9"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "a0ad4e203304ccab7e01266fa814115850edb8a9"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git@github.com:FasterXML/jackson-annotations.git"
@@ -1009,12 +1013,14 @@ analyzer:
         homepage_url: "https://github.com/FasterXML/jackson-core"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.9.6/jackson-core-2.9.6.jar"
-          hash: "4e393793c37c77e042ccc7be5a914ae39251b365"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "4e393793c37c77e042ccc7be5a914ae39251b365"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.9.6/jackson-core-2.9.6-sources.jar"
-          hash: "297b561cc2ca89e07bf4cb6445c08260b524aa4d"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "297b561cc2ca89e07bf4cb6445c08260b524aa4d"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git@github.com:FasterXML/jackson-core.git"
@@ -1038,12 +1044,14 @@ analyzer:
         homepage_url: "http://github.com/FasterXML/jackson"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.6/jackson-databind-2.9.6.jar"
-          hash: "cfa4f316351a91bfd95cb0644c6a2c95f52db1fc"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "cfa4f316351a91bfd95cb0644c6a2c95f52db1fc"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.6/jackson-databind-2.9.6-sources.jar"
-          hash: "dad3a9fbbedf8781dfd138539cd82638ebad5678"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "dad3a9fbbedf8781dfd138539cd82638ebad5678"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git@github.com:FasterXML/jackson-databind.git"
@@ -1066,12 +1074,14 @@ analyzer:
         homepage_url: "https://github.com/andrewoma/dexx"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/com/github/andrewoma/dexx/collection/0.7/collection-0.7.jar"
-          hash: "264efc08bdcd22126bd429aaea9efaf5158b2b90"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "264efc08bdcd22126bd429aaea9efaf5158b2b90"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/com/github/andrewoma/dexx/collection/0.7/collection-0.7-sources.jar"
-          hash: "2ae719e29cc8881a0e27714acf8ef56597c1fb1f"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "2ae719e29cc8881a0e27714acf8ef56597c1fb1f"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "https://github.com/andrewoma/dexx.git"
@@ -1095,12 +1105,14 @@ analyzer:
         homepage_url: "https://cliftonlabs.github.io/json-simple/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/com/github/cliftonlabs/json-simple/2.3.1/json-simple-2.3.1.jar"
-          hash: "3c85e3c6bd74262da4ae008c657b8ec2e2e35c89"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "3c85e3c6bd74262da4ae008c657b8ec2e2e35c89"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/com/github/cliftonlabs/json-simple/2.3.1/json-simple-2.3.1-sources.jar"
-          hash: "5b5b13c1b449042bd342c4ec4a103b34375a1494"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "5b5b13c1b449042bd342c4ec4a103b34375a1494"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "https://github.com/cliftonlabs/json-simple.git"
@@ -1124,12 +1136,14 @@ analyzer:
         homepage_url: "http://github.com/jsonld-java/jsonld-java/jsonld-java/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/com/github/jsonld-java/jsonld-java/0.12.1/jsonld-java-0.12.1.jar"
-          hash: "a47686f733038125bd327147487dec96a2fb238e"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "a47686f733038125bd327147487dec96a2fb238e"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/com/github/jsonld-java/jsonld-java/0.12.1/jsonld-java-0.12.1-sources.jar"
-          hash: "0db9097c3b633c55017cca9d5a2d6bc4e3af203c"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "0db9097c3b633c55017cca9d5a2d6bc4e3af203c"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git@github.com:jsonld-java/jsonld-java.git"
@@ -1152,12 +1166,14 @@ analyzer:
         homepage_url: "http://github.com/spullara/mustache.java"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/com/github/spullara/mustache/java/compiler/0.7.9/compiler-0.7.9.jar"
-          hash: "ff7dba87e24f6074a84f31e2ab7c041e3e94e35b"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "ff7dba87e24f6074a84f31e2ab7c041e3e94e35b"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/com/github/spullara/mustache/java/compiler/0.7.9/compiler-0.7.9-sources.jar"
-          hash: "1014c81c0c36ca20359e6094af3bf94ee2d6ea2e"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "1014c81c0c36ca20359e6094af3bf94ee2d6ea2e"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/spullara/mustache.java.git"
@@ -1183,12 +1199,14 @@ analyzer:
         homepage_url: "https://github.com/virtuald/curvesapi"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/com/github/virtuald/curvesapi/1.04/curvesapi-1.04.jar"
-          hash: "3386abf821719bc89c7685f9eaafaf4a842f0199"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "3386abf821719bc89c7685f9eaafaf4a842f0199"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/com/github/virtuald/curvesapi/1.04/curvesapi-1.04-sources.jar"
-          hash: "5c01708d122c6a61e90716e931b58226d8261312"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "5c01708d122c6a61e90716e931b58226d8261312"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/virtuald/curvesapi.git"
@@ -1211,12 +1229,14 @@ analyzer:
         homepage_url: "https://github.com/google/gson/gson"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/com/google/code/gson/gson/2.8.0/gson-2.8.0.jar"
-          hash: "c4ba5371a29ac9b2ad6129b1d39ea38750043eff"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "c4ba5371a29ac9b2ad6129b1d39ea38750043eff"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/com/google/code/gson/gson/2.8.0/gson-2.8.0-sources.jar"
-          hash: "baf95d8519fc1a11d388f8543cb40cd2bb9d66dc"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "baf95d8519fc1a11d388f8543cb40cd2bb9d66dc"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "https://github.com/google/gson.git"
@@ -1242,12 +1262,14 @@ analyzer:
         homepage_url: "http://code.google.com/p/guava-libraries/guava"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/com/google/guava/guava/16.0.1/guava-16.0.1.jar"
-          hash: "5fa98cd1a63c99a44dd8d3b77e4762b066a5d0c5"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "5fa98cd1a63c99a44dd8d3b77e4762b066a5d0c5"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/com/google/guava/guava/16.0.1/guava-16.0.1-sources.jar"
-          hash: "2477d012cd5379f9696e0d9d3ccc62ad13a09ca4"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "2477d012cd5379f9696e0d9d3ccc62ad13a09ca4"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "https://code.google.com/p/guava-libraries/"
@@ -1271,12 +1293,14 @@ analyzer:
         homepage_url: "http://commons.apache.org/proper/commons-cli/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/commons-cli/commons-cli/1.4/commons-cli-1.4.jar"
-          hash: "c51c00206bb913cd8612b24abd9fa98ae89719b1"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "c51c00206bb913cd8612b24abd9fa98ae89719b1"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/commons-cli/commons-cli/1.4/commons-cli-1.4-sources.jar"
-          hash: "40dfd9fdef125e19136135e68d54af6d9b0cfbb8"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "40dfd9fdef125e19136135e68d54af6d9b0cfbb8"
+            algorithm: "SHA-1"
         vcs:
           type: "svn"
           url: "http://svn.apache.org/repos/asf/commons/proper/cli/trunk/"
@@ -1302,12 +1326,14 @@ analyzer:
         homepage_url: "http://commons.apache.org/proper/commons-codec/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.10/commons-codec-1.10.jar"
-          hash: "4b95f4897fa13f2cd904aee711aeafc0c5295cd8"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "4b95f4897fa13f2cd904aee711aeafc0c5295cd8"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.10/commons-codec-1.10-sources.jar"
-          hash: "11fb3d88ae7e3b757d70237064210ceb954a5a04"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "11fb3d88ae7e3b757d70237064210ceb954a5a04"
+            algorithm: "SHA-1"
         vcs:
           type: "svn"
           url: "http://svn.apache.org/repos/asf/commons/proper/codec/trunk"
@@ -1332,12 +1358,14 @@ analyzer:
         homepage_url: "http://commons.apache.org/proper/commons-io/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/commons-io/commons-io/2.6/commons-io-2.6.jar"
-          hash: "815893df5f31da2ece4040fe0a12fd44b577afaf"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "815893df5f31da2ece4040fe0a12fd44b577afaf"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/commons-io/commons-io/2.6/commons-io-2.6-sources.jar"
-          hash: "2566800dc841d9d2c5a0d34d807e45d4107dbbdf"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "2566800dc841d9d2c5a0d34d807e45d4107dbbdf"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "http://git-wip-us.apache.org/repos/asf/commons-io.git"
@@ -1361,12 +1389,14 @@ analyzer:
         homepage_url: "http://junit.org"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12.jar"
-          hash: "2973d150c0dc1fefe998f834810d68f278ea58ec"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "2973d150c0dc1fefe998f834810d68f278ea58ec"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
-          hash: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/junit-team/junit.git"
@@ -1389,12 +1419,14 @@ analyzer:
         homepage_url: "http://opencsv.sf.net"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/net/sf/opencsv/opencsv/2.3/opencsv-2.3.jar"
-          hash: "c23708cdb9e80a144db433e23344a788a1fd6599"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "c23708cdb9e80a144db433e23344a788a1fd6599"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/net/sf/opencsv/opencsv/2.3/opencsv-2.3-sources.jar"
-          hash: "235993117036d44d126f76db9ea2202ee4884682"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "235993117036d44d126f76db9ea2202ee4884682"
+            algorithm: "SHA-1"
         vcs:
           type: "svn"
           url: "https://opencsv.svn.sourceforge.net/svnroot/opencsv/trunk"
@@ -1417,12 +1449,14 @@ analyzer:
         homepage_url: "http://saxon.sf.net"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/net/sf/saxon/saxon-dom/8.7/saxon-dom-8.7.jar"
-          hash: "ca5abeba98e41eca830e6ddc74385a9538c0c908"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "ca5abeba98e41eca830e6ddc74385a9538c0c908"
+            algorithm: "SHA-1"
         source_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         vcs:
           type: ""
           url: ""
@@ -1445,12 +1479,14 @@ analyzer:
         homepage_url: "http://saxon.sf.net"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/net/sf/saxon/saxon/8.7/saxon-8.7.jar"
-          hash: "68f963a06e2c384ab8d60aaa89ed0363928f6e84"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "68f963a06e2c384ab8d60aaa89ed0363928f6e84"
+            algorithm: "SHA-1"
         source_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         vcs:
           type: ""
           url: ""
@@ -1478,12 +1514,14 @@ analyzer:
         homepage_url: "http://about.validator.nu/htmlparser/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/nu/validator/htmlparser/htmlparser/1.4/htmlparser-1.4.jar"
-          hash: "70573d780fa08271499e201bbd86caa3c62f20e1"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "70573d780fa08271499e201bbd86caa3c62f20e1"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/nu/validator/htmlparser/htmlparser/1.4/htmlparser-1.4-sources.jar"
-          hash: "7703abdb7fba3ed993330e5d3aac163268f69e15"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "7703abdb7fba3ed993330e5d3aac163268f69e15"
+            algorithm: "SHA-1"
         vcs:
           type: "hg"
           url: "http://hg.mozilla.org/projects/htmlparser/"
@@ -1516,12 +1554,14 @@ analyzer:
         homepage_url: "http://www.stringtemplate.org"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/antlr/ST4/4.0.4/ST4-4.0.4.jar"
-          hash: "467a2aa12be6d0f0f68c70eecf6714ab733027ac"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "467a2aa12be6d0f0f68c70eecf6714ab733027ac"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/antlr/ST4/4.0.4/ST4-4.0.4-sources.jar"
-          hash: "e13c7f5f536ad6cabfa5de628fcb93910531a293"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "e13c7f5f536ad6cabfa5de628fcb93910531a293"
+            algorithm: "SHA-1"
         vcs:
           type: ""
           url: ""
@@ -1543,12 +1583,14 @@ analyzer:
         homepage_url: "http://www.antlr.org"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/antlr/antlr-runtime/3.4/antlr-runtime-3.4.jar"
-          hash: "8f011408269a8e42b8548687e137d8eeb56df4b4"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "8f011408269a8e42b8548687e137d8eeb56df4b4"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/antlr/antlr-runtime/3.4/antlr-runtime-3.4-sources.jar"
-          hash: "57a73190ad97f56c0cb83a6a5b6c08d5d428319b"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "57a73190ad97f56c0cb83a6a5b6c08d5d428319b"
+            algorithm: "SHA-1"
         vcs:
           type: ""
           url: ""
@@ -1570,12 +1612,14 @@ analyzer:
         homepage_url: "http://antlr.org"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/antlr/antlr/3.4/antlr-3.4.jar"
-          hash: "7797e70e3f5cb4229695f08ff50333266cf81125"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "7797e70e3f5cb4229695f08ff50333266cf81125"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/antlr/antlr/3.4/antlr-3.4-sources.jar"
-          hash: "2e6a31f24631eb533d8170da9cac6849345f8fda"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "2e6a31f24631eb533d8170da9cac6849345f8fda"
+            algorithm: "SHA-1"
         vcs:
           type: "svn"
           url: "http://svn.sonatype.org/spice/tags/oss-parent-7"
@@ -1608,12 +1652,14 @@ analyzer:
         homepage_url: "http://www.stringtemplate.org"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/antlr/stringtemplate/3.2.1/stringtemplate-3.2.1.jar"
-          hash: "59ec8083721eae215c6f3caee944c410d2be34de"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "59ec8083721eae215c6f3caee944c410d2be34de"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/antlr/stringtemplate/3.2.1/stringtemplate-3.2.1-sources.jar"
-          hash: "105785687b0c85a7f70cddfdc3a391bcab121872"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "105785687b0c85a7f70cddfdc3a391bcab121872"
+            algorithm: "SHA-1"
         vcs:
           type: ""
           url: ""
@@ -1637,12 +1683,14 @@ analyzer:
         homepage_url: "http://commons.apache.org/proper/commons-collections/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-collections4/4.1/commons-collections4-4.1.jar"
-          hash: "a4cf4688fe1c7e3a63aa636cc96d013af537768e"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "a4cf4688fe1c7e3a63aa636cc96d013af537768e"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-collections4/4.1/commons-collections4-4.1-sources.jar"
-          hash: "f305f3aa45a3b208c013ef92328f8f230329f20e"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "f305f3aa45a3b208c013ef92328f8f230329f20e"
+            algorithm: "SHA-1"
         vcs:
           type: "svn"
           url: "http://svn.apache.org/repos/asf/commons/proper/collections/trunk"
@@ -1668,12 +1716,14 @@ analyzer:
         homepage_url: "https://commons.apache.org/proper/commons-compress/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/1.17/commons-compress-1.17.jar"
-          hash: "474c20609032e7f815ef534cd8174d2e400d9a8d"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "474c20609032e7f815ef534cd8174d2e400d9a8d"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/1.17/commons-compress-1.17-sources.jar"
-          hash: "9d064d7d42ee1d04ae07ad23025b4f9616652eed"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "9d064d7d42ee1d04ae07ad23025b4f9616652eed"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "https://git-wip-us.apache.org/repos/asf/commons-compress.git"
@@ -1697,12 +1747,14 @@ analyzer:
         homepage_url: "http://commons.apache.org/proper/commons-csv/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-csv/1.5/commons-csv-1.5.jar"
-          hash: "e10f140af5b82167640f254fa9d88e35ad74329c"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "e10f140af5b82167640f254fa9d88e35ad74329c"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-csv/1.5/commons-csv-1.5-sources.jar"
-          hash: "b76c277916ffef14d63279b896b6a82252ddeb79"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "b76c277916ffef14d63279b896b6a82252ddeb79"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "http://git-wip-us.apache.org/repos/asf/commons-csv.git"
@@ -1727,12 +1779,14 @@ analyzer:
         homepage_url: "http://commons.apache.org/lang/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.1/commons-lang3-3.1.jar"
-          hash: "905075e6c80f206bbe6cf1e809d2caa69f420c76"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "905075e6c80f206bbe6cf1e809d2caa69f420c76"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.1/commons-lang3-3.1-sources.jar"
-          hash: "8d30b90ae8bda4fbac8363161c8a9b5a99e23baf"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "8d30b90ae8bda4fbac8363161c8a9b5a99e23baf"
+            algorithm: "SHA-1"
         vcs:
           type: "svn"
           url: "http://svn.apache.org/repos/asf/commons/proper/lang/trunk"
@@ -1757,12 +1811,14 @@ analyzer:
         homepage_url: "http://commons.apache.org/proper/commons-lang/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar"
-          hash: "6505a72a097d9270f7a9e7bf42c4238283247755"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "6505a72a097d9270f7a9e7bf42c4238283247755"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1-sources.jar"
-          hash: "e9748d7783594da3735ad9724390a10e7cebc01d"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "e9748d7783594da3735ad9724390a10e7cebc01d"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
@@ -1785,12 +1841,14 @@ analyzer:
         homepage_url: "http://hc.apache.org/httpcomponents-client"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient-cache/4.5.5/httpclient-cache-4.5.5.jar"
-          hash: "8115af15235c603db957db37f24e0faa168474f7"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "8115af15235c603db957db37f24e0faa168474f7"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient-cache/4.5.5/httpclient-cache-4.5.5-sources.jar"
-          hash: "f619aff61d2307f2f01de79ca4ffb554f695d7c3"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "f619aff61d2307f2f01de79ca4ffb554f695d7c3"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "https://git-wip-us.apache.org/repos/asf/httpcomponents-client.git"
@@ -1813,12 +1871,14 @@ analyzer:
         homepage_url: "http://hc.apache.org/httpcomponents-client"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.5.5/httpclient-4.5.5.jar"
-          hash: "1603dfd56ebcd583ccdf337b6c3984ac55d89e58"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "1603dfd56ebcd583ccdf337b6c3984ac55d89e58"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.5.5/httpclient-4.5.5-sources.jar"
-          hash: "9fd59f6f22326a4241f9524fdfd66a1f34824054"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "9fd59f6f22326a4241f9524fdfd66a1f34824054"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "https://git-wip-us.apache.org/repos/asf/httpcomponents-client.git"
@@ -1841,12 +1901,14 @@ analyzer:
         homepage_url: "http://hc.apache.org/httpcomponents-core-ga"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.9/httpcore-4.4.9.jar"
-          hash: "a86ce739e5a7175b4b234c290a00a5fdb80957a0"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "a86ce739e5a7175b4b234c290a00a5fdb80957a0"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.9/httpcore-4.4.9-sources.jar"
-          hash: "5808b4637c385d939e901eee3dc5f1121fc73a3b"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "5808b4637c385d939e901eee3dc5f1121fc73a3b"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "https://git-wip-us.apache.org/repos/asf/httpcomponents-core.git"
@@ -1870,12 +1932,14 @@ analyzer:
         homepage_url: "http://jena.apache.org/apache-jena-libs/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/jena/apache-jena-libs/3.9.0/apache-jena-libs-3.9.0.pom"
-          hash: "91f9355a290f35e94c30d4cef30cc5328f1d68a5"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "91f9355a290f35e94c30d4cef30cc5328f1d68a5"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/jena/apache-jena-libs/3.9.0/apache-jena-libs-3.9.0.pom"
-          hash: "91f9355a290f35e94c30d4cef30cc5328f1d68a5"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "91f9355a290f35e94c30d4cef30cc5328f1d68a5"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "https://git-wip-us.apache.org/repos/asf/jena.git"
@@ -1898,12 +1962,14 @@ analyzer:
         homepage_url: "http://jena.apache.org/jena-arq/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/jena/jena-arq/3.9.0/jena-arq-3.9.0.jar"
-          hash: "b44ea2da8bdaf61e77272070f96ee2e29a70bfe3"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "b44ea2da8bdaf61e77272070f96ee2e29a70bfe3"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/jena/jena-arq/3.9.0/jena-arq-3.9.0-sources.jar"
-          hash: "51048d4801496588fab0a91ffd38b4c8d3f5d94c"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "51048d4801496588fab0a91ffd38b4c8d3f5d94c"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "https://git-wip-us.apache.org/repos/asf/jena.git"
@@ -1927,12 +1993,14 @@ analyzer:
         homepage_url: "http://jena.apache.org/jena-base/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/jena/jena-base/3.9.0/jena-base-3.9.0.jar"
-          hash: "9e4acf03fa31d4408ab6aafc492e8595de2fe731"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "9e4acf03fa31d4408ab6aafc492e8595de2fe731"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/jena/jena-base/3.9.0/jena-base-3.9.0-sources.jar"
-          hash: "cba2a11b8d1b4636f0836e5125c6b5b62cde121e"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "cba2a11b8d1b4636f0836e5125c6b5b62cde121e"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "https://git-wip-us.apache.org/repos/asf/jena.git"
@@ -1957,12 +2025,14 @@ analyzer:
         homepage_url: "http://jena.apache.org/jena-core/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/jena/jena-core/3.9.0/jena-core-3.9.0.jar"
-          hash: "2133974da091ea11638c47d9977bff6ee92e2877"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "2133974da091ea11638c47d9977bff6ee92e2877"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/jena/jena-core/3.9.0/jena-core-3.9.0-sources.jar"
-          hash: "dd16c18b53a009b49f0028d2bc0e137a5ff6bf96"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "dd16c18b53a009b49f0028d2bc0e137a5ff6bf96"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "https://git-wip-us.apache.org/repos/asf/jena.git"
@@ -1991,12 +2061,14 @@ analyzer:
         homepage_url: "http://jena.apache.org/jena-dboe-base/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/jena/jena-dboe-base/3.9.0/jena-dboe-base-3.9.0.jar"
-          hash: "5a7ba9babdcfb8e2fcfc8acb5a6be93c0e086548"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "5a7ba9babdcfb8e2fcfc8acb5a6be93c0e086548"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/jena/jena-dboe-base/3.9.0/jena-dboe-base-3.9.0-sources.jar"
-          hash: "1fb6ed0e206bf1bef38afdef2fae7cd6610039c0"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "1fb6ed0e206bf1bef38afdef2fae7cd6610039c0"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "https://git-wip-us.apache.org/repos/asf/jena.git"
@@ -2025,12 +2097,14 @@ analyzer:
         homepage_url: "http://jena.apache.org/jena-dboe-index/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/jena/jena-dboe-index/3.9.0/jena-dboe-index-3.9.0.jar"
-          hash: "4f9d134b1fc2caf43baad59e4decf3bb64d6dbdb"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "4f9d134b1fc2caf43baad59e4decf3bb64d6dbdb"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/jena/jena-dboe-index/3.9.0/jena-dboe-index-3.9.0-sources.jar"
-          hash: "b602643a7642887ba423fe99742e835f2751ea82"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "b602643a7642887ba423fe99742e835f2751ea82"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "https://git-wip-us.apache.org/repos/asf/jena.git"
@@ -2059,12 +2133,14 @@ analyzer:
         homepage_url: "http://jena.apache.org/jena-dboe-trans-data/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/jena/jena-dboe-trans-data/3.9.0/jena-dboe-trans-data-3.9.0.jar"
-          hash: "fb6e44296842cd7c1f374c9b6cf36a4a7babd8d8"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "fb6e44296842cd7c1f374c9b6cf36a4a7babd8d8"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/jena/jena-dboe-trans-data/3.9.0/jena-dboe-trans-data-3.9.0-sources.jar"
-          hash: "7dc38aa7173425e941f2a0f7ba740e1f705dfe81"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "7dc38aa7173425e941f2a0f7ba740e1f705dfe81"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "https://git-wip-us.apache.org/repos/asf/jena.git"
@@ -2093,12 +2169,14 @@ analyzer:
         homepage_url: "http://jena.apache.org/jena-dboe-transaction/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/jena/jena-dboe-transaction/3.9.0/jena-dboe-transaction-3.9.0.jar"
-          hash: "2ae13878df1bdb473b15ca40cee6dbbcaff777db"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "2ae13878df1bdb473b15ca40cee6dbbcaff777db"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/jena/jena-dboe-transaction/3.9.0/jena-dboe-transaction-3.9.0-sources.jar"
-          hash: "a382cf6d002eb576b062fa185b31a4998be95016"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "a382cf6d002eb576b062fa185b31a4998be95016"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "https://git-wip-us.apache.org/repos/asf/jena.git"
@@ -2124,12 +2202,14 @@ analyzer:
         homepage_url: "http://jena.apache.org/jena-iri/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/jena/jena-iri/3.9.0/jena-iri-3.9.0.jar"
-          hash: "721937f1d096bba145e9f92c1166489bf6848e56"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "721937f1d096bba145e9f92c1166489bf6848e56"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/jena/jena-iri/3.9.0/jena-iri-3.9.0-sources.jar"
-          hash: "3505cf1e1115017225e0c3bf0da94ca957864aa7"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "3505cf1e1115017225e0c3bf0da94ca957864aa7"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "https://git-wip-us.apache.org/repos/asf/jena.git"
@@ -2152,12 +2232,14 @@ analyzer:
         homepage_url: "http://jena.apache.org/jena-rdfconnection/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/jena/jena-rdfconnection/3.9.0/jena-rdfconnection-3.9.0.jar"
-          hash: "ecdafc24fb75d1dd73df4166672eda2931e5d491"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "ecdafc24fb75d1dd73df4166672eda2931e5d491"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/jena/jena-rdfconnection/3.9.0/jena-rdfconnection-3.9.0-sources.jar"
-          hash: "338fb223d2c84ec68b152f712f1bf069bf71b9ed"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "338fb223d2c84ec68b152f712f1bf069bf71b9ed"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "https://git-wip-us.apache.org/repos/asf/jena.git"
@@ -2183,12 +2265,14 @@ analyzer:
         homepage_url: "http://jena.apache.org/jena-shaded-guava/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/jena/jena-shaded-guava/3.9.0/jena-shaded-guava-3.9.0.jar"
-          hash: "612c6e587e07f280771e5e27a94778414e51bd52"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "612c6e587e07f280771e5e27a94778414e51bd52"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/jena/jena-shaded-guava/3.9.0/jena-shaded-guava-3.9.0-sources.jar"
-          hash: "701d64fb3c688ee88e3c201a38b8299ea360fb37"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "701d64fb3c688ee88e3c201a38b8299ea360fb37"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "https://git-wip-us.apache.org/repos/asf/jena.git"
@@ -2217,12 +2301,14 @@ analyzer:
         homepage_url: "http://jena.apache.org/jena-tdb2/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/jena/jena-tdb2/3.9.0/jena-tdb2-3.9.0.jar"
-          hash: "2dd3d5f89c6a3025e18e0b50d17a7509f001528d"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "2dd3d5f89c6a3025e18e0b50d17a7509f001528d"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/jena/jena-tdb2/3.9.0/jena-tdb2-3.9.0-sources.jar"
-          hash: "9aa945b5f64400870893b9399d93ac6a4942417e"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "9aa945b5f64400870893b9399d93ac6a4942417e"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "https://git-wip-us.apache.org/repos/asf/jena.git"
@@ -2246,12 +2332,14 @@ analyzer:
         homepage_url: "http://jena.apache.org/jena-tdb/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/jena/jena-tdb/3.9.0/jena-tdb-3.9.0.jar"
-          hash: "f2e40a4fa8a8ee02aaaec5c9a5f3dc7579e68227"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "f2e40a4fa8a8ee02aaaec5c9a5f3dc7579e68227"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/jena/jena-tdb/3.9.0/jena-tdb-3.9.0-sources.jar"
-          hash: "fe2889a11367d5538ca4e17204155a984ac8c101"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "fe2889a11367d5538ca4e17204155a984ac8c101"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "https://git-wip-us.apache.org/repos/asf/jena.git"
@@ -2274,12 +2362,14 @@ analyzer:
         homepage_url: "https://logging.apache.org/log4j/2.x/log4j-api/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-api/2.10.0/log4j-api-2.10.0.jar"
-          hash: "fec5797a55b786184a537abd39c3fa1449d752d6"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "fec5797a55b786184a537abd39c3fa1449d752d6"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-api/2.10.0/log4j-api-2.10.0-sources.jar"
-          hash: "fd42afa6acbfb3801accec744106ee28b9342567"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "fd42afa6acbfb3801accec744106ee28b9342567"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "https://git-wip-us.apache.org/repos/asf/logging-log4j2.git"
@@ -2302,12 +2392,14 @@ analyzer:
         homepage_url: "https://logging.apache.org/log4j/2.x/log4j-core/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-core/2.10.0/log4j-core-2.10.0.jar"
-          hash: "c90b597163cd28ab6d9687edd53db601b6ea75a1"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "c90b597163cd28ab6d9687edd53db601b6ea75a1"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-core/2.10.0/log4j-core-2.10.0-sources.jar"
-          hash: "a2041b29bc3e761fba750c0df933cd48f76f5b3a"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "a2041b29bc3e761fba750c0df933cd48f76f5b3a"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "https://git-wip-us.apache.org/repos/asf/logging-log4j2.git"
@@ -2330,12 +2422,14 @@ analyzer:
         homepage_url: "https://logging.apache.org/log4j/2.x/log4j-slf4j-impl/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-slf4j-impl/2.10.0/log4j-slf4j-impl-2.10.0.jar"
-          hash: "8e4e0a30736175e31c7f714d95032c1734cfbdea"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "8e4e0a30736175e31c7f714d95032c1734cfbdea"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-slf4j-impl/2.10.0/log4j-slf4j-impl-2.10.0-sources.jar"
-          hash: "51e9adc49fcb32d961c66170c9b4b092ee809d9c"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "51e9adc49fcb32d961c66170c9b4b092ee809d9c"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "https://git-wip-us.apache.org/repos/asf/logging-log4j2.git"
@@ -2358,12 +2452,14 @@ analyzer:
         homepage_url: "http://poi.apache.org/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/poi/poi-ooxml-schemas/3.15/poi-ooxml-schemas-3.15.jar"
-          hash: "de4a50ca39de48a19606b35644ecadb2f733c479"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "de4a50ca39de48a19606b35644ecadb2f733c479"
+            algorithm: "SHA-1"
         source_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         vcs:
           type: ""
           url: ""
@@ -2386,12 +2482,14 @@ analyzer:
         homepage_url: "http://poi.apache.org/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/poi/poi-ooxml/3.15/poi-ooxml-3.15.jar"
-          hash: "e2800856735b07b8edd417aee07685470216a00f"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "e2800856735b07b8edd417aee07685470216a00f"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/poi/poi-ooxml/3.15/poi-ooxml-3.15-sources.jar"
-          hash: "b49e9cf942f8ba4492017a274c6c3480584909d8"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "b49e9cf942f8ba4492017a274c6c3480584909d8"
+            algorithm: "SHA-1"
         vcs:
           type: ""
           url: ""
@@ -2414,12 +2512,14 @@ analyzer:
         homepage_url: "http://poi.apache.org/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/poi/poi/3.15/poi-3.15.jar"
-          hash: "965bba8899988008bb2341e300347de62aad5391"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "965bba8899988008bb2341e300347de62aad5391"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/poi/poi/3.15/poi-3.15-sources.jar"
-          hash: "bd552aa859b560a2ab85694f23771b6ef50698dd"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "bd552aa859b560a2ab85694f23771b6ef50698dd"
+            algorithm: "SHA-1"
         vcs:
           type: ""
           url: ""
@@ -2443,12 +2543,14 @@ analyzer:
         homepage_url: "http://thrift.apache.org"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/thrift/libthrift/0.10.0/libthrift-0.10.0.jar"
-          hash: "3201c5a6d85d3f030bae5a520abaaf81ef7df037"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "3201c5a6d85d3f030bae5a520abaaf81ef7df037"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/thrift/libthrift/0.10.0/libthrift-0.10.0-sources.jar"
-          hash: "e52aec15d774e90d2c9588571634c054e352b26b"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "e52aec15d774e90d2c9588571634c054e352b26b"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "https://git-wip-us.apache.org/repos/asf/thrift.git"
@@ -2471,12 +2573,14 @@ analyzer:
         homepage_url: "http://xmlbeans.apache.org"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/xmlbeans/xmlbeans/2.6.0/xmlbeans-2.6.0.jar"
-          hash: "29e80d2dd51f9dcdef8f9ffaee0d4dc1c9bbfc87"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "29e80d2dd51f9dcdef8f9ffaee0d4dc1c9bbfc87"
+            algorithm: "SHA-1"
         source_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         vcs:
           type: "svn"
           url: "https://svn.apache.org/repos/asf/xmlbeans/"
@@ -2499,12 +2603,14 @@ analyzer:
         homepage_url: "https://github.com/apiguardian-team/apiguardian"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apiguardian/apiguardian-api/1.0.0/apiguardian-api-1.0.0.jar"
-          hash: "3ef5276905e36f4d8055fe3cb0bdcc7503ffc85d"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "3ef5276905e36f4d8055fe3cb0bdcc7503ffc85d"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apiguardian/apiguardian-api/1.0.0/apiguardian-api-1.0.0-sources.jar"
-          hash: "777508fa9f3e03cafb3c1fb2eba3dca317f4b1ee"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "777508fa9f3e03cafb3c1fb2eba3dca317f4b1ee"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/apiguardian-team/apiguardian.git"
@@ -2527,12 +2633,14 @@ analyzer:
         homepage_url: "http://assertj.org/assertj-core"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/assertj/assertj-core/3.11.1/assertj-core-3.11.1.jar"
-          hash: "fdac3217b804d6900fa3650f17b5cb48e620b140"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "fdac3217b804d6900fa3650f17b5cb48e620b140"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/assertj/assertj-core/3.11.1/assertj-core-3.11.1-sources.jar"
-          hash: "55362d8f04018b1140c5a370057bf8cd4a63c3de"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "55362d8f04018b1140c5a370057bf8cd4a63c3de"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git@github.com:joel-costigliola/assertj-core.git"
@@ -2557,12 +2665,14 @@ analyzer:
         homepage_url: "https://github.com/hamcrest/JavaHamcrest/hamcrest-core"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"
-          hash: "42a25dc3219429f0e5d060061f71acb49bf010a0"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "42a25dc3219429f0e5d060061f71acb49bf010a0"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
-          hash: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git@github.com:hamcrest/JavaHamcrest.git"
@@ -2585,12 +2695,14 @@ analyzer:
         homepage_url: "http://jsoup.org/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/jsoup/jsoup/1.7.2/jsoup-1.7.2.jar"
-          hash: "d7e275ba05aa380ca254f72d0c0ffebaedc3adcf"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "d7e275ba05aa380ca254f72d0c0ffebaedc3adcf"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/jsoup/jsoup/1.7.2/jsoup-1.7.2-sources.jar"
-          hash: "833f425e7a40d7fc88922370a072965dda8ee216"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "833f425e7a40d7fc88922370a072965dda8ee216"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "http://github.com/jhy/jsoup.git"
@@ -2613,12 +2725,14 @@ analyzer:
         homepage_url: "http://junit.org/junit5/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-api/5.3.1/junit-jupiter-api-5.3.1.jar"
-          hash: "a7e97eac2784395cb991403f9641b042ad972941"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "a7e97eac2784395cb991403f9641b042ad972941"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-api/5.3.1/junit-jupiter-api-5.3.1-sources.jar"
-          hash: "b03f607c0822a283c972e37eaeacb00dc3a3c2e7"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "b03f607c0822a283c972e37eaeacb00dc3a3c2e7"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/junit-team/junit5.git"
@@ -2641,12 +2755,14 @@ analyzer:
         homepage_url: "http://junit.org/junit5/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-engine/5.3.1/junit-jupiter-engine-5.3.1.jar"
-          hash: "e2676b1786c57a80eb98f5bebd51a3d05e228c40"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "e2676b1786c57a80eb98f5bebd51a3d05e228c40"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-engine/5.3.1/junit-jupiter-engine-5.3.1-sources.jar"
-          hash: "c769957170b2240854d6da6c6706dcc2a281542f"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "c769957170b2240854d6da6c6706dcc2a281542f"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/junit-team/junit5.git"
@@ -2669,12 +2785,14 @@ analyzer:
         homepage_url: "http://junit.org/junit5/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-params/5.3.1/junit-jupiter-params-5.3.1.jar"
-          hash: "9dfac3fbd6768974fc0c142304a3e90ba713b2a8"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "9dfac3fbd6768974fc0c142304a3e90ba713b2a8"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-params/5.3.1/junit-jupiter-params-5.3.1-sources.jar"
-          hash: "bc4eb2ef307286fcd45551d4da397518c2e15394"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "bc4eb2ef307286fcd45551d4da397518c2e15394"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/junit-team/junit5.git"
@@ -2697,12 +2815,14 @@ analyzer:
         homepage_url: "http://junit.org/junit5/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-commons/1.3.1/junit-platform-commons-1.3.1.jar"
-          hash: "67b7edddfac1935e6e6d9b58d7c7df6db59b1d39"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "67b7edddfac1935e6e6d9b58d7c7df6db59b1d39"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-commons/1.3.1/junit-platform-commons-1.3.1-sources.jar"
-          hash: "297bb35bca3d229c5e6edbffd22de7b5ad4cf430"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "297bb35bca3d229c5e6edbffd22de7b5ad4cf430"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/junit-team/junit5.git"
@@ -2725,12 +2845,14 @@ analyzer:
         homepage_url: "http://junit.org/junit5/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-engine/1.3.1/junit-platform-engine-1.3.1.jar"
-          hash: "3ee68a06bbdab157dd260e2095c356481d6cd172"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "3ee68a06bbdab157dd260e2095c356481d6cd172"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-engine/1.3.1/junit-platform-engine-1.3.1-sources.jar"
-          hash: "effe038ffcf21f6988e78b12119ca456d7d144fd"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "effe038ffcf21f6988e78b12119ca456d7d144fd"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/junit-team/junit5.git"
@@ -2753,12 +2875,14 @@ analyzer:
         homepage_url: "http://junit.org/junit5/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-launcher/1.3.1/junit-platform-launcher-1.3.1.jar"
-          hash: "8a07cb776e5aeb320b051183dc8ff142650ddb4e"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "8a07cb776e5aeb320b051183dc8ff142650ddb4e"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-launcher/1.3.1/junit-platform-launcher-1.3.1-sources.jar"
-          hash: "e144c1c4935632fa730c8a2d0c0c879b824562df"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "e144c1c4935632fa730c8a2d0c0c879b824562df"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/junit-team/junit5.git"
@@ -2781,12 +2905,14 @@ analyzer:
         homepage_url: "https://github.com/ota4j-team/opentest4j"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/opentest4j/opentest4j/1.1.1/opentest4j-1.1.1.jar"
-          hash: "efd9f971e91074491ea55b19f67b13470cf4fcdd"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "efd9f971e91074491ea55b19f67b13470cf4fcdd"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/opentest4j/opentest4j/1.1.1/opentest4j-1.1.1-sources.jar"
-          hash: "88a3a2cb15c413565462cea99f201b67bc6d2f10"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "88a3a2cb15c413565462cea99f201b67bc6d2f10"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/ota4j-team/opentest4j.git"
@@ -2809,12 +2935,14 @@ analyzer:
         homepage_url: "http://www.slf4j.org"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/slf4j/jcl-over-slf4j/1.7.25/jcl-over-slf4j-1.7.25.jar"
-          hash: "f8c32b13ff142a513eeb5b6330b1588dcb2c0461"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "f8c32b13ff142a513eeb5b6330b1588dcb2c0461"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/slf4j/jcl-over-slf4j/1.7.25/jcl-over-slf4j-1.7.25-sources.jar"
-          hash: "ffd0827a7c67d5915b7dc611afbda56a1f247191"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "ffd0827a7c67d5915b7dc611afbda56a1f247191"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git@github.com:qos-ch/slf4j.git"
@@ -2837,12 +2965,14 @@ analyzer:
         homepage_url: "http://www.slf4j.org"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar"
-          hash: "da76ca59f6a57ee3102f8f9bd9cee742973efa8a"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "da76ca59f6a57ee3102f8f9bd9cee742973efa8a"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25-sources.jar"
-          hash: "962153db4a9ea71b79d047dfd1b2a0d80d8f4739"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "962153db4a9ea71b79d047dfd1b2a0d80d8f4739"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git@github.com:qos-ch/slf4j.git"
@@ -2866,12 +2996,14 @@ analyzer:
         homepage_url: "http://stax.codehaus.org/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/stax/stax-api/1.0.1/stax-api-1.0.1.jar"
-          hash: "49c100caf72d658aca8e58bd74a4ba90fa2b0d70"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "49c100caf72d658aca8e58bd74a4ba90fa2b0d70"
+            algorithm: "SHA-1"
         source_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         vcs:
           type: ""
           url: ""
@@ -2894,12 +3026,14 @@ analyzer:
         homepage_url: "https://github.com/isaacs/abbrev-js#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
-          hash: "91b4792588a7738c25f35dd6f63752a2f8776135"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "91b4792588a7738c25f35dd6f63752a2f8776135"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+ssh://git@github.com/isaacs/abbrev-js.git"
@@ -2922,12 +3056,14 @@ analyzer:
         homepage_url: "https://github.com/epoberezkin/ajv"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz"
-          hash: "73b5eeca3fab653e3d3f9422b341ad42205dc965"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "73b5eeca3fab653e3d3f9422b341ad42205dc965"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/epoberezkin/ajv.git"
@@ -2951,12 +3087,14 @@ analyzer:
         homepage_url: "http://github.com/jrburke/amdefine"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
-          hash: "4a5282ac164729e93619bcfd3ad151f817ce91f5"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "4a5282ac164729e93619bcfd3ad151f817ce91f5"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/jrburke/amdefine.git"
@@ -2980,12 +3118,14 @@ analyzer:
         homepage_url: "https://github.com/nodeca/argparse#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz"
-          hash: "bcd6791ea5ae09725e17e5ad988134cd40b3d911"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/nodeca/argparse.git"
@@ -3008,12 +3148,14 @@ analyzer:
         homepage_url: "https://github.com/joyent/node-asn1#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz"
-          hash: "8d2475dfab553bb33e77b54e59e880bb8ce23136"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "8d2475dfab553bb33e77b54e59e880bb8ce23136"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/joyent/node-asn1.git"
@@ -3036,12 +3178,14 @@ analyzer:
         homepage_url: "https://github.com/mcavage/node-assert-plus#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-          hash: "f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/mcavage/node-assert-plus.git"
@@ -3065,12 +3209,14 @@ analyzer:
         homepage_url: "https://github.com/caolan/async#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/async/-/async-1.0.0.tgz"
-          hash: "f8fc04ca3a13784ade9e1641af98578cfbd647a9"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "f8fc04ca3a13784ade9e1641af98578cfbd647a9"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/caolan/async.git"
@@ -3094,12 +3240,14 @@ analyzer:
         homepage_url: "https://github.com/caolan/async#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
-          hash: "ec6a61ae56480c0c3cb241c95618e20892f9672a"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "ec6a61ae56480c0c3cb241c95618e20892f9672a"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/caolan/async.git"
@@ -3123,12 +3271,14 @@ analyzer:
         homepage_url: "https://caolan.github.io/async/"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/async/-/async-2.6.1.tgz"
-          hash: "b245a23ca71930044ec53fa46aa00a3e87c6a610"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "b245a23ca71930044ec53fa46aa00a3e87c6a610"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/caolan/async.git"
@@ -3151,12 +3301,14 @@ analyzer:
         homepage_url: "https://github.com/alexindigo/asynckit#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
-          hash: "c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/alexindigo/asynckit.git"
@@ -3180,12 +3332,14 @@ analyzer:
         homepage_url: "https://github.com/mikeal/aws-sign#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz"
-          hash: "b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
+            algorithm: "SHA-1"
         vcs:
           type: ""
           url: "git+https://github.com/mikeal/aws-sign.git"
@@ -3208,12 +3362,14 @@ analyzer:
         homepage_url: "https://github.com/mhart/aws4#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz"
-          hash: "f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/mhart/aws4.git"
@@ -3236,12 +3392,14 @@ analyzer:
         homepage_url: "https://github.com/juliangruber/balanced-match"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
-          hash: "89b4d199ab2bee49de164ea02b89ce462d71b767"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "89b4d199ab2bee49de164ea02b89ce462d71b767"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/juliangruber/balanced-match.git"
@@ -3264,12 +3422,14 @@ analyzer:
         homepage_url: "https://github.com/joyent/node-bcrypt-pbkdf#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz"
-          hash: "a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/joyent/node-bcrypt-pbkdf.git"
@@ -3292,12 +3452,14 @@ analyzer:
         homepage_url: "https://github.com/fb55/boolbase"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
-          hash: "68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "https://github.com/fb55/boolbase"
@@ -3320,12 +3482,14 @@ analyzer:
         homepage_url: "https://github.com/juliangruber/brace-expansion"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz"
-          hash: "3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/juliangruber/brace-expansion.git"
@@ -3348,12 +3512,14 @@ analyzer:
         homepage_url: "https://github.com/kumavis/browser-stdout#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz"
-          hash: "baa559ee14ced73452229bad7326467c61fabd60"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "baa559ee14ced73452229bad7326467c61fabd60"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+ssh://git@github.com/kumavis/browser-stdout.git"
@@ -3377,12 +3543,14 @@ analyzer:
         homepage_url: "https://github.com/LinusU/buffer-from#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz"
-          hash: "32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/LinusU/buffer-from.git"
@@ -3406,12 +3574,14 @@ analyzer:
         homepage_url: "https://github.com/mikeal/caseless#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
-          hash: "1b681c21ff84033c826543090689420d187151dc"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "1b681c21ff84033c826543090689420d187151dc"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/mikeal/caseless.git"
@@ -3435,12 +3605,14 @@ analyzer:
         homepage_url: "https://github.com/cheeriojs/cheerio#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.1.tgz"
-          hash: "2af37339eab713ef6b72cde98cefa672b87641fe"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "2af37339eab713ef6b72cde98cefa672b87641fe"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/cheeriojs/cheerio.git"
@@ -3463,12 +3635,14 @@ analyzer:
         homepage_url: "http://github.com/node-js-libs/cli"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz"
-          hash: "22817534f24bfa4950c34d532d48ecbc621b8c14"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "22817534f24bfa4950c34d532d48ecbc621b8c14"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+ssh://git@github.com/node-js-libs/cli.git"
@@ -3491,12 +3665,14 @@ analyzer:
         homepage_url: "https://github.com/tj/co#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
-          hash: "6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/tj/co.git"
@@ -3519,12 +3695,14 @@ analyzer:
         homepage_url: "http://coffeescript.org"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz"
-          hash: "c05dae0cb79591d05b3070a8433a98c9a89ccc53"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "c05dae0cb79591d05b3070a8433a98c9a89ccc53"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/jashkenas/coffeescript.git"
@@ -3547,12 +3725,14 @@ analyzer:
         homepage_url: "https://github.com/Marak/colors.js"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
-          hash: "0433f44d809680fdeb60ed260f1b0c262e82a40b"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "0433f44d809680fdeb60ed260f1b0c262e82a40b"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "http://github.com/Marak/colors.js.git"
@@ -3575,12 +3755,14 @@ analyzer:
         homepage_url: "https://github.com/felixge/node-combined-stream"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz"
-          hash: "2d1d24317afb8abe95d6d2c0b07b57813539d828"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "2d1d24317afb8abe95d6d2c0b07b57813539d828"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/felixge/node-combined-stream.git"
@@ -3603,12 +3785,14 @@ analyzer:
         homepage_url: "https://github.com/tj/commander.js#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz"
-          hash: "df46e867d0fc2aec66a34662b406a9ccafff5b0f"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "df46e867d0fc2aec66a34662b406a9ccafff5b0f"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/tj/commander.js.git"
@@ -3631,12 +3815,14 @@ analyzer:
         homepage_url: "https://github.com/tj/commander.js#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz"
-          hash: "bd77ab7de6de94205ceacc72f1716d29f20a77bf"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "bd77ab7de6de94205ceacc72f1716d29f20a77bf"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/tj/commander.js.git"
@@ -3659,12 +3845,14 @@ analyzer:
         homepage_url: "https://github.com/substack/node-concat-map"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-          hash: "d8a96bd77fd68df7793a73036a3ba0d5405d477b"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/substack/node-concat-map.git"
@@ -3688,12 +3876,14 @@ analyzer:
         homepage_url: "https://github.com/maxogden/concat-stream#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz"
-          hash: "904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+ssh://git@github.com/maxogden/concat-stream.git"
@@ -3716,12 +3906,14 @@ analyzer:
         homepage_url: "https://github.com/Raynos/console-browserify"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz"
-          hash: "f0241c45730a9fc6323b206dbf38edc741d0bb10"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "f0241c45730a9fc6323b206dbf38edc741d0bb10"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/Raynos/console-browserify.git"
@@ -3744,12 +3936,14 @@ analyzer:
         homepage_url: "https://github.com/isaacs/core-util-is#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-          hash: "b5fd54220aa2bc5ab57aab7140c940754503c1a7"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/isaacs/core-util-is.git"
@@ -3772,12 +3966,14 @@ analyzer:
         homepage_url: "https://github.com/nickmerwin/node-coveralls#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/coveralls/-/coveralls-3.0.2.tgz"
-          hash: "f5a0bcd90ca4e64e088b710fa8dda640aea4884f"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "f5a0bcd90ca4e64e088b710fa8dda640aea4884f"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/nickmerwin/node-coveralls.git"
@@ -3800,12 +3996,14 @@ analyzer:
         homepage_url: "https://github.com/groupon/cson-parser"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/cson-parser/-/cson-parser-1.3.5.tgz"
-          hash: "7ec675e039145533bf2a6a856073f1599d9c2d24"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "7ec675e039145533bf2a6a856073f1599d9c2d24"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+ssh://git@github.com/groupon/cson-parser.git"
@@ -3829,12 +4027,14 @@ analyzer:
         homepage_url: "https://github.com/bevry/cson"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/cson/-/cson-4.1.0.tgz"
-          hash: "b1075344fa9d9fe5cf88d80f21d9366296b865c7"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "b1075344fa9d9fe5cf88d80f21d9366296b865c7"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/bevry/cson.git"
@@ -3857,12 +4057,14 @@ analyzer:
         homepage_url: "https://github.com/fb55/css-select#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz"
-          hash: "2b3a110539c5355f1cd8d314623e870b121ec858"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "2b3a110539c5355f1cd8d314623e870b121ec858"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/fb55/css-select.git"
@@ -3885,12 +4087,14 @@ analyzer:
         homepage_url: "https://github.com/fb55/css-what#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz"
-          hash: "a6d7604573365fe74686c3f311c56513d88285f2"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "a6d7604573365fe74686c3f311c56513d88285f2"
+            algorithm: "SHA-1"
         vcs:
           type: ""
           url: "git+https://github.com/fb55/css-what.git"
@@ -3911,12 +4115,14 @@ analyzer:
         homepage_url: "https://github.com/douglascrockford/JSON-js"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
-          hash: "21e80b2be8580f98b468f379430662b046c34ad2"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "21e80b2be8580f98b468f379430662b046c34ad2"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "http://github.com/dscape/cycle.git"
@@ -3939,12 +4145,14 @@ analyzer:
         homepage_url: "https://github.com/trentm/node-dashdash#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
-          hash: "853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/trentm/node-dashdash.git"
@@ -3967,12 +4175,14 @@ analyzer:
         homepage_url: "https://github.com/Colingo/date-now"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
-          hash: "eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/Colingo/date-now.git"
@@ -3995,12 +4205,14 @@ analyzer:
         homepage_url: "https://github.com/visionmedia/debug#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
-          hash: "5d128515df134ff327e90a4c93f4e077a536341f"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "5d128515df134ff327e90a4c93f4e077a536341f"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/visionmedia/debug.git"
@@ -4023,12 +4235,14 @@ analyzer:
         homepage_url: "https://github.com/visionmedia/debug#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz"
-          hash: "5bb5a0672628b64149566ba16819e61518c67261"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "5bb5a0672628b64149566ba16819e61518c67261"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/visionmedia/debug.git"
@@ -4052,12 +4266,14 @@ analyzer:
         homepage_url: "https://github.com/thlorenz/deep-is"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
-          hash: "b369d6fb5dbc13eecf524f91b070feedc357cf34"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "b369d6fb5dbc13eecf524f91b070feedc357cf34"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "http://github.com/thlorenz/deep-is.git"
@@ -4080,12 +4296,14 @@ analyzer:
         homepage_url: "https://github.com/felixge/node-delayed-stream"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-          hash: "df3ae199acadfb7d440aaae0b29e2272b24ec619"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "df3ae199acadfb7d440aaae0b29e2272b24ec619"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/felixge/node-delayed-stream.git"
@@ -4108,12 +4326,14 @@ analyzer:
         homepage_url: "https://github.com/kpdecker/jsdiff#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz"
-          hash: "800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/kpdecker/jsdiff.git"
@@ -4136,12 +4356,14 @@ analyzer:
         homepage_url: "https://github.com/cheeriojs/dom-renderer"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz"
-          hash: "073c697546ce0780ce23be4a28e293e40bc30c82"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "073c697546ce0780ce23be4a28e293e40bc30c82"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/cheeriojs/dom-renderer.git"
@@ -4164,12 +4386,14 @@ analyzer:
         homepage_url: "https://github.com/cheeriojs/dom-renderer#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz"
-          hash: "1ec4059e284babed36eec2941d4a970a189ce7c0"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "1ec4059e284babed36eec2941d4a970a189ce7c0"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/cheeriojs/dom-renderer.git"
@@ -4190,12 +4414,14 @@ analyzer:
         homepage_url: "https://github.com/FB55/domelementtype"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
-          hash: "bd28773e2642881aec51544924299c5cd822185b"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "bd28773e2642881aec51544924299c5cd822185b"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/FB55/domelementtype.git"
@@ -4216,12 +4442,14 @@ analyzer:
         homepage_url: "https://github.com/FB55/domelementtype"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
-          hash: "b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/FB55/domelementtype.git"
@@ -4244,12 +4472,14 @@ analyzer:
         homepage_url: "https://github.com/fb55/domelementtype#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz"
-          hash: "d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/fb55/domelementtype.git"
@@ -4270,12 +4500,14 @@ analyzer:
         homepage_url: "https://github.com/fb55/DomHandler"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
-          hash: "2de59a0822d5027fabff6f032c2b25a2a8abe738"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "2de59a0822d5027fabff6f032c2b25a2a8abe738"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/fb55/DomHandler.git"
@@ -4298,12 +4530,14 @@ analyzer:
         homepage_url: "https://github.com/fb55/DomHandler#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz"
-          hash: "8805097e933d65e85546f726d60f5eb88b44f803"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "8805097e933d65e85546f726d60f5eb88b44f803"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/fb55/DomHandler.git"
@@ -4324,12 +4558,14 @@ analyzer:
         homepage_url: "https://github.com/FB55/domutils"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz"
-          hash: "dcd8488a26f563d61079e48c9f7b7e32373682cf"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "dcd8488a26f563d61079e48c9f7b7e32373682cf"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/FB55/domutils.git"
@@ -4354,12 +4590,14 @@ analyzer:
         homepage_url: "https://github.com/bevry/eachr"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/eachr/-/eachr-3.2.0.tgz"
-          hash: "2c35e43ea086516f7997cf80b7aa64d55a4a4484"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "2c35e43ea086516f7997cf80b7aa64d55a4a4484"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+ssh://git@github.com/bevry/eachr.git"
@@ -4382,12 +4620,14 @@ analyzer:
         homepage_url: "https://github.com/quartzjer/ecc-jsbn"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz"
-          hash: "3a83a904e54353287874c564b7549386849a98c9"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "3a83a904e54353287874c564b7549386849a98c9"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "https://github.com/quartzjer/ecc-jsbn.git"
@@ -4411,12 +4651,14 @@ analyzer:
         homepage_url: "https://github.com/bevry/editions"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz"
-          hash: "3662cb592347c3168eb8e498a0ff73271d67f50b"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "3662cb592347c3168eb8e498a0ff73271d67f50b"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/bevry/editions.git"
@@ -4440,12 +4682,14 @@ analyzer:
         homepage_url: "https://github.com/bevry/editions"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/editions/-/editions-2.1.3.tgz"
-          hash: "727ccf3ec2c7b12dcc652c71000f16c4824d6f7d"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "727ccf3ec2c7b12dcc652c71000f16c4824d6f7d"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/bevry/editions.git"
@@ -4468,12 +4712,14 @@ analyzer:
         homepage_url: "https://github.com/fb55/node-entities"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
-          hash: "b2987aa3821347fcde642b24fdfc9e4fb712bf26"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "b2987aa3821347fcde642b24fdfc9e4fb712bf26"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/fb55/node-entities.git"
@@ -4496,12 +4742,14 @@ analyzer:
         homepage_url: "https://github.com/fb55/node-entities"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
-          hash: "6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/fb55/node-entities.git"
@@ -4524,12 +4772,14 @@ analyzer:
         homepage_url: "https://github.com/fb55/entities#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz"
-          hash: "bdfa735299664dfafd34529ed4f8522a275fea56"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "bdfa735299664dfafd34529ed4f8522a275fea56"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/fb55/entities.git"
@@ -4553,12 +4803,14 @@ analyzer:
         homepage_url: "https://github.com/bevry/errlop"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/errlop/-/errlop-1.1.1.tgz"
-          hash: "d9ae4c76c3e64956c5d79e6e035d6343bfd62250"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "d9ae4c76c3e64956c5d79e6e035d6343bfd62250"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/bevry/errlop.git"
@@ -4582,12 +4834,14 @@ analyzer:
         homepage_url: "https://github.com/stefanpenner/es6-promise#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz"
-          hash: "da6d0d5692efb461e082c14817fe2427d8f5d054"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "da6d0d5692efb461e082c14817fe2427d8f5d054"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/stefanpenner/es6-promise.git"
@@ -4610,12 +4864,14 @@ analyzer:
         homepage_url: "https://github.com/sindresorhus/escape-string-regexp"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-          hash: "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "https://github.com/sindresorhus/escape-string-regexp"
@@ -4638,12 +4894,14 @@ analyzer:
         homepage_url: "http://github.com/estools/escodegen"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz"
-          hash: "5a5b53af4693110bebb0867aa3430dd3b70a1018"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "5a5b53af4693110bebb0867aa3430dd3b70a1018"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+ssh://git@github.com/estools/escodegen.git"
@@ -4666,12 +4924,14 @@ analyzer:
         homepage_url: "http://esprima.org"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
-          hash: "96e3b70d5779f6ad49cd032673d1c312767ba581"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "96e3b70d5779f6ad49cd032673d1c312767ba581"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/jquery/esprima.git"
@@ -4694,12 +4954,14 @@ analyzer:
         homepage_url: "http://esprima.org"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz"
-          hash: "13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/jquery/esprima.git"
@@ -4722,12 +4984,14 @@ analyzer:
         homepage_url: "https://github.com/estools/estraverse"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
-          hash: "af67f2dc922582415950926091a4005d29c9bb44"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "af67f2dc922582415950926091a4005d29c9bb44"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "http://github.com/estools/estraverse.git"
@@ -4750,12 +5014,14 @@ analyzer:
         homepage_url: "https://github.com/estools/esutils"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-          hash: "0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "http://github.com/estools/esutils.git"
@@ -4779,12 +5045,14 @@ analyzer:
         homepage_url: "https://github.com/cowboy/node-exit"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
-          hash: "0632638f8d877cc82107d30a0fff1a17cba1cd0c"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "0632638f8d877cc82107d30a0fff1a17cba1cd0c"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/cowboy/node-exit.git"
@@ -4807,12 +5075,14 @@ analyzer:
         homepage_url: "https://github.com/justmoon/node-extend#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz"
-          hash: "f8b1136b4071fbd8eb140aff858b1019ec2915fa"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/justmoon/node-extend.git"
@@ -4836,12 +5106,14 @@ analyzer:
         homepage_url: "https://github.com/bevry/extract-opts"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/extract-opts/-/extract-opts-3.3.1.tgz"
-          hash: "5abbedc98c0d5202e3278727f9192d7e086c6be1"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "5abbedc98c0d5202e3278727f9192d7e086c6be1"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+ssh://git@github.com/bevry/extract-opts.git"
@@ -4864,12 +5136,14 @@ analyzer:
         homepage_url: "https://github.com/maxogden/extract-zip#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz"
-          hash: "a840b4b8af6403264c8db57f4f1a74333ef81fe9"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "a840b4b8af6403264c8db57f4f1a74333ef81fe9"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/maxogden/extract-zip.git"
@@ -4892,12 +5166,14 @@ analyzer:
         homepage_url: "https://github.com/davepacheco/node-extsprintf"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"
-          hash: "96918440e3041a7a414f8c52e3c574eb3c3e1e05"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "96918440e3041a7a414f8c52e3c574eb3c3e1e05"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/davepacheco/node-extsprintf.git"
@@ -4918,12 +5194,14 @@ analyzer:
         homepage_url: ""
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
-          hash: "62cf120234c683785d902348a800ef3e0cc20bc0"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "62cf120234c683785d902348a800ef3e0cc20bc0"
+            algorithm: "SHA-1"
         vcs:
           type: ""
           url: ""
@@ -4946,12 +5224,14 @@ analyzer:
         homepage_url: "https://github.com/epoberezkin/fast-deep-equal#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz"
-          hash: "c053477817c86b51daa853c81e059b733d023614"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "c053477817c86b51daa853c81e059b733d023614"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/epoberezkin/fast-deep-equal.git"
@@ -4975,12 +5255,14 @@ analyzer:
         homepage_url: "https://github.com/epoberezkin/fast-json-stable-stringify"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz"
-          hash: "d5142c0caee6b1189f87d3a76111064f86c8bbf2"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "d5142c0caee6b1189f87d3a76111064f86c8bbf2"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/epoberezkin/fast-json-stable-stringify.git"
@@ -5004,12 +5286,14 @@ analyzer:
         homepage_url: "https://github.com/hiddentao/fast-levenshtein#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
-          hash: "3d8a5c66883a16a30ca8643e851f19baa7797917"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "3d8a5c66883a16a30ca8643e851f19baa7797917"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/hiddentao/fast-levenshtein.git"
@@ -5033,12 +5317,14 @@ analyzer:
         homepage_url: ""
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz"
-          hash: "8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/andrewrk/node-fd-slicer.git"
@@ -5062,12 +5348,14 @@ analyzer:
         homepage_url: "https://github.com/mikeal/forever-agent"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-          hash: "fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
+            algorithm: "SHA-1"
         vcs:
           type: ""
           url: "https://github.com/mikeal/forever-agent"
@@ -5091,12 +5379,14 @@ analyzer:
         homepage_url: "https://github.com/form-data/form-data#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz"
-          hash: "dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/form-data/form-data.git"
@@ -5120,12 +5410,14 @@ analyzer:
         homepage_url: "https://github.com/jprichardson/node-fs-extra"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz"
-          hash: "cd3ce5f7e7cb6145883fcae3191e9877f8587950"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "cd3ce5f7e7cb6145883fcae3191e9877f8587950"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/jprichardson/node-fs-extra.git"
@@ -5149,12 +5441,14 @@ analyzer:
         homepage_url: "https://github.com/isaacs/fs.realpath#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
-          hash: "1504ad2523158caa40db4a2787cb01411994ea4f"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "1504ad2523158caa40db4a2787cb01411994ea4f"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/isaacs/fs.realpath.git"
@@ -5177,12 +5471,14 @@ analyzer:
         homepage_url: "https://github.com/arekinath/node-getpass#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz"
-          hash: "5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/arekinath/node-getpass.git"
@@ -5205,12 +5501,14 @@ analyzer:
         homepage_url: "https://github.com/isaacs/node-glob#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
-          hash: "1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/isaacs/node-glob.git"
@@ -5233,12 +5531,14 @@ analyzer:
         homepage_url: "https://github.com/isaacs/node-glob#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
-          hash: "c19c9df9a028702d678612384a6552404c636d15"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "c19c9df9a028702d678612384a6552404c636d15"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/isaacs/node-glob.git"
@@ -5261,12 +5561,14 @@ analyzer:
         homepage_url: "https://github.com/isaacs/node-glob#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz"
-          hash: "3960832d3f1574108342dafd3a67b332c0969df1"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "3960832d3f1574108342dafd3a67b332c0969df1"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/isaacs/node-glob.git"
@@ -5289,12 +5591,14 @@ analyzer:
         homepage_url: "https://github.com/isaacs/node-graceful-fs#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-          hash: "0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/isaacs/node-graceful-fs.git"
@@ -5317,12 +5621,14 @@ analyzer:
         homepage_url: "https://github.com/isaacs/node-graceful-fs#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz"
-          hash: "ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/isaacs/node-graceful-fs.git"
@@ -5345,12 +5651,14 @@ analyzer:
         homepage_url: "https://github.com/tj/node-growl#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz"
-          hash: "f2735dc2283674fa67478b10181059355c369e5e"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "f2735dc2283674fa67478b10181059355c369e5e"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/tj/node-growl.git"
@@ -5374,12 +5682,14 @@ analyzer:
         homepage_url: "http://www.handlebarsjs.com/"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz"
-          hash: "2c15c8a96d46da5e266700518ba8cb8d919d5bc5"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "2c15c8a96d46da5e266700518ba8cb8d919d5bc5"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/wycats/handlebars.js.git"
@@ -5402,12 +5712,14 @@ analyzer:
         homepage_url: "https://github.com/ahmadnassri/har-schema"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz"
-          hash: "a94c2224ebcac04782a0d9035521f24735b7ec92"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "a94c2224ebcac04782a0d9035521f24735b7ec92"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/ahmadnassri/har-schema.git"
@@ -5430,12 +5742,14 @@ analyzer:
         homepage_url: "https://github.com/ahmadnassri/har-validator"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz"
-          hash: "44657f5688a22cfd4b72486e81b3a3fb11742c29"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "44657f5688a22cfd4b72486e81b3a3fb11742c29"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/ahmadnassri/har-validator.git"
@@ -5458,12 +5772,14 @@ analyzer:
         homepage_url: "https://github.com/sindresorhus/has-flag#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-          hash: "9d9e793165ce017a00f00418c43f942a7b1d11fa"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "9d9e793165ce017a00f00418c43f942a7b1d11fa"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/sindresorhus/has-flag.git"
@@ -5486,12 +5802,14 @@ analyzer:
         homepage_url: "https://github.com/sindresorhus/has-flag#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz"
-          hash: "b5d454dc2199ae225699f3467e5a07f3b955bafd"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "b5d454dc2199ae225699f3467e5a07f3b955bafd"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/sindresorhus/has-flag.git"
@@ -5514,12 +5832,14 @@ analyzer:
         homepage_url: "https://github.com/sindresorhus/hasha"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz"
-          hash: "78d7cbfc1e6d66303fe79837365984517b2f6ee1"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "78d7cbfc1e6d66303fe79837365984517b2f6ee1"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "https://github.com/sindresorhus/hasha"
@@ -5542,12 +5862,14 @@ analyzer:
         homepage_url: "https://mths.be/he"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/he/-/he-1.1.1.tgz"
-          hash: "93410fd21b009735151f8868c2f271f3427e23fd"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "93410fd21b009735151f8868c2f271f3427e23fd"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/mathiasbynens/he.git"
@@ -5570,12 +5892,14 @@ analyzer:
         homepage_url: "https://github.com/fb55/htmlparser2#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz"
-          hash: "bd679dc3f59897b6a34bb10749c855bb53a9392f"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "bd679dc3f59897b6a34bb10749c855bb53a9392f"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/fb55/htmlparser2.git"
@@ -5598,12 +5922,14 @@ analyzer:
         homepage_url: "https://github.com/fb55/htmlparser2#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz"
-          hash: "996c28b191516a8be86501a7d79757e5c70c1068"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "996c28b191516a8be86501a7d79757e5c70c1068"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/fb55/htmlparser2.git"
@@ -5626,12 +5952,14 @@ analyzer:
         homepage_url: "https://github.com/joyent/node-http-signature/"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz"
-          hash: "9aecd925114772f3d95b65a60abb8f7c18fbace1"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "9aecd925114772f3d95b65a60abb8f7c18fbace1"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/joyent/node-http-signature.git"
@@ -5654,12 +5982,14 @@ analyzer:
         homepage_url: "https://github.com/isaacs/inflight"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
-          hash: "49bd6331d7d02d0c09bc910a1075ba8165b56df9"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/npm/inflight.git"
@@ -5683,12 +6013,14 @@ analyzer:
         homepage_url: "https://github.com/isaacs/inherits#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-          hash: "633c2c83e3da42a502f52466022480f4208261de"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "633c2c83e3da42a502f52466022480f4208261de"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/isaacs/inherits.git"
@@ -5711,12 +6043,14 @@ analyzer:
         homepage_url: "https://github.com/sindresorhus/is-stream#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
-          hash: "12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/sindresorhus/is-stream.git"
@@ -5739,12 +6073,14 @@ analyzer:
         homepage_url: "https://github.com/hughsk/is-typedarray"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
-          hash: "e479c80858df0c1b11ddda6940f96011fcda4a9a"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "e479c80858df0c1b11ddda6940f96011fcda4a9a"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/hughsk/is-typedarray.git"
@@ -5767,12 +6103,14 @@ analyzer:
         homepage_url: "https://github.com/juliangruber/isarray"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-          hash: "8a18acfca9a8f4177e09abfc6038939b05d1eedf"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/juliangruber/isarray.git"
@@ -5795,12 +6133,14 @@ analyzer:
         homepage_url: "https://github.com/juliangruber/isarray"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-          hash: "bb935d48582cba168c06834957a54a3e07124f11"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "bb935d48582cba168c06834957a54a3e07124f11"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/juliangruber/isarray.git"
@@ -5823,12 +6163,14 @@ analyzer:
         homepage_url: "https://github.com/isaacs/isexe#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
-          hash: "e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/isaacs/isexe.git"
@@ -5851,12 +6193,14 @@ analyzer:
         homepage_url: "https://github.com/rvagg/isstream"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-          hash: "47e63f7af55afa6f92e1500e690eb8b8529c099a"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "47e63f7af55afa6f92e1500e690eb8b8529c099a"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "https://github.com/rvagg/isstream.git"
@@ -5882,12 +6226,14 @@ analyzer:
         homepage_url: "https://github.com/gotwarlost/istanbul#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz"
-          hash: "65c7d73d4c4da84d4f3ac310b918fb0b8033733b"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "65c7d73d4c4da84d4f3ac310b918fb0b8033733b"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/gotwarlost/istanbul.git"
@@ -5910,12 +6256,14 @@ analyzer:
         homepage_url: "https://github.com/nodeca/js-yaml"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz"
-          hash: "eaed656ec8344f10f527c6bfa1b6e2244de167d1"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "eaed656ec8344f10f527c6bfa1b6e2244de167d1"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/nodeca/js-yaml.git"
@@ -5940,12 +6288,14 @@ analyzer:
         homepage_url: "https://github.com/andyperlitch/jsbn#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
-          hash: "a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/andyperlitch/jsbn.git"
@@ -5968,12 +6318,14 @@ analyzer:
         homepage_url: "http://jshint.com/"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/jshint/-/jshint-2.9.6.tgz"
-          hash: "19b34e578095a34928fe006135a6cb70137b9c08"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "19b34e578095a34928fe006135a6cb70137b9c08"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/jshint/jshint.git"
@@ -5996,12 +6348,14 @@ analyzer:
         homepage_url: "https://github.com/epoberezkin/json-schema-traverse#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz"
-          hash: "349a6d44c53a51de89b40805c5d5e59b417d3340"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "349a6d44c53a51de89b40805c5d5e59b417d3340"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/epoberezkin/json-schema-traverse.git"
@@ -6025,12 +6379,14 @@ analyzer:
         homepage_url: "https://github.com/kriszyp/json-schema#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
-          hash: "b480c892e59a2f05954ce727bd3f2a4e882f9e13"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "b480c892e59a2f05954ce727bd3f2a4e882f9e13"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+ssh://git@github.com/kriszyp/json-schema.git"
@@ -6053,12 +6409,14 @@ analyzer:
         homepage_url: "https://github.com/isaacs/json-stringify-safe"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-          hash: "1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/isaacs/json-stringify-safe.git"
@@ -6081,12 +6439,14 @@ analyzer:
         homepage_url: "https://github.com/jprichardson/node-jsonfile#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz"
-          hash: "3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+ssh://git@github.com/jprichardson/node-jsonfile.git"
@@ -6109,12 +6469,14 @@ analyzer:
         homepage_url: "https://github.com/joyent/node-jsprim#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz"
-          hash: "313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/joyent/node-jsprim.git"
@@ -6137,12 +6499,14 @@ analyzer:
         homepage_url: "https://github.com/Medium/kew"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz"
-          hash: "79d93d2d33363d6fdd2970b335d9141ad591d79b"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "79d93d2d33363d6fdd2970b335d9141ad591d79b"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/Medium/kew.git"
@@ -6165,12 +6529,14 @@ analyzer:
         homepage_url: "https://github.com/jprichardson/node-klaw#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz"
-          hash: "4088433b46b3b1ba259d78785d8e96f73ba02439"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "4088433b46b3b1ba259d78785d8e96f73ba02439"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/jprichardson/node-klaw.git"
@@ -6193,12 +6559,14 @@ analyzer:
         homepage_url: "https://github.com/davglass/lcov-parse#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz"
-          hash: "1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+ssh://git@github.com/davglass/lcov-parse.git"
@@ -6222,12 +6590,14 @@ analyzer:
         homepage_url: "https://github.com/gkz/levn"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
-          hash: "3b09924edf9f083c0490fdd4c0bc4421e04764ee"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "3b09924edf9f083c0490fdd4c0bc4421e04764ee"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/gkz/levn.git"
@@ -6250,12 +6620,14 @@ analyzer:
         homepage_url: "https://lodash.com/"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz"
-          hash: "b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/lodash/lodash.git"
@@ -6278,12 +6650,14 @@ analyzer:
         homepage_url: "https://github.com/cainus/logdriver"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz"
-          hash: "63b95021f0702fedfa2c9bb0a24e7797d71871d8"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "63b95021f0702fedfa2c9bb0a24e7797d71871d8"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/cainus/logdriver.git"
@@ -6306,12 +6680,14 @@ analyzer:
         homepage_url: "https://github.com/jshttp/mime-db#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz"
-          hash: "0b6a0ce6fdbe9576e25f1f2d2fde8830dc0ad0d8"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "0b6a0ce6fdbe9576e25f1f2d2fde8830dc0ad0d8"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/jshttp/mime-db.git"
@@ -6334,12 +6710,14 @@ analyzer:
         homepage_url: "https://github.com/jshttp/mime-types#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz"
-          hash: "28995aa1ecb770742fe6ae7e58f9181c744b3f96"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "28995aa1ecb770742fe6ae7e58f9181c744b3f96"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/jshttp/mime-types.git"
@@ -6362,12 +6740,14 @@ analyzer:
         homepage_url: "https://github.com/isaacs/minimatch#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
-          hash: "5166e286457f03306064be5497e8dbb0c3d32083"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "5166e286457f03306064be5497e8dbb0c3d32083"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/isaacs/minimatch.git"
@@ -6390,12 +6770,14 @@ analyzer:
         homepage_url: "https://github.com/substack/minimist"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-          hash: "de3f98543dbf96082be48ad1a0c7cda836301dcf"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "de3f98543dbf96082be48ad1a0c7cda836301dcf"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/substack/minimist.git"
@@ -6418,12 +6800,14 @@ analyzer:
         homepage_url: "https://github.com/substack/minimist"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-          hash: "857fcabfc3397d2625b8228262e86aa7a011b05d"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "857fcabfc3397d2625b8228262e86aa7a011b05d"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/substack/minimist.git"
@@ -6446,12 +6830,14 @@ analyzer:
         homepage_url: "https://github.com/substack/minimist"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-          hash: "a35008b20f41383eec1fb914f4cd5df79a264284"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "a35008b20f41383eec1fb914f4cd5df79a264284"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/substack/minimist.git"
@@ -6474,12 +6860,14 @@ analyzer:
         homepage_url: "https://github.com/substack/node-mkdirp#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
-          hash: "30057438eac6cf7f8c4767f38648d6697d75c903"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "30057438eac6cf7f8c4767f38648d6697d75c903"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/substack/node-mkdirp.git"
@@ -6502,12 +6890,14 @@ analyzer:
         homepage_url: "https://github.com/StevenLooman/mocha-lcov-reporter#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/mocha-lcov-reporter/-/mocha-lcov-reporter-1.3.0.tgz"
-          hash: "469bdef4f8afc9a116056f079df6182d0afb0384"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "469bdef4f8afc9a116056f079df6182d0afb0384"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/StevenLooman/mocha-lcov-reporter.git"
@@ -6530,12 +6920,14 @@ analyzer:
         homepage_url: "https://mochajs.org"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz"
-          hash: "6d8ae508f59167f940f2b5b3c4a612ae50c90ae6"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "6d8ae508f59167f940f2b5b3c4a612ae50c90ae6"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/mochajs/mocha.git"
@@ -6558,12 +6950,14 @@ analyzer:
         homepage_url: "https://github.com/zeit/ms#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-          hash: "5608aeadfc00be6c2901df5f9861788de0d597c8"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "5608aeadfc00be6c2901df5f9861788de0d597c8"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/zeit/ms.git"
@@ -6587,12 +6981,14 @@ analyzer:
         homepage_url: "https://github.com/npm/nopt#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
-          hash: "c6465dbf08abcd4db359317f79ac68a646b28ff9"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "c6465dbf08abcd4db359317f79ac68a646b28ff9"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/npm/nopt.git"
@@ -6615,12 +7011,14 @@ analyzer:
         homepage_url: "https://github.com/fb55/nth-check"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz"
-          hash: "b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/fb55/nth-check.git"
@@ -6644,12 +7042,14 @@ analyzer:
         homepage_url: "https://github.com/mikeal/oauth-sign#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz"
-          hash: "47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
+            algorithm: "SHA-1"
         vcs:
           type: ""
           url: "git+https://github.com/mikeal/oauth-sign.git"
@@ -6672,12 +7072,14 @@ analyzer:
         homepage_url: "https://github.com/isaacs/once#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
-          hash: "583b1aa775961d4b113ac17d9c50baef9dd76bd1"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/isaacs/once.git"
@@ -6701,12 +7103,14 @@ analyzer:
         homepage_url: "https://github.com/substack/node-optimist"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz"
-          hash: "da3ea74686fa21a19a111c326e90eb15a0196686"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "da3ea74686fa21a19a111c326e90eb15a0196686"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "http://github.com/substack/node-optimist.git"
@@ -6729,12 +7133,14 @@ analyzer:
         homepage_url: "https://github.com/gkz/optionator"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz"
-          hash: "364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/gkz/optionator.git"
@@ -6758,12 +7164,14 @@ analyzer:
         homepage_url: "https://github.com/inikulin/parse5"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz"
-          hash: "042f792ffdd36851551cf4e9e066b3874ab45b5c"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "042f792ffdd36851551cf4e9e066b3874ab45b5c"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/inikulin/parse5.git"
@@ -6786,12 +7194,14 @@ analyzer:
         homepage_url: "https://github.com/sindresorhus/path-is-absolute#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-          hash: "174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/sindresorhus/path-is-absolute.git"
@@ -6814,12 +7224,14 @@ analyzer:
         homepage_url: ""
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
-          hash: "7a57eb550a6783f9115331fcf4663d5c8e007a50"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "7a57eb550a6783f9115331fcf4663d5c8e007a50"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/andrewrk/node-pend.git"
@@ -6842,12 +7254,14 @@ analyzer:
         homepage_url: "https://github.com/braveg1rl/performance-now"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz"
-          hash: "6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/braveg1rl/performance-now.git"
@@ -6870,12 +7284,14 @@ analyzer:
         homepage_url: "https://github.com/amir20/phantomjs-node"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/phantom/-/phantom-4.0.12.tgz"
-          hash: "78d18cf3f2a76fea4909f6160fcabf2742d7dbf0"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "78d18cf3f2a76fea4909f6160fcabf2742d7dbf0"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/amir20/phantomjs-node.git"
@@ -6898,12 +7314,14 @@ analyzer:
         homepage_url: "https://github.com/Medium/phantomjs"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz"
-          hash: "efd212a4a3966d3647684ea8ba788549be2aefef"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "efd212a4a3966d3647684ea8ba788549be2aefef"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/Medium/phantomjs.git"
@@ -6926,12 +7344,14 @@ analyzer:
         homepage_url: "https://github.com/floatdrop/pinkie-promise"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-          hash: "2135d6dfa7a358c069ac9b178776288228450ffa"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "2135d6dfa7a358c069ac9b178776288228450ffa"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "https://github.com/floatdrop/pinkie-promise"
@@ -6954,12 +7374,14 @@ analyzer:
         homepage_url: ""
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-          hash: "72556b80cfa0d48a974e80e77248e80ed4f7f870"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "72556b80cfa0d48a974e80e77248e80ed4f7f870"
+            algorithm: "SHA-1"
         vcs:
           type: ""
           url: "https://github.com/floatdrop/pinkie.git"
@@ -6984,12 +7406,14 @@ analyzer:
         homepage_url: "http://preludels.com"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
-          hash: "21932a549f5e52ffd9a827f570e04be62a97da54"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "21932a549f5e52ffd9a827f570e04be62a97da54"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/gkz/prelude-ls.git"
@@ -7012,12 +7436,14 @@ analyzer:
         homepage_url: "https://github.com/calvinmetcalf/process-nextick-args"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz"
-          hash: "a37d732f4271b4ab1ad070d35508e8290788ffaa"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "a37d732f4271b4ab1ad070d35508e8290788ffaa"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/calvinmetcalf/process-nextick-args.git"
@@ -7038,12 +7464,14 @@ analyzer:
         homepage_url: "https://github.com/visionmedia/node-progress"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
-          hash: "e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/visionmedia/node-progress"
@@ -7066,12 +7494,14 @@ analyzer:
         homepage_url: "https://github.com/wrangr/psl#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz"
-          hash: "60f580d360170bb722a797cc704411e6da850c67"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "60f580d360170bb722a797cc704411e6da850c67"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+ssh://git@github.com/wrangr/psl.git"
@@ -7095,12 +7525,14 @@ analyzer:
         homepage_url: "https://mths.be/punycode"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
-          hash: "c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/bestiejs/punycode.js.git"
@@ -7124,12 +7556,14 @@ analyzer:
         homepage_url: "https://github.com/ljharb/qs"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz"
-          hash: "cb3ae806e8740444584ef154ce8ee98d403f3e36"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "cb3ae806e8740444584ef154ce8ee98d403f3e36"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/ljharb/qs.git"
@@ -7153,12 +7587,14 @@ analyzer:
         homepage_url: ""
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
-          hash: "7cf4c54ef648e3813084c636dd2079e166c081d9"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "7cf4c54ef648e3813084c636dd2079e166c081d9"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/isaacs/readable-stream"
@@ -7181,12 +7617,14 @@ analyzer:
         homepage_url: "https://github.com/nodejs/readable-stream#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz"
-          hash: "b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/nodejs/readable-stream.git"
@@ -7209,12 +7647,14 @@ analyzer:
         homepage_url: "https://github.com/nodejs/readable-stream#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz"
-          hash: "de17f229864c120a9f56945756e4f32c4045245d"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "de17f229864c120a9f56945756e4f32c4045245d"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/nodejs/readable-stream.git"
@@ -7239,12 +7679,14 @@ analyzer:
         homepage_url: "https://github.com/IndigoUnited/node-request-progress"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz"
-          hash: "5d36bb57961c673aa5b788dbc8141fdf23b44e08"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "5d36bb57961c673aa5b788dbc8141fdf23b44e08"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/IndigoUnited/node-request-progress"
@@ -7267,12 +7709,14 @@ analyzer:
         homepage_url: "https://github.com/request/request#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/request/-/request-2.88.0.tgz"
-          hash: "9c2fca4f7d35b592efe57c7f0a55e81052124fef"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "9c2fca4f7d35b592efe57c7f0a55e81052124fef"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/request/request.git"
@@ -7295,12 +7739,14 @@ analyzer:
         homepage_url: "https://github.com/bevry/requirefresh"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/requirefresh/-/requirefresh-2.2.0.tgz"
-          hash: "68298ae66af9da3d6843375adf8351dd29d73789"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "68298ae66af9da3d6843375adf8351dd29d73789"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/bevry/requirefresh.git"
@@ -7324,12 +7770,14 @@ analyzer:
         homepage_url: "https://github.com/substack/node-resolve#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
-          hash: "203114d82ad2c5ed9e8e0411b3932875e889e97b"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "203114d82ad2c5ed9e8e0411b3932875e889e97b"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/substack/node-resolve.git"
@@ -7352,12 +7800,14 @@ analyzer:
         homepage_url: "https://github.com/feross/safe-buffer"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
-          hash: "991ec69d296e0313747d59bdfd2b745c35f8828d"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "991ec69d296e0313747d59bdfd2b745c35f8828d"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/feross/safe-buffer.git"
@@ -7381,12 +7831,14 @@ analyzer:
         homepage_url: "https://github.com/bevry/safefs"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/safefs/-/safefs-4.1.0.tgz"
-          hash: "f82aeb4bdd7ae51f653eb20f6728b3058c8d6445"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "f82aeb4bdd7ae51f653eb20f6728b3058c8d6445"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+ssh://git@github.com/bevry/safefs.git"
@@ -7409,12 +7861,14 @@ analyzer:
         homepage_url: "https://github.com/ChALkeR/safer-buffer#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
-          hash: "44fa161b0187b9549dd84bb91802f9bd8385cd6a"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/ChALkeR/safer-buffer.git"
@@ -7437,12 +7891,14 @@ analyzer:
         homepage_url: "https://github.com/npm/node-semver#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz"
-          hash: "7e74256fbaa49c75aa7c7a205cc22799cac80004"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "7e74256fbaa49c75aa7c7a205cc22799cac80004"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/npm/node-semver.git"
@@ -7465,12 +7921,14 @@ analyzer:
         homepage_url: "http://github.com/arturadib/shelljs"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
-          hash: "3596e6307a781544f591f37da618360f31db57b1"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "3596e6307a781544f591f37da618360f31db57b1"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/arturadib/shelljs.git"
@@ -7493,12 +7951,14 @@ analyzer:
         homepage_url: "https://github.com/mozilla/source-map"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz"
-          hash: "dab73fbcfc2ba819b4de03bd6f6eaa48164b3f9d"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "dab73fbcfc2ba819b4de03bd6f6eaa48164b3f9d"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "http://github.com/mozilla/source-map.git"
@@ -7521,12 +7981,14 @@ analyzer:
         homepage_url: "https://github.com/mozilla/source-map"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
-          hash: "74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+ssh://git@github.com/mozilla/source-map.git"
@@ -7549,12 +8011,14 @@ analyzer:
         homepage_url: "http://github.com/dominictarr/split"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/split/-/split-1.0.1.tgz"
-          hash: "605bd9be303aa59fb35f9229fbea0ddec9ea07d9"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "605bd9be303aa59fb35f9229fbea0ddec9ea07d9"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/dominictarr/split.git"
@@ -7577,12 +8041,14 @@ analyzer:
         homepage_url: "https://github.com/alexei/sprintf.js#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
-          hash: "04e6926f662895354f3dd015203633b857297e2c"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "04e6926f662895354f3dd015203633b857297e2c"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/alexei/sprintf.js.git"
@@ -7605,12 +8071,14 @@ analyzer:
         homepage_url: "https://github.com/arekinath/node-sshpk#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/sshpk/-/sshpk-1.15.1.tgz"
-          hash: "b79a089a732e346c6e0714830f36285cd38191a2"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "b79a089a732e346c6e0714830f36285cd38191a2"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/joyent/node-sshpk.git"
@@ -7633,12 +8101,14 @@ analyzer:
         homepage_url: "https://github.com/felixge/node-stack-trace"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz"
-          hash: "547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/felixge/node-stack-trace.git"
@@ -7661,12 +8131,14 @@ analyzer:
         homepage_url: "https://github.com/rvagg/string_decoder"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-          hash: "62e203bc41766c6c28c9fc84301dab1c5310fa94"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "62e203bc41766c6c28c9fc84301dab1c5310fa94"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/rvagg/string_decoder.git"
@@ -7689,12 +8161,14 @@ analyzer:
         homepage_url: "https://github.com/nodejs/string_decoder"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
-          hash: "9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/nodejs/string_decoder.git"
@@ -7717,12 +8191,14 @@ analyzer:
         homepage_url: "https://github.com/nodejs/string_decoder"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz"
-          hash: "fe86e738b19544afe70469243b2a1ee9240eae8d"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "fe86e738b19544afe70469243b2a1ee9240eae8d"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/nodejs/string_decoder.git"
@@ -7746,12 +8222,14 @@ analyzer:
         homepage_url: "https://github.com/sindresorhus/strip-json-comments"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
-          hash: "1e15fbcac97d3ee99bf2d73b4c656b082bbafb91"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "1e15fbcac97d3ee99bf2d73b4c656b082bbafb91"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "https://github.com/sindresorhus/strip-json-comments"
@@ -7774,12 +8252,14 @@ analyzer:
         homepage_url: "https://github.com/chalk/supports-color#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
-          hash: "65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/chalk/supports-color.git"
@@ -7802,12 +8282,14 @@ analyzer:
         homepage_url: "https://github.com/chalk/supports-color#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz"
-          hash: "1c6b337402c2137605efe19f10fec390f6faab54"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "1c6b337402c2137605efe19f10fec390f6faab54"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/chalk/supports-color.git"
@@ -7830,12 +8312,14 @@ analyzer:
         homepage_url: "https://github.com/component/throttle"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz"
-          hash: "9e785836daf46743145a5984b6268d828528ac6c"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "9e785836daf46743145a5984b6268d828528ac6c"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/component/throttle.git"
@@ -7858,12 +8342,14 @@ analyzer:
         homepage_url: "https://github.com/dominictarr/through"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-          hash: "0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/dominictarr/through.git"
@@ -7886,12 +8372,14 @@ analyzer:
         homepage_url: "https://github.com/salesforce/tough-cookie"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz"
-          hash: "53f36da3f47783b0925afa06ff9f3b165280f781"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "53f36da3f47783b0925afa06ff9f3b165280f781"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/salesforce/tough-cookie.git"
@@ -7915,12 +8403,14 @@ analyzer:
         homepage_url: "https://github.com/mikeal/tunnel-agent#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
-          hash: "27a5dea06b36b04a0a9966774b290868f0fc40fd"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "27a5dea06b36b04a0a9966774b290868f0fc40fd"
+            algorithm: "SHA-1"
         vcs:
           type: ""
           url: "git+https://github.com/mikeal/tunnel-agent.git"
@@ -7943,12 +8433,14 @@ analyzer:
         homepage_url: "https://tweetnacl.js.org"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
-          hash: "5ae68177f192d4456269d108afa93ff8743f4f64"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "5ae68177f192d4456269d108afa93ff8743f4f64"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/dchest/tweetnacl-js.git"
@@ -7972,12 +8464,14 @@ analyzer:
         homepage_url: "https://github.com/gkz/type-check"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
-          hash: "5884cab512cf1d355e3fb784f30804b2b520db72"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "5884cab512cf1d355e3fb784f30804b2b520db72"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/gkz/type-check.git"
@@ -8001,12 +8495,14 @@ analyzer:
         homepage_url: "https://github.com/bevry/typechecker"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/typechecker/-/typechecker-4.7.0.tgz"
-          hash: "5249f427358f45b7250c4924fd4d01ed9ba435e9"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "5249f427358f45b7250c4924fd4d01ed9ba435e9"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/bevry/typechecker.git"
@@ -8029,12 +8525,14 @@ analyzer:
         homepage_url: "https://github.com/substack/typedarray"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-          hash: "867ac74e3864187b1d3d47d996a78ec5c8830777"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "867ac74e3864187b1d3d47d996a78ec5c8830777"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/substack/typedarray.git"
@@ -8057,12 +8555,14 @@ analyzer:
         homepage_url: "https://github.com/mishoo/UglifyJS2#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz"
-          hash: "af02f180c1207d76432e473ed24a28f4a782bae3"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "af02f180c1207d76432e473ed24a28f4a782bae3"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/mishoo/UglifyJS2.git"
@@ -8087,12 +8587,14 @@ analyzer:
         homepage_url: "https://github.com/mathiasbynens/unicode-5.2.0"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/unicode-5.2.0/-/unicode-5.2.0-0.7.5.tgz"
-          hash: "e0df129431a28a95263d8c480fb5e9ab2b0973f0"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "e0df129431a28a95263d8c480fb5e9ab2b0973f0"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/mathiasbynens/unicode-5.2.0.git"
@@ -8115,12 +8617,14 @@ analyzer:
         homepage_url: "https://github.com/TooTallNate/util-deprecate"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-          hash: "450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/TooTallNate/util-deprecate.git"
@@ -8143,12 +8647,14 @@ analyzer:
         homepage_url: "https://github.com/kelektiv/node-uuid#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz"
-          hash: "1b4af4955eb3077c501c23872fc6513811587131"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "1b4af4955eb3077c501c23872fc6513811587131"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/kelektiv/node-uuid.git"
@@ -8171,12 +8677,14 @@ analyzer:
         homepage_url: "https://github.com/davepacheco/node-verror"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz"
-          hash: "3a105ca17053af55d6e270c1f8288682e18da400"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "3a105ca17053af55d6e270c1f8288682e18da400"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/davepacheco/node-verror.git"
@@ -8200,12 +8708,14 @@ analyzer:
         homepage_url: "https://github.com/isaacs/node-which#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/which/-/which-1.3.1.tgz"
-          hash: "a45043d54f5805316da8d62f9f50918d3da70b0a"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "a45043d54f5805316da8d62f9f50918d3da70b0a"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/isaacs/node-which.git"
@@ -8228,12 +8738,14 @@ analyzer:
         homepage_url: "https://github.com/winstonjs/winston#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/winston/-/winston-2.4.4.tgz"
-          hash: "a01e4d1d0a103cf4eada6fc1f886b3110d71c34b"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "a01e4d1d0a103cf4eada6fc1f886b3110d71c34b"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/winstonjs/winston.git"
@@ -8256,12 +8768,14 @@ analyzer:
         homepage_url: "https://github.com/substack/node-wordwrap#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-          hash: "a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/substack/node-wordwrap.git"
@@ -8284,12 +8798,14 @@ analyzer:
         homepage_url: "https://github.com/substack/node-wordwrap#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
-          hash: "27584810891456a4171c8d0226441ade90cbcaeb"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "27584810891456a4171c8d0226441ade90cbcaeb"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/substack/node-wordwrap.git"
@@ -8312,12 +8828,14 @@ analyzer:
         homepage_url: "https://github.com/npm/wrappy"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-          hash: "b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/npm/wrappy.git"
@@ -8340,12 +8858,14 @@ analyzer:
         homepage_url: "https://github.com/thejoshwolfe/yauzl"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz"
-          hash: "9528f442dab1b2284e58b4379bb194e22e0c4005"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "9528f442dab1b2284e58b4379bb194e22e0c4005"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git+https://github.com/thejoshwolfe/yauzl.git"
@@ -8368,12 +8888,14 @@ analyzer:
         homepage_url: ""
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/@types/node/-/node-11.9.6.tgz"
-          hash: "c632bbcc780a1349673a6e2e9b9dfa8c369d3c74"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "c632bbcc780a1349673a6e2e9b9dfa8c369d3c74"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "https://github.com/DefinitelyTyped/DefinitelyTyped.git"

--- a/analyzer/src/funTest/assets/projects/external/godep-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/godep-expected-output.yml
@@ -39,12 +39,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -65,12 +67,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -91,12 +95,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -117,12 +123,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -143,12 +151,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""

--- a/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
@@ -79,12 +79,14 @@ packages:
     homepage_url: "http://www.antlr.org/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/antlr/antlr/2.7.7/antlr-2.7.7.jar"
-      hash: "83cd2cd674a217ade95a4bb83a8a14f351f48bd0"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "83cd2cd674a217ade95a4bb83a8a14f351f48bd0"
+        algorithm: "SHA-1"
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -108,12 +110,14 @@ packages:
     homepage_url: "http://github.com/cowtowncoder/java-classmate"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/com/fasterxml/classmate/1.3.0/classmate-1.3.0.jar"
-      hash: "183407ff982e9375f1a1c4a51ed0a9307c598fc7"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "183407ff982e9375f1a1c4a51ed0a9307c598fc7"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/com/fasterxml/classmate/1.3.0/classmate-1.3.0-sources.jar"
-      hash: "818530d5e3e8f862d0aeefb4c2df8e07a1d9ad83"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "818530d5e3e8f862d0aeefb4c2df8e07a1d9ad83"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git@github.com:cowtowncoder/java-classmate.git"
@@ -139,12 +143,14 @@ packages:
     homepage_url: "https://github.com/virtuald/curvesapi"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/com/github/virtuald/curvesapi/1.03/curvesapi-1.03.jar"
-      hash: "6b0977602901464b056959027fdf2396050f9dd2"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "6b0977602901464b056959027fdf2396050f9dd2"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/com/github/virtuald/curvesapi/1.03/curvesapi-1.03-sources.jar"
-      hash: "ae647720b4094f3e6fefea06144b89ebdacff390"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "ae647720b4094f3e6fefea06144b89ebdacff390"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/virtuald/curvesapi.git"
@@ -167,12 +173,14 @@ packages:
     homepage_url: "http://www.h2database.com"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.194/h2-1.4.194.jar"
-      hash: "a180e95af52ad8116d52beb5f1d28596dcafa9d8"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "a180e95af52ad8116d52beb5f1d28596dcafa9d8"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.194/h2-1.4.194-sources.jar"
-      hash: "60aba689ca3459012da9115f68c4dcfcceee51b2"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "60aba689ca3459012da9115f68c4dcfcceee51b2"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/h2database/h2database"
@@ -196,12 +204,14 @@ packages:
     homepage_url: "https://github.com/swaldman/c3p0"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/com/mchange/c3p0/0.9.5.2/c3p0-0.9.5.2.jar"
-      hash: "5f86cb6130bc6e8475615ed82d5b5e6fb226a86a"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "5f86cb6130bc6e8475615ed82d5b5e6fb226a86a"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/com/mchange/c3p0/0.9.5.2/c3p0-0.9.5.2-sources.jar"
-      hash: "147cbd16cde386d978a7d5f23f42778102a08cfc"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "147cbd16cde386d978a7d5f23f42778102a08cfc"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git@github.com:swaldman/c3p0.git"
@@ -225,12 +235,14 @@ packages:
     homepage_url: "https://github.com/swaldman/mchange-commons-java"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/com/mchange/mchange-commons-java/0.2.11/mchange-commons-java-0.2.11.jar"
-      hash: "2a6a6c1fe25f28f5a073171956ce6250813467ef"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "2a6a6c1fe25f28f5a073171956ce6250813467ef"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/com/mchange/mchange-commons-java/0.2.11/mchange-commons-java-0.2.11-sources.jar"
-      hash: "33a53955501fa830ecfc98d6ae611c6dc451946c"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "33a53955501fa830ecfc98d6ae611c6dc451946c"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git@github.com:swaldman/mchange-commons-java.git"
@@ -253,12 +265,14 @@ packages:
     homepage_url: "http://x-stream.github.io/xstream-hibernate"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/com/thoughtworks/xstream/xstream-hibernate/1.4.9/xstream-hibernate-1.4.9.jar"
-      hash: "340bab230ead26225457a8968e342f3034dcb6c2"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "340bab230ead26225457a8968e342f3034dcb6c2"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/com/thoughtworks/xstream/xstream-hibernate/1.4.9/xstream-hibernate-1.4.9-sources.jar"
-      hash: "f81ce4545c480c4e7a7d73fd6faf7578479b130a"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "f81ce4545c480c4e7a7d73fd6faf7578479b130a"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/x-stream/xstream.git"
@@ -282,12 +296,14 @@ packages:
     homepage_url: "http://x-stream.github.io/xstream"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/com/thoughtworks/xstream/xstream/1.4.9/xstream-1.4.9.jar"
-      hash: "c43f6e6bfa79b56e04a8898a923c3cf7144dd460"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "c43f6e6bfa79b56e04a8898a923c3cf7144dd460"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/com/thoughtworks/xstream/xstream/1.4.9/xstream-1.4.9-sources.jar"
-      hash: "a9eb7942e1c58d99d53226b13cc21b4b88cb5cab"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "a9eb7942e1c58d99d53226b13cc21b4b88cb5cab"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/x-stream/xstream.git"
@@ -313,12 +329,14 @@ packages:
     homepage_url: "http://commons.apache.org/proper/commons-codec/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.10/commons-codec-1.10.jar"
-      hash: "4b95f4897fa13f2cd904aee711aeafc0c5295cd8"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "4b95f4897fa13f2cd904aee711aeafc0c5295cd8"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.10/commons-codec-1.10-sources.jar"
-      hash: "11fb3d88ae7e3b757d70237064210ceb954a5a04"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "11fb3d88ae7e3b757d70237064210ceb954a5a04"
+        algorithm: "SHA-1"
     vcs:
       type: "svn"
       url: "http://svn.apache.org/repos/asf/commons/proper/codec/trunk"
@@ -339,12 +357,14 @@ packages:
     homepage_url: "http://dom4j.org"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/dom4j/dom4j/1.6.1/dom4j-1.6.1.jar"
-      hash: "5d3ccc056b6f056dbf0dddfdf43894b9065a8f94"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "5d3ccc056b6f056dbf0dddfdf43894b9065a8f94"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/dom4j/dom4j/1.6.1/dom4j-1.6.1-sources.jar"
-      hash: "a8e7149359255f43e0e5e3b1837948f9ed5861fb"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "a8e7149359255f43e0e5e3b1837948f9ed5861fb"
+        algorithm: "SHA-1"
     vcs:
       type: "cvs"
       url: ":pserver:anonymous@cvs.sourceforge.net:/cvsroot/dom4j:dom4j"
@@ -369,12 +389,14 @@ packages:
     homepage_url: "http://netty.io/netty-buffer/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/io/netty/netty-buffer/4.1.9.Final/netty-buffer-4.1.9.Final.jar"
-      hash: "6ec75e26374569ec0120c63c50fb930c48270e0d"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "6ec75e26374569ec0120c63c50fb930c48270e0d"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/io/netty/netty-buffer/4.1.9.Final/netty-buffer-4.1.9.Final-sources.jar"
-      hash: "368f4f76cdd5991442f284aeecd1d7684ee2e32d"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "368f4f76cdd5991442f284aeecd1d7684ee2e32d"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/netty/netty.git"
@@ -399,12 +421,14 @@ packages:
     homepage_url: "http://netty.io/netty-codec/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/io/netty/netty-codec/4.1.9.Final/netty-codec-4.1.9.Final.jar"
-      hash: "f41b5fdaaaf7b1e8de4e05be5f5b540f3b205959"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "f41b5fdaaaf7b1e8de4e05be5f5b540f3b205959"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/io/netty/netty-codec/4.1.9.Final/netty-codec-4.1.9.Final-sources.jar"
-      hash: "086dc41eab00c51f56d384b3ea4772f3d7704e4a"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "086dc41eab00c51f56d384b3ea4772f3d7704e4a"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/netty/netty.git"
@@ -429,12 +453,14 @@ packages:
     homepage_url: "http://netty.io/netty-common/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/io/netty/netty-common/4.1.9.Final/netty-common-4.1.9.Final.jar"
-      hash: "7c6ba17f3b9e08fbbfc000fa3ce46208446a0019"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "7c6ba17f3b9e08fbbfc000fa3ce46208446a0019"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/io/netty/netty-common/4.1.9.Final/netty-common-4.1.9.Final-sources.jar"
-      hash: "c8615de0902bdb6658e308c2eb8c339556b559b0"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "c8615de0902bdb6658e308c2eb8c339556b559b0"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/netty/netty.git"
@@ -459,12 +485,14 @@ packages:
     homepage_url: "http://netty.io/netty-resolver/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/io/netty/netty-resolver/4.1.9.Final/netty-resolver-4.1.9.Final.jar"
-      hash: "9e1f26ad1988fcbe0fc824940dfe6de9d2f438da"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "9e1f26ad1988fcbe0fc824940dfe6de9d2f438da"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/io/netty/netty-resolver/4.1.9.Final/netty-resolver-4.1.9.Final-sources.jar"
-      hash: "2618cb7663514bfb77d2dd9bc8df2ba93ce141e7"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "2618cb7663514bfb77d2dd9bc8df2ba93ce141e7"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/netty/netty.git"
@@ -489,12 +517,14 @@ packages:
     homepage_url: "http://netty.io/netty-transport/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/io/netty/netty-transport/4.1.9.Final/netty-transport-4.1.9.Final.jar"
-      hash: "aaeed88d6a5c0bfc8d7a78225f4f093544470f5a"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "aaeed88d6a5c0bfc8d7a78225f4f093544470f5a"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/io/netty/netty-transport/4.1.9.Final/netty-transport-4.1.9.Final-sources.jar"
-      hash: "000eb6886a1c21a41975dffc87cbc1c5c341d344"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "000eb6886a1c21a41975dffc87cbc1c5c341d344"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/netty/netty.git"
@@ -518,12 +548,14 @@ packages:
     homepage_url: "http://junit.org"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12.jar"
-      hash: "2973d150c0dc1fefe998f834810d68f278ea58ec"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "2973d150c0dc1fefe998f834810d68f278ea58ec"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
-      hash: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/junit-team/junit.git"
@@ -546,12 +578,14 @@ packages:
     homepage_url: "http://logging.apache.org/log4j/1.2/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/log4j/log4j/1.2.17/log4j-1.2.17.jar"
-      hash: "5af35056b4d257e4b64b9e8069c0746e8b08629f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "5af35056b4d257e4b64b9e8069c0746e8b08629f"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/log4j/log4j/1.2.17/log4j-1.2.17-sources.jar"
-      hash: "677abe279b68c5e7490d6d50c6951376238d7d3e"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "677abe279b68c5e7490d6d50c6951376238d7d3e"
+        algorithm: "SHA-1"
     vcs:
       type: "svn"
       url: "http://svn.apache.org/repos/asf/logging/log4j/tags/v1_2_17_rc3"
@@ -577,12 +611,14 @@ packages:
     homepage_url: "http://kxml.sourceforge.net/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/net/sf/kxml/kxml2/2.3.0/kxml2-2.3.0.jar"
-      hash: "ccbc77a5fd907ef863c29f3596c6f54ffa4e9442"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "ccbc77a5fd907ef863c29f3596c6f54ffa4e9442"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/net/sf/kxml/kxml2/2.3.0/kxml2-2.3.0-sources.jar"
-      hash: "309cd2cff7260e465792fda3dcbb063b730d8050"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "309cd2cff7260e465792fda3dcbb063b730d8050"
+        algorithm: "SHA-1"
     vcs:
       type: ""
       url: ""
@@ -607,12 +643,14 @@ packages:
     homepage_url: "http://commons.apache.org/proper/commons-lang/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.3.2/commons-lang3-3.3.2.jar"
-      hash: "90a3822c38ec8c996e84c16a3477ef632cbc87a3"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "90a3822c38ec8c996e84c16a3477ef632cbc87a3"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.3.2/commons-lang3-3.3.2-sources.jar"
-      hash: "d2a489573c0ed2c4942b3660decad5d65087b406"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "d2a489573c0ed2c4942b3660decad5d65087b406"
+        algorithm: "SHA-1"
     vcs:
       type: "svn"
       url: "http://svn.apache.org/repos/asf/commons/proper/lang/trunk"
@@ -635,12 +673,14 @@ packages:
     homepage_url: "http://poi.apache.org/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/poi/poi-ooxml-schemas/3.14/poi-ooxml-schemas-3.14.jar"
-      hash: "97fe4bfdef7f103bfd9ec63c98ea90469afeec7b"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "97fe4bfdef7f103bfd9ec63c98ea90469afeec7b"
+        algorithm: "SHA-1"
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -663,12 +703,14 @@ packages:
     homepage_url: "http://poi.apache.org/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/poi/poi-ooxml/3.14/poi-ooxml-3.14.jar"
-      hash: "911b3a5562b5dc4c5156d2d5f0f68a83346100d0"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "911b3a5562b5dc4c5156d2d5f0f68a83346100d0"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/poi/poi-ooxml/3.14/poi-ooxml-3.14-sources.jar"
-      hash: "736eeb639587c8efa620d5f10fd6fee53ad1996f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "736eeb639587c8efa620d5f10fd6fee53ad1996f"
+        algorithm: "SHA-1"
     vcs:
       type: ""
       url: ""
@@ -691,12 +733,14 @@ packages:
     homepage_url: "http://poi.apache.org/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/poi/poi/3.14/poi-3.14.jar"
-      hash: "fad7ae6d2e59c59ffdb45f1981500babfa765180"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "fad7ae6d2e59c59ffdb45f1981500babfa765180"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/poi/poi/3.14/poi-3.14-sources.jar"
-      hash: "5cf7a94c492c51ed82cf32c44cb63494d353a048"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "5cf7a94c492c51ed82cf32c44cb63494d353a048"
+        algorithm: "SHA-1"
     vcs:
       type: ""
       url: ""
@@ -719,12 +763,14 @@ packages:
     homepage_url: "http://xmlbeans.apache.org"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/xmlbeans/xmlbeans/2.6.0/xmlbeans-2.6.0.jar"
-      hash: "29e80d2dd51f9dcdef8f9ffaee0d4dc1c9bbfc87"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "29e80d2dd51f9dcdef8f9ffaee0d4dc1c9bbfc87"
+        algorithm: "SHA-1"
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "svn"
       url: "https://svn.apache.org/repos/asf/xmlbeans/"
@@ -748,12 +794,14 @@ packages:
     homepage_url: "https://github.com/hamcrest/JavaHamcrest/hamcrest-all"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar"
-      hash: "63a21ebc981131004ad02e0434e799fd7f3a8d5a"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "63a21ebc981131004ad02e0434e799fd7f3a8d5a"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3-sources.jar"
-      hash: "47e033b7ab18c5dbd5fe29fc1bd5a40afe028818"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "47e033b7ab18c5dbd5fe29fc1bd5a40afe028818"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git@github.com:hamcrest/JavaHamcrest.git"
@@ -776,12 +824,14 @@ packages:
     homepage_url: "http://hibernate.org"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/hibernate/common/hibernate-commons-annotations/5.0.1.Final/hibernate-commons-annotations-5.0.1.Final.jar"
-      hash: "71e1cff3fcb20d3b3af4f3363c3ddb24d33c6879"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "71e1cff3fcb20d3b3af4f3363c3ddb24d33c6879"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/hibernate/common/hibernate-commons-annotations/5.0.1.Final/hibernate-commons-annotations-5.0.1.Final-sources.jar"
-      hash: "203038e420aaa3fa6df8bad4fda19ca1e2824005"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "203038e420aaa3fa6df8bad4fda19ca1e2824005"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "http://github.com/hibernate/hibernate-commons-annotations.git"
@@ -806,12 +856,14 @@ packages:
     homepage_url: "http://hibernate.org"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/hibernate/javax/persistence/hibernate-jpa-2.1-api/1.0.0.Final/hibernate-jpa-2.1-api-1.0.0.Final.jar"
-      hash: "5e731d961297e5a07290bfaf3db1fbc8bbbf405a"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "5e731d961297e5a07290bfaf3db1fbc8bbbf405a"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/hibernate/javax/persistence/hibernate-jpa-2.1-api/1.0.0.Final/hibernate-jpa-2.1-api-1.0.0.Final-sources.jar"
-      hash: "33fbaa7276b774ef0925f541640f6ff23fbc62dc"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "33fbaa7276b774ef0925f541640f6ff23fbc62dc"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "http://github.com/hibernate/hibernate-jpa-api.git"
@@ -834,12 +886,14 @@ packages:
     homepage_url: "http://hibernate.org"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/hibernate/hibernate-c3p0/5.2.10.Final/hibernate-c3p0-5.2.10.Final.jar"
-      hash: "0e98696f92ea8df4147a95fae9bab9093db294da"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "0e98696f92ea8df4147a95fae9bab9093db294da"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/hibernate/hibernate-c3p0/5.2.10.Final/hibernate-c3p0-5.2.10.Final-sources.jar"
-      hash: "eec7c630bc036b28e082949d5f9463bd9abc57b7"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "eec7c630bc036b28e082949d5f9463bd9abc57b7"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "http://github.com/hibernate/hibernate-orm.git"
@@ -862,12 +916,14 @@ packages:
     homepage_url: "http://hibernate.org"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/hibernate/hibernate-core/5.2.10.Final/hibernate-core-5.2.10.Final.jar"
-      hash: "b46a4ba34b52d335cc45c0f33d029f782f7db887"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "b46a4ba34b52d335cc45c0f33d029f782f7db887"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/hibernate/hibernate-core/5.2.10.Final/hibernate-core-5.2.10.Final-sources.jar"
-      hash: "6a853e528cfaa39342f408619b404fda6a9af228"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "6a853e528cfaa39342f408619b404fda6a9af228"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "http://github.com/hibernate/hibernate-orm.git"
@@ -890,12 +946,14 @@ packages:
     homepage_url: "http://hsqldb.org"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/hsqldb/hsqldb/2.4.0/hsqldb-2.4.0.jar"
-      hash: "195957160ed990dbc798207c0d577280d9919208"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "195957160ed990dbc798207c0d577280d9919208"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/hsqldb/hsqldb/2.4.0/hsqldb-2.4.0-sources.jar"
-      hash: "a9174917777d96078daaa3b519088fe9ebc7b40e"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "a9174917777d96078daaa3b519088fe9ebc7b40e"
+        algorithm: "SHA-1"
     vcs:
       type: "svn"
       url: "http://svn.code.sf.net/p/hsqldb/svn/base/"
@@ -921,12 +979,14 @@ packages:
     homepage_url: "http://www.javassist.org/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/javassist/javassist/3.20.0-GA/javassist-3.20.0-GA.jar"
-      hash: "a9cbcdfb7e9f86fbc74d3afae65f2248bfbf82a0"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "a9cbcdfb7e9f86fbc74d3afae65f2248bfbf82a0"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/javassist/javassist/3.20.0-GA/javassist-3.20.0-GA-sources.jar"
-      hash: "d8fdc08a455bc0b28bc0bed1f0d032d935cee8e1"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "d8fdc08a455bc0b28bc0bed1f0d032d935cee8e1"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git@github.com:jboss-javassist/javassist.git"
@@ -949,12 +1009,14 @@ packages:
     homepage_url: "http://www.jboss.org"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jboss/logging/jboss-logging/3.3.0.Final/jboss-logging-3.3.0.Final.jar"
-      hash: "3616bb87707910296e2c195dc016287080bba5af"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "3616bb87707910296e2c195dc016287080bba5af"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jboss/logging/jboss-logging/3.3.0.Final/jboss-logging-3.3.0.Final-sources.jar"
-      hash: "3625e6818158ddb4754fa2ec51299e5f57e596b4"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "3625e6818158ddb4754fa2ec51299e5f57e596b4"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/jboss-logging/jboss-logging.git"
@@ -978,12 +1040,14 @@ packages:
     homepage_url: "http://www.jboss.org/jboss-transaction-api_1.2_spec"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jboss/spec/javax/transaction/jboss-transaction-api_1.2_spec/1.0.1.Final/jboss-transaction-api_1.2_spec-1.0.1.Final.jar"
-      hash: "4441f144a2a1f46ed48fcc6b476a4b6295e6d524"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "4441f144a2a1f46ed48fcc6b476a4b6295e6d524"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jboss/spec/javax/transaction/jboss-transaction-api_1.2_spec/1.0.1.Final/jboss-transaction-api_1.2_spec-1.0.1.Final-sources.jar"
-      hash: "2d0cb1e79e030277b094ef55fcfb97fd0443ee43"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "2d0cb1e79e030277b094ef55fcfb97fd0443ee43"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git@github.com:jboss/jboss-transaction-api_spec.git"
@@ -1006,12 +1070,14 @@ packages:
     homepage_url: "http://www.jboss.org/jandex"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jboss/jandex/2.0.3.Final/jandex-2.0.3.Final.jar"
-      hash: "bfc4d6257dbff7a33a357f0de116be6ff951d849"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "bfc4d6257dbff7a33a357f0de116be6ff951d849"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jboss/jandex/2.0.3.Final/jandex-2.0.3.Final-sources.jar"
-      hash: "edc4552ad816df11579a8e02e19f778c77a915b5"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "edc4552ad816df11579a8e02e19f778c77a915b5"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git@github.com:jboss/jboss-parent-pom.git"
@@ -1034,12 +1100,14 @@ packages:
     homepage_url: "http://www.slf4j.org"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.21/slf4j-api-1.7.21.jar"
-      hash: "139535a69a4239db087de9bab0bee568bf8e0b70"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "139535a69a4239db087de9bab0bee568bf8e0b70"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.21/slf4j-api-1.7.21-sources.jar"
-      hash: "f285ac123f201fb4b028bac556928d7cf527ef48"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "f285ac123f201fb4b028bac556928d7cf527ef48"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git@github.com:qos-ch/slf4j.git"
@@ -1062,12 +1130,14 @@ packages:
     homepage_url: "http://www.slf4j.org"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-log4j12/1.7.21/slf4j-log4j12-1.7.21.jar"
-      hash: "7238b064d1aba20da2ac03217d700d91e02460fa"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "7238b064d1aba20da2ac03217d700d91e02460fa"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-log4j12/1.7.21/slf4j-log4j12-1.7.21-sources.jar"
-      hash: "16b1333786ea93d16bff6fb0f5e3b82716d1b008"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "16b1333786ea93d16bff6fb0f5e3b82716d1b008"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git@github.com:qos-ch/slf4j.git"

--- a/analyzer/src/funTest/assets/projects/external/jgnash-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/jgnash-expected-output.yml
@@ -34,12 +34,14 @@ packages:
     homepage_url: "http://junit.org"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12.jar"
-      hash: "2973d150c0dc1fefe998f834810d68f278ea58ec"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "2973d150c0dc1fefe998f834810d68f278ea58ec"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
-      hash: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/junit-team/junit.git"
@@ -63,12 +65,14 @@ packages:
     homepage_url: "https://github.com/hamcrest/JavaHamcrest/hamcrest-all"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar"
-      hash: "63a21ebc981131004ad02e0434e799fd7f3a8d5a"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "63a21ebc981131004ad02e0434e799fd7f3a8d5a"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3-sources.jar"
-      hash: "47e033b7ab18c5dbd5fe29fc1bd5a40afe028818"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "47e033b7ab18c5dbd5fe29fc1bd5a40afe028818"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git@github.com:hamcrest/JavaHamcrest.git"

--- a/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-cli.yml
+++ b/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-cli.yml
@@ -244,12 +244,14 @@ packages:
     homepage_url: "https://kotlinlang.org/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-compiler-embeddable/1.3.11/kotlin-compiler-embeddable-1.3.11.jar"
-      hash: "a8db6c14f8b8ed74aa11b8379f961587b639c571"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "a8db6c14f8b8ed74aa11b8379f961587b639c571"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-compiler-embeddable/1.3.11/kotlin-compiler-embeddable-1.3.11-sources.jar"
-      hash: "86e3750eb7fc889a61af127ef5b2b843d141ba09"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "86e3750eb7fc889a61af127ef5b2b843d141ba09"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/JetBrains/kotlin.git"
@@ -272,12 +274,14 @@ packages:
     homepage_url: "https://kotlinlang.org/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.3.11/kotlin-reflect-1.3.11.jar"
-      hash: "aae7b33412715e9ed441934c4ffaad1bb80e9d36"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "aae7b33412715e9ed441934c4ffaad1bb80e9d36"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.3.11/kotlin-reflect-1.3.11-sources.jar"
-      hash: "92835479c406bf6b1d55c41b0013f238a5ed5bd8"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "92835479c406bf6b1d55c41b0013f238a5ed5bd8"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/JetBrains/kotlin.git"
@@ -300,12 +304,14 @@ packages:
     homepage_url: "https://kotlinlang.org/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-script-runtime/1.3.11/kotlin-script-runtime-1.3.11.jar"
-      hash: "1ef3a816aeacb9cd051b3ed37e2abf88910f1503"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "1ef3a816aeacb9cd051b3ed37e2abf88910f1503"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-script-runtime/1.3.11/kotlin-script-runtime-1.3.11-sources.jar"
-      hash: "819822a4658989d09761f8e3e9d31b4743897b22"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "819822a4658989d09761f8e3e9d31b4743897b22"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/JetBrains/kotlin.git"
@@ -328,12 +334,14 @@ packages:
     homepage_url: "https://kotlinlang.org/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/1.3.11/kotlin-scripting-compiler-embeddable-1.3.11.jar"
-      hash: "d7d145f70c063e3bb2edb41b766971e359155b99"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "d7d145f70c063e3bb2edb41b766971e359155b99"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/1.3.11/kotlin-scripting-compiler-embeddable-1.3.11-sources.jar"
-      hash: "9ed059e6df49c3e812b4a8d9431287a629a0e5bb"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "9ed059e6df49c3e812b4a8d9431287a629a0e5bb"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/JetBrains/kotlin.git"
@@ -356,12 +364,14 @@ packages:
     homepage_url: "https://kotlinlang.org/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/1.3.11/kotlin-stdlib-common-1.3.11.jar"
-      hash: "d8b8e746e279f1c4f5e08bc14a96b82e6bb1de02"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "d8b8e746e279f1c4f5e08bc14a96b82e6bb1de02"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/1.3.11/kotlin-stdlib-common-1.3.11-sources.jar"
-      hash: "e49742d3259938ea3539346c8ca3babb54a5140f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "e49742d3259938ea3539346c8ca3babb54a5140f"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/JetBrains/kotlin.git"
@@ -384,12 +394,14 @@ packages:
     homepage_url: "https://kotlinlang.org/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.3.11/kotlin-stdlib-1.3.11.jar"
-      hash: "4cbc5922a54376018307a731162ccaf3ef851a39"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "4cbc5922a54376018307a731162ccaf3ef851a39"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.3.11/kotlin-stdlib-1.3.11-sources.jar"
-      hash: "d46e00faac79f8ec6bb956154ecde4282871a6bf"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "d46e00faac79f8ec6bb956154ecde4282871a6bf"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/JetBrains/kotlin.git"
@@ -412,12 +424,14 @@ packages:
     homepage_url: "http://www.jetbrains.org"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0.jar"
-      hash: "919f0dfe192fb4e063e7dacadee7f8bb9a2672a9"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "919f0dfe192fb4e063e7dacadee7f8bb9a2672a9"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0-sources.jar"
-      hash: "5991ca87ef1fb5544943d9abc5a9a37583fabe03"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "5991ca87ef1fb5544943d9abc5a9a37583fabe03"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/JetBrains/intellij-community.git"

--- a/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-core.yml
+++ b/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-core.yml
@@ -153,12 +153,14 @@ packages:
     homepage_url: "https://kotlinlang.org/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-compiler-embeddable/1.3.11/kotlin-compiler-embeddable-1.3.11.jar"
-      hash: "a8db6c14f8b8ed74aa11b8379f961587b639c571"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "a8db6c14f8b8ed74aa11b8379f961587b639c571"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-compiler-embeddable/1.3.11/kotlin-compiler-embeddable-1.3.11-sources.jar"
-      hash: "86e3750eb7fc889a61af127ef5b2b843d141ba09"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "86e3750eb7fc889a61af127ef5b2b843d141ba09"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/JetBrains/kotlin.git"
@@ -181,12 +183,14 @@ packages:
     homepage_url: "https://kotlinlang.org/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.3.11/kotlin-reflect-1.3.11.jar"
-      hash: "aae7b33412715e9ed441934c4ffaad1bb80e9d36"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "aae7b33412715e9ed441934c4ffaad1bb80e9d36"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.3.11/kotlin-reflect-1.3.11-sources.jar"
-      hash: "92835479c406bf6b1d55c41b0013f238a5ed5bd8"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "92835479c406bf6b1d55c41b0013f238a5ed5bd8"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/JetBrains/kotlin.git"
@@ -209,12 +213,14 @@ packages:
     homepage_url: "https://kotlinlang.org/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-script-runtime/1.3.11/kotlin-script-runtime-1.3.11.jar"
-      hash: "1ef3a816aeacb9cd051b3ed37e2abf88910f1503"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "1ef3a816aeacb9cd051b3ed37e2abf88910f1503"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-script-runtime/1.3.11/kotlin-script-runtime-1.3.11-sources.jar"
-      hash: "819822a4658989d09761f8e3e9d31b4743897b22"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "819822a4658989d09761f8e3e9d31b4743897b22"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/JetBrains/kotlin.git"
@@ -237,12 +243,14 @@ packages:
     homepage_url: "https://kotlinlang.org/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/1.3.11/kotlin-scripting-compiler-embeddable-1.3.11.jar"
-      hash: "d7d145f70c063e3bb2edb41b766971e359155b99"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "d7d145f70c063e3bb2edb41b766971e359155b99"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/1.3.11/kotlin-scripting-compiler-embeddable-1.3.11-sources.jar"
-      hash: "9ed059e6df49c3e812b4a8d9431287a629a0e5bb"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "9ed059e6df49c3e812b4a8d9431287a629a0e5bb"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/JetBrains/kotlin.git"
@@ -265,12 +273,14 @@ packages:
     homepage_url: "https://kotlinlang.org/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/1.3.11/kotlin-stdlib-common-1.3.11.jar"
-      hash: "d8b8e746e279f1c4f5e08bc14a96b82e6bb1de02"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "d8b8e746e279f1c4f5e08bc14a96b82e6bb1de02"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/1.3.11/kotlin-stdlib-common-1.3.11-sources.jar"
-      hash: "e49742d3259938ea3539346c8ca3babb54a5140f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "e49742d3259938ea3539346c8ca3babb54a5140f"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/JetBrains/kotlin.git"
@@ -293,12 +303,14 @@ packages:
     homepage_url: "https://kotlinlang.org/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.3.11/kotlin-stdlib-1.3.11.jar"
-      hash: "4cbc5922a54376018307a731162ccaf3ef851a39"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "4cbc5922a54376018307a731162ccaf3ef851a39"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.3.11/kotlin-stdlib-1.3.11-sources.jar"
-      hash: "d46e00faac79f8ec6bb956154ecde4282871a6bf"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "d46e00faac79f8ec6bb956154ecde4282871a6bf"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/JetBrains/kotlin.git"
@@ -321,12 +333,14 @@ packages:
     homepage_url: "http://www.jetbrains.org"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0.jar"
-      hash: "919f0dfe192fb4e063e7dacadee7f8bb9a2672a9"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "919f0dfe192fb4e063e7dacadee7f8bb9a2672a9"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0-sources.jar"
-      hash: "5991ca87ef1fb5544943d9abc5a9a37583fabe03"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "5991ca87ef1fb5544943d9abc5a9a37583fabe03"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/JetBrains/intellij-community.git"

--- a/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-root.yml
@@ -54,12 +54,14 @@ packages:
     homepage_url: "https://kotlinlang.org/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/1.3.11/kotlin-stdlib-common-1.3.11.jar"
-      hash: "d8b8e746e279f1c4f5e08bc14a96b82e6bb1de02"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "d8b8e746e279f1c4f5e08bc14a96b82e6bb1de02"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/1.3.11/kotlin-stdlib-common-1.3.11-sources.jar"
-      hash: "e49742d3259938ea3539346c8ca3babb54a5140f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "e49742d3259938ea3539346c8ca3babb54a5140f"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/JetBrains/kotlin.git"
@@ -82,12 +84,14 @@ packages:
     homepage_url: "https://kotlinlang.org/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.3.11/kotlin-stdlib-1.3.11.jar"
-      hash: "4cbc5922a54376018307a731162ccaf3ef851a39"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "4cbc5922a54376018307a731162ccaf3ef851a39"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.3.11/kotlin-stdlib-1.3.11-sources.jar"
-      hash: "d46e00faac79f8ec6bb956154ecde4282871a6bf"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "d46e00faac79f8ec6bb956154ecde4282871a6bf"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/JetBrains/kotlin.git"
@@ -110,12 +114,14 @@ packages:
     homepage_url: "http://www.jetbrains.org"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0.jar"
-      hash: "919f0dfe192fb4e063e7dacadee7f8bb9a2672a9"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "919f0dfe192fb4e063e7dacadee7f8bb9a2672a9"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0-sources.jar"
-      hash: "5991ca87ef1fb5544943d9abc5a9a37583fabe03"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "5991ca87ef1fb5544943d9abc5a9a37583fabe03"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/JetBrains/intellij-community.git"

--- a/analyzer/src/funTest/assets/projects/external/qmstr-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/qmstr-expected-output.yml
@@ -53,12 +53,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -79,12 +81,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -105,12 +109,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -131,12 +137,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -157,12 +165,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -183,12 +193,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -209,12 +221,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -235,12 +249,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -261,12 +277,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -287,12 +305,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -313,12 +333,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -339,12 +361,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""

--- a/analyzer/src/funTest/assets/projects/external/quickcheck-state-machine-expected-output-win32.yml
+++ b/analyzer/src/funTest/assets/projects/external/quickcheck-state-machine-expected-output-win32.yml
@@ -1382,12 +1382,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -1418,12 +1420,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/base-compat-0.9.3/base-compat-0.9.3.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/haskell-compat/base-compat"
@@ -1451,12 +1455,14 @@ packages:
     homepage_url: "http://github.com/ekmett/transformers-compat/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/transformers-compat-0.5.1.4/transformers-compat-0.5.1.4.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "git://github.com/ekmett/transformers-compat.git"
@@ -1487,12 +1493,14 @@ packages:
     homepage_url: "https://github.com/simonmar/async"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/async-2.1.1.1/async-2.1.1.1.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/simonmar/async.git"
@@ -1516,12 +1524,14 @@ packages:
     homepage_url: "https://github.com/maoe/lifted-async"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/lifted-async-0.9.3.3/lifted-async-0.9.3.3.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/maoe/lifted-async.git"
@@ -1549,12 +1559,14 @@ packages:
     homepage_url: "https://wiki.haskell.org/Software_transactional_memory"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/stm-2.4.5.0/stm-2.4.5.0.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/haskell/stm.git"
@@ -1579,12 +1591,14 @@ packages:
     homepage_url: "http://github.com/ekmett/constraints/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/constraints-0.9.1/constraints-0.9.1.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "git://github.com/ekmett/constraints.git"
@@ -1615,12 +1629,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/deepseq-1.4.3.0/deepseq-1.4.3.0.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/haskell/deepseq.git"
@@ -1648,12 +1664,14 @@ packages:
     homepage_url: "https://github.com/basvandijk/lifted-base"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/lifted-base-0.2.3.11/lifted-base-0.2.3.11.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/basvandijk/lifted-base.git"
@@ -1686,12 +1704,14 @@ packages:
     homepage_url: "https://github.com/basvandijk/monad-control"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/monad-control-1.0.2.2/monad-control-1.0.2.2.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "git://github.com/basvandijk/monad-control.git"
@@ -1717,12 +1737,14 @@ packages:
     homepage_url: "http://github.com/ekmett/mtl"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/mtl-2.2.1/mtl-2.2.1.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "git://github.com/ekmett/mtl.git"
@@ -1746,12 +1768,14 @@ packages:
     homepage_url: "https://github.com/mvv/transformers-base"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/transformers-base-0.4.4/transformers-base-0.4.4.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/mvv/transformers-base.git"
@@ -1786,12 +1810,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/transformers-0.5.2.0/transformers-0.5.2.0.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "darcs"
       url: "http://hub.darcs.net/ross/transformers"
@@ -1817,12 +1843,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/array-0.5.2.0/array-0.5.2.0.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "http://git.haskell.org/packages/array.git"
@@ -1848,12 +1876,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/containers-0.5.10.2/containers-0.5.10.2.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "http://github.com/haskell/containers.git"
@@ -1881,12 +1911,14 @@ packages:
     homepage_url: "https://github.com/kolmodin/binary"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/binary-0.8.5.1/binary-0.8.5.1.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "git://github.com/kolmodin/binary.git"
@@ -1922,12 +1954,14 @@ packages:
     homepage_url: "https://github.com/bos/text"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/text-1.2.2.2/text-1.2.2.2.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "mercurial"
       url: "https://bitbucket.org/bos/text"
@@ -1971,12 +2005,14 @@ packages:
     homepage_url: "https://github.com/haskell/bytestring"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/bytestring-0.10.8.2/bytestring-0.10.8.2.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/haskell/bytestring"
@@ -2002,12 +2038,14 @@ packages:
     homepage_url: "http://github.com/tibbe/hashable"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/hashable-1.2.6.1/hashable-1.2.6.1.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/tibbe/hashable.git"
@@ -2030,12 +2068,14 @@ packages:
     homepage_url: "https://github.com/haskell/primitive"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/primitive-0.6.3.0/primitive-0.6.3.0.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/haskell/primitive"
@@ -2061,12 +2101,14 @@ packages:
     homepage_url: "https://github.com/glguy/th-abstraction"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/th-abstraction-0.2.6.0/th-abstraction-0.2.6.0.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/glguy/th-abstraction.git"
@@ -2092,12 +2134,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/ghc-boot-th-8.2.2/ghc-boot-th-8.2.2.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "http://git.haskell.org/ghc.git"
@@ -2121,12 +2165,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/ghc-prim-0.5.1.1/ghc-prim-0.5.1.1.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "http://git.haskell.org/ghc.git"
@@ -2153,12 +2199,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/integer-gmp-1.0.1.0/integer-gmp-1.0.1.0.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -2183,12 +2231,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/base-4.10.1.0/base-4.10.1.0.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "http://git.haskell.org/ghc.git"
@@ -2229,12 +2279,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/tf-random-0.5/tf-random-0.5.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "darcs"
       url: "http://hub.darcs.net/michal.palka/tf-random"
@@ -2257,12 +2309,14 @@ packages:
     homepage_url: "https://github.com/haskell/win32"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/Win32-2.5.4.1/Win32-2.5.4.1.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "git://github.com/haskell/win32"
@@ -2286,12 +2340,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/directory-1.3.0.2/directory-1.3.0.2.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/haskell/directory"
@@ -2322,12 +2378,14 @@ packages:
     homepage_url: "https://github.com/haskell/filepath#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/filepath-1.4.1.2/filepath-1.4.1.2.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/haskell/filepath.git"
@@ -2353,12 +2411,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/process-1.6.1.0/process-1.6.1.0.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/haskell/process.git"
@@ -2382,12 +2442,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/random-1.1/random-1.1.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "http://git.haskell.org/packages/random.git"
@@ -2412,12 +2474,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/template-haskell-2.12.0.0/template-haskell-2.12.0.0.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "http://git.haskell.org/ghc.git"
@@ -2450,12 +2514,14 @@ packages:
     homepage_url: "https://github.com/nick8325/quickcheck"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/QuickCheck-2.10.1/QuickCheck-2.10.1.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/nick8325/quickcheck"
@@ -2485,12 +2551,14 @@ packages:
     homepage_url: "http://www.github.com/nick8325/quickcheck-with-counterexamples"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/quickcheck-with-counterexamples-1.0/quickcheck-with-counterexamples-1.0.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/nick8325/quickcheck-with-counterexamples"
@@ -2517,12 +2585,14 @@ packages:
     homepage_url: "http://github.com/haskell/pretty"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/pretty-1.1.3.3/pretty-1.1.3.3.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "http://github.com/haskell/pretty.git"
@@ -2545,12 +2615,14 @@ packages:
     homepage_url: "https://github.com/haskell/time"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/time-1.8.0.2/time-1.8.0.2.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/haskell/time"
@@ -2576,12 +2648,14 @@ packages:
     homepage_url: "http://github.com/ekmett/ansi-wl-pprint"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/ansi-wl-pprint-0.6.8.2/ansi-wl-pprint-0.6.8.2.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/ekmett/ansi-wl-pprint.git"
@@ -2606,12 +2680,14 @@ packages:
     homepage_url: "https://github.com/feuerbach/ansi-terminal"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/ansi-terminal-0.7.1.1/ansi-terminal-0.7.1.1.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "git://github.com/feuerbach/ansi-terminal.git"
@@ -2636,12 +2712,14 @@ packages:
     homepage_url: "http://www.haskell.org/haskellwiki/Colour"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/colour-2.3.4/colour-2.3.4.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""

--- a/analyzer/src/funTest/assets/projects/external/quickcheck-state-machine-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/quickcheck-state-machine-expected-output.yml
@@ -1069,12 +1069,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -1102,12 +1104,14 @@ packages:
     homepage_url: "http://github.com/ekmett/transformers-compat/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/transformers-compat-0.5.1.4/transformers-compat-0.5.1.4.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "git://github.com/ekmett/transformers-compat.git"
@@ -1138,12 +1142,14 @@ packages:
     homepage_url: "https://github.com/simonmar/async"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/async-2.1.1.1/async-2.1.1.1.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/simonmar/async.git"
@@ -1167,12 +1173,14 @@ packages:
     homepage_url: "https://github.com/maoe/lifted-async"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/lifted-async-0.9.3.3/lifted-async-0.9.3.3.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/maoe/lifted-async.git"
@@ -1200,12 +1208,14 @@ packages:
     homepage_url: "https://wiki.haskell.org/Software_transactional_memory"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/stm-2.4.5.0/stm-2.4.5.0.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/haskell/stm.git"
@@ -1230,12 +1240,14 @@ packages:
     homepage_url: "http://github.com/ekmett/constraints/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/constraints-0.9.1/constraints-0.9.1.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "git://github.com/ekmett/constraints.git"
@@ -1266,12 +1278,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/deepseq-1.4.3.0/deepseq-1.4.3.0.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/haskell/deepseq.git"
@@ -1299,12 +1313,14 @@ packages:
     homepage_url: "https://github.com/basvandijk/lifted-base"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/lifted-base-0.2.3.11/lifted-base-0.2.3.11.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/basvandijk/lifted-base.git"
@@ -1337,12 +1353,14 @@ packages:
     homepage_url: "https://github.com/basvandijk/monad-control"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/monad-control-1.0.2.2/monad-control-1.0.2.2.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "git://github.com/basvandijk/monad-control.git"
@@ -1368,12 +1386,14 @@ packages:
     homepage_url: "http://github.com/ekmett/mtl"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/mtl-2.2.1/mtl-2.2.1.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "git://github.com/ekmett/mtl.git"
@@ -1397,12 +1417,14 @@ packages:
     homepage_url: "https://github.com/mvv/transformers-base"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/transformers-base-0.4.4/transformers-base-0.4.4.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/mvv/transformers-base.git"
@@ -1437,12 +1459,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/transformers-0.5.2.0/transformers-0.5.2.0.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "darcs"
       url: "http://hub.darcs.net/ross/transformers"
@@ -1468,12 +1492,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/array-0.5.2.0/array-0.5.2.0.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "http://git.haskell.org/packages/array.git"
@@ -1499,12 +1525,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/containers-0.5.10.2/containers-0.5.10.2.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "http://github.com/haskell/containers.git"
@@ -1532,12 +1560,14 @@ packages:
     homepage_url: "https://github.com/kolmodin/binary"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/binary-0.8.5.1/binary-0.8.5.1.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "git://github.com/kolmodin/binary.git"
@@ -1573,12 +1603,14 @@ packages:
     homepage_url: "https://github.com/bos/text"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/text-1.2.2.2/text-1.2.2.2.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "mercurial"
       url: "https://bitbucket.org/bos/text"
@@ -1622,12 +1654,14 @@ packages:
     homepage_url: "https://github.com/haskell/bytestring"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/bytestring-0.10.8.2/bytestring-0.10.8.2.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/haskell/bytestring"
@@ -1653,12 +1687,14 @@ packages:
     homepage_url: "http://github.com/tibbe/hashable"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/hashable-1.2.6.1/hashable-1.2.6.1.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/tibbe/hashable.git"
@@ -1681,12 +1717,14 @@ packages:
     homepage_url: "https://github.com/haskell/primitive"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/primitive-0.6.3.0/primitive-0.6.3.0.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/haskell/primitive"
@@ -1712,12 +1750,14 @@ packages:
     homepage_url: "https://github.com/glguy/th-abstraction"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/th-abstraction-0.2.6.0/th-abstraction-0.2.6.0.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/glguy/th-abstraction.git"
@@ -1743,12 +1783,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/ghc-boot-th-8.2.2/ghc-boot-th-8.2.2.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "http://git.haskell.org/ghc.git"
@@ -1772,12 +1814,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/ghc-prim-0.5.1.1/ghc-prim-0.5.1.1.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "http://git.haskell.org/ghc.git"
@@ -1804,12 +1848,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/integer-gmp-1.0.1.0/integer-gmp-1.0.1.0.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -1834,12 +1880,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/base-4.10.1.0/base-4.10.1.0.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "http://git.haskell.org/ghc.git"
@@ -1880,12 +1928,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/tf-random-0.5/tf-random-0.5.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "darcs"
       url: "http://hub.darcs.net/michal.palka/tf-random"
@@ -1909,12 +1959,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/random-1.1/random-1.1.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "http://git.haskell.org/packages/random.git"
@@ -1939,12 +1991,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/template-haskell-2.12.0.0/template-haskell-2.12.0.0.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "http://git.haskell.org/ghc.git"
@@ -1977,12 +2031,14 @@ packages:
     homepage_url: "https://github.com/nick8325/quickcheck"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/QuickCheck-2.10.1/QuickCheck-2.10.1.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/nick8325/quickcheck"
@@ -2012,12 +2068,14 @@ packages:
     homepage_url: "http://www.github.com/nick8325/quickcheck-with-counterexamples"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/quickcheck-with-counterexamples-1.0/quickcheck-with-counterexamples-1.0.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/nick8325/quickcheck-with-counterexamples"
@@ -2044,12 +2102,14 @@ packages:
     homepage_url: "http://github.com/haskell/pretty"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/pretty-1.1.3.3/pretty-1.1.3.3.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "http://github.com/haskell/pretty.git"
@@ -2072,12 +2132,14 @@ packages:
     homepage_url: "https://github.com/haskell/time"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/time-1.8.0.2/time-1.8.0.2.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/haskell/time"
@@ -2103,12 +2165,14 @@ packages:
     homepage_url: "http://github.com/ekmett/ansi-wl-pprint"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/ansi-wl-pprint-0.6.8.2/ansi-wl-pprint-0.6.8.2.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/ekmett/ansi-wl-pprint.git"
@@ -2133,12 +2197,14 @@ packages:
     homepage_url: "https://github.com/feuerbach/ansi-terminal"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/ansi-terminal-0.7.1.1/ansi-terminal-0.7.1.1.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "git://github.com/feuerbach/ansi-terminal.git"
@@ -2163,12 +2229,14 @@ packages:
     homepage_url: "http://www.haskell.org/haskellwiki/Colour"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://hackage.haskell.org/package/colour-2.3.4/colour-2.3.4.tar.gz"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""

--- a/analyzer/src/funTest/assets/projects/external/sbt-multi-project-example-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/sbt-multi-project-example-expected-output.yml
@@ -231,12 +231,14 @@ analyzer:
         homepage_url: "http://logback.qos.ch/logback-classic"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/ch/qos/logback/logback-classic/1.2.3/logback-classic-1.2.3.jar"
-          hash: "7c4f3c474fb2c041d8028740440937705ebb473a"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "7c4f3c474fb2c041d8028740440937705ebb473a"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/ch/qos/logback/logback-classic/1.2.3/logback-classic-1.2.3-sources.jar"
-          hash: "cfd5385e0c5ed1c8a5dce57d86e79cf357153a64"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "cfd5385e0c5ed1c8a5dce57d86e79cf357153a64"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git@github.com:ceki/logback.git"
@@ -260,12 +262,14 @@ analyzer:
         homepage_url: "http://logback.qos.ch/logback-core"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/ch/qos/logback/logback-core/1.2.3/logback-core-1.2.3.jar"
-          hash: "864344400c3d4d92dfeb0a305dc87d953677c03c"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "864344400c3d4d92dfeb0a305dc87d953677c03c"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/ch/qos/logback/logback-core/1.2.3/logback-core-1.2.3-sources.jar"
-          hash: "3ebabe69eba0196af9ad3a814f723fb720b9101e"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "3ebabe69eba0196af9ad3a814f723fb720b9101e"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git@github.com:ceki/logback.git"
@@ -288,12 +292,14 @@ analyzer:
         homepage_url: "https://github.com/milessabin/shapeless"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/com/chuusai/shapeless_2.12/2.3.2/shapeless_2.12-2.3.2.jar"
-          hash: "27e115ffed7917b456e54891de67173f4a68d5f1"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "27e115ffed7917b456e54891de67173f4a68d5f1"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/com/chuusai/shapeless_2.12/2.3.2/shapeless_2.12-2.3.2-sources.jar"
-          hash: "6d83fa4fa6d25b1e8d8cd9d9d551c05c745633b1"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "6d83fa4fa6d25b1e8d8cd9d9d551c05c745633b1"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git@github.com:milessabin/shapeless.git"
@@ -317,12 +323,14 @@ analyzer:
         homepage_url: "http://github.com/FasterXML/jackson"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.8.0/jackson-annotations-2.8.0.jar"
-          hash: "45b426f7796b741035581a176744d91090e2e6fb"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "45b426f7796b741035581a176744d91090e2e6fb"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.8.0/jackson-annotations-2.8.0-sources.jar"
-          hash: "29a1a95363d497e856c0a7d682e4f7973e334068"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "29a1a95363d497e856c0a7d682e4f7973e334068"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git@github.com:FasterXML/jackson-annotations.git"
@@ -345,12 +353,14 @@ analyzer:
         homepage_url: "https://github.com/FasterXML/jackson-core"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.8.9/jackson-core-2.8.9.jar"
-          hash: "569b1752705da98f49aabe2911cc956ff7d8ed9d"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "569b1752705da98f49aabe2911cc956ff7d8ed9d"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.8.9/jackson-core-2.8.9-sources.jar"
-          hash: "8cf3613202ddcd495137f8cb944e2da69964a641"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "8cf3613202ddcd495137f8cb944e2da69964a641"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git@github.com:FasterXML/jackson-core.git"
@@ -374,12 +384,14 @@ analyzer:
         homepage_url: "http://github.com/FasterXML/jackson"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.8.9/jackson-databind-2.8.9.jar"
-          hash: "4dfca3975be3c1a98eacb829e70f02e9a71bc159"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "4dfca3975be3c1a98eacb829e70f02e9a71bc159"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.8.9/jackson-databind-2.8.9-sources.jar"
-          hash: "98e1b4171628d8f230f6a60b248de84ed04fab0d"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "98e1b4171628d8f230f6a60b248de84ed04fab0d"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git@github.com:FasterXML/jackson-databind.git"
@@ -402,12 +414,14 @@ analyzer:
         homepage_url: "https://github.com/julien-truffaut/Monocle"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/com/github/julien-truffaut/monocle-core_2.12/1.4.0/monocle-core_2.12-1.4.0.jar"
-          hash: "219da9cc75878a75c888e38ad883fe4d30a7651d"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "219da9cc75878a75c888e38ad883fe4d30a7651d"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/com/github/julien-truffaut/monocle-core_2.12/1.4.0/monocle-core_2.12-1.4.0-sources.jar"
-          hash: "37d333798ca15a03f5dfbb02f133d5b6b8e57b8c"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "37d333798ca15a03f5dfbb02f133d5b6b8e57b8c"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git@github.com:julien-truffaut/Monocle.git"
@@ -430,12 +444,14 @@ analyzer:
         homepage_url: "https://github.com/julien-truffaut/Monocle"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/com/github/julien-truffaut/monocle-macro_2.12/1.4.0/monocle-macro_2.12-1.4.0.jar"
-          hash: "319242d130983fec319a2e2d4f8e7741b809b5a0"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "319242d130983fec319a2e2d4f8e7741b809b5a0"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/com/github/julien-truffaut/monocle-macro_2.12/1.4.0/monocle-macro_2.12-1.4.0-sources.jar"
-          hash: "e7ce64d7973ad64f3fa872b931a31c8c25de59b3"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "e7ce64d7973ad64f3fa872b931a31c8c25de59b3"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git@github.com:julien-truffaut/Monocle.git"
@@ -458,12 +474,14 @@ analyzer:
         homepage_url: "https://github.com/pureconfig/pureconfig"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/com/github/pureconfig/pureconfig-macros_2.12/0.8.0/pureconfig-macros_2.12-0.8.0.jar"
-          hash: "eea0e86f18c08e7fd00c90626f4f17a9ee6ef088"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "eea0e86f18c08e7fd00c90626f4f17a9ee6ef088"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/com/github/pureconfig/pureconfig-macros_2.12/0.8.0/pureconfig-macros_2.12-0.8.0-sources.jar"
-          hash: "7411f96540756236648b48347827b6ba2622e5e0"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "7411f96540756236648b48347827b6ba2622e5e0"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git@github.com:pureconfig/pureconfig.git"
@@ -486,12 +504,14 @@ analyzer:
         homepage_url: "https://github.com/pureconfig/pureconfig"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/com/github/pureconfig/pureconfig_2.12/0.8.0/pureconfig_2.12-0.8.0.jar"
-          hash: "891fde63cda086f593bffddb0b47933abc75523f"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "891fde63cda086f593bffddb0b47933abc75523f"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/com/github/pureconfig/pureconfig_2.12/0.8.0/pureconfig_2.12-0.8.0-sources.jar"
-          hash: "fa6de3ab2dd82543fb37288626687a9a6c1a67a2"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "fa6de3ab2dd82543fb37288626687a9a6c1a67a2"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git@github.com:pureconfig/pureconfig.git"
@@ -514,12 +534,14 @@ analyzer:
         homepage_url: "http://akka.io/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/com/typesafe/akka/akka-actor_2.12/2.5.6/akka-actor_2.12-2.5.6.jar"
-          hash: "1e9f4c1829d3ce5640c17164b1756d1e98eb7af3"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "1e9f4c1829d3ce5640c17164b1756d1e98eb7af3"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/com/typesafe/akka/akka-actor_2.12/2.5.6/akka-actor_2.12-2.5.6-sources.jar"
-          hash: "9642cf6f2a774d781e2f2a2e5de152971bfd714e"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "9642cf6f2a774d781e2f2a2e5de152971bfd714e"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git@github.com:akka/akka.git"
@@ -542,12 +564,14 @@ analyzer:
         homepage_url: "http://akka.io/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/com/typesafe/akka/akka-stream_2.12/2.5.6/akka-stream_2.12-2.5.6.jar"
-          hash: "876aa1471ac773a3dd02f70c1e511a9a014b3491"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "876aa1471ac773a3dd02f70c1e511a9a014b3491"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/com/typesafe/akka/akka-stream_2.12/2.5.6/akka-stream_2.12-2.5.6-sources.jar"
-          hash: "14459df7523aea2cfd04080fe88eccd20897bcc5"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "14459df7523aea2cfd04080fe88eccd20897bcc5"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git@github.com:akka/akka.git"
@@ -570,12 +594,14 @@ analyzer:
         homepage_url: "https://github.com/typesafehub/scala-logging"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/com/typesafe/scala-logging/scala-logging_2.12/3.7.2/scala-logging_2.12-3.7.2.jar"
-          hash: "a1dc97509765287faa4747f7cb411f0b85dc9a34"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "a1dc97509765287faa4747f7cb411f0b85dc9a34"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/com/typesafe/scala-logging/scala-logging_2.12/3.7.2/scala-logging_2.12-3.7.2-sources.jar"
-          hash: "a5f760917b60283e37c84bf3db2aeaf976980ad3"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "a5f760917b60283e37c84bf3db2aeaf976980ad3"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/typesafehub/scala-logging.git"
@@ -598,12 +624,14 @@ analyzer:
         homepage_url: "https://github.com/typesafehub/config"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/com/typesafe/config/1.3.1/config-1.3.1.jar"
-          hash: "2cf7a6cc79732e3bdf1647d7404279900ca63eb0"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "2cf7a6cc79732e3bdf1647d7404279900ca63eb0"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/com/typesafe/config/1.3.1/config-1.3.1-sources.jar"
-          hash: "a27878630ff503b63ed25ff2a25fa8ef888740b3"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "a27878630ff503b63ed25ff2a25fa8ef888740b3"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/typesafehub/config.git"
@@ -626,12 +654,14 @@ analyzer:
         homepage_url: "https://github.com/typesafehub/ssl-config"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/com/typesafe/ssl-config-core_2.12/0.2.2/ssl-config-core_2.12-0.2.2.jar"
-          hash: "8a357d491f7f94c5b4b1e0b27644e1306cc8742d"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "8a357d491f7f94c5b4b1e0b27644e1306cc8742d"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/com/typesafe/ssl-config-core_2.12/0.2.2/ssl-config-core_2.12-0.2.2-sources.jar"
-          hash: "1baaec9149929d0970330aa80aca73e3f1f15624"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "1baaec9149929d0970330aa80aca73e3f1f15624"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/typesafehub/ssl-config.git"
@@ -656,12 +686,14 @@ analyzer:
         homepage_url: "https://github.com/logstash/logstash-logback-encoder"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/net/logstash/logback/logstash-logback-encoder/4.11/logstash-logback-encoder-4.11.jar"
-          hash: "163b6b046de5414ac17c83cbd6cb619e541fc69a"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "163b6b046de5414ac17c83cbd6cb619e541fc69a"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/net/logstash/logback/logstash-logback-encoder/4.11/logstash-logback-encoder-4.11-sources.jar"
-          hash: "8b889d5eb55aabfa5d9aa9cad95529668f3edb2b"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "8b889d5eb55aabfa5d9aa9cad95529668f3edb2b"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git@github.com:logstash/logstash-logback-encoder.git"
@@ -684,12 +716,14 @@ analyzer:
         homepage_url: "http://www.reactive-streams.org/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/reactivestreams/reactive-streams/1.0.1/reactive-streams-1.0.1.jar"
-          hash: "1b1c911686eb40179219466e6a59b634b9d7a748"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "1b1c911686eb40179219466e6a59b634b9d7a748"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/reactivestreams/reactive-streams/1.0.1/reactive-streams-1.0.1-sources.jar"
-          hash: "af471e34e448bd4f1c183e9b26c85679be11035c"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "af471e34e448bd4f1c183e9b26c85679be11035c"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git@github.com:reactive-streams/reactive-streams.git"
@@ -712,12 +746,14 @@ analyzer:
         homepage_url: "http://www.scala-lang.org/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-java8-compat_2.12/0.8.0/scala-java8-compat_2.12-0.8.0.jar"
-          hash: "1e6f1e745bf6d3c34d1e2ab150653306069aaf34"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "1e6f1e745bf6d3c34d1e2ab150653306069aaf34"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-java8-compat_2.12/0.8.0/scala-java8-compat_2.12-0.8.0-sources.jar"
-          hash: "0a33ce48278b9e3bbea8aed726e3c0abad3afadd"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "0a33ce48278b9e3bbea8aed726e3c0abad3afadd"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/scala/scala-java8-compat.git"
@@ -740,12 +776,14 @@ analyzer:
         homepage_url: "http://www.scala-lang.org/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-parser-combinators_2.12/1.0.4/scala-parser-combinators_2.12-1.0.4.jar"
-          hash: "7c5f25a2d40ea7651452f0f0d1d4c12dabffcb8b"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "7c5f25a2d40ea7651452f0f0d1d4c12dabffcb8b"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-parser-combinators_2.12/1.0.4/scala-parser-combinators_2.12-1.0.4-sources.jar"
-          hash: "9ec2f46c07d355853654af38e8b06e15ccca8cd0"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "9ec2f46c07d355853654af38e8b06e15ccca8cd0"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/scala/scala-parser-combinators.git"
@@ -768,12 +806,14 @@ analyzer:
         homepage_url: "http://www.scala-lang.org/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.0.5/scala-xml_2.12-1.0.5.jar"
-          hash: "a2b2afbeea86818a911b05851bb11d7d4840bb75"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "a2b2afbeea86818a911b05851bb11d7d4840bb75"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.0.5/scala-xml_2.12-1.0.5-sources.jar"
-          hash: "d12864d1a73aa540f7b624c8a92a5f48783c342c"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "d12864d1a73aa540f7b624c8a92a5f48783c342c"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/scala/scala-xml.git"
@@ -796,12 +836,14 @@ analyzer:
         homepage_url: "http://www.scala-lang.org/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-compiler/2.12.3/scala-compiler-2.12.3.jar"
-          hash: "b6b9ca202fc8405260d30e703b9790e91c75cd85"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "b6b9ca202fc8405260d30e703b9790e91c75cd85"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-compiler/2.12.3/scala-compiler-2.12.3-sources.jar"
-          hash: "b8fe133c260f72b7fe9889195e19efeeab1b8087"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "b8fe133c260f72b7fe9889195e19efeeab1b8087"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/scala/scala.git"
@@ -824,12 +866,14 @@ analyzer:
         homepage_url: "http://www.scala-lang.org/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-library/2.12.3/scala-library-2.12.3.jar"
-          hash: "f2e496f21af2d80b48e0a61773f84c3a76a0d06f"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "f2e496f21af2d80b48e0a61773f84c3a76a0d06f"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-library/2.12.3/scala-library-2.12.3-sources.jar"
-          hash: "499c91b0a64bc706eee174481a3b7dde81b3591d"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "499c91b0a64bc706eee174481a3b7dde81b3591d"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/scala/scala.git"
@@ -852,12 +896,14 @@ analyzer:
         homepage_url: "http://www.scala-lang.org/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-reflect/2.12.2/scala-reflect-2.12.2.jar"
-          hash: "fa13c13351566738ff156ef8a56b869868f4b77e"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "fa13c13351566738ff156ef8a56b869868f4b77e"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-reflect/2.12.2/scala-reflect-2.12.2-sources.jar"
-          hash: "a8808be417014e233b25ee44439f725e1f5e92a4"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "a8808be417014e233b25ee44439f725e1f5e92a4"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/scala/scala.git"
@@ -881,12 +927,14 @@ analyzer:
         homepage_url: "http://www.scala-sbt.org"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0.jar"
-          hash: "0a3f14d010c4cb32071f863d97291df31603b521"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "0a3f14d010c4cb32071f863d97291df31603b521"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0-sources.jar"
-          hash: "d44b23e9e3419ad0e00b91bba764a48d43075000"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "d44b23e9e3419ad0e00b91bba764a48d43075000"
+            algorithm: "SHA-1"
         vcs:
           type: ""
           url: ""
@@ -909,12 +957,14 @@ analyzer:
         homepage_url: "http://www.scalacheck.org"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/scalacheck/scalacheck_2.12/1.13.5/scalacheck_2.12-1.13.5.jar"
-          hash: "fff972ccaa0d83ca53bfdbbd0763c1059281fb76"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "fff972ccaa0d83ca53bfdbbd0763c1059281fb76"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/scalacheck/scalacheck_2.12/1.13.5/scalacheck_2.12-1.13.5-sources.jar"
-          hash: "d0e1376902de65c7fa327f455b61d5d71957d78e"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "d0e1376902de65c7fa327f455b61d5d71957d78e"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git@github.com:rickynils/scalacheck.git"
@@ -937,12 +987,14 @@ analyzer:
         homepage_url: "http://www.scalatest.org"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/scalactic/scalactic_2.12/3.0.4/scalactic_2.12-3.0.4.jar"
-          hash: "e75f0f9c77aa391e01797cfc42fb82fd7c7d59a5"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "e75f0f9c77aa391e01797cfc42fb82fd7c7d59a5"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/scalactic/scalactic_2.12/3.0.4/scalactic_2.12-3.0.4-sources.jar"
-          hash: "9f7f02217c7d2f14c6b1982493c39243a20b749d"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "9f7f02217c7d2f14c6b1982493c39243a20b749d"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git@github.com:scalatest/scalatest.git"
@@ -965,12 +1017,14 @@ analyzer:
         homepage_url: "http://www.scalatest.org"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/scalatest/scalatest_2.12/3.0.4/scalatest_2.12-3.0.4.jar"
-          hash: "87d68f3d06dbf698fd0084c0a8b8996864d15465"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "87d68f3d06dbf698fd0084c0a8b8996864d15465"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/scalatest/scalatest_2.12/3.0.4/scalatest_2.12-3.0.4-sources.jar"
-          hash: "ba669c2c9b7092151e2a19e975b1bf2a2e7a5fda"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "ba669c2c9b7092151e2a19e975b1bf2a2e7a5fda"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git@github.com:scalatest/scalatest.git"
@@ -993,12 +1047,14 @@ analyzer:
         homepage_url: "http://scalaz.org"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/scalaz/scalaz-core_2.12/7.2.8/scalaz-core_2.12-7.2.8.jar"
-          hash: "2922d47f6dc7aba452634fe674087b6221b90dbf"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "2922d47f6dc7aba452634fe674087b6221b90dbf"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/scalaz/scalaz-core_2.12/7.2.8/scalaz-core_2.12-7.2.8-sources.jar"
-          hash: "c94295a434f26b5650ec0fcbf93c9d2c7aada88e"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "c94295a434f26b5650ec0fcbf93c9d2c7aada88e"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git@github.com:scalaz/scalaz.git"
@@ -1021,12 +1077,14 @@ analyzer:
         homepage_url: "http://www.slf4j.org"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/slf4j/jcl-over-slf4j/1.7.25/jcl-over-slf4j-1.7.25.jar"
-          hash: "f8c32b13ff142a513eeb5b6330b1588dcb2c0461"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "f8c32b13ff142a513eeb5b6330b1588dcb2c0461"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/slf4j/jcl-over-slf4j/1.7.25/jcl-over-slf4j-1.7.25-sources.jar"
-          hash: "ffd0827a7c67d5915b7dc611afbda56a1f247191"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "ffd0827a7c67d5915b7dc611afbda56a1f247191"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git@github.com:qos-ch/slf4j.git"
@@ -1049,12 +1107,14 @@ analyzer:
         homepage_url: "http://www.slf4j.org"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar"
-          hash: "da76ca59f6a57ee3102f8f9bd9cee742973efa8a"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "da76ca59f6a57ee3102f8f9bd9cee742973efa8a"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25-sources.jar"
-          hash: "962153db4a9ea71b79d047dfd1b2a0d80d8f4739"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "962153db4a9ea71b79d047dfd1b2a0d80d8f4739"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git@github.com:qos-ch/slf4j.git"
@@ -1077,12 +1137,14 @@ analyzer:
         homepage_url: "https://github.com/milessabin/macro-compat"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/typelevel/macro-compat_2.12/1.1.1/macro-compat_2.12-1.1.1.jar"
-          hash: "ed809d26ef4237d7c079ae6cf7ebd0dfa7986adf"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "ed809d26ef4237d7c079ae6cf7ebd0dfa7986adf"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/typelevel/macro-compat_2.12/1.1.1/macro-compat_2.12-1.1.1-sources.jar"
-          hash: "ade6d6ec81975cf514b0f9e2061614f2799cfe97"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "ade6d6ec81975cf514b0f9e2061614f2799cfe97"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git@github.com:milessabin/macro-compat.git"

--- a/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
@@ -42,12 +42,14 @@ packages:
     homepage_url: "https://github.com/gweis/isodate/"
     binary_artifact:
       url: "https://files.pythonhosted.org/packages/9b/9f/b36f7774ff5ea8e428fdcfc4bb332c39ee5b9362ddd3d40d9516a55221b2/isodate-0.6.0-py2.py3-none-any.whl"
-      hash: "d993beffb0b78627721d9ef1dda4df87"
-      hash_algorithm: "MD5"
+      hash:
+        value: "d993beffb0b78627721d9ef1dda4df87"
+        algorithm: "MD5"
     source_artifact:
       url: "https://files.pythonhosted.org/packages/b1/80/fb8c13a4cd38eb5021dc3741a9e588e4d1de88d895c1910c6fc8a08b7a70/isodate-0.6.0.tar.gz"
-      hash: "0e1203fce27ce65e2d01c5f21c4d428f"
-      hash_algorithm: "MD5"
+      hash:
+        value: "0e1203fce27ce65e2d01c5f21c4d428f"
+        algorithm: "MD5"
     vcs:
       type: ""
       url: ""
@@ -70,12 +72,14 @@ packages:
     homepage_url: "http://www.dabeaz.com/ply/"
     binary_artifact:
       url: "https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl"
-      hash: "62b6ad5affddc9926ab5571f390cc840"
-      hash_algorithm: "MD5"
+      hash:
+        value: "62b6ad5affddc9926ab5571f390cc840"
+        algorithm: "MD5"
     source_artifact:
       url: "https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz"
-      hash: "6465f602e656455affcd7c5734c638f8"
-      hash_algorithm: "MD5"
+      hash:
+        value: "6465f602e656455affcd7c5734c638f8"
+        algorithm: "MD5"
     vcs:
       type: ""
       url: ""
@@ -98,12 +102,14 @@ packages:
     homepage_url: "https://github.com/pyparsing/pyparsing/"
     binary_artifact:
       url: "https://files.pythonhosted.org/packages/dd/d9/3ec19e966301a6e25769976999bd7bbe552016f0d32b577dc9d63d2e0c49/pyparsing-2.4.0-py2.py3-none-any.whl"
-      hash: "0a90ca524ce3ba201be4b80e21ae7c3b"
-      hash_algorithm: "MD5"
+      hash:
+        value: "0a90ca524ce3ba201be4b80e21ae7c3b"
+        algorithm: "MD5"
     source_artifact:
       url: "https://files.pythonhosted.org/packages/5d/3a/24d275393f493004aeb15a1beae2b4a3043526e8b692b65b4a9341450ebe/pyparsing-2.4.0.tar.gz"
-      hash: "e534c0ca755155823bf45fdd8d084922"
-      hash_algorithm: "MD5"
+      hash:
+        value: "e534c0ca755155823bf45fdd8d084922"
+        algorithm: "MD5"
     vcs:
       type: ""
       url: ""
@@ -128,12 +134,14 @@ packages:
     homepage_url: "https://github.com/RDFLib/rdflib"
     binary_artifact:
       url: "https://files.pythonhosted.org/packages/3c/fe/630bacb652680f6d481b9febbb3e2c3869194a1a5fc3401a4a41195a2f8f/rdflib-4.2.2-py3-none-any.whl"
-      hash: "380422af59a6f0e5cc62879f68de3397"
-      hash_algorithm: "MD5"
+      hash:
+        value: "380422af59a6f0e5cc62879f68de3397"
+        algorithm: "MD5"
     source_artifact:
       url: "https://files.pythonhosted.org/packages/c5/77/1fa0f4cffd5faad496b1344ab665902bb2609f56e0fb19bcf80cff485da0/rdflib-4.2.2.tar.gz"
-      hash: "534fe35b13c5857d53fa1ac5a41eca67"
-      hash_algorithm: "MD5"
+      hash:
+        value: "534fe35b13c5857d53fa1ac5a41eca67"
+        algorithm: "MD5"
     vcs:
       type: ""
       url: ""
@@ -156,12 +164,14 @@ packages:
     homepage_url: "https://github.com/benjaminp/six"
     binary_artifact:
       url: "https://files.pythonhosted.org/packages/73/fb/00a976f728d0d1fecfe898238ce23f502a721c0ac0ecfedb80e0d88c64e9/six-1.12.0-py2.py3-none-any.whl"
-      hash: "b0dc15d494e2d6e6c19cbbe482e91c5d"
-      hash_algorithm: "MD5"
+      hash:
+        value: "b0dc15d494e2d6e6c19cbbe482e91c5d"
+        algorithm: "MD5"
     source_artifact:
       url: "https://files.pythonhosted.org/packages/dd/bf/4138e7bfb757de47d1f4b6994648ec67a51efe58fa907c1e11e350cddfca/six-1.12.0.tar.gz"
-      hash: "9ae5d1feed8c0215f4ae4adcd9207fcb"
-      hash_algorithm: "MD5"
+      hash:
+        value: "9ae5d1feed8c0215f4ae4adcd9207fcb"
+        algorithm: "MD5"
     vcs:
       type: ""
       url: ""

--- a/analyzer/src/funTest/assets/projects/external/sprig-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/sprig-expected-output.yml
@@ -47,12 +47,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -73,12 +75,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -99,12 +103,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -125,12 +131,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -151,12 +159,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -177,12 +187,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -203,12 +215,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -229,12 +243,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -255,12 +271,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/bower-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/bower-expected-output.yml
@@ -40,12 +40,14 @@ packages:
     homepage_url: "https://github.com/jquery/jquery-dist"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: "https://github.com/jquery/jquery-dist.git"
@@ -68,12 +70,14 @@ packages:
     homepage_url: "https://github.com/Polymer/polymer"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/Polymer/polymer.git"
@@ -94,12 +98,14 @@ packages:
     homepage_url: "https://github.com/webcomponents/shadycss"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: "https://github.com/webcomponents/shadycss.git"
@@ -122,12 +128,14 @@ packages:
     homepage_url: "http://webcomponents.org"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/webcomponents/webcomponentsjs.git"

--- a/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-gemspec.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-gemspec.yml
@@ -59,12 +59,14 @@ packages:
     homepage_url: "https://github.com/sporkmonger/addressable"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://rubygems.org/gems/addressable-2.5.2.gem"
-      hash: "73771ea960b3900d96e6b3729bd203e66f387d0717df83304411bf37efd7386e"
-      hash_algorithm: "SHA-256"
+      hash:
+        value: "73771ea960b3900d96e6b3729bd203e66f387d0717df83304411bf37efd7386e"
+        algorithm: "SHA-256"
     vcs:
       type: "git"
       url: "http://github.com/sporkmonger/addressable.git"
@@ -95,12 +97,14 @@ packages:
     homepage_url: "https://github.com/halostatue/diff-lcs"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://rubygems.org/gems/diff-lcs-1.3.gem"
-      hash: "ea7bf591567e391ef262a7c29edaf87c6205204afb5bb39dfa8f08f2e51282a3"
-      hash_algorithm: "SHA-256"
+      hash:
+        value: "ea7bf591567e391ef262a7c29edaf87c6205204afb5bb39dfa8f08f2e51282a3"
+        algorithm: "SHA-256"
     vcs:
       type: "git"
       url: "https://github.com/halostatue/diff-lcs.git"
@@ -123,12 +127,14 @@ packages:
     homepage_url: "https://github.com/lostisland/faraday"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://rubygems.org/gems/faraday-0.15.1.gem"
-      hash: "bd5bd1ab8db9b3f99ed1113d80522dabf95941e40cc3107f9621546f6a357f60"
-      hash_algorithm: "SHA-256"
+      hash:
+        value: "bd5bd1ab8db9b3f99ed1113d80522dabf95941e40cc3107f9621546f6a357f60"
+        algorithm: "SHA-256"
     vcs:
       type: "git"
       url: "https://github.com/lostisland/faraday.git"
@@ -154,12 +160,14 @@ packages:
     homepage_url: "http://github.com/jwt/ruby-jwt"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://rubygems.org/gems/jwt-2.1.0.gem"
-      hash: "7e7e7ffc1a5ebce628ac7da428341c50615a3a10ac47bb74c22c1cba325613f0"
-      hash_algorithm: "SHA-256"
+      hash:
+        value: "7e7e7ffc1a5ebce628ac7da428341c50615a3a10ac47bb74c22c1cba325613f0"
+        algorithm: "SHA-256"
     vcs:
       type: "git"
       url: "http://github.com/jwt/ruby-jwt.git"
@@ -186,12 +194,14 @@ packages:
     homepage_url: "http://github.com/intridea/multi_json"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://rubygems.org/gems/multi_json-1.13.1.gem"
-      hash: "db8613c039b9501e6b2fb85efe4feabb02f55c3365bae52bba35381b89c780e6"
-      hash_algorithm: "SHA-256"
+      hash:
+        value: "db8613c039b9501e6b2fb85efe4feabb02f55c3365bae52bba35381b89c780e6"
+        algorithm: "SHA-256"
     vcs:
       type: "git"
       url: "http://github.com/intridea/multi_json.git"
@@ -218,12 +228,14 @@ packages:
     homepage_url: "https://github.com/nicksieger/multipart-post"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://rubygems.org/gems/multipart-post-2.0.0.gem"
-      hash: "3dc44e50d3df3d42da2b86272c568fd7b75c928d8af3cc5f9834e2e5d9586026"
-      hash_algorithm: "SHA-256"
+      hash:
+        value: "3dc44e50d3df3d42da2b86272c568fd7b75c928d8af3cc5f9834e2e5d9586026"
+        algorithm: "SHA-256"
     vcs:
       type: "git"
       url: "https://github.com/nicksieger/multipart-post.git"
@@ -249,12 +261,14 @@ packages:
     homepage_url: "https://simonecarletti.com/code/publicsuffix-ruby"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://rubygems.org/gems/public_suffix-3.0.2.gem"
-      hash: "3a0168c33fa0b00886423a2ceb21c74199273ccd01bc250360fc8d18600bb0f4"
-      hash_algorithm: "SHA-256"
+      hash:
+        value: "3a0168c33fa0b00886423a2ceb21c74199273ccd01bc250360fc8d18600bb0f4"
+        algorithm: "SHA-256"
     vcs:
       type: "git"
       url: "http://github.com/weppos/publicsuffix-ruby.git"
@@ -281,12 +295,14 @@ packages:
     homepage_url: "https://rack.github.io/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://rubygems.org/gems/rack-1.6.11.gem"
-      hash: "ee2016b1ddf820f6e5ee437d10a85319506b60c0d493da1d15815361a91129bd"
-      hash_algorithm: "SHA-256"
+      hash:
+        value: "ee2016b1ddf820f6e5ee437d10a85319506b60c0d493da1d15815361a91129bd"
+        algorithm: "SHA-256"
     vcs:
       type: "git"
       url: "http://github.com/rack/rack.git"
@@ -309,12 +325,14 @@ packages:
     homepage_url: "https://github.com/rspec/rspec-core"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://rubygems.org/gems/rspec-core-3.7.1.gem"
-      hash: "526e0b2d22feae638eb99bd746bbb25b18a4869a8f6ce4e8a87dabd1ab5f727f"
-      hash_algorithm: "SHA-256"
+      hash:
+        value: "526e0b2d22feae638eb99bd746bbb25b18a4869a8f6ce4e8a87dabd1ab5f727f"
+        algorithm: "SHA-256"
     vcs:
       type: "git"
       url: "http://github.com/rspec/rspec-core.git"
@@ -338,12 +356,14 @@ packages:
     homepage_url: "https://github.com/rspec/rspec-expectations"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://rubygems.org/gems/rspec-expectations-3.7.0.gem"
-      hash: "7e571848a5cbdb1661187d04e5c1f29287ec80fcb5a395f9994836892a3780bb"
-      hash_algorithm: "SHA-256"
+      hash:
+        value: "7e571848a5cbdb1661187d04e5c1f29287ec80fcb5a395f9994836892a3780bb"
+        algorithm: "SHA-256"
     vcs:
       type: "git"
       url: "http://github.com/rspec/rspec-expectations.git"
@@ -366,12 +386,14 @@ packages:
     homepage_url: "https://github.com/rspec/rspec-mocks"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://rubygems.org/gems/rspec-mocks-3.7.0.gem"
-      hash: "23f7f0039e17f2841edfb51d678ac9e06c056903a7908db967f5618887f2022c"
-      hash_algorithm: "SHA-256"
+      hash:
+        value: "23f7f0039e17f2841edfb51d678ac9e06c056903a7908db967f5618887f2022c"
+        algorithm: "SHA-256"
     vcs:
       type: "git"
       url: "http://github.com/rspec/rspec-mocks.git"
@@ -394,12 +416,14 @@ packages:
     homepage_url: "https://github.com/rspec/rspec-support"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://rubygems.org/gems/rspec-support-3.7.1.gem"
-      hash: "4152975a068756076f10c97317e9d2baf10028f3d25c0cb902945569560783da"
-      hash_algorithm: "SHA-256"
+      hash:
+        value: "4152975a068756076f10c97317e9d2baf10028f3d25c0cb902945569560783da"
+        algorithm: "SHA-256"
     vcs:
       type: "git"
       url: "https://github.com/rspec/rspec-support.git"
@@ -424,12 +448,14 @@ packages:
     homepage_url: "http://github.com/rspec"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://rubygems.org/gems/rspec-3.7.0.gem"
-      hash: "0174cfbed780e42aa181227af623e2ae37511f20a2fdfec48b54f6cf4d7a6404"
-      hash_algorithm: "SHA-256"
+      hash:
+        value: "0174cfbed780e42aa181227af623e2ae37511f20a2fdfec48b54f6cf4d7a6404"
+        algorithm: "SHA-256"
     vcs:
       type: "git"
       url: "http://github.com/rspec/rspec.git"
@@ -452,12 +478,14 @@ packages:
     homepage_url: "https://github.com/google/signet/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://rubygems.org/gems/signet-0.8.1.gem"
-      hash: "7b2efb61e689a22b4fc721ba5e9f4fc45b1702dcca38e11e52bfe5883b0d484b"
-      hash_algorithm: "SHA-256"
+      hash:
+        value: "7b2efb61e689a22b4fc721ba5e9f4fc45b1702dcca38e11e52bfe5883b0d484b"
+        algorithm: "SHA-256"
     vcs:
       type: ""
       url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-lockfile.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-lockfile.yml
@@ -58,12 +58,14 @@ packages:
     homepage_url: "https://github.com/halostatue/diff-lcs"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://rubygems.org/gems/diff-lcs-1.3.gem"
-      hash: "ea7bf591567e391ef262a7c29edaf87c6205204afb5bb39dfa8f08f2e51282a3"
-      hash_algorithm: "SHA-256"
+      hash:
+        value: "ea7bf591567e391ef262a7c29edaf87c6205204afb5bb39dfa8f08f2e51282a3"
+        algorithm: "SHA-256"
     vcs:
       type: "git"
       url: "https://github.com/halostatue/diff-lcs.git"
@@ -88,12 +90,14 @@ packages:
     homepage_url: "http://github.com/flavorjones/mini_portile"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://rubygems.org/gems/mini_portile2-2.3.0.gem"
-      hash: "216417b241ff4e7b1c726f257241eaf223e3abbe6ec2c6453352dea6a414a38d"
-      hash_algorithm: "SHA-256"
+      hash:
+        value: "216417b241ff4e7b1c726f257241eaf223e3abbe6ec2c6453352dea6a414a38d"
+        algorithm: "SHA-256"
     vcs:
       type: "git"
       url: "http://github.com/flavorjones/mini_portile.git"
@@ -119,12 +123,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://rubygems.org/gems/nokogiri-1.8.5.gem"
-      hash: "1f93a829257b621d40c4cbfce3acdcd688b0b3d70497ceae4fa2baf955eede2f"
-      hash_algorithm: "SHA-256"
+      hash:
+        value: "1f93a829257b621d40c4cbfce3acdcd688b0b3d70497ceae4fa2baf955eede2f"
+        algorithm: "SHA-256"
     vcs:
       type: "git"
       url: "https://github.com/sparklemotion/nokogiri.git"
@@ -151,12 +157,14 @@ packages:
     homepage_url: "https://rack.github.io/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://rubygems.org/gems/rack-1.6.11.gem"
-      hash: "ee2016b1ddf820f6e5ee437d10a85319506b60c0d493da1d15815361a91129bd"
-      hash_algorithm: "SHA-256"
+      hash:
+        value: "ee2016b1ddf820f6e5ee437d10a85319506b60c0d493da1d15815361a91129bd"
+        algorithm: "SHA-256"
     vcs:
       type: "git"
       url: "http://github.com/rack/rack.git"
@@ -179,12 +187,14 @@ packages:
     homepage_url: "https://github.com/rspec/rspec-core"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://rubygems.org/gems/rspec-core-3.7.1.gem"
-      hash: "526e0b2d22feae638eb99bd746bbb25b18a4869a8f6ce4e8a87dabd1ab5f727f"
-      hash_algorithm: "SHA-256"
+      hash:
+        value: "526e0b2d22feae638eb99bd746bbb25b18a4869a8f6ce4e8a87dabd1ab5f727f"
+        algorithm: "SHA-256"
     vcs:
       type: "git"
       url: "http://github.com/rspec/rspec-core.git"
@@ -208,12 +218,14 @@ packages:
     homepage_url: "https://github.com/rspec/rspec-expectations"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://rubygems.org/gems/rspec-expectations-3.7.0.gem"
-      hash: "7e571848a5cbdb1661187d04e5c1f29287ec80fcb5a395f9994836892a3780bb"
-      hash_algorithm: "SHA-256"
+      hash:
+        value: "7e571848a5cbdb1661187d04e5c1f29287ec80fcb5a395f9994836892a3780bb"
+        algorithm: "SHA-256"
     vcs:
       type: "git"
       url: "http://github.com/rspec/rspec-expectations.git"
@@ -236,12 +248,14 @@ packages:
     homepage_url: "https://github.com/rspec/rspec-mocks"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://rubygems.org/gems/rspec-mocks-3.7.0.gem"
-      hash: "23f7f0039e17f2841edfb51d678ac9e06c056903a7908db967f5618887f2022c"
-      hash_algorithm: "SHA-256"
+      hash:
+        value: "23f7f0039e17f2841edfb51d678ac9e06c056903a7908db967f5618887f2022c"
+        algorithm: "SHA-256"
     vcs:
       type: "git"
       url: "http://github.com/rspec/rspec-mocks.git"
@@ -264,12 +278,14 @@ packages:
     homepage_url: "https://github.com/rspec/rspec-support"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://rubygems.org/gems/rspec-support-3.7.1.gem"
-      hash: "4152975a068756076f10c97317e9d2baf10028f3d25c0cb902945569560783da"
-      hash_algorithm: "SHA-256"
+      hash:
+        value: "4152975a068756076f10c97317e9d2baf10028f3d25c0cb902945569560783da"
+        algorithm: "SHA-256"
     vcs:
       type: "git"
       url: "https://github.com/rspec/rspec-support.git"
@@ -294,12 +310,14 @@ packages:
     homepage_url: "http://github.com/rspec"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://rubygems.org/gems/rspec-3.7.0.gem"
-      hash: "0174cfbed780e42aa181227af623e2ae37511f20a2fdfec48b54f6cf4d7a6404"
-      hash_algorithm: "SHA-256"
+      hash:
+        value: "0174cfbed780e42aa181227af623e2ae37511f20a2fdfec48b54f6cf4d7a6404"
+        algorithm: "SHA-256"
     vcs:
       type: "git"
       url: "http://github.com/rspec/rspec.git"

--- a/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output.yml
@@ -36,12 +36,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: "https://api.nuget.org/v3-flatcontainer/antlr/3.4.1.9004/antlr.3.4.1.9004.nupkg"
-      hash: "b7846aa81ff2bd21d4f2892bc924b52f629a68fb003820ccf0d3db88ecbc389c3fa223488e35334b98a021525db349b993902663219657d8c156915072af37d3"
-      hash_algorithm: "SHA-512"
+      hash:
+        value: "b7846aa81ff2bd21d4f2892bc924b52f629a68fb003820ccf0d3db88ecbc389c3fa223488e35334b98a021525db349b993902663219657d8c156915072af37d3"
+        algorithm: "SHA-512"
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -65,12 +67,14 @@ packages:
     homepage_url: "http://james.newtonking.com/projects/json-net.aspx"
     binary_artifact:
       url: "https://api.nuget.org/v3-flatcontainer/newtonsoft.json/5.0.4/newtonsoft.json.5.0.4.nupkg"
-      hash: "760d9348be5813285b8ad38795a2a5afe788bcddab4f7190ed581c6ea524c0d67a7dd5bdd5384f197e3b5a58c070ab5bdb704493cc8e0ad63ab35f753b6d61bf"
-      hash_algorithm: "SHA-512"
+      hash:
+        value: "760d9348be5813285b8ad38795a2a5afe788bcddab4f7190ed581c6ea524c0d67a7dd5bdd5384f197e3b5a58c070ab5bdb704493cc8e0ad63ab35f753b6d61bf"
+        algorithm: "SHA-512"
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -95,12 +99,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: "https://api.nuget.org/v3-flatcontainer/webgrease/1.5.2/webgrease.1.5.2.nupkg"
-      hash: "453fa7a3483b424dbc27f5d5c07827e6527faa6e21c96169ef0b7423bd54c348f749f4df3a636a3ccc5f79d1da9c08ed7f7741dbfd0a8d0ddf424bd57b0b2fb0"
-      hash_algorithm: "SHA-512"
+      hash:
+        value: "453fa7a3483b424dbc27f5d5c07827e6527faa6e21c96169ef0b7423bd54c348f749f4df3a636a3ccc5f79d1da9c08ed7f7741dbfd0a8d0ddf424bd57b0b2fb0"
+        algorithm: "SHA-512"
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -129,12 +135,14 @@ packages:
     homepage_url: "http://jquery.com/"
     binary_artifact:
       url: "https://api.nuget.org/v3-flatcontainer/jquery/3.3.1/jquery.3.3.1.nupkg"
-      hash: "126b2db350fa1360201d5066e1c4c3d9dc684725951bedf32b5c7c9986dffa4e9a000acf4d71d1d88a7efa8d6eb6535b99823368f167846c376037b1a7c3e395"
-      hash_algorithm: "SHA-512"
+      hash:
+        value: "126b2db350fa1360201d5066e1c4c3d9dc684725951bedf32b5c7c9986dffa4e9a000acf4d71d1d88a7efa8d6eb6535b99823368f167846c376037b1a7c3e395"
+        algorithm: "SHA-512"
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
@@ -425,12 +425,14 @@ analyzer:
         homepage_url: "http://junit.org"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12.jar"
-          hash: "2973d150c0dc1fefe998f834810d68f278ea58ec"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "2973d150c0dc1fefe998f834810d68f278ea58ec"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
-          hash: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/junit-team/junit.git"
@@ -455,12 +457,14 @@ analyzer:
         homepage_url: "http://commons.apache.org/proper/commons-lang/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar"
-          hash: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
-          hash: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
@@ -484,12 +488,14 @@ analyzer:
         homepage_url: "http://commons.apache.org/proper/commons-text/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1.jar"
-          hash: "c336bf600f44b88af356c8a85eef4af822b06a4d"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "c336bf600f44b88af356c8a85eef4af822b06a4d"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
-          hash: "f0770f7f0472bf120ada47beecadce4056fbd20a"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
@@ -512,12 +518,14 @@ analyzer:
         homepage_url: "http://struts.apache.org/struts2-assembly/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/struts/struts2-assembly/2.5.14.1/struts2-assembly-2.5.14.1-min-lib.zip"
-          hash: "8e75a38e3b8ceb01e007c5899d8d29e7a075cb7d"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "8e75a38e3b8ceb01e007c5899d8d29e7a075cb7d"
+            algorithm: "SHA-1"
         source_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         vcs:
           type: "git"
           url: "https://gitbox.apache.org/repos/asf/struts.git"
@@ -543,12 +551,14 @@ analyzer:
         homepage_url: "http://hamcrest.org/JavaHamcrest/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"
-          hash: "42a25dc3219429f0e5d060061f71acb49bf010a0"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "42a25dc3219429f0e5d060061f71acb49bf010a0"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
-          hash: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git@github.com:hamcrest/JavaHamcrest.git"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
@@ -425,12 +425,14 @@ analyzer:
         homepage_url: "http://junit.org"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12.jar"
-          hash: "2973d150c0dc1fefe998f834810d68f278ea58ec"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "2973d150c0dc1fefe998f834810d68f278ea58ec"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
-          hash: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git://github.com/junit-team/junit.git"
@@ -455,12 +457,14 @@ analyzer:
         homepage_url: "http://commons.apache.org/proper/commons-lang/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar"
-          hash: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
-          hash: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
@@ -484,12 +488,14 @@ analyzer:
         homepage_url: "http://commons.apache.org/proper/commons-text/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1.jar"
-          hash: "c336bf600f44b88af356c8a85eef4af822b06a4d"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "c336bf600f44b88af356c8a85eef4af822b06a4d"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
-          hash: "f0770f7f0472bf120ada47beecadce4056fbd20a"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
@@ -512,12 +518,14 @@ analyzer:
         homepage_url: "http://struts.apache.org/struts2-assembly/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/struts/struts2-assembly/2.5.14.1/struts2-assembly-2.5.14.1-min-lib.zip"
-          hash: "8e75a38e3b8ceb01e007c5899d8d29e7a075cb7d"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "8e75a38e3b8ceb01e007c5899d8d29e7a075cb7d"
+            algorithm: "SHA-1"
         source_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         vcs:
           type: "git"
           url: "https://gitbox.apache.org/repos/asf/struts.git"
@@ -542,12 +550,14 @@ analyzer:
         homepage_url: "https://github.com/hamcrest/JavaHamcrest/hamcrest-core"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"
-          hash: "42a25dc3219429f0e5d060061f71acb49bf010a0"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "42a25dc3219429f0e5d060061f71acb49bf010a0"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
-          hash: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+            algorithm: "SHA-1"
         vcs:
           type: "git"
           url: "git@github.com:hamcrest/JavaHamcrest.git"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-app.yml
@@ -467,12 +467,14 @@ packages:
     homepage_url: "https://github.com/square/okhttp/okhttp"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/com/squareup/okhttp3/okhttp/3.10.0/okhttp-3.10.0-sources.jar"
-      hash: "0e99b7b608968f16b07104b93e62cb90701174d0"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "0e99b7b608968f16b07104b93e62cb90701174d0"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/square/okhttp.git"
@@ -495,12 +497,14 @@ packages:
     homepage_url: "https://github.com/square/okio/okio"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/com/squareup/okio/okio/1.14.0/okio-1.14.0-sources.jar"
-      hash: "e7c96b4fe5651490d8f3c022042940d743a3bdd9"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "e7c96b4fe5651490d8f3c022042940d743a3bdd9"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/square/okio.git"
@@ -524,12 +528,14 @@ packages:
     homepage_url: "http://junit.org"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
-      hash: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/junit-team/junit.git"
@@ -555,12 +561,14 @@ packages:
     homepage_url: "https://commons.apache.org/proper/commons-compress/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/1.17/commons-compress-1.17-sources.jar"
-      hash: "9d064d7d42ee1d04ae07ad23025b4f9616652eed"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "9d064d7d42ee1d04ae07ad23025b4f9616652eed"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://git-wip-us.apache.org/repos/asf/commons-compress.git"
@@ -585,12 +593,14 @@ packages:
     homepage_url: "http://commons.apache.org/proper/commons-lang/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.7/commons-lang3-3.7-sources.jar"
-      hash: "e7e36219edde1c66c93495a75490d8f526c377cb"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "e7e36219edde1c66c93495a75490d8f526c377cb"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
@@ -614,12 +624,14 @@ packages:
     homepage_url: "http://commons.apache.org/proper/commons-text/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.2/commons-text-1.2-sources.jar"
-      hash: "679282ee0f6f2b236f58a7a1dc8395861ad9fd97"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "679282ee0f6f2b236f58a7a1dc8395861ad9fd97"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
@@ -643,12 +655,14 @@ packages:
     homepage_url: "http://commons.apache.org/proper/commons-text/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.3/commons-text-1.3-sources.jar"
-      hash: "9c51853f855aca4ea31785f30385e980a58eaf4b"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "9c51853f855aca4ea31785f30385e980a58eaf4b"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
@@ -673,12 +687,14 @@ packages:
     homepage_url: "https://github.com/hamcrest/JavaHamcrest/hamcrest-core"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
-      hash: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git@github.com:hamcrest/JavaHamcrest.git"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-lib.yml
@@ -186,12 +186,14 @@ packages:
     homepage_url: "https://commons.apache.org/proper/commons-compress/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/1.17/commons-compress-1.17.jar"
-      hash: "474c20609032e7f815ef534cd8174d2e400d9a8d"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "474c20609032e7f815ef534cd8174d2e400d9a8d"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/1.17/commons-compress-1.17-sources.jar"
-      hash: "9d064d7d42ee1d04ae07ad23025b4f9616652eed"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "9d064d7d42ee1d04ae07ad23025b4f9616652eed"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://git-wip-us.apache.org/repos/asf/commons-compress.git"
@@ -216,12 +218,14 @@ packages:
     homepage_url: "http://commons.apache.org/proper/commons-lang/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.7/commons-lang3-3.7.jar"
-      hash: "557edd918fd41f9260963583ebf5a61a43a6b423"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "557edd918fd41f9260963583ebf5a61a43a6b423"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.7/commons-lang3-3.7-sources.jar"
-      hash: "e7e36219edde1c66c93495a75490d8f526c377cb"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "e7e36219edde1c66c93495a75490d8f526c377cb"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
@@ -245,12 +249,14 @@ packages:
     homepage_url: "http://commons.apache.org/proper/commons-text/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.2/commons-text-1.2.jar"
-      hash: "74acdec7237f576c4803fff0c1008ab8a3808b2b"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "74acdec7237f576c4803fff0c1008ab8a3808b2b"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.2/commons-text-1.2-sources.jar"
-      hash: "679282ee0f6f2b236f58a7a1dc8395861ad9fd97"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "679282ee0f6f2b236f58a7a1dc8395861ad9fd97"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
@@ -274,12 +280,14 @@ packages:
     homepage_url: "http://commons.apache.org/proper/commons-text/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.3/commons-text-1.3.jar"
-      hash: "9abf61708a66ab5e55f6169a200dbfc584b546d9"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "9abf61708a66ab5e55f6169a200dbfc584b546d9"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.3/commons-text-1.3-sources.jar"
-      hash: "9c51853f855aca4ea31785f30385e980a58eaf4b"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "9c51853f855aca4ea31785f30385e980a58eaf4b"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-2.14.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-2.14.yml
@@ -96,12 +96,14 @@ packages:
     homepage_url: "http://commons.apache.org/proper/commons-lang/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar"
-      hash: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
-      hash: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
@@ -125,12 +127,14 @@ packages:
     homepage_url: "http://commons.apache.org/proper/commons-text/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1.jar"
-      hash: "c336bf600f44b88af356c8a85eef4af822b06a4d"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "c336bf600f44b88af356c8a85eef4af822b06a4d"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
-      hash: "f0770f7f0472bf120ada47beecadce4056fbd20a"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
@@ -153,12 +157,14 @@ packages:
     homepage_url: "http://struts.apache.org/struts2-assembly/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/struts/struts2-assembly/2.5.14.1/struts2-assembly-2.5.14.1-min-lib.zip"
-      hash: "8e75a38e3b8ceb01e007c5899d8d29e7a075cb7d"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "8e75a38e3b8ceb01e007c5899d8d29e7a075cb7d"
+        algorithm: "SHA-1"
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://gitbox.apache.org/repos/asf/struts.git"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-3.4.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-3.4.yml
@@ -82,12 +82,14 @@ packages:
     homepage_url: "http://commons.apache.org/proper/commons-lang/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar"
-      hash: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
-      hash: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
@@ -111,12 +113,14 @@ packages:
     homepage_url: "http://commons.apache.org/proper/commons-text/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1.jar"
-      hash: "c336bf600f44b88af356c8a85eef4af822b06a4d"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "c336bf600f44b88af356c8a85eef4af822b06a4d"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
-      hash: "f0770f7f0472bf120ada47beecadce4056fbd20a"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
@@ -139,12 +143,14 @@ packages:
     homepage_url: "http://struts.apache.org/struts2-assembly/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/struts/struts2-assembly/2.5.14.1/struts2-assembly-2.5.14.1-min-lib.zip"
-      hash: "8e75a38e3b8ceb01e007c5899d8d29e7a075cb7d"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "8e75a38e3b8ceb01e007c5899d8d29e7a075cb7d"
+        algorithm: "SHA-1"
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://gitbox.apache.org/repos/asf/struts.git"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
@@ -122,12 +122,14 @@ packages:
     homepage_url: "http://commons.apache.org/proper/commons-lang/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar"
-      hash: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
-      hash: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
@@ -151,12 +153,14 @@ packages:
     homepage_url: "http://commons.apache.org/proper/commons-text/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1.jar"
-      hash: "c336bf600f44b88af356c8a85eef4af822b06a4d"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "c336bf600f44b88af356c8a85eef4af822b06a4d"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
-      hash: "f0770f7f0472bf120ada47beecadce4056fbd20a"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
@@ -179,12 +183,14 @@ packages:
     homepage_url: "http://struts.apache.org/struts2-assembly/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/struts/struts2-assembly/2.5.14.1/struts2-assembly-2.5.14.1-min-lib.zip"
-      hash: "8e75a38e3b8ceb01e007c5899d8d29e7a075cb7d"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "8e75a38e3b8ceb01e007c5899d8d29e7a075cb7d"
+        algorithm: "SHA-1"
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://gitbox.apache.org/repos/asf/struts.git"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
@@ -106,12 +106,14 @@ packages:
     homepage_url: "http://junit.org"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12.jar"
-      hash: "2973d150c0dc1fefe998f834810d68f278ea58ec"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "2973d150c0dc1fefe998f834810d68f278ea58ec"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
-      hash: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/junit-team/junit.git"
@@ -136,12 +138,14 @@ packages:
     homepage_url: "http://commons.apache.org/proper/commons-lang/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar"
-      hash: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
-      hash: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
@@ -165,12 +169,14 @@ packages:
     homepage_url: "http://commons.apache.org/proper/commons-text/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1.jar"
-      hash: "c336bf600f44b88af356c8a85eef4af822b06a4d"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "c336bf600f44b88af356c8a85eef4af822b06a4d"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
-      hash: "f0770f7f0472bf120ada47beecadce4056fbd20a"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
@@ -193,12 +199,14 @@ packages:
     homepage_url: "http://struts.apache.org/struts2-assembly/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/struts/struts2-assembly/2.5.14.1/struts2-assembly-2.5.14.1-min-lib.zip"
-      hash: "8e75a38e3b8ceb01e007c5899d8d29e7a075cb7d"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "8e75a38e3b8ceb01e007c5899d8d29e7a075cb7d"
+        algorithm: "SHA-1"
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://gitbox.apache.org/repos/asf/struts.git"
@@ -223,12 +231,14 @@ packages:
     homepage_url: "https://github.com/hamcrest/JavaHamcrest/hamcrest-core"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"
-      hash: "42a25dc3219429f0e5d060061f71acb49bf010a0"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "42a25dc3219429f0e5d060061f71acb49bf010a0"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
-      hash: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git@github.com:hamcrest/JavaHamcrest.git"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-app.yml
@@ -120,12 +120,14 @@ packages:
     homepage_url: "http://commons.apache.org/proper/commons-lang/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar"
-      hash: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
-      hash: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
@@ -149,12 +151,14 @@ packages:
     homepage_url: "http://commons.apache.org/proper/commons-text/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1.jar"
-      hash: "c336bf600f44b88af356c8a85eef4af822b06a4d"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "c336bf600f44b88af356c8a85eef4af822b06a4d"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
-      hash: "f0770f7f0472bf120ada47beecadce4056fbd20a"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
@@ -177,12 +181,14 @@ packages:
     homepage_url: "http://struts.apache.org/struts2-assembly/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/struts/struts2-assembly/2.5.14.1/struts2-assembly-2.5.14.1-min-lib.zip"
-      hash: "8e75a38e3b8ceb01e007c5899d8d29e7a075cb7d"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "8e75a38e3b8ceb01e007c5899d8d29e7a075cb7d"
+        algorithm: "SHA-1"
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://gitbox.apache.org/repos/asf/struts.git"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-lib.yml
@@ -84,12 +84,14 @@ packages:
     homepage_url: "http://junit.org"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12.jar"
-      hash: "2973d150c0dc1fefe998f834810d68f278ea58ec"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "2973d150c0dc1fefe998f834810d68f278ea58ec"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
-      hash: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/junit-team/junit.git"
@@ -114,12 +116,14 @@ packages:
     homepage_url: "http://commons.apache.org/proper/commons-lang/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar"
-      hash: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
-      hash: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
@@ -143,12 +147,14 @@ packages:
     homepage_url: "http://commons.apache.org/proper/commons-text/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1.jar"
-      hash: "c336bf600f44b88af356c8a85eef4af822b06a4d"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "c336bf600f44b88af356c8a85eef4af822b06a4d"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
-      hash: "f0770f7f0472bf120ada47beecadce4056fbd20a"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
@@ -171,12 +177,14 @@ packages:
     homepage_url: "http://struts.apache.org/struts2-assembly/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/struts/struts2-assembly/2.5.14.1/struts2-assembly-2.5.14.1-min-lib.zip"
-      hash: "8e75a38e3b8ceb01e007c5899d8d29e7a075cb7d"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "8e75a38e3b8ceb01e007c5899d8d29e7a075cb7d"
+        algorithm: "SHA-1"
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://gitbox.apache.org/repos/asf/struts.git"
@@ -201,12 +209,14 @@ packages:
     homepage_url: "https://github.com/hamcrest/JavaHamcrest/hamcrest-core"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"
-      hash: "42a25dc3219429f0e5d060061f71acb49bf010a0"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "42a25dc3219429f0e5d060061f71acb49bf010a0"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
-      hash: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git@github.com:hamcrest/JavaHamcrest.git"

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-app.yml
@@ -43,12 +43,14 @@ packages:
     homepage_url: "http://beam.apache.org/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/beam/beam-parent/2.3.0/beam-parent-2.3.0.pom"
-      hash: "9e1ed0d1f714b13d0625fc9feb1410a7a2250424"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "9e1ed0d1f714b13d0625fc9feb1410a7a2250424"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/beam/beam-parent/2.3.0/beam-parent-2.3.0.pom"
-      hash: "9e1ed0d1f714b13d0625fc9feb1410a7a2250424"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "9e1ed0d1f714b13d0625fc9feb1410a7a2250424"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://gitbox.apache.org/repos/asf/beam.git"
@@ -73,12 +75,14 @@ packages:
     homepage_url: "http://commons.apache.org/proper/commons-lang/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar"
-      hash: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
-      hash: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
@@ -102,12 +106,14 @@ packages:
     homepage_url: "http://commons.apache.org/proper/commons-text/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1.jar"
-      hash: "c336bf600f44b88af356c8a85eef4af822b06a4d"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "c336bf600f44b88af356c8a85eef4af822b06a4d"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
-      hash: "f0770f7f0472bf120ada47beecadce4056fbd20a"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
@@ -130,12 +136,14 @@ packages:
     homepage_url: "http://jenkins-ci.org/version-number/"
     binary_artifact:
       url: "http://repo.jenkins-ci.org/public/org/jenkins-ci/version-number/1.4/version-number-1.4.jar"
-      hash: "5d0f2ea16514c0ec8de86c102ce61a7837e45eb8"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "5d0f2ea16514c0ec8de86c102ce61a7837e45eb8"
+        algorithm: "SHA-1"
     source_artifact:
       url: "http://repo.jenkins-ci.org/public/org/jenkins-ci/version-number/1.4/version-number-1.4-sources.jar"
-      hash: "ab4e04d731d43157f66d80e4a5daef33ce24f0c2"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "ab4e04d731d43157f66d80e4a5daef33ce24f0c2"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/jenkinsci/lib-version-number.git"

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-lib.yml
@@ -42,12 +42,14 @@ packages:
     homepage_url: "http://junit.org"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/junit/junit/3.8.1/junit-3.8.1.jar"
-      hash: "99129f16442844f6a4a11ae22fbbee40b14d774f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "99129f16442844f6a4a11ae22fbbee40b14d774f"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/junit/junit/3.8.1/junit-3.8.1-sources.jar"
-      hash: "0525753763e53f6f76da052b316d0f2e3bfa4d73"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "0525753763e53f6f76da052b316d0f2e3bfa4d73"
+        algorithm: "SHA-1"
     vcs:
       type: ""
       url: ""
@@ -72,12 +74,14 @@ packages:
     homepage_url: "http://beam.apache.org/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/beam/beam-parent/2.3.0/beam-parent-2.3.0.pom"
-      hash: "9e1ed0d1f714b13d0625fc9feb1410a7a2250424"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "9e1ed0d1f714b13d0625fc9feb1410a7a2250424"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/beam/beam-parent/2.3.0/beam-parent-2.3.0.pom"
-      hash: "9e1ed0d1f714b13d0625fc9feb1410a7a2250424"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "9e1ed0d1f714b13d0625fc9feb1410a7a2250424"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://gitbox.apache.org/repos/asf/beam.git"
@@ -102,12 +106,14 @@ packages:
     homepage_url: "http://commons.apache.org/proper/commons-lang/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar"
-      hash: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
-      hash: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
@@ -131,12 +137,14 @@ packages:
     homepage_url: "http://commons.apache.org/proper/commons-text/"
     binary_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1.jar"
-      hash: "c336bf600f44b88af356c8a85eef4af822b06a4d"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "c336bf600f44b88af356c8a85eef4af822b06a4d"
+        algorithm: "SHA-1"
     source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
-      hash: "f0770f7f0472bf120ada47beecadce4056fbd20a"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
@@ -159,12 +167,14 @@ packages:
     homepage_url: "http://jenkins-ci.org/version-number/"
     binary_artifact:
       url: "http://repo.jenkins-ci.org/public/org/jenkins-ci/version-number/1.4/version-number-1.4.jar"
-      hash: "5d0f2ea16514c0ec8de86c102ce61a7837e45eb8"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "5d0f2ea16514c0ec8de86c102ce61a7837e45eb8"
+        algorithm: "SHA-1"
     source_artifact:
       url: "http://repo.jenkins-ci.org/public/org/jenkins-ci/version-number/1.4/version-number-1.4-sources.jar"
-      hash: "ab4e04d731d43157f66d80e4a5daef33ce24f0c2"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "ab4e04d731d43157f66d80e4a5daef33ce24f0c2"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/jenkinsci/lib-version-number.git"

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
@@ -776,12 +776,14 @@ packages:
     homepage_url: "https://github.com/chalk/ansi-regex#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-      hash: "c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/chalk/ansi-regex.git"
@@ -804,12 +806,14 @@ packages:
     homepage_url: "https://github.com/chalk/ansi-styles#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-      hash: "b432dd3358b634cf75e1e4664368240533c1ddbe"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "b432dd3358b634cf75e1e4664368240533c1ddbe"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/chalk/ansi-styles.git"
@@ -833,12 +837,14 @@ packages:
     homepage_url: "https://github.com/es128/anymatch"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz"
-      hash: "553dcb8f91e3c889845dfdba34c77721b90b9d7a"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "553dcb8f91e3c889845dfdba34c77721b90b9d7a"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/es128/anymatch.git"
@@ -862,12 +868,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/arr-diff"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz"
-      hash: "8f3b827f955a8bd669697e4a4256ac3ceae356cf"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "8f3b827f955a8bd669697e4a4256ac3ceae356cf"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/arr-diff.git"
@@ -890,12 +898,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/arr-flatten"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz"
-      hash: "36048bbff4e7b47e136644316c99669ea5ae91f1"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "36048bbff4e7b47e136644316c99669ea5ae91f1"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/arr-flatten.git"
@@ -918,12 +928,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/array-unique"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
-      hash: "a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/jonschlinkert/array-unique.git"
@@ -947,12 +959,14 @@ packages:
     homepage_url: "https://github.com/paulmillr/async-each/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz"
-      hash: "19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/paulmillr/async-each.git"
@@ -975,12 +989,14 @@ packages:
     homepage_url: "https://babeljs.io/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz"
-      hash: "502ab54874d7db88ad00b887a06383ce03d002f1"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "502ab54874d7db88ad00b887a06383ce03d002f1"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/babel/babel/tree/master/packages/babel-cli"
@@ -1003,12 +1019,14 @@ packages:
     homepage_url: "https://babeljs.io/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz"
-      hash: "63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/babel/babel/tree/master/packages/babel-code-frame"
@@ -1031,12 +1049,14 @@ packages:
     homepage_url: "https://babeljs.io/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz"
-      hash: "b2e2f09e342d0f0c88e2f02e067794125e75c207"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "b2e2f09e342d0f0c88e2f02e067794125e75c207"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/babel/babel/tree/master/packages/babel-core"
@@ -1059,12 +1079,14 @@ packages:
     homepage_url: "https://babeljs.io/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz"
-      hash: "1844408d3b8f0d35a404ea7ac180f087a601bd90"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "1844408d3b8f0d35a404ea7ac180f087a601bd90"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/babel/babel/tree/master/packages/babel-generator"
@@ -1087,12 +1109,14 @@ packages:
     homepage_url: "https://babeljs.io/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz"
-      hash: "3471de9caec388e5c850e597e58a26ddf37602b2"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "3471de9caec388e5c850e597e58a26ddf37602b2"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/babel/babel/tree/master/packages/babel-helpers"
@@ -1115,12 +1139,14 @@ packages:
     homepage_url: "https://babeljs.io/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
-      hash: "f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/babel/babel/tree/master/packages/babel-messages"
@@ -1143,12 +1169,14 @@ packages:
     homepage_url: "https://babeljs.io/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz"
-      hash: "379937abc67d7895970adc621f284cd966cf2153"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "379937abc67d7895970adc621f284cd966cf2153"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/babel/babel/tree/master/packages/babel-polyfill"
@@ -1171,12 +1199,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz"
-      hash: "6ed021173e2fcb486d7acb45c6009a856f647071"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "6ed021173e2fcb486d7acb45c6009a856f647071"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/babel/babel/tree/master/packages/babel-register"
@@ -1199,12 +1229,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz"
-      hash: "965c7058668e82b55d7bfe04ff2337bc8b5647fe"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/babel/babel/tree/master/packages/babel-runtime"
@@ -1227,12 +1259,14 @@ packages:
     homepage_url: "https://babeljs.io/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz"
-      hash: "de03e2d16396b069f46dd9fff8521fb1a0e35e02"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "de03e2d16396b069f46dd9fff8521fb1a0e35e02"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/babel/babel/tree/master/packages/babel-template"
@@ -1256,12 +1290,14 @@ packages:
     homepage_url: "https://babeljs.io/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz"
-      hash: "46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/babel/babel/tree/master/packages/babel-traverse"
@@ -1284,12 +1320,14 @@ packages:
     homepage_url: "https://babeljs.io/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz"
-      hash: "a3b073f94ab49eb6fa55cd65227a334380632497"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "a3b073f94ab49eb6fa55cd65227a334380632497"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/babel/babel/tree/master/packages/babel-types"
@@ -1312,12 +1350,14 @@ packages:
     homepage_url: "https://babeljs.io/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz"
-      hash: "af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/babel/babylon.git"
@@ -1340,12 +1380,14 @@ packages:
     homepage_url: "https://github.com/juliangruber/balanced-match"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
-      hash: "89b4d199ab2bee49de164ea02b89ce462d71b767"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "89b4d199ab2bee49de164ea02b89ce462d71b767"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/juliangruber/balanced-match.git"
@@ -1368,12 +1410,14 @@ packages:
     homepage_url: "https://github.com/sindresorhus/binary-extensions#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz"
-      hash: "46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/sindresorhus/binary-extensions.git"
@@ -1396,12 +1440,14 @@ packages:
     homepage_url: "https://github.com/juliangruber/brace-expansion"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz"
-      hash: "3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/juliangruber/brace-expansion.git"
@@ -1425,12 +1471,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/braces"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz"
-      hash: "ba77962e12dff969d6b76711e914b737857bf6a7"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "ba77962e12dff969d6b76711e914b737857bf6a7"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/braces.git"
@@ -1453,12 +1501,14 @@ packages:
     homepage_url: "https://github.com/chalk/chalk#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
-      hash: "a8115c55e4a702fe4d150abd3872822a7e09fc98"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "a8115c55e4a702fe4d150abd3872822a7e09fc98"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/chalk/chalk.git"
@@ -1481,12 +1531,14 @@ packages:
     homepage_url: "https://github.com/paulmillr/chokidar"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz"
-      hash: "798e689778151c8076b4b360e5edd28cda2bb468"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "798e689778151c8076b4b360e5edd28cda2bb468"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/paulmillr/chokidar.git"
@@ -1509,12 +1561,14 @@ packages:
     homepage_url: "https://github.com/tj/commander.js#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz"
-      hash: "bd77ab7de6de94205ceacc72f1716d29f20a77bf"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "bd77ab7de6de94205ceacc72f1716d29f20a77bf"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/tj/commander.js.git"
@@ -1537,12 +1591,14 @@ packages:
     homepage_url: "https://github.com/substack/node-concat-map"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-      hash: "d8a96bd77fd68df7793a73036a3ba0d5405d477b"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/substack/node-concat-map.git"
@@ -1566,12 +1622,14 @@ packages:
     homepage_url: "https://github.com/thlorenz/convert-source-map"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz"
-      hash: "b8278097b9bc229365de5c62cf5fcaed8b5599e5"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "b8278097b9bc229365de5c62cf5fcaed8b5599e5"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/thlorenz/convert-source-map.git"
@@ -1594,12 +1652,14 @@ packages:
     homepage_url: "https://github.com/zloirock/core-js#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz"
-      hash: "f972608ff0cead68b841a16a932d0b183791814e"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "f972608ff0cead68b841a16a932d0b183791814e"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/zloirock/core-js.git"
@@ -1622,12 +1682,14 @@ packages:
     homepage_url: "https://github.com/isaacs/core-util-is#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-      hash: "b5fd54220aa2bc5ab57aab7140c940754503c1a7"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/isaacs/core-util-is.git"
@@ -1650,12 +1712,14 @@ packages:
     homepage_url: "https://github.com/visionmedia/debug#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
-      hash: "5d128515df134ff327e90a4c93f4e077a536341f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "5d128515df134ff327e90a4c93f4e077a536341f"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/visionmedia/debug.git"
@@ -1678,12 +1742,14 @@ packages:
     homepage_url: "https://github.com/sindresorhus/detect-indent"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz"
-      hash: "f76d064352cdf43a1cb6ce619c4ee3a9475de208"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "f76d064352cdf43a1cb6ce619c4ee3a9475de208"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/sindresorhus/detect-indent"
@@ -1706,12 +1772,14 @@ packages:
     homepage_url: "https://github.com/sindresorhus/escape-string-regexp"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-      hash: "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/sindresorhus/escape-string-regexp"
@@ -1734,12 +1802,14 @@ packages:
     homepage_url: "https://github.com/estools/esutils"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-      hash: "0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "http://github.com/estools/esutils.git"
@@ -1762,12 +1832,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/expand-brackets"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz"
-      hash: "df07284e342a807cd733ac5af72411e581d1177b"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "df07284e342a807cd733ac5af72411e581d1177b"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/expand-brackets.git"
@@ -1791,12 +1863,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/expand-range"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz"
-      hash: "a299effd335fe2721ebae8e257ec79644fc85337"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "a299effd335fe2721ebae8e257ec79644fc85337"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/expand-range.git"
@@ -1820,12 +1894,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/extglob"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
-      hash: "2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/jonschlinkert/extglob.git"
@@ -1848,12 +1924,14 @@ packages:
     homepage_url: "https://github.com/regexhq/filename-regex"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz"
-      hash: "c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/regexhq/filename-regex.git"
@@ -1877,12 +1955,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/fill-range"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz"
-      hash: "eb1e773abb056dcd8df2bfdf6af59b8b3a936565"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "eb1e773abb056dcd8df2bfdf6af59b8b3a936565"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/fill-range.git"
@@ -1907,12 +1987,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/for-in"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
-      hash: "81068d295a8142ec0ac726c6e2200c30fb6d5e80"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "81068d295a8142ec0ac726c6e2200c30fb6d5e80"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/for-in.git"
@@ -1937,12 +2019,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/for-own"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz"
-      hash: "5265c681a4f294dabbf17c9509b6763aa84510ce"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "5265c681a4f294dabbf17c9509b6763aa84510ce"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/for-own.git"
@@ -1965,12 +2049,14 @@ packages:
     homepage_url: "https://github.com/fs-utils/fs-readdir-recursive#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz"
-      hash: "e32fc030a2ccee44a6b5371308da54be0b397d27"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "e32fc030a2ccee44a6b5371308da54be0b397d27"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/fs-utils/fs-readdir-recursive.git"
@@ -1994,12 +2080,14 @@ packages:
     homepage_url: "https://github.com/isaacs/fs.realpath#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
-      hash: "1504ad2523158caa40db4a2787cb01411994ea4f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "1504ad2523158caa40db4a2787cb01411994ea4f"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/isaacs/fs.realpath.git"
@@ -2022,12 +2110,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/glob-base"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
-      hash: "dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/jonschlinkert/glob-base.git"
@@ -2050,12 +2140,14 @@ packages:
     homepage_url: "https://github.com/es128/glob-parent"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
-      hash: "81383d72db054fcccf5336daa902f182f6edbb28"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "81383d72db054fcccf5336daa902f182f6edbb28"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/es128/glob-parent.git"
@@ -2078,12 +2170,14 @@ packages:
     homepage_url: "https://github.com/isaacs/node-glob#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
-      hash: "c19c9df9a028702d678612384a6552404c636d15"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "c19c9df9a028702d678612384a6552404c636d15"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/isaacs/node-glob.git"
@@ -2106,12 +2200,14 @@ packages:
     homepage_url: "https://github.com/sindresorhus/globals#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
-      hash: "aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/sindresorhus/globals.git"
@@ -2134,12 +2230,14 @@ packages:
     homepage_url: "https://github.com/isaacs/node-graceful-fs#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-      hash: "0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/isaacs/node-graceful-fs.git"
@@ -2162,12 +2260,14 @@ packages:
     homepage_url: "https://github.com/sindresorhus/has-ansi"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
-      hash: "34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/sindresorhus/has-ansi"
@@ -2190,12 +2290,14 @@ packages:
     homepage_url: "https://github.com/sindresorhus/home-or-tmp"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz"
-      hash: "e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/sindresorhus/home-or-tmp"
@@ -2218,12 +2320,14 @@ packages:
     homepage_url: "https://github.com/isaacs/inflight"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
-      hash: "49bd6331d7d02d0c09bc910a1075ba8165b56df9"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/npm/inflight.git"
@@ -2247,12 +2351,14 @@ packages:
     homepage_url: "https://github.com/isaacs/inherits#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-      hash: "633c2c83e3da42a502f52466022480f4208261de"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "633c2c83e3da42a502f52466022480f4208261de"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/isaacs/inherits.git"
@@ -2275,12 +2381,14 @@ packages:
     homepage_url: "https://github.com/zertosh/invariant#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz"
-      hash: "610f3c92c9359ce1db616e538008d23ff35158e6"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "610f3c92c9359ce1db616e538008d23ff35158e6"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/zertosh/invariant.git"
@@ -2303,12 +2411,14 @@ packages:
     homepage_url: "https://github.com/sindresorhus/is-binary-path"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz"
-      hash: "75f16642b480f187a711c814161fd3a4a7655898"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "75f16642b480f187a711c814161fd3a4a7655898"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/sindresorhus/is-binary-path"
@@ -2331,12 +2441,14 @@ packages:
     homepage_url: "https://github.com/feross/is-buffer#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
-      hash: "efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/feross/is-buffer.git"
@@ -2360,12 +2472,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/is-dotfile"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz"
-      hash: "a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/is-dotfile.git"
@@ -2389,12 +2503,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/is-equal-shallow"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
-      hash: "2238098fc221de0bcfa5d9eac4c45d638aa1c534"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "2238098fc221de0bcfa5d9eac4c45d638aa1c534"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/jonschlinkert/is-equal-shallow.git"
@@ -2419,12 +2535,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/is-extendable"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
-      hash: "62b110e289a471418e3ec36a617d472e301dfc89"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "62b110e289a471418e3ec36a617d472e301dfc89"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/is-extendable.git"
@@ -2447,12 +2565,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/is-extglob"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-      hash: "ac468177c4943405a092fc8f29760c6ffc6206c0"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "ac468177c4943405a092fc8f29760c6ffc6206c0"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/jonschlinkert/is-extglob"
@@ -2475,12 +2595,14 @@ packages:
     homepage_url: "https://github.com/sindresorhus/is-finite#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
-      hash: "cc6677695602be550ef11e8b4aa6305342b6d0aa"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "cc6677695602be550ef11e8b4aa6305342b6d0aa"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/sindresorhus/is-finite.git"
@@ -2506,12 +2628,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/is-glob"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
-      hash: "d096f926a3ded5600f3fdfd91198cb0888c2d863"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "d096f926a3ded5600f3fdfd91198cb0888c2d863"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/is-glob.git"
@@ -2534,12 +2658,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/is-number"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
-      hash: "01fcbbb393463a548f2f466cce16dece49db908f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "01fcbbb393463a548f2f466cce16dece49db908f"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/is-number.git"
@@ -2562,12 +2688,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/is-number"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz"
-      hash: "0026e37f5454d73e356dfe6564699867c6a7f0ff"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "0026e37f5454d73e356dfe6564699867c6a7f0ff"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/is-number.git"
@@ -2591,12 +2719,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/is-posix-bracket"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
-      hash: "3334dc79774368e92f016e6fbc0a88f5cd6e6bc4"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "3334dc79774368e92f016e6fbc0a88f5cd6e6bc4"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/is-posix-bracket.git"
@@ -2619,12 +2749,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/is-primitive"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
-      hash: "207bab91638499c07b2adf240a41a87210034575"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "207bab91638499c07b2adf240a41a87210034575"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/jonschlinkert/is-primitive.git"
@@ -2647,12 +2779,14 @@ packages:
     homepage_url: "https://github.com/juliangruber/isarray"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-      hash: "bb935d48582cba168c06834957a54a3e07124f11"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "bb935d48582cba168c06834957a54a3e07124f11"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/juliangruber/isarray.git"
@@ -2675,12 +2809,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/isobject"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
-      hash: "f065561096a3f1da2ef46272f815c840d87e0c89"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "f065561096a3f1da2ef46272f815c840d87e0c89"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/isobject.git"
@@ -2703,12 +2839,14 @@ packages:
     homepage_url: "https://github.com/lydell/js-tokens#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-      hash: "9866df395102130e38f7f996bceb65443209c25b"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "9866df395102130e38f7f996bceb65443209c25b"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/lydell/js-tokens.git"
@@ -2732,12 +2870,14 @@ packages:
     homepage_url: "https://mths.be/jsesc"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz"
-      hash: "46c3fec8c1892b12b0833db9bc7622176dbab34b"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "46c3fec8c1892b12b0833db9bc7622176dbab34b"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/mathiasbynens/jsesc.git"
@@ -2760,12 +2900,14 @@ packages:
     homepage_url: "http://json5.org/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
-      hash: "1eade7acc012034ad84e2396767ead9fa5495821"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "1eade7acc012034ad84e2396767ead9fa5495821"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/aseemk/json5.git"
@@ -2788,12 +2930,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/kind-of"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
-      hash: "31ea21a734bab9bbb0f32466d893aea51e4a3c64"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "31ea21a734bab9bbb0f32466d893aea51e4a3c64"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/kind-of.git"
@@ -2816,12 +2960,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/kind-of"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz"
-      hash: "01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/kind-of.git"
@@ -2844,12 +2990,14 @@ packages:
     homepage_url: "https://lodash.com/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz"
-      hash: "b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/lodash/lodash.git"
@@ -2873,12 +3021,14 @@ packages:
     homepage_url: "https://github.com/zertosh/loose-envify"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz"
-      hash: "71ee51fa7be4caec1a63839f7e682d8132d30caf"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "71ee51fa7be4caec1a63839f7e682d8132d30caf"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/zertosh/loose-envify.git"
@@ -2902,12 +3052,14 @@ packages:
     homepage_url: "https://github.com/michaelrhodes/math-random"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz"
-      hash: "8b3aac588b8a66e4975e3cdea67f7bb329601fac"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "8b3aac588b8a66e4975e3cdea67f7bb329601fac"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git@github.com:michaelrhodes/math-random"
@@ -2931,12 +3083,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/micromatch"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz"
-      hash: "86677c97d1720b363431d04d0d15293bd38c1565"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "86677c97d1720b363431d04d0d15293bd38c1565"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/micromatch.git"
@@ -2959,12 +3113,14 @@ packages:
     homepage_url: "https://github.com/isaacs/minimatch#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
-      hash: "5166e286457f03306064be5497e8dbb0c3d32083"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "5166e286457f03306064be5497e8dbb0c3d32083"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/isaacs/minimatch.git"
@@ -2987,12 +3143,14 @@ packages:
     homepage_url: "https://github.com/substack/minimist"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-      hash: "857fcabfc3397d2625b8228262e86aa7a011b05d"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "857fcabfc3397d2625b8228262e86aa7a011b05d"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/substack/minimist.git"
@@ -3015,12 +3173,14 @@ packages:
     homepage_url: "https://github.com/substack/node-mkdirp#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
-      hash: "30057438eac6cf7f8c4767f38648d6697d75c903"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "30057438eac6cf7f8c4767f38648d6697d75c903"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/substack/node-mkdirp.git"
@@ -3043,12 +3203,14 @@ packages:
     homepage_url: "https://github.com/zeit/ms#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-      hash: "5608aeadfc00be6c2901df5f9861788de0d597c8"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "5608aeadfc00be6c2901df5f9861788de0d597c8"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/zeit/ms.git"
@@ -3073,12 +3235,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/normalize-path"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz"
-      hash: "1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/normalize-path.git"
@@ -3101,12 +3265,14 @@ packages:
     homepage_url: "https://github.com/sindresorhus/number-is-nan#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-      hash: "097b602b53422a522c1afb8790318336941a011d"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "097b602b53422a522c1afb8790318336941a011d"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/sindresorhus/number-is-nan.git"
@@ -3129,12 +3295,14 @@ packages:
     homepage_url: "https://github.com/sindresorhus/object-assign#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-      hash: "2109adc7965887cfc05cbbd442cac8bfbb360863"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "2109adc7965887cfc05cbbd442cac8bfbb360863"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/sindresorhus/object-assign.git"
@@ -3158,12 +3326,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/object.omit"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz"
-      hash: "1a9c744829f39dbb858c76ca3579ae2a54ebd1fa"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "1a9c744829f39dbb858c76ca3579ae2a54ebd1fa"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/object.omit.git"
@@ -3186,12 +3356,14 @@ packages:
     homepage_url: "https://github.com/isaacs/once#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
-      hash: "583b1aa775961d4b113ac17d9c50baef9dd76bd1"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/isaacs/once.git"
@@ -3214,12 +3386,14 @@ packages:
     homepage_url: "https://github.com/sindresorhus/os-homedir#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
-      hash: "ffbc4988336e0e833de0c168c7ef152121aa7fb3"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "ffbc4988336e0e833de0c168c7ef152121aa7fb3"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/sindresorhus/os-homedir.git"
@@ -3242,12 +3416,14 @@ packages:
     homepage_url: "https://github.com/sindresorhus/os-tmpdir#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
-      hash: "bbe67406c79aa85c5cfec766fe5734555dfa1274"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "bbe67406c79aa85c5cfec766fe5734555dfa1274"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/sindresorhus/os-tmpdir.git"
@@ -3271,12 +3447,14 @@ packages:
     homepage_url: "https://github.com/shinnn/output-file-sync#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz"
-      hash: "d0a33eefe61a205facb90092e826598d5245ce76"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "d0a33eefe61a205facb90092e826598d5245ce76"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/shinnn/output-file-sync.git"
@@ -3299,12 +3477,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/parse-glob"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz"
-      hash: "b2c376cfb11f35513badd173ef0bb6e3a388391c"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "b2c376cfb11f35513badd173ef0bb6e3a388391c"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/parse-glob.git"
@@ -3327,12 +3507,14 @@ packages:
     homepage_url: "https://github.com/sindresorhus/path-is-absolute#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-      hash: "174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/sindresorhus/path-is-absolute.git"
@@ -3356,12 +3538,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/preserve"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
-      hash: "815ed1f6ebc65926f865b310c0713bcb3315ce4b"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "815ed1f6ebc65926f865b310c0713bcb3315ce4b"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/jonschlinkert/preserve.git"
@@ -3385,12 +3569,14 @@ packages:
     homepage_url: "http://github.com/benjamn/private"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/private/-/private-0.1.8.tgz"
-      hash: "2381edb3689f7a53d653190060fcf822d2f368ff"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "2381edb3689f7a53d653190060fcf822d2f368ff"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/benjamn/private.git"
@@ -3413,12 +3599,14 @@ packages:
     homepage_url: "https://github.com/calvinmetcalf/process-nextick-args"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz"
-      hash: "a37d732f4271b4ab1ad070d35508e8290788ffaa"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "a37d732f4271b4ab1ad070d35508e8290788ffaa"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/calvinmetcalf/process-nextick-args.git"
@@ -3442,12 +3630,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/randomatic"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz"
-      hash: "36f2ca708e9e567f5ed2ec01949026d50aa10116"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "36f2ca708e9e567f5ed2ec01949026d50aa10116"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/randomatic.git"
@@ -3470,12 +3660,14 @@ packages:
     homepage_url: "https://github.com/nodejs/readable-stream#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz"
-      hash: "b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/nodejs/readable-stream.git"
@@ -3498,12 +3690,14 @@ packages:
     homepage_url: "https://github.com/thlorenz/readdirp"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz"
-      hash: "4ed0ad060df3073300c48440373f72d1cc642d78"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "4ed0ad060df3073300c48440373f72d1cc642d78"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/thlorenz/readdirp.git"
@@ -3526,12 +3720,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-      hash: "336c3efc1220adcedda2c9fab67b5a7955a33658"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "336c3efc1220adcedda2c9fab67b5a7955a33658"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/facebook/regenerator/tree/master/packages/regenerator-runtime"
@@ -3554,12 +3750,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz"
-      hash: "be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/facebook/regenerator/tree/master/packages/regenerator-runtime"
@@ -3584,12 +3782,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/regex-cache"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz"
-      hash: "75bdc58a2a1496cec48a12835bc54c8d562336dd"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "75bdc58a2a1496cec48a12835bc54c8d562336dd"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/regex-cache.git"
@@ -3612,12 +3812,14 @@ packages:
     homepage_url: "https://github.com/darsain/remove-trailing-separator#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz"
-      hash: "c24bce2a283adad5bc3f58e0d48249b92379d8ef"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "c24bce2a283adad5bc3f58e0d48249b92379d8ef"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/darsain/remove-trailing-separator.git"
@@ -3640,12 +3842,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/repeat-element"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
-      hash: "ef089a178d1483baae4d93eb98b4f9e4e11d990a"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "ef089a178d1483baae4d93eb98b4f9e4e11d990a"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/jonschlinkert/repeat-element.git"
@@ -3669,12 +3873,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/repeat-string"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
-      hash: "8dcae470e1c88abc2d600fff4a776286da75e637"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "8dcae470e1c88abc2d600fff4a776286da75e637"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/repeat-string.git"
@@ -3697,12 +3903,14 @@ packages:
     homepage_url: "https://github.com/sindresorhus/repeating#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
-      hash: "5214c53a926d3552707527fbab415dbc08d06dda"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "5214c53a926d3552707527fbab415dbc08d06dda"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/sindresorhus/repeating.git"
@@ -3725,12 +3933,14 @@ packages:
     homepage_url: "https://github.com/feross/safe-buffer"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
-      hash: "991ec69d296e0313747d59bdfd2b745c35f8828d"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "991ec69d296e0313747d59bdfd2b745c35f8828d"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/feross/safe-buffer.git"
@@ -3753,12 +3963,14 @@ packages:
     homepage_url: "https://github.com/sindresorhus/set-immediate-shim"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
-      hash: "4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/sindresorhus/set-immediate-shim"
@@ -3781,12 +3993,14 @@ packages:
     homepage_url: "https://github.com/sindresorhus/slash"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
-      hash: "c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/sindresorhus/slash"
@@ -3809,12 +4023,14 @@ packages:
     homepage_url: "https://github.com/evanw/node-source-map-support#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz"
-      hash: "0286a6de8be42641338594e97ccea75f0a2c585f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "0286a6de8be42641338594e97ccea75f0a2c585f"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/evanw/node-source-map-support.git"
@@ -3837,12 +4053,14 @@ packages:
     homepage_url: "https://github.com/mozilla/source-map"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
-      hash: "8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+ssh://git@github.com/mozilla/source-map.git"
@@ -3865,12 +4083,14 @@ packages:
     homepage_url: "https://github.com/nodejs/string_decoder"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
-      hash: "9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/nodejs/string_decoder.git"
@@ -3893,12 +4113,14 @@ packages:
     homepage_url: "https://github.com/chalk/strip-ansi"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-      hash: "6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/chalk/strip-ansi"
@@ -3921,12 +4143,14 @@ packages:
     homepage_url: "https://github.com/chalk/supports-color"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-      hash: "535d045ce6b6363fa40117084629995e9df324c7"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "535d045ce6b6363fa40117084629995e9df324c7"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/chalk/supports-color"
@@ -3949,12 +4173,14 @@ packages:
     homepage_url: "https://github.com/sindresorhus/to-fast-properties#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-      hash: "b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/sindresorhus/to-fast-properties.git"
@@ -3977,12 +4203,14 @@ packages:
     homepage_url: "https://github.com/sindresorhus/trim-right"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
-      hash: "cb2e1203067e0c8de1f614094b9fe45704ea6003"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "cb2e1203067e0c8de1f614094b9fe45704ea6003"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/sindresorhus/trim-right"
@@ -4005,12 +4233,14 @@ packages:
     homepage_url: "https://github.com/sindresorhus/user-home"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
-      hash: "2b5be23a32b63a7c9deb8d0f28d485724a3df190"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "2b5be23a32b63a7c9deb8d0f28d485724a3df190"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/sindresorhus/user-home"
@@ -4033,12 +4263,14 @@ packages:
     homepage_url: "https://github.com/TooTallNate/util-deprecate"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-      hash: "450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/TooTallNate/util-deprecate.git"
@@ -4061,12 +4293,14 @@ packages:
     homepage_url: "https://github.com/tkellen/node-v8flags"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz"
-      hash: "aab1a1fa30d45f88dd321148875ac02c0b55e5b4"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "aab1a1fa30d45f88dd321148875ac02c0b55e5b4"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/tkellen/node-v8flags.git"
@@ -4089,12 +4323,14 @@ packages:
     homepage_url: "https://github.com/npm/wrappy"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-      hash: "b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/npm/wrappy.git"

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output.yml
@@ -115,12 +115,14 @@ packages:
     homepage_url: "https://github.com/kriskowal/asap#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz"
-      hash: "e50347611d7e690943208bbdafebcbc2fb866d46"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "e50347611d7e690943208bbdafebcbc2fb866d46"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/kriskowal/asap.git"
@@ -143,12 +145,14 @@ packages:
     homepage_url: "https://github.com/fb55/boolbase"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
-      hash: "68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/fb55/boolbase"
@@ -172,12 +176,14 @@ packages:
     homepage_url: "https://github.com/cheeriojs/cheerio#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.1.tgz"
-      hash: "2af37339eab713ef6b72cde98cefa672b87641fe"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "2af37339eab713ef6b72cde98cefa672b87641fe"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/cheeriojs/cheerio.git"
@@ -200,12 +206,14 @@ packages:
     homepage_url: "http://coffeescript.org"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz"
-      hash: "c05dae0cb79591d05b3070a8433a98c9a89ccc53"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "c05dae0cb79591d05b3070a8433a98c9a89ccc53"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/jashkenas/coffeescript.git"
@@ -228,12 +236,14 @@ packages:
     homepage_url: "https://github.com/isaacs/core-util-is#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-      hash: "b5fd54220aa2bc5ab57aab7140c940754503c1a7"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/isaacs/core-util-is.git"
@@ -256,12 +266,14 @@ packages:
     homepage_url: "https://github.com/groupon/cson-parser"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/cson-parser/-/cson-parser-1.3.5.tgz"
-      hash: "7ec675e039145533bf2a6a856073f1599d9c2d24"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "7ec675e039145533bf2a6a856073f1599d9c2d24"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+ssh://git@github.com/groupon/cson-parser.git"
@@ -285,12 +297,14 @@ packages:
     homepage_url: "https://github.com/bevry/cson"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/cson/-/cson-4.1.0.tgz"
-      hash: "b1075344fa9d9fe5cf88d80f21d9366296b865c7"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "b1075344fa9d9fe5cf88d80f21d9366296b865c7"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/bevry/cson.git"
@@ -313,12 +327,14 @@ packages:
     homepage_url: "https://github.com/fb55/css-select#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz"
-      hash: "2b3a110539c5355f1cd8d314623e870b121ec858"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "2b3a110539c5355f1cd8d314623e870b121ec858"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/fb55/css-select.git"
@@ -341,12 +357,14 @@ packages:
     homepage_url: "https://github.com/fb55/css-what#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz"
-      hash: "9467d032c38cfaefb9f2d79501253062f87fa1bd"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "9467d032c38cfaefb9f2d79501253062f87fa1bd"
+        algorithm: "SHA-1"
     vcs:
       type: ""
       url: "git+https://github.com/fb55/css-what.git"
@@ -369,12 +387,14 @@ packages:
     homepage_url: "https://github.com/cheeriojs/dom-renderer"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz"
-      hash: "073c697546ce0780ce23be4a28e293e40bc30c82"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "073c697546ce0780ce23be4a28e293e40bc30c82"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/cheeriojs/dom-renderer.git"
@@ -395,12 +415,14 @@ packages:
     homepage_url: "https://github.com/FB55/domelementtype"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
-      hash: "bd28773e2642881aec51544924299c5cd822185b"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "bd28773e2642881aec51544924299c5cd822185b"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/FB55/domelementtype.git"
@@ -421,12 +443,14 @@ packages:
     homepage_url: "https://github.com/FB55/domelementtype"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
-      hash: "b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/FB55/domelementtype.git"
@@ -449,12 +473,14 @@ packages:
     homepage_url: "https://github.com/fb55/DomHandler#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz"
-      hash: "8805097e933d65e85546f726d60f5eb88b44f803"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "8805097e933d65e85546f726d60f5eb88b44f803"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/fb55/DomHandler.git"
@@ -475,12 +501,14 @@ packages:
     homepage_url: "https://github.com/FB55/domutils"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz"
-      hash: "dcd8488a26f563d61079e48c9f7b7e32373682cf"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "dcd8488a26f563d61079e48c9f7b7e32373682cf"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/FB55/domutils.git"
@@ -505,12 +533,14 @@ packages:
     homepage_url: "https://github.com/bevry/eachr"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/eachr/-/eachr-3.2.0.tgz"
-      hash: "2c35e43ea086516f7997cf80b7aa64d55a4a4484"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "2c35e43ea086516f7997cf80b7aa64d55a4a4484"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+ssh://git@github.com/bevry/eachr.git"
@@ -534,12 +564,14 @@ packages:
     homepage_url: "https://github.com/bevry/editions"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz"
-      hash: "3662cb592347c3168eb8e498a0ff73271d67f50b"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "3662cb592347c3168eb8e498a0ff73271d67f50b"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/bevry/editions.git"
@@ -562,12 +594,14 @@ packages:
     homepage_url: "https://github.com/fb55/node-entities"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
-      hash: "6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/fb55/node-entities.git"
@@ -590,12 +624,14 @@ packages:
     homepage_url: "https://github.com/bevry/extract-opts"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/extract-opts/-/extract-opts-3.3.1.tgz"
-      hash: "5abbedc98c0d5202e3278727f9192d7e086c6be1"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "5abbedc98c0d5202e3278727f9192d7e086c6be1"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+ssh://git@github.com/bevry/extract-opts.git"
@@ -618,12 +654,14 @@ packages:
     homepage_url: "https://github.com/isaacs/node-graceful-fs#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-      hash: "0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/isaacs/node-graceful-fs.git"
@@ -646,12 +684,14 @@ packages:
     homepage_url: "https://github.com/fb55/htmlparser2#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz"
-      hash: "1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/fb55/htmlparser2.git"
@@ -675,12 +715,14 @@ packages:
     homepage_url: "https://github.com/isaacs/inherits#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-      hash: "633c2c83e3da42a502f52466022480f4208261de"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "633c2c83e3da42a502f52466022480f4208261de"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/isaacs/inherits.git"
@@ -703,12 +745,14 @@ packages:
     homepage_url: "https://github.com/juliangruber/isarray"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-      hash: "bb935d48582cba168c06834957a54a3e07124f11"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "bb935d48582cba168c06834957a54a3e07124f11"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/juliangruber/isarray.git"
@@ -731,12 +775,14 @@ packages:
     homepage_url: "https://lodash.com/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz"
-      hash: "b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/lodash/lodash.git"
@@ -760,12 +806,14 @@ packages:
     homepage_url: "https://github.com/dcodeIO/long.js#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/long/-/long-3.2.0.tgz"
-      hash: "d821b7138ca1cb581c172990ef14db200b5c474b"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "d821b7138ca1cb581c172990ef14db200b5c474b"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/dcodeIO/long.js.git"
@@ -788,12 +836,14 @@ packages:
     homepage_url: "https://github.com/fb55/nth-check"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz"
-      hash: "9929acdf628fc2c41098deab82ac580cf149aae4"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "9929acdf628fc2c41098deab82ac580cf149aae4"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/fb55/nth-check"
@@ -817,12 +867,14 @@ packages:
     homepage_url: "https://github.com/inikulin/parse5"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz"
-      hash: "042f792ffdd36851551cf4e9e066b3874ab45b5c"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "042f792ffdd36851551cf4e9e066b3874ab45b5c"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/inikulin/parse5.git"
@@ -845,12 +897,14 @@ packages:
     homepage_url: "https://github.com/calvinmetcalf/process-nextick-args"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz"
-      hash: "a37d732f4271b4ab1ad070d35508e8290788ffaa"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "a37d732f4271b4ab1ad070d35508e8290788ffaa"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/calvinmetcalf/process-nextick-args.git"
@@ -873,12 +927,14 @@ packages:
     homepage_url: "https://github.com/then/promise#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz"
-      hash: "064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/then/promise.git"
@@ -901,12 +957,14 @@ packages:
     homepage_url: "https://github.com/nodejs/readable-stream#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz"
-      hash: "b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/nodejs/readable-stream.git"
@@ -929,12 +987,14 @@ packages:
     homepage_url: "https://github.com/bevry/requirefresh"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/requirefresh/-/requirefresh-2.1.0.tgz"
-      hash: "742dccc20f3a96918d66c6f1597dc8ffebc4f6f5"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "742dccc20f3a96918d66c6f1597dc8ffebc4f6f5"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+ssh://git@github.com/bevry/requirefresh.git"
@@ -957,12 +1017,14 @@ packages:
     homepage_url: "https://github.com/feross/safe-buffer"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
-      hash: "991ec69d296e0313747d59bdfd2b745c35f8828d"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "991ec69d296e0313747d59bdfd2b745c35f8828d"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/feross/safe-buffer.git"
@@ -986,12 +1048,14 @@ packages:
     homepage_url: "https://github.com/bevry/safefs"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/safefs/-/safefs-4.1.0.tgz"
-      hash: "f82aeb4bdd7ae51f653eb20f6728b3058c8d6445"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "f82aeb4bdd7ae51f653eb20f6728b3058c8d6445"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+ssh://git@github.com/bevry/safefs.git"
@@ -1014,12 +1078,14 @@ packages:
     homepage_url: "https://github.com/nodejs/string_decoder"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
-      hash: "9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/nodejs/string_decoder.git"
@@ -1043,12 +1109,14 @@ packages:
     homepage_url: "https://github.com/bevry/typechecker"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/typechecker/-/typechecker-4.5.0.tgz"
-      hash: "c382920097812364bbaf4595b0ab6588244117a6"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "c382920097812364bbaf4595b0ab6588244117a6"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/bevry/typechecker.git"
@@ -1071,12 +1139,14 @@ packages:
     homepage_url: "https://github.com/TooTallNate/util-deprecate"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-      hash: "450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/TooTallNate/util-deprecate.git"
@@ -1099,12 +1169,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/@types/node/-/node-10.5.8.tgz"
-      hash: "6f14ccecad1d19332f063a6a764f8907801fece0"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "6f14ccecad1d19332f063a6a764f8907801fece0"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/DefinitelyTyped/DefinitelyTyped.git"

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-version-urls-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-version-urls-expected-output.yml
@@ -618,12 +618,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/ansi-green"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz"
-      hash: "8a5d9a979e458d57c40e33580b37390b8e10d0f7"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "8a5d9a979e458d57c40e33580b37390b8e10d0f7"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/ansi-green.git"
@@ -646,12 +648,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/ansi-wrap"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
-      hash: "a82250ddb0015e9a27ca82e82ea603bbfa45efaf"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "a82250ddb0015e9a27ca82e82ea603bbfa45efaf"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/jonschlinkert/ansi-wrap.git"
@@ -675,12 +679,14 @@ packages:
     homepage_url: "https://github.com/nodeca/argparse"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz"
-      hash: "cfd01e0fbba3d6caed049fbd758d40f65196f57c"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "cfd01e0fbba3d6caed049fbd758d40f65196f57c"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/nodeca/argparse.git"
@@ -704,12 +710,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/arr-union"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz"
-      hash: "e39b09aea9def866a8f206e288af63919bae39c4"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "e39b09aea9def866a8f206e288af63919bae39c4"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/arr-union.git"
@@ -733,12 +741,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/array-each"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz"
-      hash: "a794af0c05ab1752846ee753a1f211a05ba0c44f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "a794af0c05ab1752846ee753a1f211a05ba0c44f"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/array-each.git"
@@ -762,12 +772,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/array-slice"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
-      hash: "dd3cfb80ed7973a75117cdac69b0b99ec86186f5"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "dd3cfb80ed7973a75117cdac69b0b99ec86186f5"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/jonschlinkert/array-slice.git"
@@ -793,12 +805,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/assign-symbols"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz"
-      hash: "59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/assign-symbols.git"
@@ -821,12 +835,14 @@ packages:
     homepage_url: "https://git.coolaj86.com/coolaj86/atob.js.git"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz"
-      hash: "6d9517eb9e030d2436666651e86bd9f6f13533c9"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "6d9517eb9e030d2436666651e86bd9f6f13533c9"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://git.coolaj86.com/coolaj86/atob.js.git"
@@ -850,12 +866,14 @@ packages:
     homepage_url: "https://github.com/gregjacobs/Autolinker.js"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/autolinker/-/autolinker-0.15.3.tgz"
-      hash: "342417d8f2f3461b14cf09088d5edf8791dc9832"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "342417d8f2f3461b14cf09088d5edf8791dc9832"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/gregjacobs/Autolinker.js.git"
@@ -878,12 +896,14 @@ packages:
     homepage_url: "https://github.com/juliangruber/balanced-match"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
-      hash: "89b4d199ab2bee49de164ea02b89ce462d71b767"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "89b4d199ab2bee49de164ea02b89ce462d71b767"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/juliangruber/balanced-match.git"
@@ -908,12 +928,14 @@ packages:
     homepage_url: "https://github.com/node-base/base"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/base/-/base-0.11.2.tgz"
-      hash: "7bde5ced145b6d551a90db87f83c558b4eb48a8f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "7bde5ced145b6d551a90db87f83c558b4eb48a8f"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/node-base/base.git"
@@ -936,12 +958,14 @@ packages:
     homepage_url: "https://github.com/juliangruber/brace-expansion"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz"
-      hash: "3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/juliangruber/brace-expansion.git"
@@ -964,12 +988,14 @@ packages:
     homepage_url: "https://github.com/kumavis/browser-stdout#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz"
-      hash: "baa559ee14ced73452229bad7326467c61fabd60"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "baa559ee14ced73452229bad7326467c61fabd60"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+ssh://git@github.com/kumavis/browser-stdout.git"
@@ -993,12 +1019,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/cache-base"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz"
-      hash: "0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/cache-base.git"
@@ -1021,12 +1049,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/class-utils"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz"
-      hash: "f93369ae8b9a7ce02fd41faad0ca83033190c463"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "f93369ae8b9a7ce02fd41faad0ca83033190c463"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/class-utils.git"
@@ -1049,12 +1079,14 @@ packages:
     homepage_url: "https://github.com/gulpjs/clone-buffer#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz"
-      hash: "e3e25b207ac4e701af721e2cb5a16792cac3dc58"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "e3e25b207ac4e701af721e2cb5a16792cac3dc58"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/gulpjs/clone-buffer.git"
@@ -1078,12 +1110,14 @@ packages:
     homepage_url: "https://github.com/hughsk/clone-stats"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz"
-      hash: "b3782dff8bb5474e18b9b6bf0fdfe782f8777680"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "b3782dff8bb5474e18b9b6bf0fdfe782f8777680"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/hughsk/clone-stats.git"
@@ -1106,12 +1140,14 @@ packages:
     homepage_url: "https://github.com/pvorb/node-clone#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz"
-      hash: "1b7f4b9f591f1e8f83670401600345a02887435f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "1b7f4b9f591f1e8f83670401600345a02887435f"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/pvorb/node-clone.git"
@@ -1134,12 +1170,14 @@ packages:
     homepage_url: "https://github.com/mcollina/cloneable-readable#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz"
-      hash: "d591dee4a8f8bc15da43ce97dceeba13d43e2a65"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "d591dee4a8f8bc15da43ce97dceeba13d43e2a65"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/mcollina/cloneable-readable.git"
@@ -1163,12 +1201,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/collection-visit"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz"
-      hash: "4bc0373c164bc3291b4d368c829cf1a80a59dca0"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "4bc0373c164bc3291b4d368c829cf1a80a59dca0"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/collection-visit.git"
@@ -1191,12 +1231,14 @@ packages:
     homepage_url: "https://github.com/tj/commander.js#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz"
-      hash: "df46e867d0fc2aec66a34662b406a9ccafff5b0f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "df46e867d0fc2aec66a34662b406a9ccafff5b0f"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/tj/commander.js.git"
@@ -1219,12 +1261,14 @@ packages:
     homepage_url: "https://github.com/component/emitter#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz"
-      hash: "16e4070fba8ae29b679f2215853ee181ab2eabc0"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "16e4070fba8ae29b679f2215853ee181ab2eabc0"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/component/emitter.git"
@@ -1247,12 +1291,14 @@ packages:
     homepage_url: "https://github.com/substack/node-concat-map"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-      hash: "d8a96bd77fd68df7793a73036a3ba0d5405d477b"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/substack/node-concat-map.git"
@@ -1275,12 +1321,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/copy-descriptor"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz"
-      hash: "676f6eb3c39997c2ee1ac3a924fd6124748f578d"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "676f6eb3c39997c2ee1ac3a924fd6124748f578d"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/copy-descriptor.git"
@@ -1303,12 +1351,14 @@ packages:
     homepage_url: "https://github.com/isaacs/core-util-is#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-      hash: "b5fd54220aa2bc5ab57aab7140c940754503c1a7"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/isaacs/core-util-is.git"
@@ -1331,12 +1381,14 @@ packages:
     homepage_url: "https://github.com/visionmedia/debug#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
-      hash: "5d128515df134ff327e90a4c93f4e077a536341f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "5d128515df134ff327e90a4c93f4e077a536341f"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/visionmedia/debug.git"
@@ -1359,12 +1411,14 @@ packages:
     homepage_url: "https://github.com/visionmedia/debug#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz"
-      hash: "5bb5a0672628b64149566ba16819e61518c67261"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "5bb5a0672628b64149566ba16819e61518c67261"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/visionmedia/debug.git"
@@ -1387,12 +1441,14 @@ packages:
     homepage_url: "https://github.com/samverschueren/decode-uri-component#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz"
-      hash: "eb3913333458775cb84cd1a1fae062106bb87545"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "eb3913333458775cb84cd1a1fae062106bb87545"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/samverschueren/decode-uri-component.git"
@@ -1415,12 +1471,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/define-property"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz"
-      hash: "c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/define-property.git"
@@ -1443,12 +1501,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/define-property"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz"
-      hash: "769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/define-property.git"
@@ -1472,12 +1532,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/define-property"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz"
-      hash: "d459689e8d654ba77e02a817f8710d702cb16e9d"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "d459689e8d654ba77e02a817f8710d702cb16e9d"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/define-property.git"
@@ -1500,12 +1562,14 @@ packages:
     homepage_url: "https://github.com/kpdecker/jsdiff#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz"
-      hash: "800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/kpdecker/jsdiff.git"
@@ -1528,12 +1592,14 @@ packages:
     homepage_url: "https://github.com/sindresorhus/escape-string-regexp"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-      hash: "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/sindresorhus/escape-string-regexp"
@@ -1557,12 +1623,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/expand-range"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz"
-      hash: "a299effd335fe2721ebae8e257ec79644fc85337"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "a299effd335fe2721ebae8e257ec79644fc85337"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/expand-range.git"
@@ -1585,12 +1653,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/expand-reflinks"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/expand-reflinks/-/expand-reflinks-0.2.1.tgz"
-      hash: "6d5e2199eb0ee3e6474e8edebe9a5c6c05a02a30"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "6d5e2199eb0ee3e6474e8edebe9a5c6c05a02a30"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/expand-reflinks.git"
@@ -1614,12 +1684,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/extend-shallow"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz"
-      hash: "51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/extend-shallow.git"
@@ -1643,12 +1715,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/extend-shallow"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz"
-      hash: "26a71aaf073b39fb2127172746131c2704028db8"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "26a71aaf073b39fb2127172746131c2704028db8"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/extend-shallow.git"
@@ -1672,12 +1746,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/fill-range"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz"
-      hash: "eb1e773abb056dcd8df2bfdf6af59b8b3a936565"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "eb1e773abb056dcd8df2bfdf6af59b8b3a936565"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/fill-range.git"
@@ -1702,12 +1778,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/for-in"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
-      hash: "81068d295a8142ec0ac726c6e2200c30fb6d5e80"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "81068d295a8142ec0ac726c6e2200c30fb6d5e80"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/for-in.git"
@@ -1732,12 +1810,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/fs-exists-sync"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz"
-      hash: "982d6893af918e72d08dec9e8673ff2b5a8d6add"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "982d6893af918e72d08dec9e8673ff2b5a8d6add"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/fs-exists-sync.git"
@@ -1761,12 +1841,14 @@ packages:
     homepage_url: "https://github.com/isaacs/fs.realpath#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
-      hash: "1504ad2523158caa40db4a2787cb01411994ea4f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "1504ad2523158caa40db4a2787cb01411994ea4f"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/isaacs/fs.realpath.git"
@@ -1789,12 +1871,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/get-value"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz"
-      hash: "dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/get-value.git"
@@ -1817,12 +1901,14 @@ packages:
     homepage_url: "https://github.com/regexhq/gfm-code-block-regex"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/gfm-code-block-regex/-/gfm-code-block-regex-1.0.0.tgz"
-      hash: "bb83c7d6284e6b5b72fa02198a58ac0d256215d2"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "bb83c7d6284e6b5b72fa02198a58ac0d256215d2"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/regexhq/gfm-code-block-regex.git"
@@ -1846,12 +1932,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/gfm-code-blocks"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/gfm-code-blocks/-/gfm-code-blocks-1.0.0.tgz"
-      hash: "614d21059b844c6bbc9d588c089b25c4e8bccf0d"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "614d21059b844c6bbc9d588c089b25c4e8bccf0d"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/gfm-code-blocks.git"
@@ -1874,12 +1962,14 @@ packages:
     homepage_url: "https://github.com/isaacs/node-glob#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
-      hash: "c19c9df9a028702d678612384a6552404c636d15"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "c19c9df9a028702d678612384a6552404c636d15"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/isaacs/node-glob.git"
@@ -1902,12 +1992,14 @@ packages:
     homepage_url: "https://github.com/tj/node-growl#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz"
-      hash: "f2735dc2283674fa67478b10181059355c369e5e"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "f2735dc2283674fa67478b10181059355c369e5e"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/tj/node-growl.git"
@@ -1930,12 +2022,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/gulp-format-md"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/gulp-format-md/-/gulp-format-md-1.0.0.tgz"
-      hash: "0a866365b5e118caef89cd449525d5477589da62"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "0a866365b5e118caef89cd449525d5477589da62"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/gulp-format-md.git"
@@ -1958,12 +2052,14 @@ packages:
     homepage_url: "https://github.com/sindresorhus/has-flag#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz"
-      hash: "b5d454dc2199ae225699f3467e5a07f3b955bafd"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "b5d454dc2199ae225699f3467e5a07f3b955bafd"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/sindresorhus/has-flag.git"
@@ -1987,12 +2083,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/has-value"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz"
-      hash: "7b1f58bada62ca827ec0a2078025654845995e1f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "7b1f58bada62ca827ec0a2078025654845995e1f"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/has-value.git"
@@ -2016,12 +2114,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/has-value"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz"
-      hash: "18b281da585b1c5c51def24c930ed29a0be6b177"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "18b281da585b1c5c51def24c930ed29a0be6b177"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/has-value.git"
@@ -2045,12 +2145,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/has-values"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz"
-      hash: "6d61de95d91dfca9b9a02089ad384bff8f62b771"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "6d61de95d91dfca9b9a02089ad384bff8f62b771"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/has-values.git"
@@ -2074,12 +2176,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/has-values"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz"
-      hash: "95b0b63fec2146619a6fe57fe75628d5a39efe4f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "95b0b63fec2146619a6fe57fe75628d5a39efe4f"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/has-values.git"
@@ -2102,12 +2206,14 @@ packages:
     homepage_url: "https://mths.be/he"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/he/-/he-1.1.1.tgz"
-      hash: "93410fd21b009735151f8868c2f271f3427e23fd"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "93410fd21b009735151f8868c2f271f3427e23fd"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/mathiasbynens/he.git"
@@ -2130,12 +2236,14 @@ packages:
     homepage_url: "https://github.com/isaacs/inflight"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
-      hash: "49bd6331d7d02d0c09bc910a1075ba8165b56df9"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/npm/inflight.git"
@@ -2159,12 +2267,14 @@ packages:
     homepage_url: "https://github.com/isaacs/inherits#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-      hash: "633c2c83e3da42a502f52466022480f4208261de"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "633c2c83e3da42a502f52466022480f4208261de"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/isaacs/inherits.git"
@@ -2188,12 +2298,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/is-accessor-descriptor"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz"
-      hash: "a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/is-accessor-descriptor.git"
@@ -2217,12 +2329,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/is-accessor-descriptor"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz"
-      hash: "169c2f6d3df1f992618072365c9b0ea1f6878656"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "169c2f6d3df1f992618072365c9b0ea1f6878656"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/is-accessor-descriptor.git"
@@ -2245,12 +2359,14 @@ packages:
     homepage_url: "https://github.com/feross/is-buffer#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
-      hash: "efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/feross/is-buffer.git"
@@ -2274,12 +2390,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/is-data-descriptor"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz"
-      hash: "0b5ee648388e2c860282e793f1856fec3f301b56"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "0b5ee648388e2c860282e793f1856fec3f301b56"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/is-data-descriptor.git"
@@ -2303,12 +2421,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/is-data-descriptor"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz"
-      hash: "d84876321d0e7add03990406abbbbd36ba9268c7"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "d84876321d0e7add03990406abbbbd36ba9268c7"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/is-data-descriptor.git"
@@ -2332,12 +2452,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/is-descriptor"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz"
-      hash: "366d8240dde487ca51823b1ab9f07a10a78251ca"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "366d8240dde487ca51823b1ab9f07a10a78251ca"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/is-descriptor.git"
@@ -2361,12 +2483,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/is-descriptor"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz"
-      hash: "3b159746a66604b04f8c81524ba365c5f14d86ec"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "3b159746a66604b04f8c81524ba365c5f14d86ec"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/is-descriptor.git"
@@ -2391,12 +2515,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/is-extendable"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
-      hash: "62b110e289a471418e3ec36a617d472e301dfc89"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "62b110e289a471418e3ec36a617d472e301dfc89"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/is-extendable.git"
@@ -2419,12 +2545,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/is-extendable"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz"
-      hash: "a7470f9e426733d81bd81e1155264e3a3507cab4"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "a7470f9e426733d81bd81e1155264e3a3507cab4"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/is-extendable.git"
@@ -2447,12 +2575,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/is-number"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
-      hash: "01fcbbb393463a548f2f466cce16dece49db908f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "01fcbbb393463a548f2f466cce16dece49db908f"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/is-number.git"
@@ -2475,12 +2605,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/is-number"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz"
-      hash: "24fd6201a4782cf50561c810276afc7d12d71195"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "24fd6201a4782cf50561c810276afc7d12d71195"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/is-number.git"
@@ -2503,12 +2635,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/is-number"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz"
-      hash: "0026e37f5454d73e356dfe6564699867c6a7f0ff"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "0026e37f5454d73e356dfe6564699867c6a7f0ff"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/is-number.git"
@@ -2531,12 +2665,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/is-plain-object"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz"
-      hash: "2c163b3fafb1b606d9d17928f05c2a1c38e07677"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "2c163b3fafb1b606d9d17928f05c2a1c38e07677"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/is-plain-object.git"
@@ -2559,12 +2695,14 @@ packages:
     homepage_url: "https://github.com/IonicaBizau/is-win#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/is-win/-/is-win-1.0.8.tgz"
-      hash: "298e654acce43b6c2935b526c23b2651babe7d8b"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "298e654acce43b6c2935b526c23b2651babe7d8b"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+ssh://git@github.com/IonicaBizau/is-win.git"
@@ -2588,12 +2726,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/is-windows"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz"
-      hash: "d1850eb9791ecd18e6182ce12a30f396634bb19d"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "d1850eb9791ecd18e6182ce12a30f396634bb19d"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/is-windows.git"
@@ -2616,12 +2756,14 @@ packages:
     homepage_url: "https://github.com/juliangruber/isarray"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-      hash: "bb935d48582cba168c06834957a54a3e07124f11"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "bb935d48582cba168c06834957a54a3e07124f11"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/juliangruber/isarray.git"
@@ -2644,12 +2786,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/isobject"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
-      hash: "f065561096a3f1da2ef46272f815c840d87e0c89"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "f065561096a3f1da2ef46272f815c840d87e0c89"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/isobject.git"
@@ -2672,12 +2816,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/isobject"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz"
-      hash: "4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/isobject.git"
@@ -2700,12 +2846,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/kind-of"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
-      hash: "31ea21a734bab9bbb0f32466d893aea51e4a3c64"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "31ea21a734bab9bbb0f32466d893aea51e4a3c64"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/kind-of.git"
@@ -2728,12 +2876,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/kind-of"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz"
-      hash: "20813df3d712928b207378691a45066fae72dd57"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "20813df3d712928b207378691a45066fae72dd57"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/kind-of.git"
@@ -2756,12 +2906,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/kind-of"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz"
-      hash: "729c91e2d857b7a419a1f9aa65685c4c33f5845d"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "729c91e2d857b7a419a1f9aa65685c4c33f5845d"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/kind-of.git"
@@ -2784,12 +2936,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/kind-of"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz"
-      hash: "01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/kind-of.git"
@@ -2812,12 +2966,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/lazy-cache"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz"
-      hash: "b9190a4f913354694840859f8a8f7084d8822264"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "b9190a4f913354694840859f8a8f7084d8822264"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/lazy-cache.git"
@@ -2841,12 +2997,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/list-item"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/list-item/-/list-item-1.1.1.tgz"
-      hash: "0c65d00e287cb663ccb3cb3849a77e89ec268a56"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "0c65d00e287cb663ccb3cb3849a77e89ec268a56"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/list-item.git"
@@ -2869,12 +3027,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/log-ok"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/log-ok/-/log-ok-0.1.1.tgz"
-      hash: "bea3dd36acd0b8a7240d78736b5b97c65444a334"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "bea3dd36acd0b8a7240d78736b5b97c65444a334"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/log-ok.git"
@@ -2897,12 +3057,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/map-cache"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz"
-      hash: "c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/map-cache.git"
@@ -2925,12 +3087,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/map-visit"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz"
-      hash: "ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/map-visit.git"
@@ -2953,12 +3117,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/markdown-utils"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/markdown-utils/-/markdown-utils-0.7.3.tgz"
-      hash: "4c583a31e251d69b313aceb3802a4f5d1b0f1e76"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "4c583a31e251d69b313aceb3802a4f5d1b0f1e76"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/markdown-utils.git"
@@ -2983,12 +3149,14 @@ packages:
     homepage_url: "https://github.com/michaelrhodes/math-random#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz"
-      hash: "5dd6943c938548267016d4e34f057583080c514c"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "5dd6943c938548267016d4e34f057583080c514c"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/michaelrhodes/math-random.git"
@@ -3011,12 +3179,14 @@ packages:
     homepage_url: "https://github.com/isaacs/minimatch#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
-      hash: "5166e286457f03306064be5497e8dbb0c3d32083"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "5166e286457f03306064be5497e8dbb0c3d32083"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/isaacs/minimatch.git"
@@ -3039,12 +3209,14 @@ packages:
     homepage_url: "https://github.com/substack/minimist"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-      hash: "857fcabfc3397d2625b8228262e86aa7a011b05d"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "857fcabfc3397d2625b8228262e86aa7a011b05d"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/substack/minimist.git"
@@ -3067,12 +3239,14 @@ packages:
     homepage_url: "https://github.com/substack/minimist"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-      hash: "a35008b20f41383eec1fb914f4cd5df79a264284"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "a35008b20f41383eec1fb914f4cd5df79a264284"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/substack/minimist.git"
@@ -3096,12 +3270,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/mixin-deep"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz"
-      hash: "a49e7268dce1a0d9698e45326c5626df3543d0fe"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "a49e7268dce1a0d9698e45326c5626df3543d0fe"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/mixin-deep.git"
@@ -3124,12 +3300,14 @@ packages:
     homepage_url: "https://github.com/substack/node-mkdirp#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
-      hash: "30057438eac6cf7f8c4767f38648d6697d75c903"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "30057438eac6cf7f8c4767f38648d6697d75c903"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/substack/node-mkdirp.git"
@@ -3152,12 +3330,14 @@ packages:
     homepage_url: "https://mochajs.org"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz"
-      hash: "6d8ae508f59167f940f2b5b3c4a612ae50c90ae6"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "6d8ae508f59167f940f2b5b3c4a612ae50c90ae6"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/mochajs/mocha.git"
@@ -3180,12 +3360,14 @@ packages:
     homepage_url: "https://github.com/zeit/ms#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-      hash: "5608aeadfc00be6c2901df5f9861788de0d597c8"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "5608aeadfc00be6c2901df5f9861788de0d597c8"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/zeit/ms.git"
@@ -3209,12 +3391,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/object-copy"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz"
-      hash: "7e7d858b781bd7c991a41ba975ed3812754e998c"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "7e7d858b781bd7c991a41ba975ed3812754e998c"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/object-copy.git"
@@ -3237,12 +3421,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/object-visit"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz"
-      hash: "f79c4493af0c5377b59fe39d395e41042dd045bb"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "f79c4493af0c5377b59fe39d395e41042dd045bb"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/object-visit.git"
@@ -3265,12 +3451,14 @@ packages:
     homepage_url: "https://github.com/isaacs/once#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
-      hash: "583b1aa775961d4b113ac17d9c50baef9dd76bd1"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/isaacs/once.git"
@@ -3293,12 +3481,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/pascalcase"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz"
-      hash: "b363e55e8006ca6fe21784d2db22bd15d7917f14"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "b363e55e8006ca6fe21784d2db22bd15d7917f14"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/pascalcase.git"
@@ -3321,12 +3511,14 @@ packages:
     homepage_url: "https://github.com/sindresorhus/path-is-absolute#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-      hash: "174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/sindresorhus/path-is-absolute.git"
@@ -3350,12 +3542,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/pretty-remarkable"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/pretty-remarkable/-/pretty-remarkable-0.4.1.tgz"
-      hash: "437b53c8a7d4c47a5933c01bb25982f840560201"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "437b53c8a7d4c47a5933c01bb25982f840560201"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/pretty-remarkable.git"
@@ -3378,12 +3572,14 @@ packages:
     homepage_url: "https://github.com/calvinmetcalf/process-nextick-args"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz"
-      hash: "a37d732f4271b4ab1ad070d35508e8290788ffaa"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "a37d732f4271b4ab1ad070d35508e8290788ffaa"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/calvinmetcalf/process-nextick-args.git"
@@ -3407,12 +3603,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/randomatic"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz"
-      hash: "b776efc59375984e36c537b2f51a1f0aff0da1ed"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "b776efc59375984e36c537b2f51a1f0aff0da1ed"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/randomatic.git"
@@ -3435,12 +3633,14 @@ packages:
     homepage_url: "https://github.com/nodejs/readable-stream#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz"
-      hash: "b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/nodejs/readable-stream.git"
@@ -3464,12 +3664,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/regex-not"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz"
-      hash: "1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/regex-not.git"
@@ -3493,12 +3695,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/remarkable"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/remarkable/-/remarkable-1.7.1.tgz"
-      hash: "aaca4972100b66a642a63a1021ca4bac1be3bff6"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "aaca4972100b66a642a63a1021ca4bac1be3bff6"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/remarkable.git"
@@ -3521,12 +3725,14 @@ packages:
     homepage_url: "https://github.com/darsain/remove-trailing-separator#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz"
-      hash: "c24bce2a283adad5bc3f58e0d48249b92379d8ef"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "c24bce2a283adad5bc3f58e0d48249b92379d8ef"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/darsain/remove-trailing-separator.git"
@@ -3549,12 +3755,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/repeat-element"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz"
-      hash: "782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/repeat-element.git"
@@ -3578,12 +3786,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/repeat-string"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
-      hash: "8dcae470e1c88abc2d600fff4a776286da75e637"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "8dcae470e1c88abc2d600fff4a776286da75e637"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/repeat-string.git"
@@ -3606,12 +3816,14 @@ packages:
     homepage_url: "https://github.com/gulpjs/replace-ext#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz"
-      hash: "de63128373fcbf7c3ccfa4de5a480c45a67958eb"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "de63128373fcbf7c3ccfa4de5a480c45a67958eb"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/gulpjs/replace-ext.git"
@@ -3634,12 +3846,14 @@ packages:
     homepage_url: "https://github.com/lydell/resolve-url"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz"
-      hash: "2c637fe77c893afd2a663fe21aa9080068e2052a"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "2c637fe77c893afd2a663fe21aa9080068e2052a"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/lydell/resolve-url"
@@ -3662,12 +3876,14 @@ packages:
     homepage_url: "https://github.com/fent/ret.js#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz"
-      hash: "b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/fent/ret.js.git"
@@ -3690,12 +3906,14 @@ packages:
     homepage_url: "https://github.com/feross/safe-buffer"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
-      hash: "991ec69d296e0313747d59bdfd2b745c35f8828d"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "991ec69d296e0313747d59bdfd2b745c35f8828d"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/feross/safe-buffer.git"
@@ -3718,12 +3936,14 @@ packages:
     homepage_url: "https://github.com/substack/safe-regex"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz"
-      hash: "40a3669f3b077d1e943d44629e157dd48023bf2e"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "40a3669f3b077d1e943d44629e157dd48023bf2e"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/substack/safe-regex.git"
@@ -3747,12 +3967,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/sections"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/sections/-/sections-1.0.0.tgz"
-      hash: "db657f5a478b45d2a046d045c1aa792eb823c2c1"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "db657f5a478b45d2a046d045c1aa792eb823c2c1"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/sections.git"
@@ -3776,12 +3998,14 @@ packages:
     homepage_url: "https://github.com/doowb/set-getter"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz"
-      hash: "d769c182c9d5a51f409145f2fba82e5e86e80376"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "d769c182c9d5a51f409145f2fba82e5e86e80376"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/doowb/set-getter.git"
@@ -3805,12 +4029,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/set-value"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz"
-      hash: "7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/set-value.git"
@@ -3834,12 +4060,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/set-value"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz"
-      hash: "71ae4a88f0feefbbf52d1ea604f3fb315ebb6274"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "71ae4a88f0feefbbf52d1ea604f3fb315ebb6274"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/set-value.git"
@@ -3863,12 +4091,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/snapdragon-node"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-1.0.6.tgz"
-      hash: "2448d5ef6fea7f5e8fd5326a0a114854da271356"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "2448d5ef6fea7f5e8fd5326a0a114854da271356"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/snapdragon-node.git"
@@ -3891,12 +4121,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/snapdragon-util"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-1.0.6.tgz"
-      hash: "8b3d2d6dec8930c90e054ba052e562ca1b3a621e"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "8b3d2d6dec8930c90e054ba052e562ca1b3a621e"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/snapdragon-util.git"
@@ -3919,12 +4151,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/snapdragon-util"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-2.1.1.tgz"
-      hash: "552779df8a1493a0e78c06cc80953a262770957a"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "552779df8a1493a0e78c06cc80953a262770957a"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/snapdragon-util.git"
@@ -3948,12 +4182,14 @@ packages:
     homepage_url: "https://github.com/here-be/snapdragon"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/snapdragon/-/snapdragon-0.11.5.tgz"
-      hash: "522812d175f24f919629fd37406b02e434e645e6"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "522812d175f24f919629fd37406b02e434e645e6"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/here-be/snapdragon.git"
@@ -3976,12 +4212,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/snapdragon"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz"
-      hash: "64922e7c565b0e14204ba1aa7d6964278d25182d"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "64922e7c565b0e14204ba1aa7d6964278d25182d"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/snapdragon.git"
@@ -4005,12 +4243,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/sort-by-value"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/sort-by-value/-/sort-by-value-0.1.0.tgz"
-      hash: "d07598927d43d425e51ffa3f6c0b91b708576ba7"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "d07598927d43d425e51ffa3f6c0b91b708576ba7"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/sort-by-value.git"
@@ -4033,12 +4273,14 @@ packages:
     homepage_url: "https://github.com/lydell/source-map-resolve#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz"
-      hash: "72e2cc34095543e43b2c62b2c4c10d4a9054f259"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "72e2cc34095543e43b2c62b2c4c10d4a9054f259"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/lydell/source-map-resolve.git"
@@ -4061,12 +4303,14 @@ packages:
     homepage_url: "https://github.com/lydell/source-map-url#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz"
-      hash: "3e935d7ddd73631b97659956d55128e87b5084a3"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "3e935d7ddd73631b97659956d55128e87b5084a3"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/lydell/source-map-url.git"
@@ -4089,12 +4333,14 @@ packages:
     homepage_url: "https://github.com/mozilla/source-map"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
-      hash: "8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+ssh://git@github.com/mozilla/source-map.git"
@@ -4117,12 +4363,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/split-string"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz"
-      hash: "7cb09dda3a86585705c64b39a6466038682e8fe2"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "7cb09dda3a86585705c64b39a6466038682e8fe2"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/split-string.git"
@@ -4147,12 +4395,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/static-extend"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz"
-      hash: "60809c39cbff55337226fd5e0b520f341f1fb5c6"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "60809c39cbff55337226fd5e0b520f341f1fb5c6"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/static-extend.git"
@@ -4175,12 +4425,14 @@ packages:
     homepage_url: "https://github.com/nodejs/string_decoder"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
-      hash: "9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/nodejs/string_decoder.git"
@@ -4203,12 +4455,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/success-symbol"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz"
-      hash: "24022e486f3bf1cdca094283b769c472d3b72897"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "24022e486f3bf1cdca094283b769c472d3b72897"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/jonschlinkert/success-symbol"
@@ -4231,12 +4485,14 @@ packages:
     homepage_url: "https://github.com/chalk/supports-color#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz"
-      hash: "1c6b337402c2137605efe19f10fec390f6faab54"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "1c6b337402c2137605efe19f10fec390f6faab54"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/chalk/supports-color.git"
@@ -4260,12 +4516,14 @@ packages:
     homepage_url: "https://github.com/rvagg/through2#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz"
-      hash: "01c1e39eb31d07cb7d03a96a70823260b23132cd"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "01c1e39eb31d07cb7d03a96a70823260b23132cd"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/rvagg/through2.git"
@@ -4288,12 +4546,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/to-gfm-code-block"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/to-gfm-code-block/-/to-gfm-code-block-0.1.1.tgz"
-      hash: "25d045a5fae553189e9637b590900da732d8aa82"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "25d045a5fae553189e9637b590900da732d8aa82"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/jonschlinkert/to-gfm-code-block.git"
@@ -4316,12 +4576,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/to-object-path"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz"
-      hash: "297588b7b0e7e0ac08e04e672f85c1f4999e17af"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "297588b7b0e7e0ac08e04e672f85c1f4999e17af"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/to-object-path.git"
@@ -4344,12 +4606,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/to-regex"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz"
-      hash: "13cfdd9b336552f30b51f33a8ae1b42a7a7599ce"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "13cfdd9b336552f30b51f33a8ae1b42a7a7599ce"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/to-regex.git"
@@ -4374,12 +4638,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/tokenize-comment"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/tokenize-comment/-/tokenize-comment-1.0.3.tgz"
-      hash: "c6ef8833ce64b7c7797d161eec3bc51f6049eda5"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "c6ef8833ce64b7c7797d161eec3bc51f6049eda5"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/tokenize-comment.git"
@@ -4402,12 +4668,14 @@ packages:
     homepage_url: "http://epeli.github.com/underscore.string/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
-      hash: "8cdd8fbac4e2d2ea1e7e2e8097c42f442280f85b"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "8cdd8fbac4e2d2ea1e7e2e8097c42f442280f85b"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/epeli/underscore.string.git"
@@ -4430,12 +4698,14 @@ packages:
     homepage_url: "http://underscorejs.org"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
-      hash: "6bbaf0877500d36be34ecaa584e0db9fef035209"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "6bbaf0877500d36be34ecaa584e0db9fef035209"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/jashkenas/underscore.git"
@@ -4459,12 +4729,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/union-value"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz"
-      hash: "5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/union-value.git"
@@ -4487,12 +4759,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/unset-value"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz"
-      hash: "8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/unset-value.git"
@@ -4515,12 +4789,14 @@ packages:
     homepage_url: "https://github.com/lydell/urix"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz"
-      hash: "da937f7a62e21fec1fd18d49b35c2935067a6c72"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "da937f7a62e21fec1fd18d49b35c2935067a6c72"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/lydell/urix"
@@ -4543,12 +4819,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/use"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/use/-/use-3.1.1.tgz"
-      hash: "d50c8cac79a19fbc20f2911f56eb973f4e10070f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "d50c8cac79a19fbc20f2911f56eb973f4e10070f"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/use.git"
@@ -4571,12 +4849,14 @@ packages:
     homepage_url: "https://github.com/TooTallNate/util-deprecate"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-      hash: "450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/TooTallNate/util-deprecate.git"
@@ -4599,12 +4879,14 @@ packages:
     homepage_url: "https://github.com/gulpjs/vinyl#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz"
-      hash: "d85b07da96e458d25b2ffe19fece9f2caa13ed86"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "d85b07da96e458d25b2ffe19fece9f2caa13ed86"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/gulpjs/vinyl.git"
@@ -4627,12 +4909,14 @@ packages:
     homepage_url: "https://github.com/npm/wrappy"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-      hash: "b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/npm/wrappy.git"
@@ -4656,12 +4940,14 @@ packages:
     homepage_url: "https://github.com/jonschlinkert/write"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/write/-/write-0.3.3.tgz"
-      hash: "09cdc5a2155607ee279f45e38d91ae29fb6a5178"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "09cdc5a2155607ee279f45e38d91ae29fb6a5178"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/jonschlinkert/write.git"
@@ -4684,12 +4970,14 @@ packages:
     homepage_url: "https://github.com/Raynos/xtend"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-      hash: "a5c6d532be656e23db820efb943a1f04998d63af"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "a5c6d532be656e23db820efb943a1f04998d63af"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/Raynos/xtend.git"

--- a/analyzer/src/funTest/assets/projects/synthetic/nuget-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/nuget-expected-output.yml
@@ -36,12 +36,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: "https://api.nuget.org/v3-flatcontainer/antlr/3.4.1.9004/antlr.3.4.1.9004.nupkg"
-      hash: "b7846aa81ff2bd21d4f2892bc924b52f629a68fb003820ccf0d3db88ecbc389c3fa223488e35334b98a021525db349b993902663219657d8c156915072af37d3"
-      hash_algorithm: "SHA-512"
+      hash:
+        value: "b7846aa81ff2bd21d4f2892bc924b52f629a68fb003820ccf0d3db88ecbc389c3fa223488e35334b98a021525db349b993902663219657d8c156915072af37d3"
+        algorithm: "SHA-512"
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -65,12 +67,14 @@ packages:
     homepage_url: "http://james.newtonking.com/projects/json-net.aspx"
     binary_artifact:
       url: "https://api.nuget.org/v3-flatcontainer/newtonsoft.json/5.0.4/newtonsoft.json.5.0.4.nupkg"
-      hash: "760d9348be5813285b8ad38795a2a5afe788bcddab4f7190ed581c6ea524c0d67a7dd5bdd5384f197e3b5a58c070ab5bdb704493cc8e0ad63ab35f753b6d61bf"
-      hash_algorithm: "SHA-512"
+      hash:
+        value: "760d9348be5813285b8ad38795a2a5afe788bcddab4f7190ed581c6ea524c0d67a7dd5bdd5384f197e3b5a58c070ab5bdb704493cc8e0ad63ab35f753b6d61bf"
+        algorithm: "SHA-512"
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -95,12 +99,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: "https://api.nuget.org/v3-flatcontainer/webgrease/1.5.2/webgrease.1.5.2.nupkg"
-      hash: "453fa7a3483b424dbc27f5d5c07827e6527faa6e21c96169ef0b7423bd54c348f749f4df3a636a3ccc5f79d1da9c08ed7f7741dbfd0a8d0ddf424bd57b0b2fb0"
-      hash_algorithm: "SHA-512"
+      hash:
+        value: "453fa7a3483b424dbc27f5d5c07827e6527faa6e21c96169ef0b7423bd54c348f749f4df3a636a3ccc5f79d1da9c08ed7f7741dbfd0a8d0ddf424bd57b0b2fb0"
+        algorithm: "SHA-512"
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -129,12 +135,14 @@ packages:
     homepage_url: "http://jquery.com/"
     binary_artifact:
       url: "https://api.nuget.org/v3-flatcontainer/jquery/3.3.1/jquery.3.3.1.nupkg"
-      hash: "126b2db350fa1360201d5066e1c4c3d9dc684725951bedf32b5c7c9986dffa4e9a000acf4d71d1d88a7efa8d6eb6535b99823368f167846c376037b1a7c3e395"
-      hash_algorithm: "SHA-512"
+      hash:
+        value: "126b2db350fa1360201d5066e1c4c3d9dc684725951bedf32b5c7c9986dffa4e9a000acf4d71d1d88a7efa8d6eb6535b99823368f167846c376037b1a7c3e395"
+        algorithm: "SHA-512"
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/php-composer-expected-output-with-provide.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/php-composer-expected-output-with-provide.yml
@@ -36,12 +36,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "composer.phar"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -62,12 +64,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "composer.phar"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/php-composer-expected-output-with-replace.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/php-composer-expected-output-with-replace.yml
@@ -36,12 +36,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "composer.phar"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""
@@ -62,12 +64,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "composer.phar"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/php-composer-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/php-composer-expected-output.yml
@@ -141,12 +141,14 @@ packages:
     homepage_url: "https://github.com/clue/php-stream-filter"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/clue/php-stream-filter/zipball/d80fdee9b3a7e0d16fc330a22f41f3ad0eeb09d0"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/clue/php-stream-filter.git"
@@ -170,12 +172,14 @@ packages:
     homepage_url: "https://github.com/doctrine/instantiator"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/doctrine/instantiator/zipball/185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/doctrine/instantiator.git"
@@ -198,12 +202,14 @@ packages:
     homepage_url: "http://guzzlephp.org/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/guzzle/guzzle/zipball/f4db5a78a5ea468d4831de7f0bf9d9415e348699"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/guzzle/guzzle.git"
@@ -226,12 +232,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/guzzle/promises/zipball/a59da6cf61d80060647ff4d3eb2c03a2bc694646"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/guzzle/promises.git"
@@ -254,12 +262,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/guzzle/psr7/zipball/04a6d1a00ea5da0727ee94309a9f0d3dbaecb569"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/guzzle/psr7.git"
@@ -282,12 +292,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/mailgun/mailgun-php/zipball/20783215042b181b0dec92c9e01947b93cb5d085"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/mailgun/mailgun-php.git"
@@ -310,12 +322,14 @@ packages:
     homepage_url: "http://github.com/Seldaek/monolog"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/Seldaek/monolog/zipball/b704c49a3051536f67f2d39f13568f74615b9922"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/Seldaek/monolog.git"
@@ -338,12 +352,14 @@ packages:
     homepage_url: "http://httplug.io"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/php-http/client-common/zipball/9accb4a082eb06403747c0ffd444112eda41a0fd"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/php-http/client-common.git"
@@ -366,12 +382,14 @@ packages:
     homepage_url: "http://php-http.org"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/php-http/discovery/zipball/7b50ab4d6c9fdaa1ed53ae310c955900af6e3372"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/php-http/discovery.git"
@@ -394,12 +412,14 @@ packages:
     homepage_url: "http://httplug.io"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/php-http/guzzle6-adapter/zipball/e884cf6dae5235fffd2a07f761e0066b9ebef170"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/php-http/guzzle6-adapter.git"
@@ -422,12 +442,14 @@ packages:
     homepage_url: "http://httplug.io"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/php-http/httplug/zipball/1c6381726c18579c4ca2ef1ec1498fdae8bdf018"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/php-http/httplug.git"
@@ -450,12 +472,14 @@ packages:
     homepage_url: "http://php-http.org"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/php-http/message-factory/zipball/a478cb11f66a6ac48d8954216cfed9aa06a501a1"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/php-http/message-factory.git"
@@ -478,12 +502,14 @@ packages:
     homepage_url: "http://php-http.org"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/php-http/message/zipball/2edd63bae5f52f79363c5f18904b05ce3a4b7253"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/php-http/message.git"
@@ -506,12 +532,14 @@ packages:
     homepage_url: "http://php-http.org"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/php-http/multipart-stream-builder/zipball/1fa3c623fc813a43b39494b2a1612174e36e0fb0"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/php-http/multipart-stream-builder.git"
@@ -534,12 +562,14 @@ packages:
     homepage_url: "http://httplug.io"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/php-http/promise/zipball/dc494cdc9d7160b9a09bd5573272195242ce7980"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/php-http/promise.git"
@@ -563,12 +593,14 @@ packages:
     homepage_url: "http://www.phpdoc.org"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/phpDocumentor/ReflectionCommon.git"
@@ -592,12 +624,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/66465776cfc249844bde6d117abff1d22e06c2da"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/phpDocumentor/ReflectionDocBlock.git"
@@ -620,12 +654,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/phpDocumentor/TypeResolver.git"
@@ -648,12 +684,14 @@ packages:
     homepage_url: "https://github.com/phpspec/prophecy"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/phpspec/prophecy/zipball/e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/phpspec/prophecy.git"
@@ -677,12 +715,14 @@ packages:
     homepage_url: "https://github.com/sebastianbergmann/php-code-coverage"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/eabf68b476ac7d0f73793aada060f1c1a9bf8979"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/sebastianbergmann/php-code-coverage.git"
@@ -706,12 +746,14 @@ packages:
     homepage_url: "https://github.com/sebastianbergmann/php-file-iterator/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/sebastianbergmann/php-file-iterator.git"
@@ -734,12 +776,14 @@ packages:
     homepage_url: "https://github.com/sebastianbergmann/php-text-template/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/sebastianbergmann/php-text-template.git"
@@ -762,12 +806,14 @@ packages:
     homepage_url: "https://github.com/sebastianbergmann/php-timer/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/sebastianbergmann/php-timer.git"
@@ -790,12 +836,14 @@ packages:
     homepage_url: "https://github.com/sebastianbergmann/php-token-stream/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/1ce90ba27c42e4e44e6d8458241466380b51fa16"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/sebastianbergmann/php-token-stream.git"
@@ -818,12 +866,14 @@ packages:
     homepage_url: "https://github.com/sebastianbergmann/phpunit-mock-objects/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/ac8e7a3db35738d56ee9a76e78a4e03d97628983"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/sebastianbergmann/phpunit-mock-objects.git"
@@ -846,12 +896,14 @@ packages:
     homepage_url: "https://phpunit.de/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/283111a903eb9225aedb95e846bef876e006a688"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/sebastianbergmann/phpunit.git"
@@ -874,12 +926,14 @@ packages:
     homepage_url: "https://github.com/php-fig/http-message"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/php-fig/http-message.git"
@@ -902,12 +956,14 @@ packages:
     homepage_url: "http://www.github.com/sebastianbergmann/comparator"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/sebastianbergmann/comparator.git"
@@ -930,12 +986,14 @@ packages:
     homepage_url: "https://github.com/sebastianbergmann/diff"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/sebastianbergmann/diff.git"
@@ -958,12 +1016,14 @@ packages:
     homepage_url: "http://www.github.com/sebastianbergmann/environment"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/sebastianbergmann/environment.git"
@@ -986,12 +1046,14 @@ packages:
     homepage_url: "http://www.github.com/sebastianbergmann/exporter"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/sebastianbergmann/exporter.git"
@@ -1014,12 +1076,14 @@ packages:
     homepage_url: "http://www.github.com/sebastianbergmann/global-state"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/sebastianbergmann/global-state.git"
@@ -1042,12 +1106,14 @@ packages:
     homepage_url: "http://www.github.com/sebastianbergmann/recursion-context"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/b19cc3298482a335a95f3016d2f8a6950f0fbcd7"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/sebastianbergmann/recursion-context.git"
@@ -1071,12 +1137,14 @@ packages:
     homepage_url: "https://github.com/sebastianbergmann/version"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/sebastianbergmann/version.git"
@@ -1099,12 +1167,14 @@ packages:
     homepage_url: "https://symfony.com"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/symfony/options-resolver/zipball/75fdda335eb0adbd464089e8a0184c61097808e0"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/symfony/options-resolver.git"
@@ -1127,12 +1197,14 @@ packages:
     homepage_url: "https://symfony.com"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/symfony/yaml/zipball/afe0cd38486505c9703707707d91450cfc1bd536"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/symfony/yaml.git"
@@ -1155,12 +1227,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f"
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: "git"
       url: "https://github.com/webmozart/assert.git"

--- a/analyzer/src/funTest/assets/projects/synthetic/pip-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pip-expected-output.yml
@@ -41,12 +41,14 @@ packages:
     homepage_url: "http://github.com/pallets/flask/"
     binary_artifact:
       url: "https://files.pythonhosted.org/packages/2e/48/f1936dadac2326b3d73f2fe0a964a87d16be16eb9d7fc56f09c1bea3d17c/Flask-0.12.4-py2.py3-none-any.whl"
-      hash: "3b498df2add69ee16b228e8bdd581bce"
-      hash_algorithm: "MD5"
+      hash:
+        value: "3b498df2add69ee16b228e8bdd581bce"
+        algorithm: "MD5"
     source_artifact:
       url: "https://files.pythonhosted.org/packages/1b/72/ffc594a6832337ace475f939e61c34a44cbb150cde9589f98c482b407dd8/Flask-0.12.4.tar.gz"
-      hash: "f885afe6dd25e8d48d5ba23f2857687e"
-      hash_algorithm: "MD5"
+      hash:
+        value: "f885afe6dd25e8d48d5ba23f2857687e"
+        algorithm: "MD5"
     vcs:
       type: ""
       url: ""
@@ -70,12 +72,14 @@ packages:
     homepage_url: "http://jinja.pocoo.org/"
     binary_artifact:
       url: "https://files.pythonhosted.org/packages/1d/e7/fd8b501e7a6dfe492a433deb7b9d833d39ca74916fa8bc63dd1a4947a671/Jinja2-2.10.1-py2.py3-none-any.whl"
-      hash: "93ca8152bf9ca03214158a49d542402f"
-      hash_algorithm: "MD5"
+      hash:
+        value: "93ca8152bf9ca03214158a49d542402f"
+        algorithm: "MD5"
     source_artifact:
       url: "https://files.pythonhosted.org/packages/93/ea/d884a06f8c7f9b7afbc8138b762e80479fb17aedbbe2b06515a12de9378d/Jinja2-2.10.1.tar.gz"
-      hash: "0ae535be40fd215a8114a090c8b68e5a"
-      hash_algorithm: "MD5"
+      hash:
+        value: "0ae535be40fd215a8114a090c8b68e5a"
+        algorithm: "MD5"
     vcs:
       type: ""
       url: ""
@@ -98,12 +102,14 @@ packages:
     homepage_url: "http://github.com/pallets/markupsafe"
     binary_artifact:
       url: "https://files.pythonhosted.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-1.0.tar.gz"
-      hash: "2fcedc9284d50e577b5192e8e3578355"
-      hash_algorithm: "MD5"
+      hash:
+        value: "2fcedc9284d50e577b5192e8e3578355"
+        algorithm: "MD5"
     source_artifact:
       url: "https://files.pythonhosted.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-1.0.tar.gz"
-      hash: "2fcedc9284d50e577b5192e8e3578355"
-      hash_algorithm: "MD5"
+      hash:
+        value: "2fcedc9284d50e577b5192e8e3578355"
+        algorithm: "MD5"
     vcs:
       type: ""
       url: ""
@@ -126,12 +132,14 @@ packages:
     homepage_url: "https://www.palletsprojects.org/p/werkzeug/"
     binary_artifact:
       url: "https://files.pythonhosted.org/packages/20/c4/12e3e56473e52375aa29c4764e70d1b8f3efa6682bef8d0aae04fe335243/Werkzeug-0.14.1-py2.py3-none-any.whl"
-      hash: "11f469d64429cc75f995cf6be5662133"
-      hash_algorithm: "MD5"
+      hash:
+        value: "11f469d64429cc75f995cf6be5662133"
+        algorithm: "MD5"
     source_artifact:
       url: "https://files.pythonhosted.org/packages/9f/08/a3bb1c045ec602dc680906fc0261c267bed6b3bb4609430aff92c3888ec8/Werkzeug-0.14.1.tar.gz"
-      hash: "6d20b5be2d245be4ac7706cc390d130c"
-      hash_algorithm: "MD5"
+      hash:
+        value: "6d20b5be2d245be4ac7706cc390d130c"
+        algorithm: "MD5"
     vcs:
       type: ""
       url: ""
@@ -154,12 +162,14 @@ packages:
     homepage_url: "http://github.com/mitsuhiko/click"
     binary_artifact:
       url: "https://files.pythonhosted.org/packages/34/c1/8806f99713ddb993c5366c362b2f908f18269f8d792aff1abfd700775a77/click-6.7-py2.py3-none-any.whl"
-      hash: "5e7a4e296b3212da2ff11017675d7a4d"
-      hash_algorithm: "MD5"
+      hash:
+        value: "5e7a4e296b3212da2ff11017675d7a4d"
+        algorithm: "MD5"
     source_artifact:
       url: "https://files.pythonhosted.org/packages/95/d9/c3336b6b5711c3ab9d1d3a80f1a3e2afeb9d8c02a7166462f6cc96570897/click-6.7.tar.gz"
-      hash: "fc4cc00c4863833230d3af92af48abd4"
-      hash_algorithm: "MD5"
+      hash:
+        value: "fc4cc00c4863833230d3af92af48abd4"
+        algorithm: "MD5"
     vcs:
       type: ""
       url: ""
@@ -183,12 +193,14 @@ packages:
     homepage_url: "http://github.com/mitsuhiko/itsdangerous"
     binary_artifact:
       url: "https://files.pythonhosted.org/packages/dc/b4/a60bcdba945c00f6d608d8975131ab3f25b22f2bcfe1dab221165194b2d4/itsdangerous-0.24.tar.gz"
-      hash: "a3d55aa79369aef5345c036a8a26307f"
-      hash_algorithm: "MD5"
+      hash:
+        value: "a3d55aa79369aef5345c036a8a26307f"
+        algorithm: "MD5"
     source_artifact:
       url: "https://files.pythonhosted.org/packages/dc/b4/a60bcdba945c00f6d608d8975131ab3f25b22f2bcfe1dab221165194b2d4/itsdangerous-0.24.tar.gz"
-      hash: "a3d55aa79369aef5345c036a8a26307f"
-      hash_algorithm: "MD5"
+      hash:
+        value: "a3d55aa79369aef5345c036a8a26307f"
+        algorithm: "MD5"
     vcs:
       type: ""
       url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/python3-django-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/python3-django-expected-output.yml
@@ -35,12 +35,14 @@ packages:
     homepage_url: "https://www.djangoproject.com/"
     binary_artifact:
       url: "https://files.pythonhosted.org/packages/a9/e4/fb8f473fe8ee659859cb712e25222243bbd55ece7c319301eeb60ccddc46/Django-2.1.8-py3-none-any.whl"
-      hash: "22ad9bd7cba46295a3d88473e37418d9"
-      hash_algorithm: "MD5"
+      hash:
+        value: "22ad9bd7cba46295a3d88473e37418d9"
+        algorithm: "MD5"
     source_artifact:
       url: "https://files.pythonhosted.org/packages/78/a0/c82585ddba004f99d19eeee277bc1b9e3b5e55d883e60ed713c0a4c9e3e8/Django-2.1.8.tar.gz"
-      hash: "e4492251be65fda35c6bc0c6ea03fd1a"
-      hash_algorithm: "MD5"
+      hash:
+        value: "e4492251be65fda35c6bc0c6ea03fd1a"
+        algorithm: "MD5"
     vcs:
       type: ""
       url: ""
@@ -63,12 +65,14 @@ packages:
     homepage_url: "http://pythonhosted.org/pytz"
     binary_artifact:
       url: "https://files.pythonhosted.org/packages/3d/73/fe30c2daaaa0713420d0382b16fbb761409f532c56bdcc514bf7b6262bb6/pytz-2019.1-py2.py3-none-any.whl"
-      hash: "9494cbd701404080e83cbb316e692891"
-      hash_algorithm: "MD5"
+      hash:
+        value: "9494cbd701404080e83cbb316e692891"
+        algorithm: "MD5"
     source_artifact:
       url: "https://files.pythonhosted.org/packages/df/d5/3e3ff673e8f3096921b3f1b79ce04b832e0100b4741573154b72b756a681/pytz-2019.1.tar.gz"
-      hash: "8b2860a161bfb0a6165798b1a2d8c40c"
-      hash_algorithm: "MD5"
+      hash:
+        value: "8b2860a161bfb0a6165798b1a2d8c40c"
+        algorithm: "MD5"
     vcs:
       type: ""
       url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/yarn-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/yarn-expected-output.yml
@@ -115,12 +115,14 @@ packages:
     homepage_url: "https://github.com/kriskowal/asap#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz"
-      hash: "522765b50c3510490e52d7dcfe085ef9ba96958f"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "522765b50c3510490e52d7dcfe085ef9ba96958f"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/kriskowal/asap.git"
@@ -143,12 +145,14 @@ packages:
     homepage_url: "https://github.com/fb55/boolbase"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
-      hash: "68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/fb55/boolbase"
@@ -172,12 +176,14 @@ packages:
     homepage_url: "https://github.com/cheeriojs/cheerio#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.1.tgz"
-      hash: "2af37339eab713ef6b72cde98cefa672b87641fe"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "2af37339eab713ef6b72cde98cefa672b87641fe"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/cheeriojs/cheerio.git"
@@ -200,12 +206,14 @@ packages:
     homepage_url: "http://coffeescript.org"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.6.tgz"
-      hash: "285a3f7115689065064d6bf9ef4572db66695cbf"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "285a3f7115689065064d6bf9ef4572db66695cbf"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/jashkenas/coffeescript.git"
@@ -228,12 +236,14 @@ packages:
     homepage_url: "https://github.com/isaacs/core-util-is#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-      hash: "b5fd54220aa2bc5ab57aab7140c940754503c1a7"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/isaacs/core-util-is.git"
@@ -256,12 +266,14 @@ packages:
     homepage_url: "https://github.com/groupon/cson-parser"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/cson-parser/-/cson-parser-1.3.5.tgz"
-      hash: "7ec675e039145533bf2a6a856073f1599d9c2d24"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "7ec675e039145533bf2a6a856073f1599d9c2d24"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+ssh://git@github.com/groupon/cson-parser.git"
@@ -285,12 +297,14 @@ packages:
     homepage_url: "https://github.com/bevry/cson"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/cson/-/cson-4.1.0.tgz"
-      hash: "b1075344fa9d9fe5cf88d80f21d9366296b865c7"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "b1075344fa9d9fe5cf88d80f21d9366296b865c7"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/bevry/cson.git"
@@ -313,12 +327,14 @@ packages:
     homepage_url: "https://github.com/fb55/css-select#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz"
-      hash: "2b3a110539c5355f1cd8d314623e870b121ec858"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "2b3a110539c5355f1cd8d314623e870b121ec858"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/fb55/css-select.git"
@@ -341,12 +357,14 @@ packages:
     homepage_url: "https://github.com/fb55/css-what#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz"
-      hash: "9467d032c38cfaefb9f2d79501253062f87fa1bd"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "9467d032c38cfaefb9f2d79501253062f87fa1bd"
+        algorithm: "SHA-1"
     vcs:
       type: ""
       url: "git+https://github.com/fb55/css-what.git"
@@ -369,12 +387,14 @@ packages:
     homepage_url: "https://github.com/cheeriojs/dom-renderer"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz"
-      hash: "073c697546ce0780ce23be4a28e293e40bc30c82"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "073c697546ce0780ce23be4a28e293e40bc30c82"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/cheeriojs/dom-renderer.git"
@@ -395,12 +415,14 @@ packages:
     homepage_url: "https://github.com/FB55/domelementtype"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
-      hash: "bd28773e2642881aec51544924299c5cd822185b"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "bd28773e2642881aec51544924299c5cd822185b"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/FB55/domelementtype.git"
@@ -421,12 +443,14 @@ packages:
     homepage_url: "https://github.com/FB55/domelementtype"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
-      hash: "b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/FB55/domelementtype.git"
@@ -449,12 +473,14 @@ packages:
     homepage_url: "https://github.com/fb55/DomHandler#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz"
-      hash: "892e47000a99be55bbf3774ffea0561d8879c259"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "892e47000a99be55bbf3774ffea0561d8879c259"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/fb55/DomHandler.git"
@@ -475,12 +501,14 @@ packages:
     homepage_url: "https://github.com/FB55/domutils"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz"
-      hash: "dcd8488a26f563d61079e48c9f7b7e32373682cf"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "dcd8488a26f563d61079e48c9f7b7e32373682cf"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/FB55/domutils.git"
@@ -505,12 +533,14 @@ packages:
     homepage_url: "https://github.com/bevry/eachr"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/eachr/-/eachr-3.2.0.tgz"
-      hash: "2c35e43ea086516f7997cf80b7aa64d55a4a4484"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "2c35e43ea086516f7997cf80b7aa64d55a4a4484"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+ssh://git@github.com/bevry/eachr.git"
@@ -534,12 +564,14 @@ packages:
     homepage_url: "https://github.com/bevry/editions"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/editions/-/editions-1.3.3.tgz"
-      hash: "0907101bdda20fac3cbe334c27cbd0688dc99a5b"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "0907101bdda20fac3cbe334c27cbd0688dc99a5b"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/bevry/editions.git"
@@ -562,12 +594,14 @@ packages:
     homepage_url: "https://github.com/fb55/node-entities"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
-      hash: "6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/fb55/node-entities.git"
@@ -590,12 +624,14 @@ packages:
     homepage_url: "https://github.com/bevry/extract-opts"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/extract-opts/-/extract-opts-3.3.1.tgz"
-      hash: "5abbedc98c0d5202e3278727f9192d7e086c6be1"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "5abbedc98c0d5202e3278727f9192d7e086c6be1"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+ssh://git@github.com/bevry/extract-opts.git"
@@ -618,12 +654,14 @@ packages:
     homepage_url: "https://github.com/isaacs/node-graceful-fs#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-      hash: "0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/isaacs/node-graceful-fs.git"
@@ -646,12 +684,14 @@ packages:
     homepage_url: "https://github.com/fb55/htmlparser2#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz"
-      hash: "1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/fb55/htmlparser2.git"
@@ -675,12 +715,14 @@ packages:
     homepage_url: "https://github.com/isaacs/inherits#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-      hash: "633c2c83e3da42a502f52466022480f4208261de"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "633c2c83e3da42a502f52466022480f4208261de"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/isaacs/inherits.git"
@@ -703,12 +745,14 @@ packages:
     homepage_url: "https://github.com/juliangruber/isarray"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-      hash: "bb935d48582cba168c06834957a54a3e07124f11"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "bb935d48582cba168c06834957a54a3e07124f11"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/juliangruber/isarray.git"
@@ -731,12 +775,14 @@ packages:
     homepage_url: "https://lodash.com/"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
-      hash: "78203a4d1c328ae1d86dca6460e369b57f4055ae"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "78203a4d1c328ae1d86dca6460e369b57f4055ae"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/lodash/lodash.git"
@@ -760,12 +806,14 @@ packages:
     homepage_url: "https://github.com/dcodeIO/long.js#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/long/-/long-3.2.0.tgz"
-      hash: "d821b7138ca1cb581c172990ef14db200b5c474b"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "d821b7138ca1cb581c172990ef14db200b5c474b"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/dcodeIO/long.js.git"
@@ -788,12 +836,14 @@ packages:
     homepage_url: "https://github.com/fb55/nth-check"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz"
-      hash: "9929acdf628fc2c41098deab82ac580cf149aae4"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "9929acdf628fc2c41098deab82ac580cf149aae4"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/fb55/nth-check"
@@ -817,12 +867,14 @@ packages:
     homepage_url: "https://github.com/inikulin/parse5"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/parse5/-/parse5-3.0.2.tgz"
-      hash: "05eff57f0ef4577fb144a79f8b9a967a6cc44510"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "05eff57f0ef4577fb144a79f8b9a967a6cc44510"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/inikulin/parse5.git"
@@ -845,12 +897,14 @@ packages:
     homepage_url: "https://github.com/calvinmetcalf/process-nextick-args"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-      hash: "150e20b756590ad3f91093f25a4f2ad8bff30ba3"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "150e20b756590ad3f91093f25a4f2ad8bff30ba3"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://github.com/calvinmetcalf/process-nextick-args.git"
@@ -873,12 +927,14 @@ packages:
     homepage_url: "https://github.com/then/promise#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz"
-      hash: "064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+https://github.com/then/promise.git"
@@ -901,12 +957,14 @@ packages:
     homepage_url: "https://github.com/nodejs/readable-stream#readme"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
-      hash: "368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/nodejs/readable-stream.git"
@@ -929,12 +987,14 @@ packages:
     homepage_url: "https://github.com/bevry/requirefresh"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/requirefresh/-/requirefresh-2.1.0.tgz"
-      hash: "742dccc20f3a96918d66c6f1597dc8ffebc4f6f5"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "742dccc20f3a96918d66c6f1597dc8ffebc4f6f5"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+ssh://git@github.com/bevry/requirefresh.git"
@@ -957,12 +1017,14 @@ packages:
     homepage_url: "https://github.com/feross/safe-buffer"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
-      hash: "893312af69b2123def71f57889001671eeb2c853"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "893312af69b2123def71f57889001671eeb2c853"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/feross/safe-buffer.git"
@@ -986,12 +1048,14 @@ packages:
     homepage_url: "https://github.com/bevry/safefs"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/safefs/-/safefs-4.1.0.tgz"
-      hash: "f82aeb4bdd7ae51f653eb20f6728b3058c8d6445"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "f82aeb4bdd7ae51f653eb20f6728b3058c8d6445"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+ssh://git@github.com/bevry/safefs.git"
@@ -1014,12 +1078,14 @@ packages:
     homepage_url: "https://github.com/rvagg/string_decoder"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
-      hash: "0fc67d7c141825de94282dd536bec6b9bce860ab"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "0fc67d7c141825de94282dd536bec6b9bce860ab"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/rvagg/string_decoder.git"
@@ -1043,12 +1109,14 @@ packages:
     homepage_url: "https://github.com/bevry/typechecker"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/typechecker/-/typechecker-4.4.1.tgz"
-      hash: "f97b95f51b038417212d677d45a373ee7bced7e6"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "f97b95f51b038417212d677d45a373ee7bced7e6"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git+ssh://git@github.com/bevry/typechecker.git"
@@ -1071,12 +1139,14 @@ packages:
     homepage_url: "https://github.com/TooTallNate/util-deprecate"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-      hash: "450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "git://github.com/TooTallNate/util-deprecate.git"
@@ -1099,12 +1169,14 @@ packages:
     homepage_url: ""
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: "https://registry.npmjs.org/@types/node/-/node-6.0.79.tgz"
-      hash: "5efe7d4a6d8c453c7e9eaf55d931f4a22fac5169"
-      hash_algorithm: "SHA-1"
+      hash:
+        value: "5efe7d4a6d8c453c7e9eaf55d931f4a22fac5169"
+        algorithm: "SHA-1"
     vcs:
       type: "git"
       url: "https://www.github.com/DefinitelyTyped/DefinitelyTyped.git"

--- a/analyzer/src/main/kotlin/DotNetSupport.kt
+++ b/analyzer/src/main/kotlin/DotNetSupport.kt
@@ -91,9 +91,8 @@ class DotNetSupport(
             val encodedHash = node["packageHash"].textValueOrEmpty()
             val hashAlgorithm = node["packageHashAlgorithm"].textValueOrEmpty()
             val sri = hashAlgorithm.replace("-", "") + "-" + encodedHash
-            val hash = Hash.fromValue(sri)
 
-            return RemoteArtifact(nupkgUrl, hash.value, hash.algorithm)
+            return RemoteArtifact(nupkgUrl, Hash.create(sri))
         }
 
         private fun getCatalogURL(registrationNode: JsonNode): String =

--- a/analyzer/src/main/kotlin/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/MavenSupport.kt
@@ -23,7 +23,7 @@ import ch.frankel.slf4k.*
 
 import com.fasterxml.jackson.module.kotlin.readValue
 
-import com.here.ort.model.HashAlgorithm
+import com.here.ort.model.Hash
 import com.here.ort.model.Identifier
 import com.here.ort.model.Package
 import com.here.ort.model.RemoteArtifact
@@ -408,7 +408,7 @@ class MavenSupport(workspaceReader: WorkspaceReader) {
                 }
 
                 val downloadUrl = "${repository.url.trimEnd('/')}/$remoteLocation"
-                return RemoteArtifact(downloadUrl, actualChecksum, HashAlgorithm.fromString(checksum.algorithm)).also {
+                return RemoteArtifact(downloadUrl, Hash.create(actualChecksum, checksum.algorithm)).also {
                     log.debug { "Writing remote artifact for '$artifact' to disk cache." }
                     remoteArtifactCache.write(artifact.toString(), yamlMapper.writeValueAsString(it))
                 }

--- a/analyzer/src/main/kotlin/managers/Bundler.kt
+++ b/analyzer/src/main/kotlin/managers/Bundler.kt
@@ -27,7 +27,7 @@ import com.here.ort.analyzer.AbstractPackageManagerFactory
 import com.here.ort.analyzer.HTTP_CACHE_PATH
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.downloader.VersionControlSystem
-import com.here.ort.model.HashAlgorithm
+import com.here.ort.model.Hash
 import com.here.ort.model.Identifier
 import com.here.ort.model.OrtIssue
 import com.here.ort.model.Package
@@ -322,7 +322,7 @@ data class GemSpec(
 
             val artifact = if (json.hasNonNull("gem_uri") && json.hasNonNull("sha")) {
                 val sha = json["sha"].textValue()
-                RemoteArtifact(json["gem_uri"].textValue(), sha, HashAlgorithm.fromHash(sha))
+                RemoteArtifact(json["gem_uri"].textValue(), Hash.create(sha))
             } else {
                 RemoteArtifact.EMPTY
             }

--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -220,7 +220,7 @@ open class Npm(
 
             val identifier = "$rawName@$version"
 
-            var hash = Hash.fromValue(json["_integrity"].textValueOrEmpty())
+            var hash = Hash.create(json["_integrity"].textValueOrEmpty())
 
             // Download package info from registry.npmjs.org.
             // TODO: check if unpkg.com can be used as a fallback in case npmjs.org is down.
@@ -268,7 +268,7 @@ open class Npm(
                                         }
                                     }
 
-                                    hash = Hash.fromValue(dist["shasum"].textValueOrEmpty())
+                                    hash = Hash.create(dist["shasum"].textValueOrEmpty())
                                 }
 
                                 vcsFromPackage = parseVcsInfo(versionInfo)
@@ -301,8 +301,7 @@ open class Npm(
                 binaryArtifact = RemoteArtifact.EMPTY,
                 sourceArtifact = RemoteArtifact(
                     url = downloadUrl,
-                    hash = hash.value,
-                    hashAlgorithm = hash.algorithm
+                    hash = hash
                 ),
                 vcs = vcsFromPackage,
                 vcsProcessed = processPackageVcs(vcsFromPackage, homepageUrl)

--- a/analyzer/src/main/kotlin/managers/PhpComposer.kt
+++ b/analyzer/src/main/kotlin/managers/PhpComposer.kt
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode
 import com.here.ort.analyzer.AbstractPackageManagerFactory
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.downloader.VersionControlSystem
-import com.here.ort.model.HashAlgorithm
+import com.here.ort.model.Hash
 import com.here.ort.model.Identifier
 import com.here.ort.model.OrtIssue
 import com.here.ort.model.Package
@@ -308,7 +308,7 @@ class PhpComposer(
     private fun parseArtifact(packageInfo: JsonNode): RemoteArtifact {
         return packageInfo["dist"]?.let {
             val shasum = it["shasum"].textValueOrEmpty()
-            RemoteArtifact(it["url"].textValueOrEmpty(), shasum, HashAlgorithm.fromHash(shasum))
+            RemoteArtifact(it["url"].textValueOrEmpty(), Hash.create(shasum))
         } ?: RemoteArtifact.EMPTY
     }
 

--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -29,7 +29,7 @@ import com.here.ort.analyzer.HTTP_CACHE_PATH
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.EMPTY_JSON_NODE
-import com.here.ort.model.HashAlgorithm
+import com.here.ort.model.Hash
 import com.here.ort.model.Identifier
 import com.here.ort.model.Package
 import com.here.ort.model.PackageReference
@@ -435,9 +435,9 @@ class Pip(
         } ?: releaseNode[0]
 
         val url = binaryArtifact["url"]?.textValue() ?: pkg.binaryArtifact.url
-        val hash = binaryArtifact["md5_digest"]?.textValue() ?: pkg.binaryArtifact.hash
+        val hash = binaryArtifact["md5_digest"]?.textValue()?.let { Hash.create(it) } ?: pkg.binaryArtifact.hash
 
-        return RemoteArtifact(url, hash, HashAlgorithm.fromHash(hash))
+        return RemoteArtifact(url, hash)
     }
 
     private fun getSourceArtifact(releaseNode: ArrayNode): RemoteArtifact {
@@ -454,7 +454,7 @@ class Pip(
         val url = sourceArtifact["url"]?.textValue() ?: return RemoteArtifact.EMPTY
         val hash = sourceArtifact["md5_digest"]?.textValue() ?: return RemoteArtifact.EMPTY
 
-        return RemoteArtifact(url, hash, HashAlgorithm.fromHash(hash))
+        return RemoteArtifact(url, Hash.create(hash))
     }
 
     private fun getDeclaredLicenses(pkgInfo: JsonNode): SortedSet<String> {

--- a/downloader/src/funTest/kotlin/BabelTest.kt
+++ b/downloader/src/funTest/kotlin/BabelTest.kt
@@ -19,7 +19,7 @@
 
 package com.here.ort.downloader
 
-import com.here.ort.model.HashAlgorithm
+import com.here.ort.model.Hash
 import com.here.ort.model.Identifier
 import com.here.ort.model.Package
 import com.here.ort.model.RemoteArtifact
@@ -68,8 +68,7 @@ class BabelTest : StringSpec() {
                 homepageUrl = "https://babeljs.io/",
                 binaryArtifact = RemoteArtifact(
                     url = "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
-                    hash = "502ab54874d7db88ad00b887a06383ce03d002f1",
-                    hashAlgorithm = HashAlgorithm.SHA1
+                    hash = Hash.create("502ab54874d7db88ad00b887a06383ce03d002f1")
                 ),
                 sourceArtifact = RemoteArtifact.EMPTY,
                 vcs = vcsFromPackage,

--- a/downloader/src/funTest/kotlin/DownloaderTest.kt
+++ b/downloader/src/funTest/kotlin/DownloaderTest.kt
@@ -19,7 +19,7 @@
 
 package com.here.ort.downloader
 
-import com.here.ort.model.HashAlgorithm
+import com.here.ort.model.Hash
 import com.here.ort.model.Identifier
 import com.here.ort.model.Package
 import com.here.ort.model.RemoteArtifact
@@ -62,8 +62,7 @@ class DownloaderTest : StringSpec() {
                 binaryArtifact = RemoteArtifact.EMPTY,
                 sourceArtifact = RemoteArtifact(
                     url = "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar",
-                    hash = "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa",
-                    hashAlgorithm = HashAlgorithm.SHA1
+                    hash = Hash.create("a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa")
                 ),
                 vcs = VcsInfo.EMPTY
             )
@@ -73,7 +72,6 @@ class DownloaderTest : StringSpec() {
             downloadResult.sourceArtifact shouldNotBe null
             downloadResult.sourceArtifact!!.url shouldBe pkg.sourceArtifact.url
             downloadResult.sourceArtifact!!.hash shouldBe pkg.sourceArtifact.hash
-            downloadResult.sourceArtifact!!.hashAlgorithm shouldBe pkg.sourceArtifact.hashAlgorithm
 
             val licenseFile = File(downloadResult.downloadDirectory, "LICENSE-junit.txt")
             licenseFile.isFile shouldBe true
@@ -96,8 +94,7 @@ class DownloaderTest : StringSpec() {
                 binaryArtifact = RemoteArtifact.EMPTY,
                 sourceArtifact = RemoteArtifact(
                     url = "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar",
-                    hash = "0123456789abcdef0123456789abcdef01234567",
-                    hashAlgorithm = HashAlgorithm.SHA1
+                    hash = Hash.create("0123456789abcdef0123456789abcdef01234567")
                 ),
                 vcs = VcsInfo.EMPTY
             )
@@ -128,8 +125,7 @@ class DownloaderTest : StringSpec() {
                 binaryArtifact = RemoteArtifact.EMPTY,
                 sourceArtifact = RemoteArtifact(
                     url = "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar",
-                    hash = "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa",
-                    hashAlgorithm = HashAlgorithm.SHA1
+                    hash = Hash.create("a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa")
                 ),
                 vcs = VcsInfo(
                     type = "Git",
@@ -143,7 +139,6 @@ class DownloaderTest : StringSpec() {
             downloadResult.sourceArtifact shouldNotBe null
             downloadResult.sourceArtifact!!.url shouldBe pkg.sourceArtifact.url
             downloadResult.sourceArtifact!!.hash shouldBe pkg.sourceArtifact.hash
-            downloadResult.sourceArtifact!!.hashAlgorithm shouldBe pkg.sourceArtifact.hashAlgorithm
 
             val licenseFile = File(downloadResult.downloadDirectory, "LICENSE-junit.txt")
             licenseFile.isFile shouldBe true
@@ -167,8 +162,7 @@ class DownloaderTest : StringSpec() {
                 binaryArtifact = RemoteArtifact.EMPTY,
                 sourceArtifact = RemoteArtifact(
                     url = url,
-                    hash = "49fe486f44197c8e5106ed7487526f77b597308f",
-                    hashAlgorithm = HashAlgorithm.SHA1
+                    hash = Hash.create("49fe486f44197c8e5106ed7487526f77b597308f")
                 ),
                 vcs = VcsInfo.EMPTY
             )
@@ -178,7 +172,6 @@ class DownloaderTest : StringSpec() {
             downloadResult.sourceArtifact shouldNotBe null
             downloadResult.sourceArtifact!!.url shouldBe pkg.sourceArtifact.url
             downloadResult.sourceArtifact!!.hash shouldBe pkg.sourceArtifact.hash
-            downloadResult.sourceArtifact!!.hashAlgorithm shouldBe pkg.sourceArtifact.hashAlgorithm
 
             val tyrexDir = File(downloadResult.downloadDirectory, "tyrex-1.0.1")
 

--- a/downloader/src/main/kotlin/Downloader.kt
+++ b/downloader/src/main/kotlin/Downloader.kt
@@ -22,7 +22,6 @@ package com.here.ort.downloader
 import ch.frankel.slf4k.*
 
 import com.here.ort.downloader.vcs.GitRepo
-import com.here.ort.model.Hash
 import com.here.ort.model.Identifier
 import com.here.ort.model.Package
 import com.here.ort.model.Project
@@ -310,12 +309,13 @@ class Downloader {
             }
         }
 
-        if (target.sourceArtifact.hash.isEmpty()) {
-            log.warn { "Source artifact has no hash, skipping verification." }
-        } else if (!Hash(target.sourceArtifact.hashAlgorithm, target.sourceArtifact.hash).verify(sourceArchive)) {
+        if (!target.sourceArtifact.hash.canVerify) {
+            log.warn {
+                "Cannot verify source artifact hash ${target.sourceArtifact.hash}, skipping verification."
+            }
+        } else if (!target.sourceArtifact.hash.verify(sourceArchive)) {
             throw DownloadException(
-                "Source artifact does not match expected ${target.sourceArtifact.hashAlgorithm} " +
-                        "hash '${target.sourceArtifact.hash}'."
+                "Source artifact does not match expected hash value ${target.sourceArtifact.hash.value}."
             )
         }
 

--- a/model/src/main/kotlin/HashAlgorithm.kt
+++ b/model/src/main/kotlin/HashAlgorithm.kt
@@ -26,16 +26,16 @@ import com.fasterxml.jackson.annotation.JsonValue
  * An enum of supported hash algorithms. Each algorithm has one or more [aliases] associated to it, where the first
  * alias is the definite name.
  */
-enum class HashAlgorithm(private vararg val aliases: String) {
+enum class HashAlgorithm(private vararg val aliases: String, val verifiable: Boolean = true) {
     /**
      * No hash algorithm.
      */
-    NONE(""),
+    NONE("", verifiable = false),
 
     /**
      * An unknown hash algorithm.
      */
-    UNKNOWN("UNKNOWN"),
+    UNKNOWN("UNKNOWN", verifiable = false),
 
     /**
      * The Message-Digest 5 hash algorithm, see [MD5](http://en.wikipedia.org/wiki/MD5).
@@ -64,6 +64,11 @@ enum class HashAlgorithm(private vararg val aliases: String) {
 
     companion object {
         /**
+         * The list of algorithms that can be verified.
+         */
+        val VERIFIABLE = enumValues<HashAlgorithm>().filter { it.verifiable }
+
+        /**
          * Create a hash algorithm from one of its [alias] names.
          */
         @JsonCreator
@@ -76,7 +81,7 @@ enum class HashAlgorithm(private vararg val aliases: String) {
         /**
          * Create a hash algorithm from a hash [value].
          */
-        fun fromHash(value: String): HashAlgorithm {
+        fun create(value: String): HashAlgorithm {
             if (value.isBlank()) return NONE
 
             return when (value.length) {

--- a/model/src/main/kotlin/Mappers.kt
+++ b/model/src/main/kotlin/Mappers.kt
@@ -35,6 +35,7 @@ import com.here.ort.model.config.AnalyzerConfigurationDeserializer
 private val ortModelModule = SimpleModule("OrtModelModule").apply {
     addDeserializer(AnalyzerConfiguration::class.java, AnalyzerConfigurationDeserializer())
     addDeserializer(CopyrightFinding::class.java, CopyrightFindingDeserializer())
+    addDeserializer(Hash::class.java, HashDeserializer())
     addDeserializer(LicenseFinding::class.java, LicenseFindingDeserializer())
     addDeserializer(OrtIssue::class.java, OrtIssueDeserializer())
     addDeserializer(VcsInfo::class.java, VcsInfoDeserializer())

--- a/model/src/main/kotlin/Provenance.kt
+++ b/model/src/main/kotlin/Provenance.kt
@@ -74,12 +74,9 @@ data class Provenance(
     fun matches(pkg: Package): Boolean {
         // If the scanned source code came from a source artifact, it has to match the package's source artifact.
         if (sourceArtifact != null) {
-            // If the (non-blank) hash values match, we do not need to compare the other properties like the URL. Only
-            // support this for known algorithms which we are able to verify as otherwise the hash could be fake.
-            if (sourceArtifact.hash.isNotBlank() && sourceArtifact.hashAlgorithm in Hash.VERIFIABLE) {
-                return sourceArtifact.hash == pkg.sourceArtifact.hash
-                        && sourceArtifact.hashAlgorithm == pkg.sourceArtifact.hashAlgorithm
-            }
+            // If the hash values match, we do not need to compare the other properties like the URL. Only support this
+            // for algorithms for which we can actually verify as otherwise the hash could be fake.
+            if (sourceArtifact.hash.canVerify) return sourceArtifact.hash == pkg.sourceArtifact.hash
 
             return sourceArtifact == pkg.sourceArtifact
         }

--- a/model/src/main/kotlin/RemoteArtifact.kt
+++ b/model/src/main/kotlin/RemoteArtifact.kt
@@ -29,14 +29,9 @@ data class RemoteArtifact(
     val url: String,
 
     /**
-     * The hash value of the remote artifact.
+     * The hash of the remote artifact.
      */
-    val hash: String,
-
-    /**
-     * The name of the algorithm used to calculate the [hash].
-     */
-    val hashAlgorithm: HashAlgorithm
+    val hash: Hash
 ) {
     companion object {
         /**
@@ -45,8 +40,7 @@ data class RemoteArtifact(
         @JvmField
         val EMPTY = RemoteArtifact(
             url = "",
-            hash = Hash.NONE.value,
-            hashAlgorithm = Hash.NONE.algorithm
+            hash = Hash.NONE
         )
     }
 }

--- a/model/src/test/assets/expected-scan-results.yml
+++ b/model/src/test/assets/expected-scan-results.yml
@@ -5,8 +5,9 @@ results:
     download_time: "1970-01-02T00:00:00Z"
     source_artifact:
       url: "url"
-      hash: "hash"
-      hash_algorithm: "UNKNOWN"
+      hash:
+        value: "hash"
+        algorithm: "UNKNOWN"
   scanner:
     name: "name 1"
     version: "version 1"

--- a/model/src/test/kotlin/HashTest.kt
+++ b/model/src/test/kotlin/HashTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.model
+
+import io.kotlintest.shouldBe
+import io.kotlintest.shouldThrow
+import io.kotlintest.specs.WordSpec
+
+import java.lang.IllegalArgumentException
+
+class HashTest : WordSpec({
+    "Passing a single string value to create()" should {
+        "create a NONE hash from an empty value" {
+            Hash.create("") shouldBe Hash.NONE
+        }
+
+        "create an UNKNOWN hash from the 'UNKOWN' value" {
+            Hash.create("UNKNOWN").algorithm shouldBe HashAlgorithm.UNKNOWN
+        }
+
+        "create an UNKNOWN hash from a value that matches no other hash" {
+            Hash.create("0123456789").algorithm shouldBe HashAlgorithm.UNKNOWN
+        }
+
+        "create a SHA1 hash from a SHA-1 value" {
+            Hash.create("3b93de94e89006954c58225ad10ac55182d32c16").algorithm shouldBe HashAlgorithm.SHA1
+        }
+
+        "create a SHA256 hash from a SHA-256 value" {
+            Hash.create(
+                "34be7ab36220c79915e4c5c740c7d496abff551ab806f56f44c90cc7cfdf9265"
+            ).algorithm shouldBe HashAlgorithm.SHA256
+        }
+
+        "create a SHA384 hash from a SHA-384 value" {
+            Hash.create(
+                "70098a0b4d429071008b9c2b0c21899b7cc2d606ba0b46f94fb91a36eb390fa70e5d5391d1651b54fe0f7d881e45bf80"
+            ).algorithm shouldBe HashAlgorithm.SHA384
+        }
+
+        "create a SHA512 hash from a SHA-512 value" {
+            Hash.create(
+                "760d9348be5813285b8ad38795a2a5afe788bcddab4f7190ed581c6ea524c0d67a7dd5bdd5384f197e3b5a58c070ab5b" +
+                        "db704493cc8e0ad63ab35f753b6d61bf"
+            ).algorithm shouldBe HashAlgorithm.SHA512
+        }
+
+        "create the correct hash from an SRI value" {
+            val hash = Hash.create("sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=")
+
+            hash.algorithm shouldBe HashAlgorithm.SHA1
+            hash.value shouldBe "a8115c55e4a702fe4d150abd3872822a7e09fc98"
+        }
+    }
+
+    "Passing a string value and name to create()" should {
+        "succeed if the name is valid for the created hash" {
+            Hash.create("6a7d2814506e9801f13e767964ae3a8f", "MD5").algorithm shouldBe HashAlgorithm.MD5
+        }
+
+        "fail if the name is invalid for the created hash" {
+            shouldThrow<IllegalArgumentException> {
+                Hash.create("0123456789", "MD5")
+            }
+        }
+    }
+})

--- a/model/src/test/kotlin/PackageCurationTest.kt
+++ b/model/src/test/kotlin/PackageCurationTest.kt
@@ -52,13 +52,11 @@ class PackageCurationTest : WordSpec({
                     homepageUrl = "http://home.page",
                     binaryArtifact = RemoteArtifact(
                         url = "http://binary.artifact",
-                        hash = "binary.hash",
-                        hashAlgorithm = HashAlgorithm.UNKNOWN
+                        hash = Hash.create("binary.hash")
                     ),
                     sourceArtifact = RemoteArtifact(
                         url = "http://source.artifact",
-                        hash = "source.hash",
-                        hashAlgorithm = HashAlgorithm.UNKNOWN
+                        hash = Hash.create("source.hash")
                     ),
                     vcs = VcsInfoCuration(
                         type = "git",

--- a/model/src/test/kotlin/PackageTest.kt
+++ b/model/src/test/kotlin/PackageTest.kt
@@ -45,8 +45,8 @@ class PackageTest : StringSpec() {
                 declaredLicenses = sortedSetOf("declared license"),
                 description = "description",
                 homepageUrl = "homepageUrl",
-                binaryArtifact = RemoteArtifact("url", "hash", HashAlgorithm.UNKNOWN),
-                sourceArtifact = RemoteArtifact("url", "hash", HashAlgorithm.UNKNOWN),
+                binaryArtifact = RemoteArtifact("url", Hash.create("hash")),
+                sourceArtifact = RemoteArtifact("url", Hash.create("hash")),
                 vcs = VcsInfo("type", "url", "revision")
             )
 
@@ -60,8 +60,8 @@ class PackageTest : StringSpec() {
                 declaredLicenses = sortedSetOf("other declared license"),
                 description = "other description",
                 homepageUrl = "other homepageUrl",
-                binaryArtifact = RemoteArtifact("other url", "other hash", HashAlgorithm.UNKNOWN),
-                sourceArtifact = RemoteArtifact("other url", "other hash", HashAlgorithm.UNKNOWN),
+                binaryArtifact = RemoteArtifact("other url", Hash.create("other hash")),
+                sourceArtifact = RemoteArtifact("other url", Hash.create("other hash")),
                 vcs = VcsInfo("other type", "other url", "other revision")
             )
 
@@ -86,8 +86,8 @@ class PackageTest : StringSpec() {
                 declaredLicenses = sortedSetOf("declared license"),
                 description = "description",
                 homepageUrl = "homepageUrl",
-                binaryArtifact = RemoteArtifact("url", "hash", HashAlgorithm.UNKNOWN),
-                sourceArtifact = RemoteArtifact("url", "hash", HashAlgorithm.UNKNOWN),
+                binaryArtifact = RemoteArtifact("url", Hash.create("hash")),
+                sourceArtifact = RemoteArtifact("url", Hash.create("hash")),
                 vcs = VcsInfo("type", "url", "revision")
             )
 

--- a/model/src/test/kotlin/ScanResultContainerTest.kt
+++ b/model/src/test/kotlin/ScanResultContainerTest.kt
@@ -38,7 +38,7 @@ class ScanResultContainerTest : WordSpec() {
 
     private val provenance1 = Provenance(
         downloadTime = downloadTime1,
-        sourceArtifact = RemoteArtifact("url", "hash", HashAlgorithm.UNKNOWN)
+        sourceArtifact = RemoteArtifact("url", Hash.create("hash"))
     )
     private val provenance2 = Provenance(
         downloadTime = downloadTime2,

--- a/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
@@ -68,12 +68,14 @@ analyzer:
         homepage_url: "http://junit.org"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12.jar"
-          hash: "2973d150c0dc1fefe998f834810d68f278ea58ec"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "2973d150c0dc1fefe998f834810d68f278ea58ec"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
-          hash: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+            algorithm: "SHA-1"
         vcs:
           type: ""
           url: ""
@@ -98,12 +100,14 @@ analyzer:
         homepage_url: "http://commons.apache.org/proper/commons-lang/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar"
-          hash: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
-          hash: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+            algorithm: "SHA-1"
         vcs:
           type: ""
           url: ""
@@ -127,12 +131,14 @@ analyzer:
         homepage_url: "http://commons.apache.org/proper/commons-text/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1.jar"
-          hash: "c336bf600f44b88af356c8a85eef4af822b06a4d"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "c336bf600f44b88af356c8a85eef4af822b06a4d"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
-          hash: "f0770f7f0472bf120ada47beecadce4056fbd20a"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+            algorithm: "SHA-1"
         vcs:
           type: ""
           url: ""
@@ -157,12 +163,14 @@ analyzer:
         homepage_url: "https://github.com/hamcrest/JavaHamcrest/hamcrest-core"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"
-          hash: "42a25dc3219429f0e5d060061f71acb49bf010a0"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "42a25dc3219429f0e5d060061f71acb49bf010a0"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
-          hash: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+            algorithm: "SHA-1"
         vcs:
           type: ""
           url: ""
@@ -224,8 +232,9 @@ scanner:
           download_time: "1970-01-01T00:00:00Z"
           source_artifact:
             url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
-            hash: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
-            hash_algorithm: "SHA-1"
+            hash:
+              value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+              algorithm: "SHA-1"
         scanner:
           name: "FileCounter"
           version: "1.0"
@@ -241,8 +250,9 @@ scanner:
           download_time: "1970-01-01T00:00:00Z"
           source_artifact:
             url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
-            hash: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
-            hash_algorithm: "SHA-1"
+            hash:
+              value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+              algorithm: "SHA-1"
         scanner:
           name: "FileCounter"
           version: "1.0"
@@ -258,8 +268,9 @@ scanner:
           download_time: "1970-01-01T00:00:00Z"
           source_artifact:
             url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
-            hash: "f0770f7f0472bf120ada47beecadce4056fbd20a"
-            hash_algorithm: "SHA-1"
+            hash:
+              value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+              algorithm: "SHA-1"
         scanner:
           name: "FileCounter"
           version: "1.0"
@@ -275,8 +286,9 @@ scanner:
           download_time: "1970-01-01T00:00:00Z"
           source_artifact:
             url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
-            hash: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
-            hash_algorithm: "SHA-1"
+            hash:
+              value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+              algorithm: "SHA-1"
         scanner:
           name: "FileCounter"
           version: "1.0"

--- a/scanner/src/funTest/kotlin/HttpStorageTest.kt
+++ b/scanner/src/funTest/kotlin/HttpStorageTest.kt
@@ -20,7 +20,7 @@
 package com.here.ort.scanner
 
 import com.here.ort.model.EMPTY_JSON_NODE
-import com.here.ort.model.HashAlgorithm
+import com.here.ort.model.Hash
 import com.here.ort.model.Identifier
 import com.here.ort.model.LicenseFinding
 import com.here.ort.model.OrtIssue
@@ -81,11 +81,7 @@ class HttpStorageTest : StringSpec() {
 
     private val id = Identifier("type", "namespace", "name", "version")
 
-    private val sourceArtifact = RemoteArtifact(
-        "url",
-        "0123456789abcdef0123456789abcdef01234567",
-        HashAlgorithm.SHA1
-    )
+    private val sourceArtifact = RemoteArtifact("url", Hash.create("0123456789abcdef0123456789abcdef01234567"))
 
     private val vcs = VcsInfo("type", "url", "revision", "resolvedRevision", "path")
     private val vcsWithoutRevision = VcsInfo("type", "url", "", "")
@@ -322,7 +318,7 @@ class HttpStorageTest : StringSpec() {
                 rawResultWithContent
             )
             val provenanceSourceArtifactNonMatching = provenanceWithSourceArtifact.copy(
-                sourceArtifact = sourceArtifact.copy(hash = "0123456789012345678901234567890123456789")
+                sourceArtifact = sourceArtifact.copy(hash = Hash.create("0123456789012345678901234567890123456789"))
             )
             val scanResultSourceArtifactNonMatching = ScanResult(
                 provenanceSourceArtifactNonMatching, scannerDetails1,


### PR DESCRIPTION
This serializes new files as

    hash:
      value: "7c4f3c474fb2c041d8028740440937705ebb473a"
      algorithm: "SHA-1"

while the old format of

    hash: "7c4f3c474fb2c041d8028740440937705ebb473a"
    hash_algorithm: "SHA-1"

can still be deserialized.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1517)
<!-- Reviewable:end -->
