### PR TITLE
SpdxExpression: Expose a deep copy function in the base class

### DIFF
--- a/spdx-utils/src/main/kotlin/SpdxExpression.kt
+++ b/spdx-utils/src/main/kotlin/SpdxExpression.kt
@@ -89,6 +89,11 @@ sealed class SpdxExpression {
     }
 
     /**
+     * Deep-copy the whole license expression object.
+     */
+    abstract fun copy(): SpdxExpression
+
+    /**
      * Return all license IDs contained in this expression. Non-SPDX licenses and SPDX license references are included.
      */
     abstract fun licenses(): List<String>
@@ -136,6 +141,8 @@ data class SpdxCompoundExpression(
     val operator: SpdxOperator,
     val right: SpdxExpression
 ) : SpdxExpression() {
+    override fun copy() = copy(left = left, operator = operator, right = right)
+
     override fun licenses() = left.licenses() + right.licenses()
 
     override fun spdxLicenses() = left.spdxLicenses() + right.spdxLicenses()
@@ -181,6 +188,8 @@ data class SpdxCompoundExpression(
 data class SpdxLicenseExceptionExpression(
     val id: String
 ) : SpdxExpression() {
+    override fun copy() = copy(id = id)
+
     override fun licenses() = emptyList<String>()
 
     override fun spdxLicenses() = enumSetOf<SpdxLicense>()
@@ -209,7 +218,9 @@ data class SpdxLicenseIdExpression(
     val id: String,
     val orLaterVersion: Boolean = false
 ) : SpdxExpression() {
-    private val spdxLicense = SpdxLicense.forId(toString())
+    internal val spdxLicense = SpdxLicense.forId(toString())
+
+    override fun copy() = copy(id = id, orLaterVersion = orLaterVersion)
 
     override fun licenses() = listOf(toString())
 
@@ -249,6 +260,8 @@ data class SpdxLicenseIdExpression(
 data class SpdxLicenseReferenceExpression(
     val id: String
 ) : SpdxExpression() {
+    override fun copy() = copy(id = id)
+
     override fun licenses() = listOf(id)
 
     override fun spdxLicenses() = enumSetOf<SpdxLicense>()

--- a/spdx-utils/src/test/kotlin/SpdxExpressionTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxExpressionTest.kt
@@ -179,6 +179,13 @@ class SpdxExpressionTest : WordSpec() {
             }
         }
 
+        "An SpdxExpression" should {
+            "be properly deep copied" {
+                ((APACHE_2_0.toExpression() as SpdxExpression).copy() as SpdxLicenseIdExpression).spdxLicense shouldBe
+                        APACHE_2_0
+            }
+        }
+
         "The expression parser" should {
             "work for deprecated license identifiers" {
                 assertSoftly {

--- a/spdx-utils/src/test/kotlin/SpdxExpressionTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxExpressionTest.kt
@@ -67,7 +67,7 @@ class SpdxExpressionTest : WordSpec() {
             }
         }
 
-        "An dummy SpdxExpression" should {
+        "A dummy SpdxExpression" should {
             val dummyExpression = "license1+ AND (license2 WITH exception1 OR license3+) AND license4 WITH exception2"
 
             "be serializable to a string representation" {


### PR DESCRIPTION
Previously, only member objects of the sealed class could be copied, and
now copy() can be called generically on the base class.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>