### PR TITLE
analyzer: Align the lockfile check in package managers

### DIFF
--- a/analyzer/src/funTest/kotlin/managers/PhpComposerTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/PhpComposerTest.kt
@@ -57,7 +57,7 @@ class PhpComposerTest : StringSpec() {
             yamlMapper.writeValueAsString(result) shouldBe expectedResults
         }
 
-        "Error is shown when no lock file is present" {
+        "Error is shown when no lockfile is present" {
             val definitionFile = File(projectsDir, "no-lockfile/composer.json")
             val result = createPhpComposer().resolveDependencies(listOf(definitionFile))[definitionFile]
 
@@ -70,7 +70,7 @@ class PhpComposerTest : StringSpec() {
                     "analyzer/src/funTest/assets/projects/synthetic/php-composer/no-lockfile/composer.json"
             result.packages.size shouldBe 0
             result.errors.size shouldBe 1
-            result.errors.first().message should startWith("IllegalArgumentException: No lock file found in")
+            result.errors.first().message should startWith("IllegalArgumentException: No lockfile found in")
         }
 
         "No composer.lock is required for projects without dependencies" {

--- a/analyzer/src/funTest/kotlin/managers/PubTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/PubTest.kt
@@ -109,7 +109,7 @@ class PubTest : WordSpec() {
                 yamlMapper.writeValueAsString(result) shouldBe expectedResult
             }
 
-            "Error is shown when no lock file is present" {
+            "Error is shown when no lockfile is present" {
                 val workingDir = File(projectsDir, "no-lockfile")
                 val packageFile = File(workingDir, "pubspec.yaml")
 
@@ -120,7 +120,7 @@ class PubTest : WordSpec() {
                         "analyzer/src/funTest/assets/projects/synthetic/pub/no-lockfile/pubspec.yaml"
                 result.packages.size shouldBe 0
                 result.errors.size shouldBe 1
-                result.errors.first().message should startWith("IllegalArgumentException: No lock file found in")
+                result.errors.first().message should startWith("IllegalArgumentException: No lockfile found in")
             }
         }
     }

--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -246,4 +246,14 @@ abstract class PackageManager(
      * Resolve dependencies for a single absolute [definitionFile] and return a [ProjectAnalyzerResult].
      */
     abstract fun resolveDependencies(definitionFile: File): ProjectAnalyzerResult?
+
+    protected fun requireLockfile(workingDir: File, condition: () -> Boolean) {
+        require(analyzerConfig.allowDynamicVersions || condition()) {
+            val relativePathString = workingDir.relativeTo(analysisRoot).invariantSeparatorsPath
+                .takeUnless { it.isEmpty() } ?: "."
+
+            "No lockfile found in '$relativePathString'. This potentially results in unstable versions of " +
+                    "dependencies. To allow this, enable support for dynamic versions."
+        }
+    }
 }

--- a/analyzer/src/main/kotlin/managers/Bundler.kt
+++ b/analyzer/src/main/kotlin/managers/Bundler.kt
@@ -224,9 +224,7 @@ class Bundler(
         workingDir.listFiles { _, name -> name.endsWith(".gemspec") }.firstOrNull()
 
     private fun installDependencies(workingDir: File) {
-        require(analyzerConfig.allowDynamicVersions || File(workingDir, "Gemfile.lock").isFile) {
-            "No lockfile found in ${workingDir.invariantSeparatorsPath}, dependency versions are unstable."
-        }
+        requireLockfile(workingDir) { File(workingDir, "Gemfile.lock").isFile }
 
         run(workingDir, "install", "--path", "vendor/bundle")
     }

--- a/analyzer/src/main/kotlin/managers/GoDep.kt
+++ b/analyzer/src/main/kotlin/managers/GoDep.kt
@@ -186,14 +186,7 @@ class GoDep(
     }
 
     private fun importLegacyManifest(lockfileName: String, workingDir: File, gopath: File) {
-        if (lockfileName.isNotEmpty() && !File(workingDir, lockfileName).isFile &&
-            !analyzerConfig.allowDynamicVersions
-        ) {
-            throw IllegalArgumentException(
-                "No lockfile found in ${workingDir.invariantSeparatorsPath}, dependency " +
-                        "versions are unstable."
-            )
-        }
+        requireLockfile(workingDir) { lockfileName.isEmpty() || File(workingDir, lockfileName).isFile }
 
         run("init", workingDir = workingDir, environment = mapOf("GOPATH" to gopath.realFile().path))
     }

--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -488,15 +488,7 @@ open class Npm(
      * Install dependencies using the given package manager command.
      */
     private fun installDependencies(workingDir: File) {
-        if (!hasLockFile(workingDir) && !analyzerConfig.allowDynamicVersions) {
-            val relativePathString = workingDir.relativeTo(analysisRoot).invariantSeparatorsPath
-                .takeUnless { it.isEmpty() } ?: "."
-
-            throw IllegalArgumentException(
-                "No lockfile found in '$relativePathString'. This potentially results in unstable versions of " +
-                        "dependencies. To allow this, enable support for dynamic versions."
-            )
-        }
+        requireLockfile(workingDir) { hasLockFile(workingDir) }
 
         // Install all NPM dependencies to enable NPM to list dependencies.
         if (hasLockFile(workingDir) && this::class.java == Npm::class.java) {

--- a/analyzer/src/main/kotlin/managers/PhpComposer.kt
+++ b/analyzer/src/main/kotlin/managers/PhpComposer.kt
@@ -342,9 +342,7 @@ class PhpComposer(
     }
 
     private fun installDependencies(workingDir: File) {
-        require(analyzerConfig.allowDynamicVersions || File(workingDir, COMPOSER_LOCK_FILE).isFile) {
-            "No lock file found in $workingDir, dependency versions are unstable."
-        }
+        requireLockfile(workingDir) { File(workingDir, COMPOSER_LOCK_FILE).isFile }
 
         // The "install" command creates a "composer.lock" file (if not yet present) except for projects without any
         // dependencies, see https://getcomposer.org/doc/01-basic-usage.md#installing-without-composer-lock.

--- a/analyzer/src/main/kotlin/managers/Pub.kt
+++ b/analyzer/src/main/kotlin/managers/Pub.kt
@@ -513,9 +513,7 @@ class Pub(
     }
 
     private fun installDependencies(workingDir: File) {
-        require(analyzerConfig.allowDynamicVersions || File(workingDir, PUB_LOCK_FILE).isFile) {
-            "No lock file found in $workingDir, dependency versions are unstable."
-        }
+        requireLockfile(workingDir) { File(workingDir, PUB_LOCK_FILE).isFile }
 
         // The "get" command creates a "pubspec.lock" file (if not yet present) except for projects without any
         // dependencies, see https://dart.dev/tools/pub/cmd/pub-get.


### PR DESCRIPTION
Align the lockfile check in all package managers that support a lockfile
to use the same error message.