### PR TITLE
Travis: Do not execute the `cli:dockerBuildImage` task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,6 @@ install:
 script:
   - set -o pipefail
   - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
-      ./gradlew --no-daemon --stacktrace :cli:dockerBuildImage;
       ./gradlew --no-daemon --stacktrace -Dkotlintest.tags.exclude=ScanCodeTag check jacocoReport | tee log.txt;
     else
       ./gradlew --no-daemon --scan --stacktrace -Dkotlintest.tags.exclude=ExpensiveTag check jacocoReport | tee log.txt;


### PR DESCRIPTION
This is a fixup for ef9923a where the task was removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1656)
<!-- Reviewable:end -->
