### PR TITLE
Git: Do not set core.askpass to an empty string to suppress prompts

### DIFF
--- a/downloader/src/main/kotlin/vcs/Git.kt
+++ b/downloader/src/main/kotlin/vcs/Git.kt
@@ -30,7 +30,6 @@ import com.here.ort.utils.ProcessCapture
 import com.here.ort.utils.log
 import com.here.ort.utils.safeMkdirs
 import com.here.ort.utils.showStackTrace
-import com.here.ort.utils.suppressInput
 
 import com.vdurmont.semver4j.Semver
 
@@ -44,9 +43,7 @@ class Git : GitBase() {
     override val priority = 100
 
     override fun isApplicableUrlInternal(vcsUrl: String) =
-        suppressInput {
-            ProcessCapture("git", "-c", "credential.helper=", "-c", "core.askpass=", "ls-remote", vcsUrl).isSuccess
-        }
+        ProcessCapture("git", "-c", "credential.helper=", "-c", "core.askpass=echo", "ls-remote", vcsUrl).isSuccess
 
     override fun download(
         pkg: Package, targetDir: File, allowMovingRevisions: Boolean,

--- a/downloader/src/main/kotlin/vcs/GitWorkingTree.kt
+++ b/downloader/src/main/kotlin/vcs/GitWorkingTree.kt
@@ -57,8 +57,8 @@ open class GitWorkingTree(workingDir: File, private val gitBase: GitBase) : Work
         File(gitBase.run(workingDir, "rev-parse", "--show-toplevel").stdout.trimEnd('\n', '/'))
 
     private fun listRemoteRefs(namespace: String): List<String> {
-        val tags = gitBase.run(workingDir, "ls-remote", "--refs", getFirstRemote(), "refs/$namespace/*")
-            .stdout.trimEnd()
+        val tags = gitBase.run(workingDir, "-c", "credential.helper=", "-c", "core.askpass=echo", "ls-remote",
+            "--refs", getFirstRemote(), "refs/$namespace/*").stdout.trimEnd()
         return tags.lines().map {
             it.split('\t').last().removePrefix("refs/$namespace/")
         }

--- a/downloader/src/test/kotlin/GitTest.kt
+++ b/downloader/src/test/kotlin/GitTest.kt
@@ -67,6 +67,7 @@ class GitTest : StringSpec() {
             git.isApplicableUrl("https://bitbucket.org/paniq/masagin") shouldBe false
         }
 
+        // TODO: Investigate why this succeeds locally on Windows but seem to make AppVeyor CI hang.
         "Git does not prompt for credentials for non-existing repositories".config(enabled = !Os.isWindows) {
             git.isApplicableUrl("https://github.com/heremaps/foobar.git") shouldBe false
         }


### PR DESCRIPTION
As it turns out, using an empty string does not work reliably on all
platforms. Instead, use "echo" as a universal dummy command which seems
to work well on Linux and Windows so we can avoid suppressing any
prompt for input.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1622)
<!-- Reviewable:end -->
