### PR TITLE
PackageManager: Prefer the normalized VCS in processPackageVcs()

### DIFF
--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -151,8 +151,7 @@ abstract class PackageManager(
             }.orEmpty()
 
             val vcsFromUrl = VersionControlSystem.splitUrl(normalizedUrl)
-
-            return vcsFromUrl.merge(normalizedVcsFromPackage)
+            return normalizedVcsFromPackage.merge(vcsFromUrl)
         }
 
         /**


### PR DESCRIPTION
VcsInfo.merge() defaults to the data in "this", and we should prefer the
normalized data (and esp. the lower-case type) here.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1599)
<!-- Reviewable:end -->
