### PR TITLE
cli: Disable "ExpandAtSign" JCommander option

### DIFF
--- a/cli/src/main/kotlin/Main.kt
+++ b/cli/src/main/kotlin/Main.kt
@@ -81,6 +81,7 @@ object Main : CommandWithHelp() {
     fun run(args: Array<String>): Int {
         val jc = JCommander(this).apply {
             programName = TOOL_NAME
+            setExpandAtSign(false)
             addCommand(AnalyzerCommand)
             addCommand(DownloaderCommand)
             addCommand(EvaluatorCommand)


### PR DESCRIPTION
The option allows reading parameters from a file, see [1]. The option is
enabled by default, as a result parameters cannot start with "@",
because JCommander then interprets the following characters as a file
path to read parameters from.

As the option is unused and there is no workaround like escaping the
parameter that starts with "@", disable the option.

[1] http://jcommander.org/#__syntax