### PR TITLE
spdx-utils: Make the key lookup for license mappings case-insensitive

### DIFF
--- a/spdx-utils/src/main/kotlin/SpdxDeclaredLicenseMapping.kt
+++ b/spdx-utils/src/main/kotlin/SpdxDeclaredLicenseMapping.kt
@@ -31,13 +31,12 @@ object SpdxDeclaredLicenseMapping {
     /**
      * The map of collected license strings associated with their corresponding SPDX expression.
      */
-    val mapping = mapOf(
+    val mapping: Map<String, SpdxExpression> = mapOf(
         "(MIT-style) netCDF C library license" to NETCDF.toExpression(),
         "2-clause BSD license" to BSD_2_CLAUSE.toExpression(),
         "2-clause BSDL" to BSD_2_CLAUSE.toExpression(),
         "3-Clause BSD" to BSD_3_CLAUSE.toExpression(),
         "3-Clause BSD License" to BSD_3_CLAUSE.toExpression(),
-        "3-clause BSD" to BSD_3_CLAUSE.toExpression(),
         "AL 2.0" to APACHE_2_0.toExpression(),
         "ASF 2.0" to APACHE_2_0.toExpression(),
         "ASL 2" to APACHE_2_0.toExpression(),
@@ -51,7 +50,6 @@ object SpdxDeclaredLicenseMapping {
         "Apache License" to APACHE_2_0.toExpression(),
         "Apache License (2.0)" to APACHE_2_0.toExpression(),
         "Apache License 2" to APACHE_2_0.toExpression(),
-        "Apache License V2.0" to APACHE_2_0.toExpression(),
         "Apache License Version 2" to APACHE_2_0.toExpression(),
         "Apache License Version 2.0" to APACHE_2_0.toExpression(),
         "Apache License v2" to APACHE_2_0.toExpression(),
@@ -63,17 +61,14 @@ object SpdxDeclaredLicenseMapping {
         """Apache License, Version 2.0 and
         Common Development And Distribution License (CDDL) Version 1.0 """.trimIndent()
                 to (APACHE_2_0 and CDDL_1_0),
-        "Apache License, version 2.0" to APACHE_2_0.toExpression(),
         "Apache License,Version 2.0" to APACHE_2_0.toExpression(),
         "Apache Public License 2.0" to APACHE_2_0.toExpression(),
         "Apache Software" to APACHE_2_0.toExpression(),
         "Apache Software License - Version 2.0" to APACHE_2_0.toExpression(),
         "Apache Software License 2.0" to APACHE_2_0.toExpression(),
-        "Apache Software License, Version 1.1" to APACHE_1_1.toExpression(),
         "Apache Software License, version 1.1" to APACHE_1_1.toExpression(),
         "Apache Software License, version 2.0" to APACHE_2_0.toExpression(),
         "Apache Software Licenses" to APACHE_2_0.toExpression(),
-        "Apache license" to APACHE_2_0.toExpression(),
         "Apache v2" to APACHE_2_0.toExpression(),
         "Apache v2.0" to APACHE_2_0.toExpression(),
         "Apache version 2.0" to APACHE_2_0.toExpression(),
@@ -90,20 +85,16 @@ object SpdxDeclaredLicenseMapping {
         "BSD 3-Clause" to BSD_3_CLAUSE.toExpression(),
         "BSD 3-Clause \"New\" or \"Revised\" License (BSD-3-Clause)" to BSD_3_CLAUSE.toExpression(),
         "BSD 3-Clause License" to BSD_3_CLAUSE.toExpression(),
-        "BSD 3-Clause license" to BSD_3_CLAUSE.toExpression(),
-        "BSD 3-clause" to BSD_3_CLAUSE.toExpression(),
         "BSD Licence 3" to BSD_3_CLAUSE.toExpression(),
         "BSD License" to BSD_2_CLAUSE.toExpression(),
         "BSD License for HSQL" to BSD_3_CLAUSE.toExpression(),
         "BSD New" to BSD_3_CLAUSE.toExpression(),
         "BSD New license" to BSD_3_CLAUSE.toExpression(),
         "BSD licence" to BSD_2_CLAUSE.toExpression(),
-        "BSD license" to BSD_2_CLAUSE.toExpression(),
         "BSD or Apache License, Version 2.0" to (BSD_2_CLAUSE or APACHE_2_0),
         "BSD style" to BSD_3_CLAUSE.toExpression(),
         "BSD style license" to BSD_3_CLAUSE.toExpression(),
         "BSD*" to BSD_3_CLAUSE.toExpression(),
-        "BSD-Style License" to BSD_3_CLAUSE.toExpression(),
         "BSD-style license" to BSD_3_CLAUSE.toExpression(),
         "Berkeley Software Distribution (BSD) License" to BSD_2_CLAUSE.toExpression(),
         "Bouncy Castle Licence" to MIT.toExpression(),
@@ -123,7 +114,6 @@ object SpdxDeclaredLicenseMapping {
         "CDDL+GPLv2" to (CDDL_1_0 and GPL_2_0_ONLY),
         "CDDL/GPLv2 dual license" to (CDDL_1_0 or GPL_2_0_ONLY),
         "CDDL/GPLv2+CE" to (CDDL_1_0 or (GPL_2_0_ONLY with CLASSPATH_EXCEPTION_2_0)),
-        "COMMON DEVELOPMENT AND DISTRIBUTION LICENSE" to CDDL_1_0.toExpression(),
         "COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0" to CDDL_1_0.toExpression(),
         "Common Development and Distribution License" to CDDL_1_0.toExpression(),
         "Common Development and Distribution License (CDDL) v1.0" to CDDL_1_0.toExpression(),
@@ -167,10 +157,7 @@ object SpdxDeclaredLicenseMapping {
                 to (GPL_2_0_ONLY with CLASSPATH_EXCEPTION_2_0),
         "GNU General Public License, version 2, with the Classpath Exception"
                 to (GPL_2_0_ONLY with CLASSPATH_EXCEPTION_2_0),
-        "GNU LESSER GENERAL PUBLIC LICENSE" to LGPL_2_1_ONLY.toExpression(),
         "GNU LESSER GENERAL PUBLIC LICENSE V3.0" to LGPL_3_0_ONLY.toExpression(),
-        "GNU LESSER GENERAL PUBLIC LICENSE Version 2.1" to LGPL_2_1_ONLY.toExpression(),
-        "GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1" to LGPL_2_1_ONLY.toExpression(),
         "GNU LGP (GNU General Public License), V2 or later" to LGPL_2_0_OR_LATER.toExpression(),
         "GNU LGPL" to LGPL_2_1_ONLY.toExpression(),
         "GNU LGPL (GNU Lesser General Public License), V2.1 or later" to LGPL_2_1_OR_LATER.toExpression(),
@@ -187,7 +174,6 @@ object SpdxDeclaredLicenseMapping {
         "GNU Lesser General Public License v3 or later (LGPLv3+)" to LGPL_3_0_OR_LATER.toExpression(),
         "GNU Lesser General Public License v3+" to LGPL_3_0_OR_LATER.toExpression(),
         "GNU Lesser General Public License, Version 2.1" to LGPL_2_1_ONLY.toExpression(),
-        "GNU Lesser General Public License, version 2.1" to LGPL_2_1_ONLY.toExpression(),
         "GNU Lesser Public License" to LGPL_2_1_ONLY.toExpression(),
         "GNU Library or Lesser General Public License (LGPL)" to LGPL_2_1_ONLY.toExpression(),
         "GNU Public" to GPL_2_0_ONLY.toExpression(),
@@ -220,7 +206,6 @@ object SpdxDeclaredLicenseMapping {
         "MIT Licence" to MIT.toExpression(),
         "MIT License (http://opensource.org/licenses/MIT)" to MIT.toExpression(),
         "MIT Licensed. http://www.opensource.org/licenses/mit-license.php" to MIT.toExpression(),
-        "MIT licence" to MIT.toExpression(),
         "MIT, 2-clause BSD" to (MIT and BSD_2_CLAUSE),
         "MIT/Expat" to MIT.toExpression(),
         "MIT/X11" to (MIT or X11),
@@ -236,14 +221,10 @@ object SpdxDeclaredLicenseMapping {
         "Mozilla Public License Version 1.0" to MPL_1_0.toExpression(),
         "Mozilla Public License Version 1.1" to MPL_1_1.toExpression(),
         "Mozilla Public License Version 2.0" to MPL_2_0.toExpression(),
-        "Mozilla Public License version 1.1" to MPL_1_1.toExpression(),
-        "Mozilla Public License version 2.0" to MPL_2_0.toExpression(),
         "Mozilla Public License, Version 2.0" to MPL_2_0.toExpression(),
-        "Mozilla Public License, version 2.0" to MPL_2_0.toExpression(),
         "NetBeans CDDL/GPL" to (CDDL_1_0 or GPL_2_0_ONLY),
         "New BSD" to BSD_3_CLAUSE.toExpression(),
         "New BSD License" to BSD_3_CLAUSE.toExpression(),
-        "New BSD license" to BSD_3_CLAUSE.toExpression(),
         "PSFL" to PYTHON_2_0.toExpression(),
         "Perl Artistic v2" to ARTISTIC_1_0_PERL.toExpression(),
         "Public Domain" to licenseRef("public-domain-disclaimer", "scancode"),
@@ -258,7 +239,6 @@ object SpdxDeclaredLicenseMapping {
         "The Apache License, Version 2.0" to APACHE_2_0.toExpression(),
         "The Apache Software Licence, Version 2.0" to APACHE_2_0.toExpression(),
         "The Apache Software License, Version 2.0" to APACHE_2_0.toExpression(),
-        "The Apache Software License, version 2.0" to APACHE_2_0.toExpression(),
         "The BSD 2-Clause License" to BSD_2_CLAUSE.toExpression(),
         "The BSD 3-Clause License" to BSD_3_CLAUSE.toExpression(),
         "The BSD License" to BSD_2_CLAUSE.toExpression(),
@@ -273,7 +253,6 @@ object SpdxDeclaredLicenseMapping {
         "The MIT License" to MIT.toExpression(),
         "The MIT License (MIT)" to MIT.toExpression(),
         "The MIT License(MIT)" to MIT.toExpression(),
-        "The MIT license" to MIT.toExpression(),
         "The New BSD License" to BSD_3_CLAUSE.toExpression(),
         "The PostgreSQL License" to POSTGRESQL.toExpression(),
         "The SAX License" to SAX_PD.toExpression(),
@@ -292,12 +271,20 @@ object SpdxDeclaredLicenseMapping {
         "http://www.apache.org/licenses/LICENSE-2.0.txt" to APACHE_2_0.toExpression(),
         "http://www.gnu.org/copyleft/lesser.html" to LGPL_3_0_ONLY.toExpression(),
         "https://raw.github.com/RDFLib/rdflib/master/LICENSE" to BSD_3_CLAUSE.toExpression(),
-        "new BSD" to BSD_3_CLAUSE.toExpression(),
         "public domain, Python, 2-Clause BSD, GPL 3 (see COPYING.txt)"
                 to (((licenseRef("public-domain-disclaimer", "scancode") and PYTHON_2_0.toExpression())
                 and BSD_2_CLAUSE.toExpression()) and GPL_3_0_ONLY.toExpression()),
         "the Apache License, ASL Version 2.0" to APACHE_2_0.toExpression()
-    )
+    ).let { caseSensitiveMap ->
+        caseSensitiveMap.toSortedMap(String.CASE_INSENSITIVE_ORDER).also { caseInsensitiveMap ->
+            if (caseSensitiveMap.size > caseInsensitiveMap.size) {
+                val difference = caseSensitiveMap.keys.subtract(caseInsensitiveMap.keys)
+                require(difference.isEmpty()) {
+                    "The following ${difference.size} keys are present in different capitalizations: $difference"
+                }
+            }
+        }
+    }
 
     /**
      * Return an SPDX LicenseRef string for the given [id] and optional [namespace].

--- a/spdx-utils/src/main/kotlin/SpdxLicenseAliasMapping.kt
+++ b/spdx-utils/src/main/kotlin/SpdxLicenseAliasMapping.kt
@@ -30,7 +30,7 @@ object SpdxLicenseAliasMapping {
     /**
      * The map of custom license names associated with their corresponding SPDX expression.
      */
-    internal val customNames = mapOf(
+    internal val customNames: Map<String, SpdxExpression> = mapOf(
         "afl" to AFL_3_0,
         "afl-2" to AFL_2_0,
         "afl2" to AFL_2_0,
@@ -39,47 +39,33 @@ object SpdxLicenseAliasMapping {
         "AFLv2.1" to AFL_2_1,
         "agpl" to AGPL_3_0_ONLY,
         "ALv2" to APACHE_2_0,
-        "alv2" to APACHE_2_0,
         "Apache" to APACHE_2_0,
-        "apache" to APACHE_2_0,
         "Apache-2" to APACHE_2_0,
         "apache-license" to APACHE_2_0,
         "Apache2" to APACHE_2_0,
         "APL2" to APACHE_2_0,
         "APLv2.0" to APACHE_2_0,
         "ASL" to APACHE_2_0,
-        "asl" to APACHE_2_0,
-        "BOOST" to BSL_1_0,
-        "boost" to BSL_1_0,
+        "Boost" to BSL_1_0,
         "Bouncy" to MIT,
-        "bouncy" to MIT,
         "bouncy-license" to MIT,
         "BSD" to BSD_3_CLAUSE,
-        "bsd" to BSD_3_CLAUSE,
         "BSD-3" to BSD_3_CLAUSE,
         "bsd-license" to BSD_3_CLAUSE,
         "bsd-licensed" to BSD_3_CLAUSE,
         "BSD-like" to BSD_3_CLAUSE,
-        "bsd-like" to BSD_3_CLAUSE,
-        "BSD-Style" to BSD_3_CLAUSE,
         "BSD-style" to BSD_3_CLAUSE,
-        "bsd-style" to BSD_3_CLAUSE,
         "BSD2" to BSD_2_CLAUSE,
-        "bsd2" to BSD_2_CLAUSE,
         "BSD3" to BSD_3_CLAUSE,
-        "bsd3" to BSD_3_CLAUSE,
         "bsl" to BSL_1_0,
         "bsl1.0" to BSL_1_0,
         "CC0" to CC0_1_0,
-        "cc0" to CC0_1_0,
-        "CDDL" to CDDL_1_0,
         "cddl" to CDDL_1_0,
         "cddl1.0" to CDDL_1_0,
         "cddl1.1" to CDDL_1_1,
         "CPL" to CPL_1_0,
         "EDL-1.0" to BSD_3_CLAUSE,
         "efl" to EFL_2_0,
-        "EPL" to EPL_1_0,
         "epl" to EPL_1_0,
         "epl1.0" to EPL_1_0,
         "epl2.0" to EPL_2_0,
@@ -91,40 +77,30 @@ object SpdxLicenseAliasMapping {
         "FreeBSD" to BSD_2_CLAUSE_FREEBSD,
         "gfdl" to GFDL_1_3_ONLY,
         "GPL" to GPL_2_0_ONLY,
-        "gpl" to GPL_2_0_ONLY,
         "GPL-2" to GPL_2_0_ONLY,
         "gpl-license" to GPL_2_0_ONLY,
         "GPL2" to GPL_2_0_ONLY,
-        "gpl2" to GPL_2_0_ONLY,
         "gpl3" to GPL_3_0_ONLY,
         "GPLv2" to GPL_2_0_ONLY,
-        "gplv2" to GPL_2_0_ONLY,
         "GPLv3" to GPL_3_0_ONLY,
-        "gplv3" to GPL_3_0_ONLY,
         "isc-license" to ISC,
         "ISCL" to ISC,
-        "iscl" to ISC,
         "LGPL" to LGPL_2_0_OR_LATER,
-        "lgpl" to LGPL_2_0_OR_LATER,
         "LGPL-3" to LGPL_3_0_ONLY,
-        "lgpl2" to LGPL_2_1_ONLY,
+        "LGPL2" to LGPL_2_1_ONLY,
         "LGPL3" to LGPL_3_0_ONLY,
-        "lgpl3" to LGPL_3_0_ONLY,
-        "lgplv2" to LGPL_2_1_ONLY,
+        "LGPLv2" to LGPL_2_1_ONLY,
         "LGPLv3" to LGPL_3_0_ONLY,
-        "lgplv3" to LGPL_3_0_ONLY,
         "mit-license" to MIT,
         "mit-licensed" to MIT,
         "MIT-like" to MIT,
         "MIT-style" to MIT,
         "MPL" to MPL_2_0,
         "mpl-2" to MPL_2_0,
-        "MPL2" to MPL_2_0,
         "mpl2" to MPL_2_0,
         "mpl2.0" to MPL_2_0,
         "MPLv2" to MPL_2_0,
         "MPLv2.0" to MPL_2_0,
-        "ODbl" to ODBL_1_0,
         "ODBL" to ODBL_1_0,
         "psf" to PYTHON_2_0,
         "psfl" to PYTHON_2_0,
@@ -133,7 +109,16 @@ object SpdxLicenseAliasMapping {
         "w3cl" to W3C,
         "wtf" to WTFPL,
         "zope" to ZPL_2_1
-    ).mapValues { (_, v) -> v.toExpression() }
+    ).mapValues { (_, v) -> v.toExpression() }.let { caseSensitiveMap ->
+        caseSensitiveMap.toSortedMap(String.CASE_INSENSITIVE_ORDER).also { caseInsensitiveMap ->
+            if (caseSensitiveMap.size > caseInsensitiveMap.size) {
+                val difference = caseSensitiveMap.keys.subtract(caseInsensitiveMap.keys)
+                require(difference.isEmpty()) {
+                    "The following ${difference.size} keys are present in different capitalizations: $difference"
+                }
+            }
+        }
+    }
 
     /**
      * The map of deprecated SPDX license names associated with their current SPDX expression.

--- a/spdx-utils/src/test/kotlin/SpdxDeclaredLicenseMappingTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxDeclaredLicenseMappingTest.kt
@@ -50,5 +50,14 @@ class SpdxDeclaredLicenseMappingTest : WordSpec({
                 }
             }
         }
+
+        "be case-insensitve" {
+            val map = SpdxDeclaredLicenseMapping.mapping
+            map.forEach { (key, license) ->
+                map[key.toLowerCase()] shouldBe license
+                map[key.toUpperCase()] shouldBe license
+                map[key.toLowerCase().capitalize()] shouldBe license
+            }
+        }
     }
 })

--- a/spdx-utils/src/test/kotlin/SpdxLicenseAliasMappingTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxLicenseAliasMappingTest.kt
@@ -48,5 +48,14 @@ class SpdxLicenseAliasMappingTest : WordSpec({
                 }
             }
         }
+
+        "be case-insensitve" {
+            val map = SpdxLicenseAliasMapping.customNames
+            map.forEach { (key, license) ->
+                map[key.toLowerCase()] shouldBe license
+                map[key.toUpperCase()] shouldBe license
+                map[key.toLowerCase().capitalize()] shouldBe license
+            }
+        }
     }
 })


### PR DESCRIPTION
This allows to again remove some mappings that only differ in case. The
check itself is not implemented as a unit test this time as that would
require to keep both the case-sensitive map and the case-insensitive map
in the classes.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>