### PR TITLE
spdx-utils: Add sanity checks for values of the mapping objects

### DIFF
--- a/spdx-utils/src/main/kotlin/SpdxLicenseAliasMapping.kt
+++ b/spdx-utils/src/main/kotlin/SpdxLicenseAliasMapping.kt
@@ -65,7 +65,6 @@ object SpdxLicenseAliasMapping {
         "MIT-style" to MIT,
         "MPL" to MPL_2_0,
         "MPLv2.0" to MPL_2_0,
-        "Ruby's" to RUBY,
         "UNLICENSE" to UNLICENSE,
         "UNLICENSED" to UNLICENSE,
         "boost" to BSL_1_0,

--- a/spdx-utils/src/test/kotlin/SpdxDeclaredLicenseMappingTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxDeclaredLicenseMappingTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2019 Bosch Software Innovations GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.spdx
+
+import com.here.ort.spdx.SpdxExpression.Strictness
+
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.StringSpec
+
+class SpdxDeclaredLicenseMappingTest : StringSpec({
+    "Mapping contains only unparsable keys" {
+        val parsableLicenses = SpdxDeclaredLicenseMapping.mapping.filter { (declaredLicense, _) ->
+            try {
+                // Restrict parsing to SPDX license identifier strings as otherwise almost anything could be parsed, but
+                // we do want to have mappings e.g. for something like "CDDL or GPLv2 with exceptions".
+                SpdxExpression.parse(declaredLicense, Strictness.ALLOW_DEPRECATED)
+                true
+            } catch (e: SpdxException) {
+                false
+            }
+        }
+
+        parsableLicenses shouldBe emptyMap()
+    }
+})

--- a/spdx-utils/src/test/kotlin/SpdxLicenseAliasMappingTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxLicenseAliasMappingTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2019 Bosch Software Innovations GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.spdx
+
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.StringSpec
+
+class SpdxLicenseAliasMappingTest : StringSpec({
+    "Mapping contains only parsable keys" {
+        val unparsableLicenses = SpdxLicenseAliasMapping.mapping.filterNot { (declaredLicense, _) ->
+            try {
+                // Be as lenient as possible when parsing declared licenses as we really only want to check for general
+                // parsability here.
+                SpdxExpression.parse(declaredLicense)
+                true
+            } catch (e: SpdxException) {
+                false
+            }
+        }
+
+        unparsableLicenses shouldBe emptyMap()
+    }
+})


### PR DESCRIPTION
To not accidentally mix up values for SpdxDeclaredLicenseMapping vs.
SpdxLicenseAliasMapping.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>