### PR TITLE
reporter-web-app: Use Kotlin's Yarn plugin to bootstrap Node.js and Yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,6 @@ Install these additional prerequisites:
 
 * OpenJDK 8 or Oracle JDK 8u161 or later (not the JRE as you need the `javac` compiler); also remember to set the
   `JAVA_HOME` environment variable accordingly.
-* For the Web App reporter:
-    * [Node.js](https://nodejs.org) 8.*
-    * [Yarn](https://yarnpkg.com) 1.9.* - 1.17.*
 
 Change into the created directory and run `./gradlew installDist` (on the first run this will bootstrap Gradle and
 download all required dependencies).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -316,7 +316,7 @@ subprojects {
     }
 }
 
-val checkCopyright by tasks.registering(Exec::class) {
+tasks.register<Exec>("checkCopyright") {
     description = "Checks for HERE Copyright headers in Kotlin files."
     group = "Verification"
 
@@ -331,13 +331,6 @@ val checkCopyright by tasks.registering(Exec::class) {
             throw GradleException("Please add copyright statements to the following Kotlin files:\n$output")
         }
     }
-}
-
-tasks.register("check") {
-    description = "Runs all checks."
-    group = "Verification"
-
-    dependsOn(checkCopyright)
 }
 
 tasks.register("allDependencies") {

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-FROM openjdk:8-jdk-alpine3.9
+FROM frolvlad/alpine-java:jdk8-slim
 
-# Required to build the reporter-web-app.
-RUN apk add --no-cache yarn
+# Required for Node.js to build the reporter-web-app.
+RUN apk add --no-cache libstdc++

--- a/reporter-web-app/build.gradle.kts
+++ b/reporter-web-app/build.gradle.kts
@@ -1,13 +1,47 @@
 import org.apache.tools.ant.taskdefs.condition.Os
 
+import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsSetupTask
+import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnPlugin
+import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnSetupTask
+
+// The Yarn plugin is only applied programmatically for Kotlin projects that target JavaScript. As we do not target
+// JavaScript from Kotlin (yet), manually apply the plugin to make its setup tasks available.
+YarnPlugin.apply(project).version = "1.17.3"
+
+// The Yarn plugin registers tasks always on the root project, see
+// https://github.com/JetBrains/kotlin/blob/2f90742/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/yarn/YarnPlugin.kt#L27-L31
+val kotlinNodeJsSetup by rootProject.tasks.existing(NodeJsSetupTask::class)
+val kotlinYarnSetup by rootProject.tasks.existing(YarnSetupTask::class)
+
+val nodeDir = kotlinNodeJsSetup.get().destination
+val nodeBinDir = if (Os.isFamily(Os.FAMILY_WINDOWS)) nodeDir else nodeDir.resolve("bin")
+val nodeExecutable = if (Os.isFamily(Os.FAMILY_WINDOWS)) nodeBinDir.resolve("node.exe") else nodeBinDir.resolve("node")
+
+val yarnDir = kotlinYarnSetup.get().destination
+val yarnJs = yarnDir.resolve("bin/yarn.js")
+
+kotlinNodeJsSetup {
+    logger.quiet("Will use the Node executable file from '$nodeExecutable'.")
+
+    // If the node binary is missing, force a re-download of the NodeJs distribution, see
+    // https://youtrack.jetbrains.com/issue/KT-34989.
+    if (!nodeExecutable.isFile && nodeDir.deleteRecursively()) {
+        logger.info("Successfully deleted the incomplete '$nodeDir' directory to trigger the NodeJs download.")
+    }
+}
+
+kotlinYarnSetup {
+    logger.quiet("Will use the Yarn JavaScript file from '$yarnJs'.")
+}
+
 tasks.addRule("Pattern: yarn<Command>") {
     val taskName = this
     if (taskName.startsWith("yarn")) {
-        val yarn = if (Os.isFamily(Os.FAMILY_WINDOWS)) "yarn.cmd" else "yarn"
         val command = taskName.removePrefix("yarn").decapitalize()
 
         tasks.register<Exec>(taskName) {
-            commandLine = listOf(yarn, command)
+            // Execute the Yarn version downloaded by Gradle using the NodeJs version downloaded by Gradle.
+            commandLine = listOf(nodeExecutable.path, yarnJs.path, command)
         }
     }
 }
@@ -20,6 +54,8 @@ tasks {
     "yarnInstall" {
         description = "Use Yarn to install the Node.js dependencies."
         group = "Node"
+
+        dependsOn(kotlinYarnSetup)
 
         inputs.files(listOf("package.json", "yarn.lock"))
         outputs.dir("node_modules")


### PR DESCRIPTION
This allows to remove Node.js and Yarn from the list of prerequisites
to build ORT, which means now nothing except for a JDK is required.

Unfortunately, the Yarn plugin always installs itself to the root project
(even if applied in a subproject) [1], and it also creates a "check" task
in the root project which clashes with our existing "check" task. As for
some reason the "check" task created by the Yarn plugin cannot be further
configured to depend on our "checkCopyright" task, simply remove our
"check" task which is not used anymore as of 6d994fd anyway.

Finally, as the Node.js binary installed by Gradle depend on glibc, but
our Alpine-based Dockerfile uses musl, switch to a Alpine base image
that comes with glic (and Java 8).

[1] https://github.com/JetBrains/kotlin/blob/2f90742/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/yarn/YarnPlugin.kt#L27-L31

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>