### PR TITLE
Gradle: Add "eap" and "pr" to the list of non-final version qualifiers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,7 +58,8 @@ tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
     resolutionStrategy {
         componentSelection {
             all {
-                val isNonFinalVersion = listOf("alpha", "beta", "rc", "cr", "m", "preview", "b", "ea").any { qualifier ->
+                val nonFinalQualifiers = listOf("alpha", "b", "beta", "cr", "ea", "eap", "m", "pr", "preview", "rc")
+                val isNonFinalVersion = nonFinalQualifiers.any { qualifier ->
                     candidate.version.matches(Regex("(?i).*[.-]$qualifier[.\\d-+]*"))
                 }
 


### PR DESCRIPTION
To not report versions like "2.10.0.pr1" or "1.3.0-RC-1.3.50-eap-5" as
updates. While at it, move the list to a separate variable and sort it
alphabetically.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1663)
<!-- Reviewable:end -->
