### PR TITLE
Add a `NamedThreadFactory` for naming coroutine threads

### DIFF
--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -33,6 +33,7 @@ import com.here.ort.model.VcsInfo
 import com.here.ort.model.config.AnalyzerConfiguration
 import com.here.ort.model.config.RepositoryConfiguration
 import com.here.ort.model.readValue
+import com.here.ort.utils.NamedThreadFactory
 import com.here.ort.utils.ORT_CONFIG_FILENAME
 import com.here.ort.utils.log
 import com.here.ort.utils.realFile
@@ -131,7 +132,7 @@ class Analyzer(private val config: AnalyzerConfiguration) {
         managedFiles: Map<PackageManager, List<File>>,
         packageCurationsFile: File?
     ): AnalyzerResult {
-        val dispatcher = Executors.newFixedThreadPool(5).asCoroutineDispatcher()
+        val dispatcher = Executors.newFixedThreadPool(5, NamedThreadFactory(TOOL_NAME)).asCoroutineDispatcher()
         val analyzerResultBuilder = AnalyzerResultBuilder()
 
         coroutineScope {

--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -41,6 +41,7 @@ import com.here.ort.model.ScannerRun
 import com.here.ort.model.config.ScannerConfiguration
 import com.here.ort.model.mapper
 import com.here.ort.utils.CommandLineTool
+import com.here.ort.utils.NamedThreadFactory
 import com.here.ort.utils.Os
 import com.here.ort.utils.collectMessagesAsString
 import com.here.ort.utils.fileSystemEncode
@@ -140,8 +141,9 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
             Map<Package, List<ScanResult>> {
         val scannerDetails = getDetails()
 
-        val storageDispatcher = Executors.newFixedThreadPool(5).asCoroutineDispatcher()
-        val scanDispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+        val storageDispatcher =
+            Executors.newFixedThreadPool(5, NamedThreadFactory(ScanResultsStorage.storage.name)).asCoroutineDispatcher()
+        val scanDispatcher = Executors.newSingleThreadExecutor(NamedThreadFactory(scannerName)).asCoroutineDispatcher()
 
         try {
             return coroutineScope {

--- a/utils/src/main/kotlin/NamedThreadFactory.kt
+++ b/utils/src/main/kotlin/NamedThreadFactory.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.utils
+
+import java.util.concurrent.Executors
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * A thread factory based on [Executors.defaultThreadFactory], that allows to set the [namePrefix].
+ */
+class NamedThreadFactory(private val namePrefix: String) : ThreadFactory {
+    private val group = System.getSecurityManager()?.threadGroup ?: Thread.currentThread().threadGroup
+    private val threadNumber = AtomicInteger(1)
+
+    override fun newThread(runnable: Runnable): Thread {
+        val thread = Thread(group, runnable, "$namePrefix-${threadNumber.getAndIncrement()}", 0)
+
+        if (thread.isDaemon) {
+            thread.isDaemon = false
+        }
+
+        if (thread.priority != Thread.NORM_PRIORITY) {
+            thread.priority = Thread.NORM_PRIORITY
+        }
+
+        return thread
+    }
+}


### PR DESCRIPTION
The default thread factory used in the thread pool factory methods of
`Executors` uses the naming pattern "pool-$i-thread-$j". Instead we
would like to use more telling names for the analyzer and scanner
threads.

To allow this add a `NamedThreadFactory` class based on the default
thread factory used by `Executors`, that allows to manually set a prefix
for the created threads.