### PR TITLE
spdx-utils: Allow parsing license references as exceptions

### DIFF
--- a/spdx-utils/src/main/antlr/com/here/ort/spdx/SpdxExpression.g4
+++ b/spdx-utils/src/main/antlr/com/here/ort/spdx/SpdxExpression.g4
@@ -33,12 +33,12 @@ package com.here.ort.spdx;
 
 licenseReferenceExpression
     :
-    LICENSEREFERENCE
+    REFERENCE
     ;
 
 licenseExceptionExpression
     :
-    IDSTRING
+    IDSTRING | LICENSEREFERENCE
     ;
 
 licenseIdExpression
@@ -83,7 +83,8 @@ OPEN  : '(' ;
 CLOSE : ')' ;
 PLUS  : '+' ;
 
-LICENSEREFERENCE : ('DocumentRef-' IDSTRING ':')? 'LicenseRef-' IDSTRING ;
+REFERENCE        : ('DocumentRef-' IDSTRING ':')? LICENSEREFERENCE ;
+LICENSEREFERENCE : 'LicenseRef-' IDSTRING ;
 IDSTRING         : (ALPHA | DIGIT)(ALPHA | DIGIT | '-' | '.')* ;
 
 WHITESPACE : ' ' -> skip ;

--- a/spdx-utils/src/test/kotlin/SpdxExpressionParserTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxExpressionParserTest.kt
@@ -205,7 +205,7 @@ class SpdxExpressionParserTest : WordSpec() {
                     SpdxExpression.parse("((")
                 }
 
-                exception.message shouldBe "mismatched input '<EOF>' expecting {'(', LICENSEREFERENCE, IDSTRING}"
+                exception.message shouldBe "mismatched input '<EOF>' expecting {'(', REFERENCE, IDSTRING}"
             }
         }
     }


### PR DESCRIPTION
Scancode also uses license references for detected exceptions. These
references could not be used, because the lexer turns them into a
`LICENSEREFERENCE` token, which is not a valid input for the
`licenseExceptionExpression` rule.

To fix this, move the "LicenseRef-" part of `LICENSEREFERENCE`, which is
a valid subset of `IDSTRING`, to a separate rule, and allow this in the
`licenseExceptionExpression` rule.

Signed-off-by: Martin Nonnenmacher <martin.nonnenmacher@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1524)
<!-- Reviewable:end -->
