### PR TITLE
Use separate loggers per class (with individual names)

### DIFF
--- a/analyzer/src/main/kotlin/managers/utils/MavenLogger.kt
+++ b/analyzer/src/main/kotlin/managers/utils/MavenLogger.kt
@@ -45,7 +45,7 @@ private fun toPlexusLoggerLevel(level: Level) =
  * Implementation of the Plexus [Logger] that forwards all logs to the [org.slf4j.Logger] [log] using the appropriate
  * log levels.
  */
-class MavenLogger(level: Level) : AbstractLogger(toPlexusLoggerLevel(level), log.delegate.name) {
+class MavenLogger(level: Level) : AbstractLogger(toPlexusLoggerLevel(level), "MavenLogger") {
     override fun getChildLogger(name: String?) = this
 
     override fun debug(message: String, throwable: Throwable?) = log.debug(message, throwable)

--- a/cli/src/main/resources/log4j2.xml
+++ b/cli/src/main/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration status="WARN">
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
-      <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level - %msg%n"/>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
     </Console>
   </Appenders>
   <Loggers>

--- a/test-utils/src/main/resources/log4j2.xml
+++ b/test-utils/src/main/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration status="WARN">
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
-      <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level - %msg%n"/>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
     </Console>
   </Appenders>
   <Loggers>

--- a/utils/src/main/kotlin/CommandLineTool.kt
+++ b/utils/src/main/kotlin/CommandLineTool.kt
@@ -25,6 +25,31 @@ import java.io.File
 import java.io.IOException
 
 /**
+ * Global variable that gets toggled by a command line parameter parsed in the main entry points of the modules.
+ */
+var printStackTrace = false
+
+/**
+ * Ordinal for mandatory program parameters.
+ */
+const val PARAMETER_ORDER_MANDATORY = 0
+
+/**
+ * Ordinal for optional program parameters.
+ */
+const val PARAMETER_ORDER_OPTIONAL = 1
+
+/**
+ * Ordinal for logging related program parameters.
+ */
+const val PARAMETER_ORDER_LOGGING = 2
+
+/**
+ * Ordinal for the help program parameter.
+ */
+const val PARAMETER_ORDER_HELP = 100
+
+/**
  * An interface to implement by classes that are backed by a command line tool.
  */
 interface CommandLineTool {

--- a/utils/src/main/kotlin/Logger.kt
+++ b/utils/src/main/kotlin/Logger.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2019 Bosch Software Innovations GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.utils
+
+val log = org.apache.logging.log4j.kotlin.logger("ORT")

--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -24,8 +24,6 @@ import java.net.URI
 import java.net.URISyntaxException
 import java.security.Permission
 
-val log = org.apache.logging.log4j.kotlin.logger("ORT")
-
 /**
  * The name of the ORT configuration file.
  */

--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -27,34 +27,9 @@ import java.security.Permission
 val log = org.apache.logging.log4j.kotlin.logger("ORT")
 
 /**
- * Global variable that gets toggled by a command line parameter parsed in the main entry points of the modules.
- */
-var printStackTrace = false
-
-/**
  * The name of the ORT configuration file.
  */
 const val ORT_CONFIG_FILENAME = ".ort.yml"
-
-/**
- * Ordinal for mandatory program parameters.
- */
-const val PARAMETER_ORDER_MANDATORY = 0
-
-/**
- * Ordinal for optional program parameters.
- */
-const val PARAMETER_ORDER_OPTIONAL = 1
-
-/**
- * Ordinal for logging related program parameters.
- */
-const val PARAMETER_ORDER_LOGGING = 2
-
-/**
- * Ordinal for the help program parameter.
- */
-const val PARAMETER_ORDER_HELP = 100
 
 /**
  * Return the set of elements which are contained in at least two of the given collections, or an empty set if all

--- a/utils/src/test/kotlin/LoggerTest.kt
+++ b/utils/src/test/kotlin/LoggerTest.kt
@@ -19,18 +19,14 @@
 
 package com.here.ort.utils
 
-import org.apache.logging.log4j.kotlin.KotlinLogger
-import org.apache.logging.log4j.kotlin.loggerOf
+import io.kotlintest.matchers.types.shouldBeSameInstanceAs
+import io.kotlintest.specs.StringSpec
 
-import java.util.concurrent.ConcurrentHashMap
+class LoggerTest : StringSpec({
+    "Only one logger is created per class" {
+        val a = this.log
+        val b = this.log
 
-/**
- * Global map of loggers for classes so only one logger needs to be instantiated per class.
- */
-val loggerOfClass = ConcurrentHashMap<Any, KotlinLogger>()
-
-/**
- * An extension property for adding a log instance to any (unique) class.
- */
-val <reified T : Any> T.log: KotlinLogger
-    inline get() = loggerOfClass.getOrPut(T::class.java) { loggerOf(T::class.java) }
+        a shouldBeSameInstanceAs b
+    }
+})


### PR DESCRIPTION
Improve logging by using one logger per class so the source of logging
can be more easily identified. Consequently, include the logger name and
thread name into the log pattern, so that the pattern now matches the
"configuration equivalent to the default" mentioned at [1].

As the "log" extension property now is only available in the context of
an object (there is no more top-level "log"), simply hard-code the
logger name for MavenLogger.

[1] https://logging.apache.org/log4j/2.x/manual/configuration.html