### PR TITLE
Gradle: Remove left-over properties for commons-codec

### DIFF
--- a/downloader/build.gradle.kts
+++ b/downloader/build.gradle.kts
@@ -1,4 +1,3 @@
-val commonsCodecVersion: String by project
 val jacksonVersion: String by project
 
 plugins {

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,6 @@ versionsPluginVersion = 0.24.0
 antlrVersion = 4.7.2
 apachePoiSchemasVersion = 1.4
 apachePoiVersion = 3.17
-commonsCodecVersion = 1.13
 commonsCompressVersion = 1.19
 cyclonedxCoreJavaVersion = 2.1.1
 digraphVersion = 1.0

--- a/spdx-utils/build.gradle.kts
+++ b/spdx-utils/build.gradle.kts
@@ -12,7 +12,6 @@ import java.net.URL
 import java.time.Year
 
 val antlrVersion: String by project
-val commonsCodecVersion: String by project
 val jacksonVersion: String by project
 
 plugins {

--- a/utils/build.gradle.kts
+++ b/utils/build.gradle.kts
@@ -1,4 +1,3 @@
-val commonsCodecVersion: String by project
 val commonsCompressVersion: String by project
 val disklrucacheVersion: String by project
 val jacksonVersion: String by project


### PR DESCRIPTION
The last dependency on commons-codec was removed in 8366286.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>