### PR TITLE
reporter-web-app: Fix app crash after model refactoring

### DIFF
--- a/reporter-web-app/src/components/ScanFindingsTable.js
+++ b/reporter-web-app/src/components/ScanFindingsTable.js
@@ -88,7 +88,7 @@ class ScanFindingsTable extends React.Component {
                 dataIndex: 'value',
                 filteredValue: filter.value,
                 filters: (() => pkg.detectedLicenses.map(license => ({ text: license, value: license })))(),
-                onFilter: (value, record) => record.license.includes(value),
+                onFilter: (value, record) => record.value.includes(value),
                 key: 'value',
                 render: value => (
                     <div className="ort-word-break-wrap">


### PR DESCRIPTION
WebApp report crashed in the browser as a variable was undefined after underlying model was refactored.

Signed-off-by: Thomas Steenbergen <thomas.steenbergen@here.com>