### PR TITLE
ReporterCommand: Correct command line help aout the ORT result file

### DIFF
--- a/cli/src/main/kotlin/commands/ReporterCommand.kt
+++ b/cli/src/main/kotlin/commands/ReporterCommand.kt
@@ -60,7 +60,7 @@ object ReporterCommand : CommandWithHelp() {
     }
 
     @Parameter(
-        description = "The ORT result file to use. Must contain a scan result.",
+        description = "The ORT result file to use.",
         names = ["--ort-file", "-i"],
         required = true,
         order = PARAMETER_ORDER_MANDATORY


### PR DESCRIPTION
As of 0ff8c21 it is not necessary to contain a scan result anymore.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1587)
<!-- Reviewable:end -->
