### PR TITLE
ScannerCommand: Remove a superfluous explicit type argument

### DIFF
--- a/cli/src/main/kotlin/commands/ScannerCommand.kt
+++ b/cli/src/main/kotlin/commands/ScannerCommand.kt
@@ -150,7 +150,7 @@ object ScannerCommand : CommandWithHelp() {
                 "The provided configuration file '$it' is not actually a file."
             }
 
-            it.readValue<ScannerConfiguration>()
+            it.readValue()
         } ?: ScannerConfiguration()
 
         config.artifactoryStorage?.let {


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1577)
<!-- Reviewable:end -->
