### PR TITLE
VCS: Support URLs ending with ".git" in `splitUrl()`

### DIFF
--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -222,6 +222,10 @@ abstract class VersionControlSystem {
 
                 else -> {
                     when {
+                        vcsUrl.endsWith(".git") -> {
+                            VcsInfo(VcsType.GIT, normalizeVcsUrl(vcsUrl), "", null, "")
+                        }
+
                         vcsUrl.contains(".git/") -> {
                             val url = normalizeVcsUrl(vcsUrl.substringBefore(".git/"))
                             val path = vcsUrl.substringAfter(".git/")

--- a/downloader/src/test/kotlin/VersionControlSystemTest.kt
+++ b/downloader/src/test/kotlin/VersionControlSystemTest.kt
@@ -67,6 +67,19 @@ class VersionControlSystemTest : WordSpec({
     "splitUrl" should {
         "split paths from a URL to a Git repository" {
             val actual = VersionControlSystem.splitUrl(
+                "https://git-wip-us.apache.org/repos/asf/zeppelin.git"
+            )
+            val expected = VcsInfo(
+                type = VcsType.GIT,
+                url = "https://git-wip-us.apache.org/repos/asf/zeppelin.git",
+                revision = "",
+                path = ""
+            )
+            actual shouldBe expected
+        }
+
+        "split paths from a URL to a Git repository with path" {
+            val actual = VersionControlSystem.splitUrl(
                 "https://git-wip-us.apache.org/repos/asf/zeppelin.git/zeppelin-interpreter"
             )
             val expected = VcsInfo(


### PR DESCRIPTION
Add handling for URLs ending with ".git" to the `splitUrl()` function.
Previously, the `VcsType` of such URLs could not be detected.