### PR TITLE
Filter project scan results by definition file paths

### DIFF
--- a/model/src/main/kotlin/ScanResult.kt
+++ b/model/src/main/kotlin/ScanResult.kt
@@ -23,9 +23,9 @@ import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.JsonNode
 
+import com.here.ort.spdx.LICENSE_FILE_MATCHERS
 import com.here.ort.spdx.LICENSE_FILE_NAMES
 
-import java.nio.file.FileSystems
 import java.nio.file.Paths
 import java.util.SortedSet
 
@@ -61,15 +61,11 @@ data class ScanResult(
      * for [provenance]. Findings in files which are listed in [LICENSE_FILE_NAMES] are also kept.
      */
     fun filterPath(path: String): ScanResult {
-        val matchersForLicenseFiles = LICENSE_FILE_NAMES.map {
-            FileSystems.getDefault().getPathMatcher("glob:$it")
-        }
-
         val pathToMatch = Paths.get(path)
 
         fun SortedSet<TextLocation>.filterPath() =
             filterTo(sortedSetOf()) { location ->
-                location.path.startsWith("$path/") || matchersForLicenseFiles.any { matcher ->
+                location.path.startsWith("$path/") || LICENSE_FILE_MATCHERS.any { matcher ->
                     matcher.matches(pathToMatch)
                 }
             }

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -37,6 +37,7 @@ import com.here.ort.spdx.SpdxLicense
 import com.here.ort.utils.log
 
 import java.io.File
+import java.lang.IllegalArgumentException
 import java.time.Instant
 import java.util.ServiceLoader
 
@@ -141,9 +142,18 @@ abstract class Scanner(val scannerName: String, protected val config: ScannerCon
         // Add scan results from de-duplicated project packages to result.
         consolidatedProjectPackageMap.forEach { (referencePackage, deduplicatedPackages) ->
             resultContainers.find { it.id == referencePackage.id }?.let { resultContainer ->
-                deduplicatedPackages.forEach {
-                    resultContainers += resultContainer.copy(id = it.id)
+                deduplicatedPackages.forEach { deduplicatedPackage ->
+                    analyzerResult.projects.find { it.id == deduplicatedPackage.id }?.let { project ->
+                        resultContainers += filterProjectScanResults(project, resultContainer)
+                    } ?: throw IllegalArgumentException(
+                        "Could not find project '${deduplicatedPackage.id.toCoordinates()}'."
+                    )
                 }
+
+                analyzerResult.projects.find { it.id == referencePackage.id }?.let { project ->
+                    resultContainers.remove(resultContainer)
+                    resultContainers += filterProjectScanResults(project, resultContainer)
+                } ?: throw IllegalArgumentException("Could not find project '${referencePackage.id.toCoordinates()}'.")
             }
         }
 
@@ -157,5 +167,23 @@ abstract class Scanner(val scannerName: String, protected val config: ScannerCon
         return ortResult.copy(scanner = scannerRun).apply {
             data += ortResult.data
         }
+    }
+
+    /**
+     * Filter the scan results in the [resultContainer] for only license findings that are in the same subdirectory as
+     * the [project]s definition file.
+     */
+    private fun filterProjectScanResults(project: Project, resultContainer: ScanResultContainer): ScanResultContainer {
+        val pathInRepository = project.definitionFilePath.substringBeforeLast("/")
+        val filteredResults = resultContainer.results.map { result ->
+            if (result.provenance.sourceArtifact != null || pathInRepository.isEmpty()) {
+                // Do not filter the result if a source artifact was scanned or the definition file is in the root
+                // directory of the repository.
+                result
+            } else {
+                result.filterPath(pathInRepository)
+            }
+        }
+        return ScanResultContainer(project.id, filteredResults)
     }
 }

--- a/scanner/src/main/kotlin/scanners/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/ScanCode.kt
@@ -40,7 +40,7 @@ import com.here.ort.scanner.HTTP_CACHE_PATH
 import com.here.ort.scanner.LocalScanner
 import com.here.ort.scanner.ScanException
 import com.here.ort.scanner.ScanResultsStorage
-import com.here.ort.spdx.LICENSE_FILE_NAMES
+import com.here.ort.spdx.LICENSE_FILE_MATCHERS
 import com.here.ort.spdx.NON_LICENSE_FILENAMES
 import com.here.ort.utils.CommandLineTool
 import com.here.ort.utils.ORT_CONFIG_FILENAME
@@ -53,7 +53,6 @@ import com.here.ort.utils.unpack
 import java.io.File
 import java.io.IOException
 import java.net.HttpURLConnection
-import java.nio.file.FileSystems
 import java.nio.file.InvalidPathException
 import java.nio.file.Paths
 import java.time.Instant
@@ -383,14 +382,10 @@ class ScanCode(name: String, config: ScannerConfiguration) : LocalScanner(name, 
      * Get the license found in one of the commonly named license files, if any, or an empty string otherwise.
      */
     internal fun getRootLicense(result: JsonNode): String {
-        val matchersForLicenseFiles = LICENSE_FILE_NAMES.map {
-            FileSystems.getDefault().getPathMatcher("glob:$it")
-        }
-
         val rootLicenseFile = result["files"].singleOrNull { file ->
             val path = file["path"].textValue()
             try {
-                matchersForLicenseFiles.any { it.matches(Paths.get(path)) }
+                LICENSE_FILE_MATCHERS.any { it.matches(Paths.get(path)) }
             } catch (e: InvalidPathException) {
                 false
             }

--- a/spdx-utils/src/main/kotlin/SpdxUtils.kt
+++ b/spdx-utils/src/main/kotlin/SpdxUtils.kt
@@ -21,6 +21,7 @@ package com.here.ort.spdx
 
 import java.io.File
 import java.io.IOException
+import java.nio.file.FileSystems
 import java.util.EnumSet
 
 import org.apache.commons.codec.binary.Hex
@@ -38,6 +39,8 @@ val LICENSE_FILE_NAMES = listOf(
     "COPYRIGHT",
     "PATENTS"
 )
+
+val LICENSE_FILE_MATCHERS = LICENSE_FILE_NAMES.map { FileSystems.getDefault().getPathMatcher("glob:$it") }
 
 /**
  * A list of globs that match file names which are not license files but typically trigger false-positives.


### PR DESCRIPTION
Filter the scan results for projects to only contain relevant license and copyright findings. See the commit messages for details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1537)
<!-- Reviewable:end -->
