### PR TITLE
Minor findings matcher improvements

### DIFF
--- a/model/src/main/kotlin/util/FindingsMatcher.kt
+++ b/model/src/main/kotlin/util/FindingsMatcher.kt
@@ -103,8 +103,7 @@ class FindingsMatcher(
 
             1 -> {
                 // If there is only a single license finding, associate all copyright findings with that license.
-                val licenseId = licenses.single().license
-                copyrightsForLicenses[licenseId] = allCopyrightStatements
+                licenses.associateByTo(copyrightsForLicenses, { it.license }, { allCopyrightStatements })
             }
 
             else -> {

--- a/model/src/main/kotlin/util/FindingsMatcher.kt
+++ b/model/src/main/kotlin/util/FindingsMatcher.kt
@@ -25,7 +25,6 @@ import com.here.ort.model.LicenseFinding
 import com.here.ort.model.LicenseFindings
 import com.here.ort.spdx.LicenseFileMatcher
 
-import java.util.SortedMap
 import java.util.SortedSet
 
 import kotlin.math.absoluteValue
@@ -88,13 +87,13 @@ class FindingsMatcher(
         licenses: List<LicenseFinding>,
         copyrights: List<CopyrightFinding>,
         rootLicenses: Collection<String>
-    ): SortedMap<String, MutableSet<CopyrightFindings>> {
+    ): Map<String, Set<CopyrightFindings>> {
         require((licenses.map { it.location.path } + copyrights.map { it.location.path }).distinct().size <= 1) {
             "The given license and copyright findings must all point to the same file."
         }
 
-        val copyrightsForLicenses = sortedMapOf<String, MutableSet<CopyrightFindings>>()
-        val allCopyrightStatements = copyrights.map { it.toCopyrightFindings() }.toSortedSet()
+        val copyrightsForLicenses = mutableMapOf<String, MutableSet<CopyrightFindings>>()
+        val allCopyrightStatements = copyrights.mapTo(mutableSetOf()) { it.toCopyrightFindings() }
 
         when (licenses.size) {
             0 -> {
@@ -116,7 +115,7 @@ class FindingsMatcher(
                         copyrights = copyrights,
                         licenseStartLine = it.location.startLine
                     )
-                    copyrightsForLicenses.getOrPut(it.license) { sortedSetOf() } += closestCopyrights
+                    copyrightsForLicenses.getOrPut(it.license) { mutableSetOf() } += closestCopyrights
                 }
             }
         }

--- a/model/src/main/kotlin/util/FindingsMatcher.kt
+++ b/model/src/main/kotlin/util/FindingsMatcher.kt
@@ -132,7 +132,7 @@ class FindingsMatcher(
      * in the result while all given [licenseFindings] are contained in the result exactly once.
      */
     fun match(licenseFindings: Collection<LicenseFinding>, copyrightFindings: Collection<CopyrightFinding>):
-            SortedSet<LicenseFindings> {
+            Set<LicenseFindings> {
         val licenseFindingsByPath = licenseFindings.groupBy { it.location.path }
         val copyrightFindingsByPath = copyrightFindings.groupBy { it.location.path }
         val paths = (licenseFindingsByPath.keys + copyrightFindingsByPath.keys).toSet()
@@ -160,12 +160,12 @@ class FindingsMatcher(
             }
         }
 
-        return (copyrightsForLicenses.keys + locationsForLicenses.keys).map { license ->
+        return (copyrightsForLicenses.keys + locationsForLicenses.keys).mapTo(mutableSetOf()) { license ->
             LicenseFindings(
                 license,
                 locationsForLicenses[license] ?: sortedSetOf(),
                 copyrightsForLicenses[license] ?: sortedSetOf()
             )
-        }.toSortedSet()
+        }
     }
 }

--- a/model/src/main/kotlin/util/FindingsMatcher.kt
+++ b/model/src/main/kotlin/util/FindingsMatcher.kt
@@ -138,10 +138,9 @@ class FindingsMatcher(
 
         val locationsForLicenses = licenseFindings
             .groupBy({ it.license }, { it.location })
-            .mapValues { it.value.toSortedSet() }
-            .toSortedMap()
+            .mapValuesTo(mutableMapOf()) { it.value.toSortedSet() }
 
-        val copyrightsForLicenses = sortedMapOf<String, SortedSet<CopyrightFindings>>()
+        val copyrightsForLicenses = mutableMapOf<String, SortedSet<CopyrightFindings>>()
         paths.forEach { path ->
             val licenses = licenseFindingsByPath[path].orEmpty()
             val copyrights = copyrightFindingsByPath[path].orEmpty()

--- a/model/src/main/kotlin/util/FindingsMatcher.kt
+++ b/model/src/main/kotlin/util/FindingsMatcher.kt
@@ -63,7 +63,7 @@ class FindingsMatcher(
     private fun getClosestCopyrightStatements(
         copyrights: List<CopyrightFinding>,
         licenseStartLine: Int
-    ): SortedSet<CopyrightFindings> {
+    ): Set<CopyrightFindings> {
         require(copyrights.map { it.location.path }.distinct().size <= 1) {
             "Given copyright statements must all point to the same file."
         }
@@ -72,7 +72,7 @@ class FindingsMatcher(
             (it.location.startLine - licenseStartLine).absoluteValue <= toleranceLines
         }
 
-        return closestCopyrights.map { it.toCopyrightFindings() }.toSortedSet()
+        return closestCopyrights.mapTo(mutableSetOf()) { it.toCopyrightFindings() }
     }
 
     private fun CopyrightFinding.toCopyrightFindings() =


### PR DESCRIPTION
Mainly switch from ```mutable``` to ```immutable``` collections and stop using ```sorted collections``` without need.