### PR TITLE
detekt: Clear wildcard excludes

### DIFF
--- a/.detekt.yml
+++ b/.detekt.yml
@@ -48,6 +48,7 @@ style:
   UnusedImports:
     active: true
   WildcardImport:
+    excludes: ''
     excludeImports: '
       ch.frankel.slf4k.*,
       com.here.ort.analyzer.managers.*,


### PR DESCRIPTION
Clear the default value [1] to check test sources, too.

[1] https://github.com/arturbosch/detekt/blob/master/detekt-cli/src/main/resources/default-detekt-config.yml#L548

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>