### PR TITLE
VersionControlSystem: Consistently use an unnormalized type in splitUrl()

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-gemspec.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-gemspec.yml
@@ -68,7 +68,7 @@ packages:
         value: "73771ea960b3900d96e6b3729bd203e66f387d0717df83304411bf37efd7386e"
         algorithm: "SHA-256"
     vcs:
-      type: "git"
+      type: "Git"
       url: "http://github.com/sporkmonger/addressable.git"
       revision: ""
       path: ""
@@ -106,7 +106,7 @@ packages:
         value: "ea7bf591567e391ef262a7c29edaf87c6205204afb5bb39dfa8f08f2e51282a3"
         algorithm: "SHA-256"
     vcs:
-      type: "git"
+      type: "Git"
       url: "https://github.com/halostatue/diff-lcs.git"
       revision: ""
       path: ""
@@ -270,7 +270,7 @@ packages:
         value: "3a0168c33fa0b00886423a2ceb21c74199273ccd01bc250360fc8d18600bb0f4"
         algorithm: "SHA-256"
     vcs:
-      type: "git"
+      type: "Git"
       url: "http://github.com/weppos/publicsuffix-ruby.git"
       revision: ""
       path: ""
@@ -304,7 +304,7 @@ packages:
         value: "ee2016b1ddf820f6e5ee437d10a85319506b60c0d493da1d15815361a91129bd"
         algorithm: "SHA-256"
     vcs:
-      type: "git"
+      type: "Git"
       url: "http://github.com/rack/rack.git"
       revision: ""
       path: ""
@@ -334,7 +334,7 @@ packages:
         value: "526e0b2d22feae638eb99bd746bbb25b18a4869a8f6ce4e8a87dabd1ab5f727f"
         algorithm: "SHA-256"
     vcs:
-      type: "git"
+      type: "Git"
       url: "http://github.com/rspec/rspec-core.git"
       revision: ""
       path: ""
@@ -365,7 +365,7 @@ packages:
         value: "7e571848a5cbdb1661187d04e5c1f29287ec80fcb5a395f9994836892a3780bb"
         algorithm: "SHA-256"
     vcs:
-      type: "git"
+      type: "Git"
       url: "http://github.com/rspec/rspec-expectations.git"
       revision: ""
       path: ""
@@ -395,7 +395,7 @@ packages:
         value: "23f7f0039e17f2841edfb51d678ac9e06c056903a7908db967f5618887f2022c"
         algorithm: "SHA-256"
     vcs:
-      type: "git"
+      type: "Git"
       url: "http://github.com/rspec/rspec-mocks.git"
       revision: ""
       path: ""
@@ -457,7 +457,7 @@ packages:
         value: "0174cfbed780e42aa181227af623e2ae37511f20a2fdfec48b54f6cf4d7a6404"
         algorithm: "SHA-256"
     vcs:
-      type: "git"
+      type: "Git"
       url: "http://github.com/rspec/rspec.git"
       revision: ""
       path: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-lockfile.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-lockfile.yml
@@ -67,7 +67,7 @@ packages:
         value: "ea7bf591567e391ef262a7c29edaf87c6205204afb5bb39dfa8f08f2e51282a3"
         algorithm: "SHA-256"
     vcs:
-      type: "git"
+      type: "Git"
       url: "https://github.com/halostatue/diff-lcs.git"
       revision: ""
       path: ""
@@ -132,7 +132,7 @@ packages:
         value: "1f93a829257b621d40c4cbfce3acdcd688b0b3d70497ceae4fa2baf955eede2f"
         algorithm: "SHA-256"
     vcs:
-      type: "git"
+      type: "Git"
       url: "https://github.com/sparklemotion/nokogiri.git"
       revision: ""
       path: ""
@@ -166,7 +166,7 @@ packages:
         value: "ee2016b1ddf820f6e5ee437d10a85319506b60c0d493da1d15815361a91129bd"
         algorithm: "SHA-256"
     vcs:
-      type: "git"
+      type: "Git"
       url: "http://github.com/rack/rack.git"
       revision: ""
       path: ""
@@ -196,7 +196,7 @@ packages:
         value: "526e0b2d22feae638eb99bd746bbb25b18a4869a8f6ce4e8a87dabd1ab5f727f"
         algorithm: "SHA-256"
     vcs:
-      type: "git"
+      type: "Git"
       url: "http://github.com/rspec/rspec-core.git"
       revision: ""
       path: ""
@@ -227,7 +227,7 @@ packages:
         value: "7e571848a5cbdb1661187d04e5c1f29287ec80fcb5a395f9994836892a3780bb"
         algorithm: "SHA-256"
     vcs:
-      type: "git"
+      type: "Git"
       url: "http://github.com/rspec/rspec-expectations.git"
       revision: ""
       path: ""
@@ -257,7 +257,7 @@ packages:
         value: "23f7f0039e17f2841edfb51d678ac9e06c056903a7908db967f5618887f2022c"
         algorithm: "SHA-256"
     vcs:
-      type: "git"
+      type: "Git"
       url: "http://github.com/rspec/rspec-mocks.git"
       revision: ""
       path: ""
@@ -319,7 +319,7 @@ packages:
         value: "0174cfbed780e42aa181227af623e2ae37511f20a2fdfec48b54f6cf4d7a6404"
         algorithm: "SHA-256"
     vcs:
-      type: "git"
+      type: "Git"
       url: "http://github.com/rspec/rspec.git"
       revision: ""
       path: ""

--- a/downloader/src/funTest/kotlin/BabelTest.kt
+++ b/downloader/src/funTest/kotlin/BabelTest.kt
@@ -79,7 +79,7 @@ class BabelTest : StringSpec() {
 
             downloadResult.sourceArtifact shouldBe null
             downloadResult.vcsInfo shouldNotBe null
-            downloadResult.vcsInfo!!.type.toLowerCase() shouldBe pkg.vcsProcessed.type
+            downloadResult.vcsInfo!!.type shouldBe pkg.vcsProcessed.type
             downloadResult.vcsInfo!!.url shouldBe pkg.vcsProcessed.url
             downloadResult.vcsInfo!!.revision shouldBe "master"
             downloadResult.vcsInfo!!.resolvedRevision shouldBe "cee4cde53e4f452d89229986b9368ecdb41e00da"

--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -177,6 +177,8 @@ abstract class VersionControlSystem {
                     }
 
                     val type = forUrl(url)?.type.orEmpty()
+
+                    // Note: This "type" is not normalized in the sense of "VcsInfo.normalize()".
                     if (type == "Git") {
                         url += ".git"
                     }
@@ -217,7 +219,7 @@ abstract class VersionControlSystem {
                         if (uri.hasFragmentRevision()) revision = uri.fragment
                     }
 
-                    VcsInfo("git", url, revision, path = path)
+                    VcsInfo("Git", url, revision, path = path)
                 }
 
                 else -> {
@@ -225,13 +227,13 @@ abstract class VersionControlSystem {
                         vcsUrl.contains(".git/") -> {
                             val url = normalizeVcsUrl(vcsUrl.substringBefore(".git/"))
                             val path = vcsUrl.substringAfter(".git/")
-                            VcsInfo("git", "$url.git", "", null, path)
+                            VcsInfo("Git", "$url.git", "", null, path)
                         }
 
                         vcsUrl.contains(".git#") || Regex("git.+#[a-fA-F0-9]{7,}").matches(vcsUrl) -> {
                             val url = normalizeVcsUrl(vcsUrl.substringBeforeLast('#'))
                             val revision = vcsUrl.substringAfterLast('#')
-                            VcsInfo("git", url, revision, null, "")
+                            VcsInfo("Git", url, revision, null, "")
                         }
 
                         else -> VcsInfo("", vcsUrl, "")

--- a/downloader/src/test/kotlin/VersionControlSystemTest.kt
+++ b/downloader/src/test/kotlin/VersionControlSystemTest.kt
@@ -69,7 +69,7 @@ class VersionControlSystemTest : WordSpec({
                 "https://git-wip-us.apache.org/repos/asf/zeppelin.git/zeppelin-interpreter"
             )
             val expected = VcsInfo(
-                type = "git",
+                type = "Git",
                 url = "https://git-wip-us.apache.org/repos/asf/zeppelin.git",
                 revision = "",
                 path = "zeppelin-interpreter"
@@ -82,7 +82,7 @@ class VersionControlSystemTest : WordSpec({
                 "git+ssh://sub.domain.com:42/foo-bar#b3b5b3c60dcdc39347b23cf94ab8f577239b7df3"
             )
             val expected = VcsInfo(
-                type = "git",
+                type = "Git",
                 url = "ssh://sub.domain.com:42/foo-bar",
                 revision = "b3b5b3c60dcdc39347b23cf94ab8f577239b7df3",
                 path = ""
@@ -95,7 +95,7 @@ class VersionControlSystemTest : WordSpec({
                 "https://github.com/mochajs/mocha.git#5bd33a0ba201d227159759e8ced86756595b0c54"
             )
             val expected = VcsInfo(
-                type = "git",
+                type = "Git",
                 url = "https://github.com/mochajs/mocha.git",
                 revision = "5bd33a0ba201d227159759e8ced86756595b0c54",
                 path = ""
@@ -150,7 +150,7 @@ class VersionControlSystemTest : WordSpec({
                 "https://github.com/heremaps/oss-review-toolkit.git"
             )
             val expected = VcsInfo(
-                type = "git",
+                type = "Git",
                 url = "https://github.com/heremaps/oss-review-toolkit.git",
                 revision = ""
             )
@@ -162,7 +162,7 @@ class VersionControlSystemTest : WordSpec({
                 "https://github.com/blob/tree.git"
             )
             val expected = VcsInfo(
-                type = "git",
+                type = "Git",
                 url = "https://github.com/blob/tree.git",
                 revision = ""
             )
@@ -174,7 +174,7 @@ class VersionControlSystemTest : WordSpec({
                 "https://github.com/babel/babel/tree/master/packages/babel-code-frame.git"
             )
             val expected = VcsInfo(
-                type = "git",
+                type = "Git",
                 url = "https://github.com/babel/babel.git",
                 revision = "master",
                 path = "packages/babel-code-frame"
@@ -187,7 +187,7 @@ class VersionControlSystemTest : WordSpec({
                 "https://github.com/crypto-browserify/crypto-browserify/blob/6aebafa/test/create-hmac.js"
             )
             val expected = VcsInfo(
-                type = "git",
+                type = "Git",
                 url = "https://github.com/crypto-browserify/crypto-browserify.git",
                 revision = "6aebafa",
                 path = "test/create-hmac.js"
@@ -200,7 +200,7 @@ class VersionControlSystemTest : WordSpec({
                 "ssh://git@github.com/EsotericSoftware/kryo.git/kryo-shaded"
             )
             val expected = VcsInfo(
-                type = "git",
+                type = "Git",
                 url = "ssh://git@github.com/EsotericSoftware/kryo.git",
                 revision = "",
                 path = "kryo-shaded"
@@ -215,7 +215,7 @@ class VersionControlSystemTest : WordSpec({
                 "https://gitlab.com/rich-harris/rollup-plugin-buble.git"
             )
             val expected = VcsInfo(
-                type = "git",
+                type = "Git",
                 url = "https://gitlab.com/rich-harris/rollup-plugin-buble.git",
                 revision = ""
             )
@@ -227,7 +227,7 @@ class VersionControlSystemTest : WordSpec({
                 "https://gitlab.com/Rich-Harris/rollup-plugin-buble/tree/master/src"
             )
             val expected = VcsInfo(
-                type = "git",
+                type = "Git",
                 url = "https://gitlab.com/Rich-Harris/rollup-plugin-buble.git",
                 revision = "master",
                 path = "src"
@@ -240,7 +240,7 @@ class VersionControlSystemTest : WordSpec({
                 "https://gitlab.com/Rich-Harris/rollup-plugin-buble/blob/v0.15.0/README.md"
             )
             val expected = VcsInfo(
-                type = "git",
+                type = "Git",
                 url = "https://gitlab.com/Rich-Harris/rollup-plugin-buble.git",
                 revision = "v0.15.0",
                 path = "README.md"


### PR DESCRIPTION
To not create the impression it was ever normalized to lower-case like
VcsInfo.normalize() would do it.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1608)
<!-- Reviewable:end -->
