### PR TITLE
FindingsMatcher: Handle mutliple root licenses

### DIFF
--- a/model/src/test/kotlin/utils/FindingsMatcherTest.kt
+++ b/model/src/test/kotlin/utils/FindingsMatcherTest.kt
@@ -99,20 +99,20 @@ class FindingsMatcherTest : WordSpec() {
         }
 
         "Given license findings in two license files and a copyright finding in a file without license, match" should {
-            "associate that copyright finding with exactly one root license" {
-                setupLicenseFinding(license = "some id", path = "a/LICENSE")
-                setupLicenseFinding(license = "some other id", path = "b/LICENSE")
+            "associate that copyright finding with all root licenses" {
+                setupLicenseFinding(license = "license-a1", path = "a/LICENSE")
+                setupLicenseFinding(license = "license-a2", path = "a/LICENSE")
+                setupLicenseFinding(license = "license-b1", path = "b/LICENSE")
 
                 setupCopyrightFinding(statement = "some stmt", path = "some/file")
 
                 val result = FindingsMatcher(LicenseFileMatcher("a/LICENSE", "b/LICENSE"))
                     .match(licenseFindings, copyrightFindings)
 
-                result.size shouldBe 2
-                result
-                    .filter { it.license in listOf("some id", "some other id") }
-                    .filter { it.copyrights.map { it.statement } == listOf("some stmt") }
-                    .size shouldBe 1
+                result.size shouldBe 3
+                result.getFindings("license-a1").copyrights.map { it.statement } shouldBe listOf("some stmt")
+                result.getFindings("license-a2").copyrights.map { it.statement } shouldBe listOf("some stmt")
+                result.getFindings("license-b1").copyrights.map { it.statement } shouldBe listOf("some stmt")
             }
         }
 


### PR DESCRIPTION
In case there are multiple root licenses, no matter if found in a
single or in multiple files, all copyright findings found in files
without licenses are associated with single arbitrary root license.
Thus the links to all other root licenses are missing which results in
underreporting of copyrights in the generated NOTICE files.

Fix this issue by associating the copyrights to all root licenses in
that particular case.

Signed-off-by: Frank Viernau <frank.viernau@here.com>