### PR TITLE
Gradle: Use Kotlin syntactic sugar to add plugins

### DIFF
--- a/analyzer/build.gradle.kts
+++ b/analyzer/build.gradle.kts
@@ -7,7 +7,7 @@ val toml4jVersion: String by project
 
 plugins {
     // Apply core plugins.
-    id("java-library")
+    `java-library`
 }
 
 repositories {

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -6,7 +6,7 @@ val reflectionsVersion: String by project
 
 plugins {
     // Apply core plugins.
-    id("application")
+    application
 
     // Apply third-party plugins.
     id("com.bmuschko.docker-java-application")

--- a/downloader/build.gradle.kts
+++ b/downloader/build.gradle.kts
@@ -3,7 +3,7 @@ val jacksonVersion: String by project
 
 plugins {
     // Apply core plugins.
-    id("java-library")
+    `java-library`
 }
 
 dependencies {

--- a/evaluator/build.gradle.kts
+++ b/evaluator/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     // Apply core plugins.
-    id("java-library")
+    `java-library`
 }
 
 dependencies {

--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -9,7 +9,7 @@ val semverVersion: String by project
 
 plugins {
     // Apply core plugins.
-    id("java-library")
+    `java-library`
 }
 
 dependencies {

--- a/reporter/build.gradle.kts
+++ b/reporter/build.gradle.kts
@@ -7,7 +7,7 @@ val xalanVersion: String by project
 
 plugins {
     // Apply core plugins.
-    id("java-library")
+    `java-library`
 }
 
 val generatedResourcesDir = file("$buildDir/generated-resources/main")

--- a/scanner/build.gradle.kts
+++ b/scanner/build.gradle.kts
@@ -2,7 +2,7 @@ val kotlinxCoroutinesVersion: String by project
 
 plugins {
     // Apply core plugins.
-    id("java-library")
+    `java-library`
 }
 
 dependencies {

--- a/spdx-utils/build.gradle.kts
+++ b/spdx-utils/build.gradle.kts
@@ -17,8 +17,8 @@ val jacksonVersion: String by project
 
 plugins {
     // Apply core plugins.
-    id("antlr")
-    id("java-library")
+    antlr
+    `java-library`
 
     // Apply third-party plugins.
     id("at.bxm.svntools")

--- a/test-utils/build.gradle.kts
+++ b/test-utils/build.gradle.kts
@@ -2,7 +2,7 @@ val kotlintestVersion: String by project
 
 plugins {
     // Apply core plugins.
-    id("java-library")
+    `java-library`
 }
 
 dependencies {

--- a/utils/build.gradle.kts
+++ b/utils/build.gradle.kts
@@ -10,7 +10,7 @@ val xzVersion: String by project
 
 plugins {
     // Apply core plugins.
-    id("java-library")
+    `java-library`
 }
 
 dependencies {


### PR DESCRIPTION
Core plugins can be directly added by their name. If their name does not
only consist of letters, it must be enclosed in backticks.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1536)
<!-- Reviewable:end -->
