### PR TITLE
OrtResult: Make the code to exclude subprojects more readable

### DIFF
--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -234,16 +234,17 @@ data class OrtResult(
      */
     fun collectProjectsAndPackages(includeSubProjects: Boolean = true): SortedSet<Identifier> {
         val projectsAndPackages = sortedSetOf<Identifier>()
-        val allSubProjects = sortedSetOf<Identifier>()
+
+        getProjects().mapTo(projectsAndPackages) { it.id }
 
         if (!includeSubProjects) {
+            val allSubProjects = sortedSetOf<Identifier>()
+
             getProjects().forEach {
                 it.collectSubProjects().mapTo(allSubProjects) { ref -> ref.id }
             }
-        }
 
-        getProjects().mapNotNullTo(projectsAndPackages) { project ->
-            project.id.takeUnless { it in allSubProjects }
+            projectsAndPackages -= allSubProjects
         }
 
         getPackages().mapTo(projectsAndPackages) { it.pkg.id }


### PR DESCRIPTION
Previously, it was a bit unclear why subprojects were only determined if
they should be excluded. Rewrite the code to make it more obvious (and
performant) that subprojects are removed from the set of all projects.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>