### PR TITLE
Gradle: Upgrade Docker plugins to version 4.9.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 detektPluginVersion = 1.0.0-RC12
-dockerJavaApplicationPluginVersion = 4.8.1
-dockerRemoteApiPluginVersion = 4.8.1
+dockerJavaApplicationPluginVersion = 4.9.0
+dockerRemoteApiPluginVersion = 4.9.0
 dokkaPluginVersion = 0.9.18
 grgitPluginVersion = 3.1.1
 ideaExtPluginVersion = 0.5


### PR DESCRIPTION
See https://bmuschko.github.io/gradle-docker-plugin/#change_log. Despite
version 4.9.0 being marked as "TBA" on that page, it was actually
already released. Also see

https://github.com/bmuschko/gradle-docker-plugin/issues/822

about that issue.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1540)
<!-- Reviewable:end -->
