### PR TITLE
GitHub: Fix the automatic rebase workflow

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,9 +1,17 @@
+name: Automatic Rebase
+
 on: issue_comment
 
 jobs:
   rebase:
+    name: Rebase
     runs-on: ubuntu-latest
     steps:
-    - uses: docker://cirrusactions/rebase:latest
+    - name: Checkout Action
+      if: github.event.issue.pull_request != null && github.event.action == 'created' && github.event.comment.body == '/rebase'
+      uses: actions/checkout@master
+    - name: Rebase Action
+      if: github.event.issue.pull_request != null && github.event.action == 'created' && github.event.comment.body == '/rebase'
+      uses: docker://cirrusactions/rebase:latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,6 +1,8 @@
 name: Automatic Rebase
 
-on: issue_comment
+on:
+  issue_comment:
+    types: [created]
 
 jobs:
   rebase:
@@ -8,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Action
-      if: github.event.issue.pull_request != null && github.event.action == 'created' && github.event.comment.body == '/rebase'
+      if: github.event.issue.pull_request != null && github.event.comment.body == '/rebase'
       uses: actions/checkout@master
     - name: Rebase Action
-      if: github.event.issue.pull_request != null && github.event.action == 'created' && github.event.comment.body == '/rebase'
+      if: github.event.issue.pull_request != null && github.event.comment.body == '/rebase'
       uses: docker://cirrusactions/rebase:latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
YML-based actions, in contrast to the legacy HCL-based ones, do not
support the neutral exit code 78 from Docker images anymore. This
resulted in bogus failures due to non-zero exit codes for non-"/rebase"
comments.

To avoid this, filter comments early before even running the rebase
action. As unfortunately GitHub Actions do not currently support
conditionals at the job level [1], repeat the condition for every step.

Also, the YML-based actions do not provide a workspace by default
anymore, so use GitHub's "checkout" action to explicitly provide one.

Finally, white at it, also give the workflow, the job, and the steps
proper names.

[1] https://github.community/t5/GitHub-Actions/Github-Actions-CI-CD-Need-optional-jobs/m-p/29696

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>