### PR TITLE
Gradle: Improve the plugin version property check

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,7 +3,7 @@ pluginManagement {
         eachPlugin {
             // Work around https://github.com/gradle/gradle/issues/1697.
             if (requested.id.namespace != "org.gradle" && requested.version == null) {
-                val versionPropertyName = if (requested.id.id == "org.jetbrains.kotlin.jvm") {
+                val versionPropertyName = if (requested.id.id.startsWith("org.jetbrains.kotlin.")) {
                     "kotlinPluginVersion"
                 } else {
                     val pluginName = requested.id.name.split('-').joinToString("") { it.capitalize() }.decapitalize()


### PR DESCRIPTION
This way no separate property has to be introduced e.g. for the
"org.jetbrains.kotlin.js" plugin, but the same version as for the main
Kotlin plugin will be used.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>