### PR TITLE
Pip: Assign less ambigious project IDs for `requirements.txt`

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
@@ -1,7 +1,7 @@
 ---
 project:
-  id: "PIP::example-python-flask:0773991e36a4c69b121cdb05146d6140347d4065"
-  purl: "pkg://PIP//example-python-flask@0773991e36a4c69b121cdb05146d6140347d4065"
+  id: "PIP::src/funTest/assets/projects/external/example-python-flask/requirements.txt:0773991e36a4c69b121cdb05146d6140347d4065"
+  purl: "pkg://PIP//src%2FfunTest%2Fassets%2Fprojects%2Fexternal%2Fexample-python-flask%2Frequirements.txt@0773991e36a4c69b121cdb05146d6140347d4065"
   definition_file_path: "requirements.txt"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/analyzer/src/funTest/assets/projects/synthetic/python3-django-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/python3-django-expected-output.yml
@@ -1,7 +1,7 @@
 ---
 project:
-  id: "PIP::python3-django:<REPLACE_REVISION>"
-  purl: "pkg://PIP//python3-django@<REPLACE_REVISION>"
+  id: "PIP::src/funTest/assets/projects/synthetic/python3-django/requirements.txt:<REPLACE_REVISION>"
+  purl: "pkg://PIP//src%2FfunTest%2Fassets%2Fprojects%2Fsynthetic%2Fpython3-django%2Frequirements.txt@<REPLACE_REVISION>"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/python3-django/requirements.txt"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -287,7 +287,9 @@ class Pip(
         // Amend information from "setup.py" with that from "requirements.txt".
         val projectName = when (Pair(setupName.isNotEmpty(), requirementsName.isNotEmpty())) {
             Pair(true, false) -> setupName
-            Pair(false, true) -> requirementsName
+            // In case of only a requirements file without further meta-data, use the relative path to the analyzer
+            // root as a unique project name.
+            Pair(false, true) -> definitionFile.relativeTo(analyzerRoot).invariantSeparatorsPath
             Pair(true, true) -> "$setupName-requirements$requirementsSuffix"
             else -> throw IllegalArgumentException("Unable to determine a project name for '$definitionFile'.")
         }


### PR DESCRIPTION
`setup.py` files do provide means for declaring a package name while
`requirements.txt` files don't. Thus in case there is only a `requirements.txt`
but no `setup.py` present in a project's base directory there is no way to
derive a non-ambigious name for the project identifier just from the meta-data
provided in the definition file(s). In fact in that case the name was previously
set to the name of the parent directory of the definition file which is not
very unique and thus leads to duplicate project IDs resulting in an analyzer
error.

As of this change the path to the definition file relavtive to the analyzer root
directory as project name which should be highly likely unique. The path relative
to the VCS root could be used alternatively which I decided against having Git
Repo based projects in mind which may include the same repository multiple times
into a manifest.

Signed-off-by: Frank Viernau <frank.viernau@here.com>