### PR TITLE
Get detected licenses

### DIFF
--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -133,60 +133,6 @@ data class OrtResult(
     }
 
     /**
-     * Return the concluded licenses for each package. If [omitExcluded] is set to true, excluded packages are omitted
-     * from the result.
-     */
-    @Suppress("UNUSED") // This is intended to be mostly used via scripting.
-    fun collectConcludedLicenses(omitExcluded: Boolean = false) =
-        sortedMapOf<Identifier, SpdxExpression?>().also { licenses ->
-            getPackages().filter { !omitExcluded || !isPackageExcluded(it.pkg.id) }
-                .associateTo(licenses) { it.pkg.id to it.pkg.concludedLicense }
-        }
-
-    /**
-     * Return the declared licenses associated to their project / package identifiers. If [omitExcluded] is set to true,
-     * excluded projects / packages are omitted from the result.
-     */
-    @Suppress("UNUSED") // This is intended to be mostly used via scripting.
-    fun collectDeclaredLicenses(omitExcluded: Boolean = false) =
-        sortedMapOf<String, SortedSet<Identifier>>().also { licenses ->
-
-            getProjects().forEach { project ->
-                if (!omitExcluded || !isProjectExcluded(project.id)) {
-                    project.declaredLicenses.forEach { license ->
-                        licenses.getOrPut(license) { sortedSetOf() } += project.id
-                    }
-                }
-            }
-
-            getPackages().forEach { (pkg, _) ->
-                if (!omitExcluded || !isPackageExcluded(pkg.id)) {
-                    pkg.declaredLicenses.forEach { license ->
-                        licenses.getOrPut(license) { sortedSetOf() } += pkg.id
-                    }
-                }
-            }
-        }
-
-    /**
-     * Return the detected licenses associated to their project / package identifiers. If [omitExcluded] is set to true,
-     * excluded projects / packages are omitted from the result.
-     */
-    @Suppress("UNUSED") // This is intended to be mostly used via scripting.
-    fun collectDetectedLicenses(omitExcluded: Boolean = false) =
-        sortedMapOf<String, SortedSet<Identifier>>().also { licenses ->
-            // Note that we require the analyzer result here to determine whether a package has been implicitly
-            // excluded via its project or scope.
-            scanner?.results?.scanResults?.forEach { result ->
-                if (!omitExcluded || !isPackageExcluded(result.id)) {
-                    result.getAllDetectedLicenses().forEach { license ->
-                        licenses.getOrPut(license) { sortedSetOf() } += result.id
-                    }
-                }
-            }
-        }
-
-    /**
      * Return the dependencies of the given [id] (which can refer to a [Project] or a [Package]), up to and including a
      * depth of [maxLevel] where counting starts at 0 (for the [Project] or [Package] itself) and 1 are direct
      * dependencies etc. A value below 0 means to not limit the depth.

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -170,8 +170,10 @@ data class OrtResult(
      *
      * If [omitExcluded] is set to true, excluded projects / packages are omitted from the result.
      */
-    fun collectLicenseFindings(omitExcluded: Boolean = false) =
-        sortedMapOf<Identifier, MutableMap<LicenseFindings, List<PathExclude>>>().also { findings ->
+    fun collectLicenseFindings(
+        omitExcluded: Boolean = false
+    ): Map<Identifier, Map<LicenseFindings, List<PathExclude>>> =
+        mutableMapOf<Identifier, MutableMap<LicenseFindings, List<PathExclude>>>().also { findings ->
             val excludes = getExcludes()
 
             scanner?.results?.scanResults?.forEach { result ->

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -256,7 +256,7 @@ data class OrtResult(
      */
     @Suppress("UNUSED") // This is intended to be mostly used via scripting.
     fun getDetectedLicensesForId(id: Identifier): SortedSet<String> =
-        scanResultsById[id]?.flatMap { it.summary.licenses.toList() }.orEmpty().toSortedSet()
+        collectLicenseFindings(id).keys.mapTo(sortedSetOf()) { it.license }
 
     /**
      * Return all projects and packages that are likely to belong to one of the organizations of the given [names]. If

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -132,6 +132,10 @@ data class OrtResult(
         result
     }
 
+    private val scanResultsById: Map<Identifier, ScanResultContainer> by lazy {
+        scanner?.results?.scanResults?.associateBy { it.id }.orEmpty()
+    }
+
     /**
      * Return the dependencies of the given [id] (which can refer to a [Project] or a [Package]), up to and including a
      * depth of [maxLevel] where counting starts at 0 (for the [Project] or [Package] itself) and 1 are direct
@@ -246,7 +250,7 @@ data class OrtResult(
      */
     @Suppress("UNUSED") // This is intended to be mostly used via scripting.
     fun getDetectedLicensesForId(id: Identifier) =
-        scanner?.results?.scanResults?.find { it.id == id }.getAllDetectedLicenses()
+        scanResultsById[id].getAllDetectedLicenses()
 
     /**
      * Return all projects and packages that are likely to belong to one of the organizations of the given [names]. If

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -271,6 +271,18 @@ data class OrtResult(
         collectLicenseFindings(id).keys.mapTo(sortedSetOf()) { it.license }
 
     /**
+     * Return all detected licenses for the given package[id] along with the copyrights.
+     */
+    @Suppress("UNUSED") // This is intended to be mostly used via scripting.
+    fun getDetectedLicensesWithCopyrights(id: Identifier): Map<String, Set<String>> =
+        collectLicenseFindings(id)
+            .map { (findings, _) -> findings }
+            .associateBy(
+                { it.license },
+                { it.copyrights.mapTo(mutableSetOf()) { it.statement } }
+            )
+
+    /**
      * Return all projects and packages that are likely to belong to one of the organizations of the given [names]. If
      * [omitExcluded] is set to true, excluded projects / packages are omitted from the result. Projects are converted
      * to packages in the result. If no analyzer result is present an empty set is returned.

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -27,6 +27,7 @@ import com.here.ort.model.config.PathExclude
 import com.here.ort.model.config.RepositoryConfiguration
 import com.here.ort.model.config.Resolutions
 import com.here.ort.model.config.orEmpty
+import com.here.ort.model.util.FindingsMatcher
 import com.here.ort.spdx.SpdxExpression
 import com.here.ort.utils.log
 import com.here.ort.utils.zipWithDefault
@@ -173,7 +174,9 @@ data class OrtResult(
         val excludes = getExcludes()
         val project = getProject(id)
 
-        scanResultsById[id].orEmpty().flatMap { it.summary.groupedLicenseFindings }.forEach { finding ->
+        scanResultsById[id].orEmpty().flatMap {
+            FindingsMatcher().match(it.summary.licenseFindings, it.summary.copyrightFindings)
+        }.forEach { finding ->
             val matchingExcludes = mutableSetOf<PathExclude>()
 
             // Only license findings of projects can be excluded by path excludes.

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -132,8 +132,8 @@ data class OrtResult(
         result
     }
 
-    private val scanResultsById: Map<Identifier, ScanResultContainer> by lazy {
-        scanner?.results?.scanResults?.associateBy { it.id }.orEmpty()
+    private val scanResultsById: Map<Identifier, List<ScanResult>> by lazy {
+        scanner?.results?.scanResults?.associateBy({ it.id }, { it.results }).orEmpty()
     }
 
     /**
@@ -249,8 +249,8 @@ data class OrtResult(
      * scanning, the [id] may either refer to a project or to a package. If [id] is not found an empty set is returned.
      */
     @Suppress("UNUSED") // This is intended to be mostly used via scripting.
-    fun getDetectedLicensesForId(id: Identifier) =
-        scanResultsById[id].getAllDetectedLicenses()
+    fun getDetectedLicensesForId(id: Identifier): SortedSet<String> =
+        scanResultsById[id]?.flatMap { it.summary.licenses.toList() }.orEmpty().toSortedSet()
 
     /**
      * Return all projects and packages that are likely to belong to one of the organizations of the given [names]. If

--- a/model/src/main/kotlin/ScanResultContainer.kt
+++ b/model/src/main/kotlin/ScanResultContainer.kt
@@ -19,8 +19,6 @@
 
 package com.here.ort.model
 
-import java.util.SortedSet
-
 /**
  * A container for [ScanResult]s for the package identified by [id].
  */
@@ -40,16 +38,3 @@ data class ScanResultContainer(
      */
     override fun compareTo(other: ScanResultContainer) = id.compareTo(other.id)
 }
-
-/**
- * Return all detected licenses for the container's package [id][ScanResultContainer.id], or an empty set if the
- * container is null.
- */
-fun ScanResultContainer?.getAllDetectedLicenses(): SortedSet<String> =
-    sortedSetOf<String>().also { licenses ->
-        if (this != null) {
-            results.flatMapTo(licenses) {
-                it.summary.licenses
-            }
-        }
-    }

--- a/model/src/main/kotlin/ScanSummary.kt
+++ b/model/src/main/kotlin/ScanSummary.kt
@@ -92,7 +92,7 @@ data class ScanSummary(
     }
 
     @get:JsonIgnore
-    val licenses = licenseFindingsMap.keys
+    val licenses = licenseFindings.map { it.license }.toSet()
 }
 
 class ScanSummaryDeserializer : StdDeserializer<ScanSummary>(OrtIssue::class.java) {

--- a/model/src/main/kotlin/ScanSummary.kt
+++ b/model/src/main/kotlin/ScanSummary.kt
@@ -85,13 +85,6 @@ data class ScanSummary(
     val groupedLicenseFindings = FindingsMatcher().match(licenseFindings, copyrightFindings)
 
     @get:JsonIgnore
-    val licenseFindingsMap = sortedMapOf<String, SortedSet<CopyrightFindings>>().also {
-        groupedLicenseFindings.forEach { finding ->
-            it.getOrPut(finding.license) { sortedSetOf() } += finding.copyrights
-        }
-    }
-
-    @get:JsonIgnore
     val licenses = licenseFindings.map { it.license }.toSet()
 }
 

--- a/model/src/main/kotlin/ScanSummary.kt
+++ b/model/src/main/kotlin/ScanSummary.kt
@@ -30,8 +30,6 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.module.kotlin.treeToValue
 
-import com.here.ort.model.util.FindingsMatcher
-
 import java.time.Instant
 import java.util.SortedSet
 import java.util.TreeSet
@@ -81,9 +79,6 @@ data class ScanSummary(
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     val errors: List<OrtIssue> = emptyList()
 ) {
-    @get:JsonIgnore
-    val groupedLicenseFindings = FindingsMatcher().match(licenseFindings, copyrightFindings)
-
     @get:JsonIgnore
     val licenses = licenseFindings.map { it.license }.toSet()
 }


### PR DESCRIPTION
Looking at the call hierarchy of the ```ScanSummary.licenseFindings``` shows a call tree with not so much shared code. In order to not duplicate the code for
1. applying path excludes
2. matching license to copyright findings
3. applying license finding curation (implementation is unmerged, work in progress)

The goal of this PR is to change the call tree such that all calls to ```ScanSummary.licenseFindings``` go through a single place where 1,2,3 can be done.
For this I have choosen ```OrtResult.collectLicenseFindings()``` thus detected licenses are now accessed always through that function.

Performance wise it seems likely that this implementation is slower, I'm doing some performance testing now and will comment below. If performance change is acceptable then I'd say let's optimize it later on if needed.
