### PR TITLE
FileBasedStorage: Remove the patching of ScanCode LicenseRefs

### DIFF
--- a/scanner/src/main/kotlin/storages/FileBasedStorage.kt
+++ b/scanner/src/main/kotlin/storages/FileBasedStorage.kt
@@ -21,7 +21,6 @@
 package com.here.ort.scanner.storages
 
 import com.here.ort.model.Package
-import com.here.ort.model.ScanResult
 import com.here.ort.model.ScanResultContainer
 import com.here.ort.model.ScannerDetails
 import com.here.ort.scanner.ScanResultsStorage
@@ -60,32 +59,6 @@ abstract class FileBasedStorage : ScanResultsStorage() {
                     "$scannerDetails."
         }
 
-        val patchedScanResults = patchScanCodeLicenseRefs(scanResults)
-
-        return ScanResultContainer(pkg.id, patchedScanResults)
+        return ScanResultContainer(pkg.id, scanResults)
     }
-
-    // TODO: Remove this code again once we migrated our scan result storage to contain the new "namespaced" license
-    //       names for ScanCode.
-    internal fun patchScanCodeLicenseRefs(scanResults: List<ScanResult>) =
-        scanResults.map { result ->
-            if (result.scanner.name == "ScanCode") {
-                val findings = result.summary.licenseFindings.map { finding ->
-                    if (finding.license.startsWith("LicenseRef-") &&
-                        !finding.license.startsWith("LicenseRef-scancode-")
-                    ) {
-                        val suffix = finding.license.removePrefix("LicenseRef-")
-                        val license = "LicenseRef-scancode-$suffix"
-                        log.info { "Patched license name '${finding.license}' to '$license'." }
-                        finding.copy(license = license)
-                    } else {
-                        finding
-                    }
-                }
-
-                result.copy(summary = result.summary.copy(licenseFindings = findings.toSortedSet()))
-            } else {
-                result
-            }
-        }
 }

--- a/scanner/src/test/kotlin/ScanResultsStorageTest.kt
+++ b/scanner/src/test/kotlin/ScanResultsStorageTest.kt
@@ -20,11 +20,6 @@
 
 package com.here.ort.scanner
 
-import com.here.ort.model.LicenseFinding
-import com.here.ort.model.Provenance
-import com.here.ort.model.ScanResult
-import com.here.ort.model.ScanSummary
-import com.here.ort.model.ScannerDetails
 import com.here.ort.model.config.ArtifactoryStorageConfiguration
 import com.here.ort.scanner.storages.ArtifactoryStorage
 
@@ -32,8 +27,6 @@ import io.kotlintest.shouldBe
 import io.kotlintest.shouldNotBe
 import io.kotlintest.shouldThrow
 import io.kotlintest.specs.WordSpec
-
-import java.time.Instant
 
 @Suppress("UnsafeCallOnNullableType", "UnsafeCast")
 class ScanResultsStorageTest : WordSpec() {
@@ -90,48 +83,6 @@ class ScanResultsStorageTest : WordSpec() {
                     getUrl() shouldBe "someUrl"
                     getRepository() shouldBe "someRepository"
                     getApiToken() shouldBe "someApiToken"
-                }
-            }
-        }
-
-        "patchScanCodeLicenseRefs" should {
-            "correctly patch existing ScanCode LicenseRef findings" {
-                fun generateDummyLicenseFinding(license: String) =
-                    LicenseFinding(license, sortedSetOf(), sortedSetOf())
-
-                val originalScanResult = ScanResult(
-                    Provenance(),
-                    ScannerDetails("ScanCode", "", ""),
-                    ScanSummary(
-                        Instant.EPOCH,
-                        Instant.EPOCH,
-                        0,
-                        sortedSetOf(
-                            generateDummyLicenseFinding("LicenseRef-foo-bar"),
-                            generateDummyLicenseFinding("LicenseRef-scancode-correct"),
-                            generateDummyLicenseFinding("Apache-2.0")
-                        )
-                    )
-                )
-
-                val expectedScanResult = ScanResult(
-                    Provenance(),
-                    ScannerDetails("ScanCode", "", ""),
-                    ScanSummary(
-                        Instant.EPOCH,
-                        Instant.EPOCH,
-                        0,
-                        sortedSetOf(
-                            generateDummyLicenseFinding("LicenseRef-scancode-foo-bar"),
-                            generateDummyLicenseFinding("LicenseRef-scancode-correct"),
-                            generateDummyLicenseFinding("Apache-2.0")
-                        )
-                    )
-                )
-
-                (ScanResultsStorage.storage as ArtifactoryStorage).apply {
-                    val actualScanResults = patchScanCodeLicenseRefs(listOf(originalScanResult)).single()
-                    actualScanResults shouldBe expectedScanResult
                 }
             }
         }


### PR DESCRIPTION
The mechanism was put in place for backwards compatibility with old
cache entries which do not have the later introduced prefix for
ScanCode licenseRefs.

Signed-off-by: Frank Viernau <frank.viernau@here.com>