### PR TITLE
helper-cli: Add same logging options as used in cli

### DIFF
--- a/helper-cli/src/main/kotlin/Main.kt
+++ b/helper-cli/src/main/kotlin/Main.kt
@@ -22,9 +22,15 @@ package com.here.ort.helper
 import kotlin.system.exitProcess
 
 import com.beust.jcommander.JCommander
+import com.beust.jcommander.Parameter
 
 import com.here.ort.CommandWithHelp
 import com.here.ort.helper.commands.*
+import com.here.ort.utils.PARAMETER_ORDER_LOGGING
+import com.here.ort.utils.printStackTrace
+
+import org.apache.logging.log4j.Level
+import org.apache.logging.log4j.core.config.Configurator
 
 private const val TOOL_NAME = "orth"
 
@@ -32,6 +38,27 @@ private const val TOOL_NAME = "orth"
  * The main entry point of the application.
  */
 object Main : CommandWithHelp() {
+    @Parameter(
+        description = "Enable info logging.",
+        names = ["--info"],
+        order = PARAMETER_ORDER_LOGGING
+    )
+    private var info = false
+
+    @Parameter(
+        description = "Enable debug logging and keep any temporary files.",
+        names = ["--debug"],
+        order = PARAMETER_ORDER_LOGGING
+    )
+    private var debug = false
+
+    @Parameter(
+        description = "Print out the stacktrace for all exceptions.",
+        names = ["--stacktrace"],
+        order = PARAMETER_ORDER_LOGGING
+    )
+    private var stacktrace = false
+
     /**
      * The entry point for the application.
      *
@@ -68,6 +95,14 @@ object Main : CommandWithHelp() {
     }
 
     override fun runCommand(jc: JCommander): Int {
+        when {
+            debug -> Configurator.setRootLevel(Level.DEBUG)
+            info -> Configurator.setRootLevel(Level.INFO)
+        }
+
+        // Make the parameter globally available.
+        printStackTrace = stacktrace
+
         // JCommander already validates the command names.
         val command = jc.commands[jc.parsedCommand]!!
         val commandObject = command.objects.first() as CommandWithHelp

--- a/helper-cli/src/main/resources/log4j2.xml
+++ b/helper-cli/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="warn">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
Some of the commands in helper-cli are calling code that uses the
logger, so allow to set the log level and to enable printing
stacktraces.