### PR TITLE
ScanSummary: Fix-up getSingleCopyrightFindings()

### DIFF
--- a/model/src/main/kotlin/ScanSummary.kt
+++ b/model/src/main/kotlin/ScanSummary.kt
@@ -102,12 +102,14 @@ data class ScanSummary(
      */
     @JsonIgnore
     fun getSingleCopyrightFindings(): List<CopyrightFinding> =
-        licenseFindings.flatMap { findings ->
-            findings.locations.map {
-                CopyrightFinding(
-                    statement = findings.license,
-                    location = it
-                )
+        licenseFindings.flatMap { licenseFindings ->
+            licenseFindings.copyrights.flatMap { copyrightFindings ->
+                copyrightFindings.locations.map {
+                    CopyrightFinding(
+                        statement = copyrightFindings.statement,
+                        location = it
+                    )
+                }
             }
         }
 


### PR DESCRIPTION
The function is analog to getSingleLicenseFindings, in fact the code was
copied and incorrectly adjusted, see 67abf886.

Signed-off-by: Frank Viernau <frank.viernau@here.com>