### PR TITLE
Gradle: Update the namespace check for plugins

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,7 +2,7 @@ pluginManagement {
     resolutionStrategy {
         eachPlugin {
             // Work around https://github.com/gradle/gradle/issues/1697.
-            if (requested.id.namespace != null && requested.version == null) {
+            if (requested.id.namespace != "org.gradle" && requested.version == null) {
                 val versionPropertyName = if (requested.id.id == "org.jetbrains.kotlin.jvm") {
                     "kotlinPluginVersion"
                 } else {


### PR DESCRIPTION
It seems that the Kotlin DSL behavior has changed at some point and core
plugins now report "org.gradle" instead of null as their namespace.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1538)
<!-- Reviewable:end -->
