### PR TITLE
ScanResultsStorage: Support a tilde in the directory for a local file storage

### DIFF
--- a/scanner/src/main/kotlin/ScanResultsStorage.kt
+++ b/scanner/src/main/kotlin/ScanResultsStorage.kt
@@ -30,6 +30,7 @@ import com.here.ort.model.config.ArtifactoryStorageConfiguration
 import com.here.ort.model.config.LocalFileStorageConfiguration
 import com.here.ort.model.config.PostgresStorageConfiguration
 import com.here.ort.scanner.storages.*
+import com.here.ort.utils.expandTilde
 import com.here.ort.utils.log
 
 import java.lang.IllegalArgumentException
@@ -65,9 +66,9 @@ abstract class ScanResultsStorage {
          * Configure a [LocalFileStorage] as the current storage backend.
          */
         fun configure(config: LocalFileStorageConfiguration) {
-            storage = LocalFileStorage(config.directory)
-
-            log.info { "Using local file storage at ${config.directory}." }
+            storage = LocalFileStorage(config.directory.expandTilde()).also {
+                log.info { "Using local file storage at ${it.scanResultsDirectory}." }
+            }
         }
 
         /**


### PR DESCRIPTION
And slightly improve the logging to show the real directory being used.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>