### PR TITLE
GitHub: Add an initial CODEOWNERS file to auto-assign reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @sschuberth @mnonnenmacher @fviernau
+/reporter-web-app/ @tsteenbe


### PR DESCRIPTION
See https://help.github.com/en/articles/about-code-owners.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>