### PR TITLE
Ort result performance tweaks

### DIFF
--- a/evaluator/src/main/kotlin/RuleSet.kt
+++ b/evaluator/src/main/kotlin/RuleSet.kt
@@ -87,7 +87,7 @@ class RuleSet(val ortResult: OrtResult) {
 
             val curatedPackage = ortResult.analyzer?.result?.let { analyzerResult ->
                 analyzerResult.packages.find { it.pkg.id == pkgRef.id }
-                    ?: analyzerResult.projects.find { it.id == pkgRef.id }?.toPackage()?.toCuratedPackage()
+                    ?: ortResult.getProject(pkgRef.id)?.toPackage()?.toCuratedPackage()
             }
 
             if (curatedPackage == null) {

--- a/evaluator/src/main/kotlin/RuleSet.kt
+++ b/evaluator/src/main/kotlin/RuleSet.kt
@@ -85,10 +85,8 @@ class RuleSet(val ortResult: OrtResult) {
 
             visitedPackages += pkgRef
 
-            val curatedPackage = ortResult.analyzer?.result?.let { analyzerResult ->
-                analyzerResult.packages.find { it.pkg.id == pkgRef.id }
-                    ?: ortResult.getProject(pkgRef.id)?.toPackage()?.toCuratedPackage()
-            }
+            val curatedPackage = ortResult.getPackage(pkgRef.id)
+                ?: ortResult.getProject(pkgRef.id)?.toPackage()?.toCuratedPackage()
 
             if (curatedPackage == null) {
                 log.warn { "Could not find package for dependency ${pkgRef.id.toCoordinates()}, skipping rule $name." }

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -238,8 +238,9 @@ data class OrtResult(
 
                         // Only license findings of projects can be excluded by path excludes.
                         val isExcluded = project != null && finding.locations.all { location ->
+                            val path = getFilePathRelativeToAnalyzerRoot(project, location.path)
                             excludes.paths.any { exclude ->
-                                exclude.matches(getFilePathRelativeToAnalyzerRoot(project, location.path))
+                                exclude.matches(path)
                                     .also { matches -> if (matches) matchingExcludes += exclude }
                             }
                         }

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -110,7 +110,7 @@ data class OrtResult(
         sortedMapOf<String, SortedSet<Identifier>>().also { licenses ->
 
             getProjects().forEach { project ->
-                if (!omitExcluded || !isProjectExcluded(project)) {
+                if (!omitExcluded || !isProjectExcluded(project.id)) {
                     project.declaredLicenses.forEach { license ->
                         licenses.getOrPut(license) { sortedSetOf() } += project.id
                     }
@@ -267,7 +267,7 @@ data class OrtResult(
         val vendorPackages = sortedSetOf<Package>()
 
         getProjects().filter {
-            it.id.isFromOrg(*names) && (!omitExcluded || !isProjectExcluded(it))
+            it.id.isFromOrg(*names) && (!omitExcluded || !isProjectExcluded(it.id))
         }.mapTo(vendorPackages) {
             it.toPackage()
         }
@@ -322,7 +322,7 @@ data class OrtResult(
     fun isExcluded(id: Identifier): Boolean =
         getProjects().find { it.id == id }?.let {
             // An excluded project could still be included as a dependency of another non-excluded project.
-            isProjectExcluded(it) && isPackageExcluded(id)
+            isProjectExcluded(id) && isPackageExcluded(id)
         } ?: isPackageExcluded(id)
 
 
@@ -331,7 +331,7 @@ data class OrtResult(
      */
     fun isPackageExcluded(id: Identifier): Boolean =
         getProjects().all { project ->
-            isProjectExcluded(project) || project.scopes.all { scope ->
+            isProjectExcluded(project.id) || project.scopes.all { scope ->
                 getExcludes().isScopeExcluded(scope, project, this) || !scope.contains(id)
             }
         }
@@ -339,7 +339,7 @@ data class OrtResult(
     /**
      * True if the given [project] is excluded.
      */
-    fun isProjectExcluded(project: Project): Boolean = excludedProjects.contains(project.id)
+    fun isProjectExcluded(id: Identifier): Boolean = excludedProjects.contains(id)
 
     /**
      * Return a copy of this [OrtResult] with the [Repository.config] replaced by [config].

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -107,17 +107,24 @@ data class OrtResult(
     private val packages: Map<Identifier, PackageEntry> by lazy {
         log.info { "Computing excluded packages which may take a while..." }
 
+        val includedPackages = mutableSetOf<Identifier>()
+        getProjects().forEach { project ->
+            project.scopes.forEach { scope ->
+                val isScopeExcluded = getExcludes().isScopeExcluded(scope, project, this)
+
+                if (!isProjectExcluded(project.id) && !isScopeExcluded) {
+                    val dependencies = scope.collectDependencies().map { it.id }
+                    includedPackages.addAll(dependencies)
+                }
+            }
+        }
+
         val result = getPackages().associateBy(
             { curatedPackage -> curatedPackage.pkg.id },
             { curatedPackage ->
                 PackageEntry(
                     curatedPackage = curatedPackage,
-                    isExcluded = getProjects().all { project ->
-                        isProjectExcluded(project.id) || project.scopes.all { scope ->
-                            getExcludes().isScopeExcluded(scope, project, this) ||
-                                    !scope.contains(curatedPackage.pkg.id)
-                        }
-                    }
+                    isExcluded = !includedPackages.contains(curatedPackage.pkg.id)
                 )
             }
         )

--- a/model/src/main/kotlin/config/Excludes.kt
+++ b/model/src/main/kotlin/config/Excludes.kt
@@ -55,8 +55,10 @@ data class Excludes(
     /**
      * Return the [PathExclude]s matching the [definitionFilePath][Project.definitionFilePath].
      */
-    fun findPathExcludes(project: Project, ortResult: OrtResult) =
-        paths.filter { it.matches(ortResult.getDefinitionFilePathRelativeToAnalyzerRoot(project)) }
+    fun findPathExcludes(project: Project, ortResult: OrtResult): List<PathExclude> {
+        val definitionFilePath = ortResult.getDefinitionFilePathRelativeToAnalyzerRoot(project)
+        return paths.filter { it.matches(definitionFilePath) }
+    }
 
     /**
      * Return all [ProjectExclude]s for the provided [project].

--- a/model/src/test/kotlin/config/ExcludesTest.kt
+++ b/model/src/test/kotlin/config/ExcludesTest.kt
@@ -250,28 +250,28 @@ class ExcludesTest : WordSpec() {
                 setExcludes(Excludes(projects = listOf(projectExclude1)))
                 setProjects(project1)
 
-                ortResult.isProjectExcluded(project1) shouldBe true
+                ortResult.isProjectExcluded(project1.id) shouldBe true
             }
 
             "return false if the definition file path is matched by a project exclude with scope excludes" {
                 setExcludes(Excludes(projects = listOf(projectExcludeWithScopes1)))
                 setProjects(project1)
 
-                ortResult.isProjectExcluded(project1) shouldBe false
+                ortResult.isProjectExcluded(project1.id) shouldBe false
             }
 
             "return true if the definition file path is matched by a path exclude" {
                 setExcludes(Excludes(paths = listOf(pathExclude1)))
                 setProjects(project1)
 
-                ortResult.isProjectExcluded(project1) shouldBe true
+                ortResult.isProjectExcluded(project1.id) shouldBe true
             }
 
 
             "return false if nothing is excluded" {
                 setProjects(project1)
 
-                ortResult.isProjectExcluded(project1) shouldBe false
+                ortResult.isProjectExcluded(project1.id) shouldBe false
             }
         }
 

--- a/model/src/test/kotlin/config/ExcludesTest.kt
+++ b/model/src/test/kotlin/config/ExcludesTest.kt
@@ -21,13 +21,16 @@ package com.here.ort.model.config
 
 import com.here.ort.model.AnalyzerResult
 import com.here.ort.model.AnalyzerRun
+import com.here.ort.model.CuratedPackage
 import com.here.ort.model.Environment
 import com.here.ort.model.Identifier
 import com.here.ort.model.OrtResult
+import com.here.ort.model.Package
 import com.here.ort.model.PackageReference
 import com.here.ort.model.Project
 import com.here.ort.model.Repository
 import com.here.ort.model.Scope
+
 import io.kotlintest.TestCase
 
 import io.kotlintest.matchers.beEmpty
@@ -81,7 +84,11 @@ class ExcludesTest : WordSpec() {
             analyzer = AnalyzerRun(
                 environment = Environment(),
                 config = AnalyzerConfiguration(ignoreToolVersions = false, allowDynamicVersions = false),
-                result = AnalyzerResult.EMPTY
+                result = AnalyzerResult.EMPTY.copy(
+                    packages = sortedSetOf(
+                        CuratedPackage(pkg = Package.EMPTY.copy(id = id), curations = emptyList())
+                    )
+                )
             )
         )
     }

--- a/model/src/test/kotlin/config/ExcludesTest.kt
+++ b/model/src/test/kotlin/config/ExcludesTest.kt
@@ -42,6 +42,36 @@ import io.kotlintest.shouldBe
 import io.kotlintest.specs.WordSpec
 
 class ExcludesTest : WordSpec() {
+    private val id = Identifier("type", "namespace", "name", "version")
+
+    private val projectId1 = id.copy(name = "project1")
+    private val projectId2 = id.copy(name = "project2")
+    private val projectId3 = id.copy(name = "project3")
+
+    private val project1 = Project.EMPTY.copy(id = projectId1, definitionFilePath = "path1")
+    private val project2 = Project.EMPTY.copy(id = projectId2, definitionFilePath = "path2")
+    private val project3 = Project.EMPTY.copy(id = projectId3, definitionFilePath = "path3")
+
+    private val projectExclude1 = ProjectExclude("path1", ProjectExcludeReason.BUILD_TOOL_OF, "")
+    private val projectExclude2 = ProjectExclude("path2", ProjectExcludeReason.BUILD_TOOL_OF, "")
+    private val projectExclude3 = ProjectExclude("path3", ProjectExcludeReason.BUILD_TOOL_OF, "")
+    private val projectExclude4 = ProjectExclude(".*", ProjectExcludeReason.BUILD_TOOL_OF, "")
+
+
+    private val pathExclude1 = PathExclude("path1", PathExcludeReason.BUILD_TOOL_OF, "")
+    private val pathExclude2 = PathExclude("path2", PathExcludeReason.BUILD_TOOL_OF, "")
+    private val pathExclude3 = PathExclude("**.ext", PathExcludeReason.BUILD_TOOL_OF, "")
+    private val pathExclude4 = PathExclude("**/file.ext", PathExcludeReason.BUILD_TOOL_OF, "")
+
+    private val scope1 = Scope("scope1", sortedSetOf(PackageReference(id)))
+    private val scope2 = Scope("scope2", sortedSetOf(PackageReference(id)))
+
+    private val scopeExclude1 = ScopeExclude("scope1", ScopeExcludeReason.PROVIDED_BY, "")
+    private val scopeExclude2 = ScopeExclude("scope2", ScopeExcludeReason.PROVIDED_BY, "")
+
+    private val projectExcludeWithScopes1 = ProjectExclude("path1", scopes = listOf(scopeExclude1))
+    private val projectExcludeWithScopes2 = ProjectExclude("path2", scopes = listOf(scopeExclude2))
+
 
     private lateinit var ortResult: OrtResult
 
@@ -67,36 +97,6 @@ class ExcludesTest : WordSpec() {
     }
 
     init {
-        val id = Identifier("type", "namespace", "name", "version")
-
-        val projectId1 = id.copy(name = "project1")
-        val projectId2 = id.copy(name = "project2")
-        val projectId3 = id.copy(name = "project3")
-
-        val project1 = Project.EMPTY.copy(id = projectId1, definitionFilePath = "path1")
-        val project2 = Project.EMPTY.copy(id = projectId2, definitionFilePath = "path2")
-        val project3 = Project.EMPTY.copy(id = projectId3, definitionFilePath = "path3")
-
-        val projectExclude1 = ProjectExclude("path1", ProjectExcludeReason.BUILD_TOOL_OF, "")
-        val projectExclude2 = ProjectExclude("path2", ProjectExcludeReason.BUILD_TOOL_OF, "")
-        val projectExclude3 = ProjectExclude("path3", ProjectExcludeReason.BUILD_TOOL_OF, "")
-        val projectExclude4 = ProjectExclude(".*", ProjectExcludeReason.BUILD_TOOL_OF, "")
-
-
-        val pathExclude1 = PathExclude("path1", PathExcludeReason.BUILD_TOOL_OF, "")
-        val pathExclude2 = PathExclude("path2", PathExcludeReason.BUILD_TOOL_OF, "")
-        val pathExclude3 = PathExclude("**.ext", PathExcludeReason.BUILD_TOOL_OF, "")
-        val pathExclude4 = PathExclude("**/file.ext", PathExcludeReason.BUILD_TOOL_OF, "")
-
-        val scope1 = Scope("scope1", sortedSetOf(PackageReference(id)))
-        val scope2 = Scope("scope2", sortedSetOf(PackageReference(id)))
-
-        val scopeExclude1 = ScopeExclude("scope1", ScopeExcludeReason.PROVIDED_BY, "")
-        val scopeExclude2 = ScopeExclude("scope2", ScopeExcludeReason.PROVIDED_BY, "")
-
-        val projectExcludeWithScopes1 = ProjectExclude("path1", scopes = listOf(scopeExclude1))
-        val projectExcludeWithScopes2 = ProjectExclude("path2", scopes = listOf(scopeExclude2))
-
         "findPathExcludes" should {
             "find the correct path excludes for a path" {
                 val excludes = Excludes(paths = listOf(pathExclude1, pathExclude2, pathExclude3, pathExclude4))


### PR DESCRIPTION
With a huge amount of projects the evaluator is still slow.
This PR first fixes two low hanging fruits by using lookup instead of loops.
Moreover it fixes several severe bottlenecks of the evaluator and the reporter.

Overall for the large project I used to investigate the evaluator now runs in 1:48min instead of 2.5h.
The HTML reporter takes about 4 minutes instead of 20. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1585)
<!-- Reviewable:end -->
