### PR TITLE
OrtResult: Annotate fun with Suppress("Unused")

### DIFF
--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -342,6 +342,7 @@ data class OrtResult(
      * from a VCS the analyzer root is the root of the working tree, if the project was not checked out from a VCS the
      * analyzer root is the input directory of the analyzer.
      */
+    @Suppress("UNUSED") // This is intended to be mostly used via scripting.
     fun getFilePathRelativeToAnalyzerRoot(project: Project, path: String): String {
         val vcsPath = repository.getRelativePath(project.vcsProcessed)
 


### PR DESCRIPTION
This also silences the hint from the IDE to make the function private
and gives a hint that it might be used via scripting.

Signed-off-by: Frank Viernau <frank.viernau@here.com>