### PR TITLE
evaluator: Fix the no_gpl_declared.kts script

### DIFF
--- a/evaluator/src/main/resources/rules/no_gpl_declared.kts
+++ b/evaluator/src/main/resources/rules/no_gpl_declared.kts
@@ -20,7 +20,10 @@ val ruleSet = ruleSet(ortResult) {
                 +isGpl()
             }
 
-            error("The package '${pkg.id.toCoordinates()}' has the ${licenseSource.name} license '$license'.")
+            error(
+                "The package '${pkg.id.toCoordinates()}' has the ${licenseSource.name} license '$license'.",
+                "Remove the dependency on this package."
+            )
         }
     }
 }


### PR DESCRIPTION
Add the second parameter to the `error` function call. This is a fixup
for e559b3e. The issue was not detected by the `EvalutorTest` because
Kotlin's own `error` function was called instead, so the script could
still be compiled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1609)
<!-- Reviewable:end -->
