### PR TITLE
GoDep: Set the project name based on the definition file URL

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/godep-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/godep-expected-output.yml
@@ -1,7 +1,7 @@
 ---
 project:
-  id: "GoDep::godep:ce0bfadeb516ab23c845a85c4b0eae421ec9614b"
-  purl: "pkg://GoDep//godep@ce0bfadeb516ab23c845a85c4b0eae421ec9614b"
+  id: "GoDep::github.com/tools/godep/godeps:ce0bfadeb516ab23c845a85c4b0eae421ec9614b"
+  purl: "pkg://GoDep//github.com%2Ftools%2Fgodep%2Fgodeps@ce0bfadeb516ab23c845a85c4b0eae421ec9614b"
   definition_file_path: "Godeps/Godeps.json"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/analyzer/src/funTest/assets/projects/external/qmstr-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/qmstr-expected-output.yml
@@ -1,7 +1,7 @@
 ---
 project:
-  id: "GoDep::qmstr:0cd17d10b931c9108450ca5a68d4f85b6e4953ef"
-  purl: "pkg://GoDep//qmstr@0cd17d10b931c9108450ca5a68d4f85b6e4953ef"
+  id: "GoDep::github.com/qmstr/qmstr:0cd17d10b931c9108450ca5a68d4f85b6e4953ef"
+  purl: "pkg://GoDep//github.com%2Fqmstr%2Fqmstr@0cd17d10b931c9108450ca5a68d4f85b6e4953ef"
   definition_file_path: "Gopkg.toml"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/analyzer/src/funTest/assets/projects/external/sprig-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/sprig-expected-output.yml
@@ -1,7 +1,7 @@
 ---
 project:
-  id: "GoDep::sprig:9d9aa1f74c86fd9d36ecfe3f2a44a3093c3d4c15"
-  purl: "pkg://GoDep//sprig@9d9aa1f74c86fd9d36ecfe3f2a44a3093c3d4c15"
+  id: "GoDep::github.com/masterminds/sprig:9d9aa1f74c86fd9d36ecfe3f2a44a3093c3d4c15"
+  purl: "pkg://GoDep//github.com%2Fmasterminds%2Fsprig@9d9aa1f74c86fd9d36ecfe3f2a44a3093c3d4c15"
   definition_file_path: "glide.yaml"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/downloader/src/test/kotlin/SubversionTest.kt
+++ b/downloader/src/test/kotlin/SubversionTest.kt
@@ -83,6 +83,7 @@ class SubversionTest : StringSpec() {
                 "lossless-rst-writer",
                 "nesting",
                 "plugins",
+                "rel-0.15",
                 "subdocs"
             )
 


### PR DESCRIPTION
The Gopkg.toml seems to provide no means to declare a name for
the project but the dependencies are actually referred to by names
constructed from the host and path of the repository URL. As
this would still be ambigious for multi-project repositories use
also the path to the directory containing the definition file.

While not really sure about whether appending the path inside the
repository is correct it seems to be an improvement compared to
using always empty strings as name as was done so before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1646)
<!-- Reviewable:end -->
