### PR TITLE
scanner: Fix filtering of project scan results

### DIFF
--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -174,14 +174,15 @@ abstract class Scanner(val scannerName: String, protected val config: ScannerCon
      * the [project]s definition file.
      */
     private fun filterProjectScanResults(project: Project, resultContainer: ScanResultContainer): ScanResultContainer {
-        val pathInRepository = project.definitionFilePath.substringBeforeLast("/")
+        // Do not filter the results if the definition file is in the root of the repository.
+        val parentPath = File(project.definitionFilePath).parentFile?.path ?: return resultContainer
+
         val filteredResults = resultContainer.results.map { result ->
-            if (result.provenance.sourceArtifact != null || pathInRepository.isEmpty()) {
-                // Do not filter the result if a source artifact was scanned or the definition file is in the root
-                // directory of the repository.
+            if (result.provenance.sourceArtifact != null) {
+                // Do not filter the result if a source artifact was scanned.
                 result
             } else {
-                result.filterPath(pathInRepository)
+                result.filterPath(parentPath)
             }
         }
         return ScanResultContainer(project.id, filteredResults)


### PR DESCRIPTION
If the definition file of a project is in the root of the repository,
all license findings which were not in the definition file itself or in
a license file were removed by `filterProjectScanResults`, because
`substringBeforeLast("/")` returns the definition file path itself
instead of an empty string.

To fix this, do not filter at all if the definition file is in the root
of the repository.

Signed-off-by: Martin Nonnenmacher <martin.nonnenmacher@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1551)
<!-- Reviewable:end -->
