### PR TITLE
Provenance: Simplify the matches() function a bit

### DIFF
--- a/model/src/main/kotlin/Provenance.kt
+++ b/model/src/main/kotlin/Provenance.kt
@@ -74,10 +74,6 @@ data class Provenance(
     fun matches(pkg: Package): Boolean {
         // If the scanned source code came from a source artifact, it has to match the package's source artifact.
         if (sourceArtifact != null) {
-            // If the hash values match, we do not need to compare the other properties like the URL. Only support this
-            // for algorithms for which we can actually verify as otherwise the hash could be fake.
-            if (sourceArtifact.hash.canVerify) return sourceArtifact.hash == pkg.sourceArtifact.hash
-
             return sourceArtifact == pkg.sourceArtifact
         }
 


### PR DESCRIPTION
Not comparing the hash value in some cases adds an execution
branch and thus makes testing harder. It is not needed as the
performance gains likely are neglectible and thus removed now.

Signed-off-by: Frank Viernau <frank.viernau@here.com>