### PR TITLE
FindingsMatcher: Fix a bug in getRootLicense()

### DIFF
--- a/model/src/main/kotlin/util/FindingsMatcher.kt
+++ b/model/src/main/kotlin/util/FindingsMatcher.kt
@@ -53,9 +53,7 @@ class FindingsMatcher(
     private fun getRootLicense(licenseFindings: Collection<LicenseFinding>): String =
         // TODO: This function should return a list of all licenses found in all license files instead of only a single
         // license.
-        licenseFindings.singleOrNull { finding ->
-            licenseFileMatcher.matches(finding.location.path)
-        }?.license.orEmpty()
+        licenseFindings.find { licenseFileMatcher.matches(it.location.path) }?.license.orEmpty()
 
     /**
      * Return the copyright statements in the vicinity, as specified by [toleranceLines], of [licenseStartLine] in the

--- a/model/src/test/kotlin/utils/FindingsMatcherTest.kt
+++ b/model/src/test/kotlin/utils/FindingsMatcherTest.kt
@@ -98,9 +98,8 @@ class FindingsMatcherTest : WordSpec() {
             }
         }
 
-        "Given license findings in two license files and copyright findings in a file without license, match" should {
-            "associate should discard those copyright findings" {
-                // This test illustrates a bug. TODO: Fix it.
+        "Given license findings in two license files and a copyright finding in a file without license, match" should {
+            "associate that copyright finding with exactly one root license" {
                 setupLicenseFinding(license = "some id", path = "a/LICENSE")
                 setupLicenseFinding(license = "some other id", path = "b/LICENSE")
 
@@ -110,7 +109,10 @@ class FindingsMatcherTest : WordSpec() {
                     .match(licenseFindings, copyrightFindings)
 
                 result.size shouldBe 2
-                result.flatMap { it.copyrights } should beEmpty()
+                result
+                    .filter { it.license in listOf("some id", "some other id") }
+                    .filter { it.copyrights.map { it.statement } == listOf("some stmt") }
+                    .size shouldBe 1
             }
         }
 


### PR DESCRIPTION
getRootLicense() returns an empty string in case more than one of the
given license findings are matched by the LicenseFileMatcher. In that
case all copyright statements found in files without a license are
being discarded which seems wrong. The existing code and code comments
suggest that the intention of the author was to return any license
found in any of the root license files. Adjust the code to do so in
order to fix the issue.

Signed-off-by: Frank Viernau <frank.viernau@here.com>