### PR TITLE
ScanCode: Map more license keys to NOASSERTION

### DIFF
--- a/scanner/src/main/kotlin/scanners/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/ScanCode.kt
@@ -135,6 +135,12 @@ class ScanCode(
             Pattern.DOTALL
         )
 
+        private val UNKNOWN_LICENSE_KEYS = listOf(
+            "free-unknown",
+            "unknown",
+            "unknown-license-reference"
+        )
+
         private val TIMEOUT_ERROR_REGEX = Pattern.compile(
             "(ERROR: for scanner: (?<scanner>\\w+):\n)?" +
                     "ERROR: Processing interrupted: timeout after (?<timeout>\\d+) seconds. \\(File: (?<file>.+)\\)"
@@ -382,7 +388,7 @@ class ScanCode(
 
         if (name.isEmpty()) {
             val key = license["key"].textValue()
-            name = if (key == "unknown") {
+            name = if (key in UNKNOWN_LICENSE_KEYS) {
                 "NOASSERTION"
             } else {
                 // Starting with version 2.9.8, ScanCode uses "scancode" as a LicenseRef namespace, but only for SPDX


### PR DESCRIPTION
ScanCode 3 has more keys for unknown licenses than ScanCode 2 for which
the mapping was implemented. Map those keys to NOASSERTION as well for
consistency.