### PR TITLE
docker: Fix the check whether running build.sh is required

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -20,7 +20,10 @@
 # Get the absolute directory this script resides in.
 SCRIPT_DIR="$(cd "$(dirname $0)" && pwd)"
 
-(cd $SCRIPT_DIR/.. && \
+# Get the absolute directory of the project root.
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+(cd $PROJECT_DIR && \
     . docker/lib && \
     buildWithoutContext docker/build/Dockerfile ort-build:latest && \
     runGradleWrapper ort-build :cli:installDist :cli:distTar

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -20,15 +20,24 @@
 # Get the absolute directory this script resides in.
 SCRIPT_DIR="$(cd "$(dirname $0)" && pwd)"
 
-# If required, first build the image to build ORT.
-docker image inspect ort-build > /dev/null 2>&1 || docker/build.sh
+# Get the absolute directory of the project root.
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# If required, first build the distribution.
+ORT_VERSION=$(cat $PROJECT_DIR/model/src/main/resources/VERSION)
+if [ ! -f "$PROJECT_DIR/cli/build/distributions/ort-$ORT_VERSION.tar" ]; then
+    docker/build.sh
+    ORT_VERSION=$(cat $PROJECT_DIR/model/src/main/resources/VERSION)
+fi
+
+echo Running ORT version $ORT_VERSION...
 
 DOCKER_ARGS=$1
 shift
 ORT_ARGS=$@
 
-(cd $SCRIPT_DIR/.. && \
+(cd $PROJECT_DIR && \
     . docker/lib && \
-    docker build -t ort:latest -f docker/run/Dockerfile cli/build/distributions && \
+    docker build --build-arg ORT_VERSION=$ORT_VERSION -t ort:latest -f docker/run/Dockerfile cli/build/distributions && \
     runAsUser "$DOCKER_ARGS" ort "$ORT_ARGS"
 )

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -33,8 +33,10 @@ fi
 echo Running ORT version $ORT_VERSION...
 
 DOCKER_ARGS=$1
-shift
-ORT_ARGS=$@
+if [ -n "$DOCKER_ARGS" ]; then
+    shift
+    ORT_ARGS=$@
+fi
 
 (cd $PROJECT_DIR && \
     . docker/lib && \

--- a/docker/run/Dockerfile
+++ b/docker/run/Dockerfile
@@ -83,5 +83,9 @@ RUN \
         chmod -R o=u /usr/local/scancode-toolkit-$SCANCODE_VERSION && \
         ln -s /usr/local/scancode-toolkit-$SCANCODE_VERSION/scancode /usr/local/bin/scancode
 
-ADD ort.tar .
+ARG ORT_VERSION
+ADD ort-$ORT_VERSION.tar .
+
+# As the ENTRYPOINT cannot contain variables, create a symbolic link to the specific version instead.
+RUN ln -s /ort-$ORT_VERSION /ort
 ENTRYPOINT ["/ort/bin/ort"]

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -20,10 +20,19 @@
 # Get the absolute directory this script resides in.
 SCRIPT_DIR="$(cd "$(dirname $0)" && pwd)"
 
-# If required, first build the image to build ORT.
-docker image inspect ort-build > /dev/null 2>&1 || docker/build.sh
+# Get the absolute directory of the project root.
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-(cd $SCRIPT_DIR/.. && \
+# If required, first build the distribution.
+ORT_VERSION=$(cat $PROJECT_DIR/model/src/main/resources/VERSION)
+if [ ! -f "$PROJECT_DIR/cli/build/distributions/ort-$ORT_VERSION.tar" ]; then
+    docker/build.sh
+    ORT_VERSION=$(cat $PROJECT_DIR/model/src/main/resources/VERSION)
+fi
+
+echo Testing ORT version $ORT_VERSION...
+
+(cd $PROJECT_DIR && \
     . docker/lib && \
     buildWithoutContext docker/test/Dockerfile ort-test:latest && \
     runGradleWrapper ort-test test


### PR DESCRIPTION
Instead of checking for the existence of the "ort-build" Docker image,
check for the existence of the required "ort.tar". With the recent change
in 5e82e01 to properly set the Gradle project version, the "ort.tar"
contains the version string which is also taken into account here.

Fixes #1637.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1638)
<!-- Reviewable:end -->
