### PR TITLE
ListLicensesCommand: Gracefully handle text location resolution

### DIFF
--- a/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
@@ -193,10 +193,11 @@ private fun Collection<TextLocation>.groupByText(baseDir: File): List<TextLocati
 }
 
 private fun TextLocation.resolve(baseDir: File): String? {
-    val lines = baseDir.resolve(path).readText().lines()
-    return if (lines.size <= endLine) {
-        null
-    } else {
-        lines.subList(startLine - 1, endLine).joinToString(separator = "\n")
-    }
+    val file = baseDir.resolve(path)
+    if (!file.isFile) return null
+
+    val lines = file.readText().lines()
+    if (lines.size <= endLine) return null
+
+    return lines.subList(startLine - 1, endLine).joinToString(separator = "\n")
 }


### PR DESCRIPTION
Return null instead of throwing in case the baseDir or the target
file does not exist.

Signed-off-by: Frank Viernau <frank.viernau@here.com>