### PR TITLE
spdx-utils: Also test against plain SPDX license ids in mappings

### DIFF
--- a/spdx-utils/src/test/kotlin/SpdxDeclaredLicenseMappingTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxDeclaredLicenseMappingTest.kt
@@ -21,22 +21,33 @@ package com.here.ort.spdx
 
 import com.here.ort.spdx.SpdxExpression.Strictness
 
+import io.kotlintest.assertSoftly
 import io.kotlintest.shouldBe
-import io.kotlintest.specs.StringSpec
+import io.kotlintest.specs.WordSpec
 
-class SpdxDeclaredLicenseMappingTest : StringSpec({
-    "Mapping contains only unparsable keys" {
-        val parsableLicenses = SpdxDeclaredLicenseMapping.mapping.filter { (declaredLicense, _) ->
-            try {
-                // Restrict parsing to SPDX license identifier strings as otherwise almost anything could be parsed, but
-                // we do want to have mappings e.g. for something like "CDDL or GPLv2 with exceptions".
-                SpdxExpression.parse(declaredLicense, Strictness.ALLOW_DEPRECATED)
-                true
-            } catch (e: SpdxException) {
-                false
+class SpdxDeclaredLicenseMappingTest : WordSpec({
+    "The mapping" should {
+        "contain only unparsable keys" {
+            val parsableLicenses = SpdxDeclaredLicenseMapping.mapping.filter { (declaredLicense, _) ->
+                try {
+                    // Restrict parsing to SPDX license identifier strings as otherwise almost anything could be parsed,
+                    // but we do want to have mappings e.g. for something like "CDDL or GPLv2 with exceptions".
+                    SpdxExpression.parse(declaredLicense, Strictness.ALLOW_DEPRECATED)
+                    true
+                } catch (e: SpdxException) {
+                    false
+                }
             }
+
+            parsableLicenses shouldBe emptyMap()
         }
 
-        parsableLicenses shouldBe emptyMap()
+        "not contain plain SPDX license ids" {
+            assertSoftly {
+                SpdxDeclaredLicenseMapping.mapping.forEach { (declaredLicense, _) ->
+                    SpdxLicense.forId(declaredLicense) shouldBe null
+                }
+            }
+        }
     }
 })

--- a/spdx-utils/src/test/kotlin/SpdxLicenseAliasMappingTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxLicenseAliasMappingTest.kt
@@ -19,22 +19,33 @@
 
 package com.here.ort.spdx
 
+import io.kotlintest.assertSoftly
 import io.kotlintest.shouldBe
-import io.kotlintest.specs.StringSpec
+import io.kotlintest.specs.WordSpec
 
-class SpdxLicenseAliasMappingTest : StringSpec({
-    "Mapping contains only parsable keys" {
-        val unparsableLicenses = SpdxLicenseAliasMapping.mapping.filterNot { (declaredLicense, _) ->
-            try {
-                // Be as lenient as possible when parsing declared licenses as we really only want to check for general
-                // parsability here.
-                SpdxExpression.parse(declaredLicense)
-                true
-            } catch (e: SpdxException) {
-                false
+class SpdxLicenseAliasMappingTest : WordSpec({
+    "The mapping" should {
+        "contain only parsable keys" {
+            val unparsableLicenses = SpdxLicenseAliasMapping.mapping.filterNot { (declaredLicense, _) ->
+                try {
+                    // Be as lenient as possible when parsing declared licenses as we really only want to check for
+                    // general parsability here.
+                    SpdxExpression.parse(declaredLicense)
+                    true
+                } catch (e: SpdxException) {
+                    false
+                }
             }
+
+            unparsableLicenses shouldBe emptyMap()
         }
 
-        unparsableLicenses shouldBe emptyMap()
+        "not contain plain SPDX license ids" {
+            assertSoftly {
+                SpdxDeclaredLicenseMapping.mapping.forEach { (declaredLicense, _) ->
+                    SpdxLicense.forId(declaredLicense) shouldBe null
+                }
+            }
+        }
     }
 })


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>