### PR TITLE
Downloader: Fix an error message to make DownloaderTest pass again

### DIFF
--- a/downloader/src/main/kotlin/Downloader.kt
+++ b/downloader/src/main/kotlin/Downloader.kt
@@ -315,7 +315,8 @@ class Downloader {
             }
         } else if (!target.sourceArtifact.hash.verify(sourceArchive)) {
             throw DownloadException(
-                "Source artifact does not match expected hash value ${target.sourceArtifact.hash.value}."
+                "Source artifact does not match expected ${target.sourceArtifact.hash.algorithm} hash " +
+                        "'${target.sourceArtifact.hash.value}'."
             )
         }
 


### PR DESCRIPTION
This changes the error message to like it was before eeea7ec so it again
contains the name of the hash algorithm to make the DownloaderTest pass
again.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1528)
<!-- Reviewable:end -->
