### PR TITLE
Hocon config

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,12 +229,16 @@ scan results for later reuse.
 ### Local File Storage
 
 By default the Scanner stores scan results on the local file system in the current user's home directory (i.e.
-`~/.ort/scanner/scan-results`) for later reuse. The storage directory can be customized by passing a scanner
-configuration file (`-c`) that contains a respective local file storage configuration:
+`~/.ort/scanner/scan-results`) for later reuse. The storage directory can be customized by passing an ORT configuration
+file (`-c`) that contains a respective local file storage configuration:
 
 ```hocon
-localFileStorage {
-  directory = "/tmp/ort/scan-results"
+ort {
+  scanner {
+    localFileStorage {
+      directory = "/tmp/ort/scan-results"
+    }
+  }
 }
 ```
 
@@ -243,10 +247,14 @@ localFileStorage {
 To use Artifactory to store scan results, use the following configuration:
 
 ```hocon
-artifactoryStorage {
-  url = "https://artifactory.domain.com/artifactory"
-  repository = "generic-repository-name"
-  apiToken = "api-token"
+ort {
+  scanner {
+    artifactoryStorage {
+      url = "https://artifactory.domain.com/artifactory"
+      repository = "generic-repository-name"
+      apiToken = "api-token"
+    }
+  }
 }
 ```
 
@@ -257,11 +265,15 @@ The scanner creates a directory "scan-results" in the configured repository and 
 To use PostgreSQL to store scan results, use the following configuration:
 
 ```hocon
-postgresStorage {
-  url = "jdbc:postgresql://example.com:5444/database"
-  schema = "schema"
-  username = "username"
-  password = "password"
+ort {
+  scanner {
+    postgresStorage {
+      url = "jdbc:postgresql://example.com:5444/database"
+      schema = "schema"
+      username = "username"
+      password = "password"
+    }
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -232,20 +232,22 @@ By default the Scanner stores scan results on the local file system in the curre
 `~/.ort/scanner/scan-results`) for later reuse. The storage directory can be customized by passing a scanner
 configuration file (`-c`) that contains a respective local file storage configuration:
 
-```yaml
-local_file_storage:
-  directory: "/tmp/ort/scan-results"
+```hocon
+localFileStorage {
+  directory = "/tmp/ort/scan-results"
+}
 ```
 
 ### Artifactory Storage
 
 To use Artifactory to store scan results, use the following configuration:
 
-```yaml
-artifactory_storage:
-  url: "https://artifactory.domain.com/artifactory"
-  repository: "generic-repository-name"
-  apiToken: $ARTIFACTORY_API_KEY
+```hocon
+artifactoryStorage {
+  url = "https://artifactory.domain.com/artifactory"
+  repository = "generic-repository-name"
+  apiToken = "api-token"
+}
 ```
 
 The scanner creates a directory "scan-results" in the configured repository and uses it to store scan results. 
@@ -254,12 +256,13 @@ The scanner creates a directory "scan-results" in the configured repository and 
 
 To use PostgreSQL to store scan results, use the following configuration:
 
-```yaml
-postgres_storage:
-  url: "jdbc:postgresql://example.com:5444/database"
-  schema: "schema"
-  username: "username"
-  password: "password"
+```hocon
+postgresStorage {
+  url = "jdbc:postgresql://example.com:5444/database"
+  schema = "schema"
+  username = "username"
+  password = "password"
+}
 ```
 
 The scanner creates a table called `scan_results` and stores the data in a

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -1,3 +1,4 @@
+val config4kVersion: String by project
 val jcommanderVersion: String by project
 val kotlintestVersion: String by project
 val log4jCoreVersion: String by project
@@ -31,6 +32,7 @@ dependencies {
     compile(project(":utils"))
 
     compile("com.beust:jcommander:$jcommanderVersion")
+    compile("io.github.config4k:config4k:$config4kVersion")
     compile("org.apache.logging.log4j:log4j-core:$log4jCoreVersion")
     compile("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     compile("org.jetbrains.kotlin:kotlin-reflect")

--- a/cli/src/main/kotlin/CommandWithHelp.kt
+++ b/cli/src/main/kotlin/CommandWithHelp.kt
@@ -22,6 +22,8 @@ package com.here.ort
 import com.beust.jcommander.JCommander
 import com.beust.jcommander.Parameter
 
+import com.here.ort.model.config.OrtConfiguration
+
 import com.here.ort.utils.PARAMETER_ORDER_HELP
 
 /**
@@ -39,7 +41,7 @@ abstract class CommandWithHelp {
     /**
      * Run the command after processing command line help.
      */
-    fun run(jc: JCommander): Int {
+    fun run(jc: JCommander, config: OrtConfiguration): Int {
         if (jc.parsedCommand == null) {
             jc.usage()
             return 0
@@ -50,11 +52,11 @@ abstract class CommandWithHelp {
             return 0
         }
 
-        return runCommand(jc)
+        return runCommand(jc, config)
     }
 
     /**
      * Run the underlying command.
      */
-    protected abstract fun runCommand(jc: JCommander): Int
+    protected abstract fun runCommand(jc: JCommander, config: OrtConfiguration): Int
 }

--- a/cli/src/main/kotlin/commands/AnalyzerCommand.kt
+++ b/cli/src/main/kotlin/commands/AnalyzerCommand.kt
@@ -31,6 +31,7 @@ import com.here.ort.analyzer.PackageManager
 import com.here.ort.analyzer.PackageManagerFactory
 import com.here.ort.model.OutputFormat
 import com.here.ort.model.config.AnalyzerConfiguration
+import com.here.ort.model.config.OrtConfiguration
 import com.here.ort.model.mapper
 import com.here.ort.utils.PARAMETER_ORDER_MANDATORY
 import com.here.ort.utils.PARAMETER_ORDER_OPTIONAL
@@ -118,7 +119,7 @@ object AnalyzerCommand : CommandWithHelp() {
     )
     private var repositoryConfigurationFile: File? = null
 
-    override fun runCommand(jc: JCommander): Int {
+    override fun runCommand(jc: JCommander, config: OrtConfiguration): Int {
         val absoluteOutputDir = outputDir.expandTilde().normalize()
 
         val outputFiles = outputFormats.distinct().map { format ->
@@ -149,8 +150,8 @@ object AnalyzerCommand : CommandWithHelp() {
         val absoluteInputDir = inputDir.expandTilde().normalize()
         println("Analyzing project path:\n\t$absoluteInputDir")
 
-        val config = AnalyzerConfiguration(ignoreToolVersions, allowDynamicVersions)
-        val analyzer = Analyzer(config)
+        val analyzerConfig = AnalyzerConfiguration(ignoreToolVersions, allowDynamicVersions)
+        val analyzer = Analyzer(analyzerConfig)
         val ortResult = analyzer.analyze(
             absoluteInputDir, packageManagers, absolutePackageCurationsFile,
             absoluteRepositoryConfigurationFile

--- a/cli/src/main/kotlin/commands/DownloaderCommand.kt
+++ b/cli/src/main/kotlin/commands/DownloaderCommand.kt
@@ -32,6 +32,7 @@ import com.here.ort.model.Package
 import com.here.ort.model.RemoteArtifact
 import com.here.ort.model.VcsInfo
 import com.here.ort.model.VcsType
+import com.here.ort.model.config.OrtConfiguration
 import com.here.ort.model.readValue
 import com.here.ort.utils.ARCHIVE_EXTENSIONS
 import com.here.ort.utils.PARAMETER_ORDER_MANDATORY
@@ -126,7 +127,7 @@ object DownloaderCommand : CommandWithHelp() {
     )
     private var allowMovingRevisions = false
 
-    override fun runCommand(jc: JCommander): Int {
+    override fun runCommand(jc: JCommander, config: OrtConfiguration): Int {
         if ((ortFile != null) == (projectUrl != null)) {
             throw IllegalArgumentException(
                 "Either '--ort-file' or '--project-url' must be specified."

--- a/cli/src/main/kotlin/commands/EvaluatorCommand.kt
+++ b/cli/src/main/kotlin/commands/EvaluatorCommand.kt
@@ -29,6 +29,7 @@ import com.here.ort.model.OrtResult
 import com.here.ort.model.OutputFormat
 import com.here.ort.model.RuleViolation
 import com.here.ort.model.Severity
+import com.here.ort.model.config.OrtConfiguration
 import com.here.ort.model.mapper
 import com.here.ort.model.readValue
 import com.here.ort.utils.PARAMETER_ORDER_MANDATORY
@@ -102,7 +103,7 @@ object EvaluatorCommand : CommandWithHelp() {
     )
     private var packageCurationsFile: File? = null
 
-    override fun runCommand(jc: JCommander): Int {
+    override fun runCommand(jc: JCommander, config: OrtConfiguration): Int {
         require((rulesFile == null) != (rulesResource == null)) {
             "Either '--rules-file' or '--rules-resource' must be specified."
         }

--- a/cli/src/main/kotlin/commands/ReporterCommand.kt
+++ b/cli/src/main/kotlin/commands/ReporterCommand.kt
@@ -28,6 +28,7 @@ import com.beust.jcommander.Parameters
 import com.here.ort.CommandWithHelp
 import com.here.ort.model.OrtResult
 import com.here.ort.model.config.CopyrightGarbage
+import com.here.ort.model.config.OrtConfiguration
 import com.here.ort.model.config.Resolutions
 import com.here.ort.model.readValue
 import com.here.ort.reporter.DefaultResolutionProvider
@@ -123,7 +124,7 @@ object ReporterCommand : CommandWithHelp() {
     )
     private var customLicenseTextsDir: File? = null
 
-    override fun runCommand(jc: JCommander): Int {
+    override fun runCommand(jc: JCommander, config: OrtConfiguration): Int {
         val absoluteOutputDir = outputDir.expandTilde().normalize()
 
         val reports = reporters.associateWith { reporter ->

--- a/cli/src/main/kotlin/commands/RequirementsCommand.kt
+++ b/cli/src/main/kotlin/commands/RequirementsCommand.kt
@@ -26,6 +26,7 @@ import com.here.ort.CommandWithHelp
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.config.AnalyzerConfiguration
+import com.here.ort.model.config.OrtConfiguration
 import com.here.ort.model.config.RepositoryConfiguration
 import com.here.ort.model.config.ScannerConfiguration
 import com.here.ort.scanner.Scanner
@@ -39,7 +40,7 @@ import org.reflections.Reflections
 
 @Parameters(commandNames = ["requirements"], commandDescription = "List the required command line tools.")
 object RequirementsCommand : CommandWithHelp() {
-    override fun runCommand(jc: JCommander): Int {
+    override fun runCommand(jc: JCommander, config: OrtConfiguration): Int {
         var exitCode = 0
 
         val reflections = Reflections("com.here.ort")

--- a/cli/src/main/kotlin/commands/ScannerCommand.kt
+++ b/cli/src/main/kotlin/commands/ScannerCommand.kt
@@ -29,7 +29,6 @@ import com.here.ort.CommandWithHelp
 import com.here.ort.model.OutputFormat
 import com.here.ort.model.config.ScannerConfiguration
 import com.here.ort.model.mapper
-import com.here.ort.model.readValue
 import com.here.ort.scanner.LocalScanner
 import com.here.ort.scanner.ScanResultsStorage
 import com.here.ort.scanner.Scanner
@@ -43,6 +42,10 @@ import com.here.ort.utils.PARAMETER_ORDER_OPTIONAL
 import com.here.ort.utils.expandTilde
 import com.here.ort.utils.getUserOrtDirectory
 import com.here.ort.utils.log
+
+import com.typesafe.config.ConfigFactory
+
+import io.github.config4k.extract
 
 import java.io.File
 
@@ -125,7 +128,7 @@ object ScannerCommand : CommandWithHelp() {
                 "The provided configuration file '$it' is not actually a file."
             }
 
-            it.readValue<ScannerConfiguration>()
+            ConfigFactory.parseFile(it).extract<ScannerConfiguration>()
         } ?: ScannerConfiguration()
 
         // By default use a file based scan results storage.

--- a/cli/src/main/resources/default.conf
+++ b/cli/src/main/resources/default.conf
@@ -1,0 +1,4 @@
+// The default ORT configuration. All options not overwritten using another configuration option like a configuration
+// file are used as defined in this file.
+ort {
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,6 +10,7 @@ antlrVersion = 4.7.2
 apachePoiSchemasVersion = 1.4
 apachePoiVersion = 3.17
 commonsCompressVersion = 1.19
+config4kVersion = 0.4.1
 cyclonedxCoreJavaVersion = 2.1.1
 digraphVersion = 1.0
 disklrucacheVersion = 2.0.2

--- a/helper-cli/build.gradle.kts
+++ b/helper-cli/build.gradle.kts
@@ -1,4 +1,5 @@
 val jcommanderVersion: String by project
+val log4jCoreVersion: String by project
 val reflectionsVersion: String by project
 
 plugins {
@@ -20,5 +21,11 @@ repositories {
 }
 
 dependencies {
-    compile(project(":cli"))
+    compile(project(":analyzer"))
+    compile(project(":downloader"))
+    compile(project(":reporter"))
+    compile(project(":utils"))
+
+    compile("com.beust:jcommander:$jcommanderVersion")
+    compile("org.apache.logging.log4j:log4j-core:$log4jCoreVersion")
 }

--- a/helper-cli/src/main/kotlin/CommandWithHelp.kt
+++ b/helper-cli/src/main/kotlin/CommandWithHelp.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.helper
+
+import com.beust.jcommander.JCommander
+import com.beust.jcommander.Parameter
+
+import com.here.ort.utils.PARAMETER_ORDER_HELP
+
+/**
+ * A JCommander command that offers command line help.
+ */
+abstract class CommandWithHelp {
+    @Parameter(
+        description = "Display the command line help.",
+        names = ["--help", "-h"],
+        help = true,
+        order = PARAMETER_ORDER_HELP
+    )
+    private var help = false
+
+    /**
+     * Run the command after processing command line help.
+     */
+    fun run(jc: JCommander): Int {
+        if (jc.parsedCommand == null) {
+            jc.usage()
+            return 0
+        }
+
+        if (help) {
+            jc.usageFormatter.usage(jc.parsedCommand)
+            return 0
+        }
+
+        return runCommand(jc)
+    }
+
+    /**
+     * Run the underlying command.
+     */
+    protected abstract fun runCommand(jc: JCommander): Int
+}

--- a/helper-cli/src/main/kotlin/Main.kt
+++ b/helper-cli/src/main/kotlin/Main.kt
@@ -24,7 +24,6 @@ import kotlin.system.exitProcess
 import com.beust.jcommander.JCommander
 import com.beust.jcommander.Parameter
 
-import com.here.ort.CommandWithHelp
 import com.here.ort.helper.commands.*
 import com.here.ort.utils.PARAMETER_ORDER_LOGGING
 import com.here.ort.utils.printStackTrace

--- a/helper-cli/src/main/kotlin/commands/ExportPathExcludesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ExportPathExcludesCommand.kt
@@ -23,7 +23,7 @@ import com.beust.jcommander.JCommander
 import com.beust.jcommander.Parameter
 import com.beust.jcommander.Parameters
 
-import com.here.ort.CommandWithHelp
+import com.here.ort.helper.CommandWithHelp
 import com.here.ort.helper.common.RepositoryPathExcludes
 import com.here.ort.helper.common.getRepositoryPathExcludes
 import com.here.ort.helper.common.merge

--- a/helper-cli/src/main/kotlin/commands/ExtractRepositoryConfigurationCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ExtractRepositoryConfigurationCommand.kt
@@ -23,7 +23,7 @@ import com.beust.jcommander.JCommander
 import com.beust.jcommander.Parameter
 import com.beust.jcommander.Parameters
 
-import com.here.ort.CommandWithHelp
+import com.here.ort.helper.CommandWithHelp
 import com.here.ort.helper.common.writeAsYaml
 import com.here.ort.model.OrtResult
 import com.here.ort.model.readValue

--- a/helper-cli/src/main/kotlin/commands/FormatRepositoryConfigurationCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/FormatRepositoryConfigurationCommand.kt
@@ -24,7 +24,7 @@ import com.beust.jcommander.Parameter
 import com.beust.jcommander.Parameters
 import com.beust.jcommander.converters.FileConverter
 
-import com.here.ort.CommandWithHelp
+import com.here.ort.helper.CommandWithHelp
 import com.here.ort.helper.common.writeAsYaml
 import com.here.ort.model.config.RepositoryConfiguration
 import com.here.ort.model.readValue

--- a/helper-cli/src/main/kotlin/commands/GenerateProjectExcludesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/GenerateProjectExcludesCommand.kt
@@ -23,7 +23,7 @@ import com.beust.jcommander.JCommander
 import com.beust.jcommander.Parameter
 import com.beust.jcommander.Parameters
 
-import com.here.ort.CommandWithHelp
+import com.here.ort.helper.CommandWithHelp
 import com.here.ort.helper.common.replacePathExcludes
 import com.here.ort.helper.common.sortPathExcludes
 import com.here.ort.helper.common.writeAsYaml

--- a/helper-cli/src/main/kotlin/commands/GenerateRuleViolationResolutionsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/GenerateRuleViolationResolutionsCommand.kt
@@ -23,7 +23,7 @@ import com.beust.jcommander.JCommander
 import com.beust.jcommander.Parameter
 import com.beust.jcommander.Parameters
 
-import com.here.ort.CommandWithHelp
+import com.here.ort.helper.CommandWithHelp
 import com.here.ort.helper.common.SeverityConverter
 import com.here.ort.helper.common.getUnresolvedRuleViolations
 import com.here.ort.helper.common.replaceRuleViolationResolutions

--- a/helper-cli/src/main/kotlin/commands/GenerateScopeExcludesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/GenerateScopeExcludesCommand.kt
@@ -23,7 +23,7 @@ import com.beust.jcommander.JCommander
 import com.beust.jcommander.Parameter
 import com.beust.jcommander.Parameters
 
-import com.here.ort.CommandWithHelp
+import com.here.ort.helper.CommandWithHelp
 import com.here.ort.helper.common.minimize
 import com.here.ort.helper.common.replaceScopeExcludes
 import com.here.ort.helper.common.sortScopeExcludes

--- a/helper-cli/src/main/kotlin/commands/GenerateTimeoutErrorResolutionsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/GenerateTimeoutErrorResolutionsCommand.kt
@@ -23,7 +23,7 @@ import com.beust.jcommander.JCommander
 import com.beust.jcommander.Parameter
 import com.beust.jcommander.Parameters
 
-import com.here.ort.CommandWithHelp
+import com.here.ort.helper.CommandWithHelp
 import com.here.ort.helper.common.getScanIssues
 import com.here.ort.model.OrtResult
 import com.here.ort.model.config.ErrorResolution

--- a/helper-cli/src/main/kotlin/commands/ImportPathExcludesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ImportPathExcludesCommand.kt
@@ -23,7 +23,7 @@ import com.beust.jcommander.JCommander
 import com.beust.jcommander.Parameter
 import com.beust.jcommander.Parameters
 
-import com.here.ort.CommandWithHelp
+import com.here.ort.helper.CommandWithHelp
 import com.here.ort.helper.common.RepositoryPathExcludes
 import com.here.ort.helper.common.findFilesRecursive
 import com.here.ort.helper.common.findRepositoryPaths

--- a/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
@@ -23,7 +23,7 @@ import com.beust.jcommander.JCommander
 import com.beust.jcommander.Parameter
 import com.beust.jcommander.Parameters
 
-import com.here.ort.CommandWithHelp
+import com.here.ort.helper.CommandWithHelp
 import com.here.ort.helper.common.IdentifierConverter
 import com.here.ort.helper.common.fetchScannedSources
 import com.here.ort.helper.common.getLicenseFindingsById

--- a/helper-cli/src/main/kotlin/commands/ListPackagesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListPackagesCommand.kt
@@ -23,7 +23,7 @@ import com.beust.jcommander.JCommander
 import com.beust.jcommander.Parameter
 import com.beust.jcommander.Parameters
 
-import com.here.ort.CommandWithHelp
+import com.here.ort.helper.CommandWithHelp
 import com.here.ort.model.OrtResult
 import com.here.ort.model.readValue
 import com.here.ort.utils.PARAMETER_ORDER_MANDATORY

--- a/helper-cli/src/main/kotlin/commands/RemoveConfigurationEntriesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/RemoveConfigurationEntriesCommand.kt
@@ -23,7 +23,7 @@ import com.beust.jcommander.JCommander
 import com.beust.jcommander.Parameter
 import com.beust.jcommander.Parameters
 
-import com.here.ort.CommandWithHelp
+import com.here.ort.helper.CommandWithHelp
 import com.here.ort.helper.common.findFilesRecursive
 import com.here.ort.helper.common.minimize
 import com.here.ort.helper.common.replacePathExcludes

--- a/helper-cli/src/main/kotlin/commands/SortRepositoryConfigurationCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/SortRepositoryConfigurationCommand.kt
@@ -24,7 +24,7 @@ import com.beust.jcommander.Parameter
 import com.beust.jcommander.Parameters
 import com.beust.jcommander.converters.FileConverter
 
-import com.here.ort.CommandWithHelp
+import com.here.ort.helper.CommandWithHelp
 import com.here.ort.helper.common.sortEntries
 import com.here.ort.helper.common.writeAsYaml
 import com.here.ort.model.config.RepositoryConfiguration

--- a/helper-cli/src/main/kotlin/commands/VerifySourceArtifactCurationsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/VerifySourceArtifactCurationsCommand.kt
@@ -24,7 +24,7 @@ import com.beust.jcommander.Parameter
 import com.beust.jcommander.Parameters
 import com.beust.jcommander.converters.FileConverter
 
-import com.here.ort.CommandWithHelp
+import com.here.ort.helper.CommandWithHelp
 import com.here.ort.helper.common.download
 import com.here.ort.model.PackageCuration
 import com.here.ort.model.readValue

--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -2,6 +2,7 @@ import com.here.ort.gradle.*
 
 import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
 
+val config4kVersion: String by project
 val jacksonVersion: String by project
 val semverVersion: String by project
 
@@ -26,6 +27,8 @@ dependencies {
     implementation("com.vdurmont:semver4j:$semverVersion")
 
     implementation("org.jetbrains.kotlin:kotlin-reflect")
+
+    testImplementation("io.github.config4k:config4k:$config4kVersion")
 }
 
 val generateVersionResource by tasks.registering {

--- a/model/src/main/kotlin/config/OrtConfiguration.kt
+++ b/model/src/main/kotlin/config/OrtConfiguration.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.model.config
+
+/**
+ * The configuration model for all ORT components.
+ */
+data class OrtConfiguration(
+    /**
+     * The configuration of the scanner.
+     */
+    val scanner: ScannerConfiguration? = null
+)

--- a/model/src/main/resources/reference.conf
+++ b/model/src/main/resources/reference.conf
@@ -1,0 +1,22 @@
+// A reference configuration file containing all possible ORT configuration options. Some of those options are mutually
+// exclusive, so this file is only used to show all options and to validate the configuration.
+ort {
+  scanner {
+    artifactoryStorage {
+      url = "https://your-artifactory-server"
+      repository = repository
+      apiToken = apiToken
+    }
+
+    localFileStorage {
+      directory = ~/.ort/scanner
+    }
+
+    postgresStorage {
+      url = "postgresql://your-postgresql-server:5444/your-database"
+      schema = schema
+      username = username
+      password = password
+    }
+  }
+}

--- a/model/src/test/kotlin/config/ArtifactoryStorageConfigurationTest.kt
+++ b/model/src/test/kotlin/config/ArtifactoryStorageConfigurationTest.kt
@@ -23,36 +23,12 @@ import com.fasterxml.jackson.module.kotlin.readValue
 
 import com.here.ort.model.yamlMapper
 
-import com.typesafe.config.ConfigFactory
-
-import io.github.config4k.extract
-
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.WordSpec
 
 class ArtifactoryStorageConfigurationTest : WordSpec() {
     init {
         "ArtifactoryStorageConfiguration" should {
-            "be deserializable from HOCON" {
-                val hocon = """
-                    scanner {
-                        artifactoryStorage {
-                            url = url
-                            repository = repository
-                            apiToken = apiToken
-                        }
-                    }
-                """.trimIndent()
-
-                val config = ConfigFactory.parseString(hocon)
-                val artifactoryStorageConfiguration =
-                    config.extract<ArtifactoryStorageConfiguration>("scanner.artifactoryStorage")
-
-                artifactoryStorageConfiguration.url shouldBe "url"
-                artifactoryStorageConfiguration.repository shouldBe "repository"
-                artifactoryStorageConfiguration.apiToken shouldBe "apiToken"
-            }
-
             "be deserializable" {
                 val yaml = """
                     ---

--- a/model/src/test/kotlin/config/ArtifactoryStorageConfigurationTest.kt
+++ b/model/src/test/kotlin/config/ArtifactoryStorageConfigurationTest.kt
@@ -23,12 +23,36 @@ import com.fasterxml.jackson.module.kotlin.readValue
 
 import com.here.ort.model.yamlMapper
 
+import com.typesafe.config.ConfigFactory
+
+import io.github.config4k.extract
+
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.WordSpec
 
 class ArtifactoryStorageConfigurationTest : WordSpec() {
     init {
         "ArtifactoryStorageConfiguration" should {
+            "be deserializable from HOCON" {
+                val hocon = """
+                    scanner {
+                        artifactoryStorage {
+                            url = url
+                            repository = repository
+                            apiToken = apiToken
+                        }
+                    }
+                """.trimIndent()
+
+                val config = ConfigFactory.parseString(hocon)
+                val artifactoryStorageConfiguration =
+                    config.extract<ArtifactoryStorageConfiguration>("scanner.artifactoryStorage")
+
+                artifactoryStorageConfiguration.url shouldBe "url"
+                artifactoryStorageConfiguration.repository shouldBe "repository"
+                artifactoryStorageConfiguration.apiToken shouldBe "apiToken"
+            }
+
             "be deserializable" {
                 val yaml = """
                     ---

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.model.config
+
+import com.typesafe.config.ConfigFactory
+
+import io.github.config4k.extract
+
+import io.kotlintest.shouldBe
+import io.kotlintest.shouldNotBe
+import io.kotlintest.specs.WordSpec
+
+import java.io.File
+
+class OrtConfigurationTest : WordSpec({
+    "OrtConfiguration" should {
+        "be deserializable from HOCON" {
+            val hocon = """
+                    ort {
+                      scanner {
+                        artifactoryStorage {
+                          url = url
+                          repository = repository
+                          apiToken = apiToken
+                        }
+
+                        localFileStorage {
+                          directory = /storage
+                        }
+
+                        postgresStorage {
+                          url = url
+                          schema = schema
+                          username = username
+                          password = password
+                        }
+                      }
+                    }
+                """.trimIndent()
+
+            val config = ConfigFactory.parseString(hocon)
+            val ortConfig = config.extract<OrtConfiguration>("ort")
+
+            ortConfig shouldNotBe null
+
+            ortConfig.scanner.let { scanner ->
+                scanner shouldNotBe null
+
+                scanner!!.artifactoryStorage.let { artifactory ->
+                    artifactory shouldNotBe null
+                    artifactory!!.url shouldBe "url"
+                    artifactory.repository shouldBe "repository"
+                    artifactory.apiToken shouldBe "apiToken"
+                }
+
+                scanner.localFileStorage.let { localFile ->
+                    localFile shouldNotBe null
+                    localFile!!.directory shouldBe File("/storage")
+                }
+
+                scanner.postgresStorage.let { postgres ->
+                    postgres shouldNotBe null
+                    postgres!!.url shouldBe "url"
+                    postgres.schema shouldBe "schema"
+                    postgres.username shouldBe "username"
+                    postgres.password shouldBe "password"
+                }
+            }
+        }
+    }
+})

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -32,28 +32,7 @@ import java.io.File
 class OrtConfigurationTest : WordSpec({
     "OrtConfiguration" should {
         "be deserializable from HOCON" {
-            val hocon = """
-                    ort {
-                      scanner {
-                        artifactoryStorage {
-                          url = url
-                          repository = repository
-                          apiToken = apiToken
-                        }
-
-                        localFileStorage {
-                          directory = /storage
-                        }
-
-                        postgresStorage {
-                          url = url
-                          schema = schema
-                          username = username
-                          password = password
-                        }
-                      }
-                    }
-                """.trimIndent()
+            val hocon = javaClass.getResource("/reference.conf").readText()
 
             val config = ConfigFactory.parseString(hocon)
             val ortConfig = config.extract<OrtConfiguration>("ort")
@@ -65,19 +44,19 @@ class OrtConfigurationTest : WordSpec({
 
                 scanner!!.artifactoryStorage.let { artifactory ->
                     artifactory shouldNotBe null
-                    artifactory!!.url shouldBe "url"
+                    artifactory!!.url shouldBe "https://your-artifactory-server"
                     artifactory.repository shouldBe "repository"
                     artifactory.apiToken shouldBe "apiToken"
                 }
 
                 scanner.localFileStorage.let { localFile ->
                     localFile shouldNotBe null
-                    localFile!!.directory shouldBe File("/storage")
+                    localFile!!.directory shouldBe File("~/.ort/scanner")
                 }
 
                 scanner.postgresStorage.let { postgres ->
                     postgres shouldNotBe null
-                    postgres!!.url shouldBe "url"
+                    postgres!!.url shouldBe "postgresql://your-postgresql-server:5444/your-database"
                     postgres.schema shouldBe "schema"
                     postgres.username shouldBe "username"
                     postgres.password shouldBe "password"


### PR DESCRIPTION
Switch to using HOCON as configuration file format. In combination with [typesafe config](https://github.com/lightbend/config) this allows to easily use different configuration sources like command line or configuration file.
This PR contains the migration of the existing YAML scanner configuration to a global ORT configuration using HOCON, follow-up PRs will make more configuration options available and update the README accordingly.