### PR TITLE
NPM: Change the log level of a message from info to debug

### DIFF
--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -466,7 +466,7 @@ open class Npm(
 
             // E.g. when using Yarn workspaces, the dependencies of the projects are consolidated in a single top-level
             // "node_modules" directory for de-duplication, so go up.
-            log.info {
+            log.debug {
                 "Could not find package file for '$name' in '$startModulesDir', looking in '$parentModulesDir' instead."
             }
 


### PR DESCRIPTION
The message is mainly printed in projects using Yarn workspaces and for
projects with many dependencies this can easily generate more than 100M
of logs, so make the message debug instead of info.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heremaps/oss-review-toolkit/1671)
<!-- Reviewable:end -->
