### PR TITLE
evaluator: Add a LicenseView for concluded or detected licenses

### DIFF
--- a/evaluator/src/main/kotlin/LicenseView.kt
+++ b/evaluator/src/main/kotlin/LicenseView.kt
@@ -86,6 +86,19 @@ sealed class LicenseView {
     }
 
     /**
+     * Return only the concluded licenses if they exist, otherwise return detected licenses.
+     */
+    object ConcludedOrDetected : LicenseView() {
+        override fun licenses(pkg: Package, detectedLicenses: List<String>): List<Pair<String, LicenseSource>> {
+            pkg.concludedLicense?.licenses()?.let {
+                return it.map { license -> Pair(license, LicenseSource.CONCLUDED) }
+            }
+
+            return detectedLicenses.map { Pair(it, LicenseSource.DETECTED) }
+        }
+    }
+
+    /**
      * Return only the concluded licenses.
      */
     object OnlyConcluded : LicenseView() {

--- a/evaluator/src/test/kotlin/LicenseViewTest.kt
+++ b/evaluator/src/test/kotlin/LicenseViewTest.kt
@@ -208,6 +208,68 @@ class LicenseViewTest : WordSpec({
         }
     }
 
+    "ConcludedOrDetected" should {
+        "return the correct licenses" {
+            LicenseView.ConcludedOrDetected.licenses(
+                packageWithoutLicense,
+                emptyList()
+            ) shouldBe emptyList()
+
+            LicenseView.ConcludedOrDetected.licenses(
+                packageWithoutLicense,
+                detectedLicenses
+            ) shouldBe listOf(
+                Pair("LicenseRef-a", LicenseSource.DETECTED),
+                Pair("LicenseRef-b", LicenseSource.DETECTED)
+            )
+
+            LicenseView.ConcludedOrDetected.licenses(
+                packageWithOnlyConcludedLicense,
+                emptyList()
+            ) shouldBe listOf(
+                Pair("LicenseRef-a", LicenseSource.CONCLUDED),
+                Pair("LicenseRef-b", LicenseSource.CONCLUDED)
+            )
+
+            LicenseView.ConcludedOrDetected.licenses(
+                packageWithOnlyConcludedLicense,
+                detectedLicenses
+            ) shouldBe listOf(
+                Pair("LicenseRef-a", LicenseSource.CONCLUDED),
+                Pair("LicenseRef-b", LicenseSource.CONCLUDED)
+            )
+
+            LicenseView.ConcludedOrDetected.licenses(
+                packageWithOnlyDeclaredLicense,
+                emptyList()
+            ) shouldBe emptyList()
+
+            LicenseView.ConcludedOrDetected.licenses(
+                packageWithOnlyDeclaredLicense,
+                detectedLicenses
+            ) shouldBe listOf(
+                Pair("LicenseRef-a", LicenseSource.DETECTED),
+                Pair("LicenseRef-b", LicenseSource.DETECTED)
+            )
+
+            LicenseView.ConcludedOrDetected.licenses(
+                packageWithConcludedAndDeclaredLicense,
+                emptyList()
+            ) shouldBe listOf(
+                Pair("LicenseRef-a", LicenseSource.CONCLUDED),
+                Pair("LicenseRef-b", LicenseSource.CONCLUDED)
+            )
+
+            LicenseView.ConcludedOrDetected.licenses(
+                packageWithConcludedAndDeclaredLicense,
+                detectedLicenses
+            ) shouldBe listOf(
+                Pair("LicenseRef-a", LicenseSource.CONCLUDED),
+                Pair("LicenseRef-b", LicenseSource.CONCLUDED)
+            )
+        }
+    }
+
     "OnlyConcluded" should {
         "return only the concluded licenses" {
             LicenseView.OnlyConcluded.licenses(


### PR DESCRIPTION
Adding new license view to enable writing evaluator rules only on concluded or detected licenses