### PR TITLE
model: Use annotations to add custom (de-)serializers

### DIFF
--- a/model/src/main/kotlin/CopyrightFinding.kt
+++ b/model/src/main/kotlin/CopyrightFinding.kt
@@ -22,6 +22,7 @@ package com.here.ort.model
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.module.kotlin.treeToValue
 
@@ -31,6 +32,7 @@ import com.here.ort.utils.constructTreeSetType
 import java.util.SortedSet
 import java.util.TreeSet
 
+@JsonDeserialize(using = CopyrightFindingDeserializer::class)
 data class CopyrightFinding(
     val statement: String,
     val locations: SortedSet<TextLocation>

--- a/model/src/main/kotlin/Hash.kt
+++ b/model/src/main/kotlin/Hash.kt
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 
 import com.here.ort.utils.hash
@@ -34,6 +35,7 @@ import java.util.Base64
 /**
  * A class that bundles a hash algorithm with its hash value.
  */
+@JsonDeserialize(using = HashDeserializer::class)
 data class Hash(
     /**
      * The value calculated using the hash algorithm.

--- a/model/src/main/kotlin/LicenseFinding.kt
+++ b/model/src/main/kotlin/LicenseFinding.kt
@@ -22,6 +22,7 @@ package com.here.ort.model
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.module.kotlin.treeToValue
 
@@ -55,6 +56,7 @@ fun LicenseFindingsMap.removeGarbage(copyrightGarbage: CopyrightGarbage) =
  * A class to store a [license] finding along with its belonging [copyrights] and the [locations] where the license was
  * found.
  */
+@JsonDeserialize(using = LicenseFindingDeserializer::class)
 data class LicenseFinding(
     val license: String,
     val locations: SortedSet<TextLocation>,

--- a/model/src/main/kotlin/Mappers.kt
+++ b/model/src/main/kotlin/Mappers.kt
@@ -23,25 +23,10 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.dataformat.xml.XmlMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
-
-import com.here.ort.model.config.AnalyzerConfiguration
-import com.here.ort.model.config.AnalyzerConfigurationDeserializer
-
-private val ortModelModule = SimpleModule("OrtModelModule").apply {
-    addDeserializer(AnalyzerConfiguration::class.java, AnalyzerConfigurationDeserializer())
-    addDeserializer(CopyrightFinding::class.java, CopyrightFindingDeserializer())
-    addDeserializer(Hash::class.java, HashDeserializer())
-    addDeserializer(LicenseFinding::class.java, LicenseFindingDeserializer())
-    addDeserializer(OrtIssue::class.java, OrtIssueDeserializer())
-    addDeserializer(VcsInfo::class.java, VcsInfoDeserializer())
-
-    addSerializer(OrtIssue::class.java, OrtIssueSerializer())
-}
 
 val PROPERTY_NAMING_STRATEGY = PropertyNamingStrategy.SNAKE_CASE as PropertyNamingStrategy.PropertyNamingStrategyBase
 
@@ -53,8 +38,6 @@ private val mapperConfig: ObjectMapper.() -> Unit = {
 
     registerModule(JavaTimeModule())
     disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-
-    registerModule(ortModelModule)
 
     propertyNamingStrategy = PROPERTY_NAMING_STRATEGY
 }

--- a/model/src/main/kotlin/OrtIssue.kt
+++ b/model/src/main/kotlin/OrtIssue.kt
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.databind.ser.std.StdSerializer
 
@@ -34,6 +36,8 @@ import java.time.Instant
 /**
  * An issue that occurred while executing ORT.
  */
+@JsonDeserialize(using = OrtIssueDeserializer::class)
+@JsonSerialize(using = OrtIssueSerializer::class)
 data class OrtIssue(
     /**
      * The timestamp of the issue.

--- a/model/src/main/kotlin/VcsInfo.kt
+++ b/model/src/main/kotlin/VcsInfo.kt
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException
 
@@ -35,6 +36,7 @@ import kotlin.reflect.full.memberProperties
 /**
  * Bundles general Version Control System information.
  */
+@JsonDeserialize(using = VcsInfoDeserializer::class)
 data class VcsInfo(
     /**
      * The name of the VCS type, for example Git, GitRepo, Mercurial or Subversion.

--- a/model/src/main/kotlin/config/AnalyzerConfiguration.kt
+++ b/model/src/main/kotlin/config/AnalyzerConfiguration.kt
@@ -22,8 +22,10 @@ package com.here.ort.model.config
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 
+@JsonDeserialize(using = AnalyzerConfigurationDeserializer::class)
 data class AnalyzerConfiguration(
     /**
      * If set to true, ignore the versions of used command line tools. Note that this might lead to erroneous


### PR DESCRIPTION
This keeps all (de-)serialization code alongside the class.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1527)
<!-- Reviewable:end -->
