### PR TITLE
spdx-utils: Fix parsing license references as exceptions

### DIFF
--- a/spdx-utils/src/main/antlr/com/here/ort/spdx/SpdxExpression.g4
+++ b/spdx-utils/src/main/antlr/com/here/ort/spdx/SpdxExpression.g4
@@ -33,7 +33,7 @@ package com.here.ort.spdx;
 
 licenseReferenceExpression
     :
-    REFERENCE
+    DOCUMENTREFERENCE | LICENSEREFERENCE
     ;
 
 licenseExceptionExpression
@@ -83,8 +83,8 @@ OPEN  : '(' ;
 CLOSE : ')' ;
 PLUS  : '+' ;
 
-REFERENCE        : ('DocumentRef-' IDSTRING ':')? LICENSEREFERENCE ;
-LICENSEREFERENCE : 'LicenseRef-' IDSTRING ;
-IDSTRING         : (ALPHA | DIGIT)(ALPHA | DIGIT | '-' | '.')* ;
+DOCUMENTREFERENCE : 'DocumentRef-' IDSTRING ':' LICENSEREFERENCE ;
+LICENSEREFERENCE  : 'LicenseRef-' IDSTRING ;
+IDSTRING          : (ALPHA | DIGIT)(ALPHA | DIGIT | '-' | '.')* ;
 
 WHITESPACE : ' ' -> skip ;

--- a/spdx-utils/src/test/kotlin/SpdxExpressionParserTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxExpressionParserTest.kt
@@ -205,7 +205,8 @@ class SpdxExpressionParserTest : WordSpec() {
                     SpdxExpression.parse("((")
                 }
 
-                exception.message shouldBe "mismatched input '<EOF>' expecting {'(', REFERENCE, IDSTRING}"
+                exception.message shouldBe
+                        "mismatched input '<EOF>' expecting {'(', DOCUMENTREFERENCE, LICENSEREFERENCE, IDSTRING}"
             }
         }
     }


### PR DESCRIPTION
This is a fixup for 91056e1 which did not acutally fix the issue.

The problem was that the first part of the `REFERENCE` rule was
optional, as a result any license reference was always put in a
`REFERENCE` token, but never in a `LICENSEREFERENCE` token by the lexer.

Fix this by making two separate rule for license references and document
references, to prevent overlap in the rules.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1529)
<!-- Reviewable:end -->
