### PR TITLE
ScanResult: Fix-up the filtering of license findings

### DIFF
--- a/model/src/main/kotlin/ScanResult.kt
+++ b/model/src/main/kotlin/ScanResult.kt
@@ -61,12 +61,10 @@ data class ScanResult(
      * for [provenance]. Findings in files which are listed in [LICENSE_FILE_NAMES] are also kept.
      */
     fun filterPath(path: String): ScanResult {
-        val pathToMatch = Paths.get(path)
-
         fun SortedSet<TextLocation>.filterPath() =
             filterTo(sortedSetOf()) { location ->
                 location.path.startsWith("$path/") || LICENSE_FILE_MATCHERS.any { matcher ->
-                    matcher.matches(pathToMatch)
+                    matcher.matches(Paths.get(location.path))
                 }
             }
 


### PR DESCRIPTION
The intention of the code was to not filter out any license findings in any
LICENSE file(s) which makes sense. It was broken as the wrong parameter was
passed to the matcher.

This is a fix-up for 987a541c.

Signed-off-by: Frank Viernau <frank.viernau@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1545)
<!-- Reviewable:end -->
