### PR TITLE
analyzer: Fix expected results for GitRepoTest

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
@@ -14,7 +14,7 @@ repository:
     spdx-tools:
       type: "Git"
       url: "https://github.com/spdx/tools"
-      revision: "c4193eeb4b89c7d6266f5647e4d81e9cf0a442a1"
+      revision: "e179fae47590eccedc46186ea0ce20cbade5fda7"
       path: ""
     submodules:
       type: "Git"
@@ -129,7 +129,7 @@ analyzer:
       vcs_processed:
         type: "git"
         url: "https://github.com/spdx/tools.git"
-        revision: "c4193eeb4b89c7d6266f5647e4d81e9cf0a442a1"
+        revision: "e179fae47590eccedc46186ea0ce20cbade5fda7"
         path: ""
       homepage_url: "http://spdx.org/tools"
       scopes:


### PR DESCRIPTION
The SHA1 of the v2.1.15 tag in the spdx/tools repository has changed.
Probably the history of the repository was rewritten [1].

[1] https://github.com/spdx/tools/issues/193#issuecomment-501356678

Signed-off-by: Martin Nonnenmacher <martin.nonnenmacher@here.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1553)
<!-- Reviewable:end -->
