### PR TITLE
.ort.yml: Add license findings curations

### DIFF
--- a/.ort.yml
+++ b/.ort.yml
@@ -1,3 +1,26 @@
+curations:
+  license_findings:
+  - path: "spdx-utils/src/main/kotlin/SpdxLicense.kt"
+    comment: "This file defines official SPDX.org licenses so they can be used in OSS Review Toolkit."
+    reason: "DATA_OF"
+    concluded_license: "Apache-2.0"
+  - path: "spdx-utils/src/main/resources/licenses/**"
+    comment: "This directory contains all official SPDX.org license ids which are used to generate open source notices. \
+      SPDX and ScanCode license files are licensed under CC0-1.0, see \
+      https://github.com/spdx/license-list-XML/blob/master/package.json#L33"
+    reason: "DATA_OF"
+    concluded_license: "CC0-1.0"
+  - path: "spdx-utils/src/main/resources/licensesrefs/**"
+    comment: "This directory contains all non-official SPDX license ids which are used to generate open source notices. \
+      SPDX and ScanCode license files are licensed under CC0-1.0, see \
+      https://github.com/spdx/license-list-XML/blob/master/package.json#L33 \
+      https://github.com/nexB/scancode-toolkit/blame/develop/README.rst#L168"
+    reason: "DATA_OF"
+    concluded_license: "CC0-1.0"
+  - path: "analyzer/src/funTest/assets/projects/synthetic/php-composer/{empty-des, lockfile, no-deps, with-provide, with-replace}/composer.phar"
+    comment: "This file 'composer.phar' is part of PHP Composer and includes a mapping from human readable strings to SPDX license ids."
+    reason: "DATA_OF"
+    concluded_license: "MIT"
 excludes:
   paths:
   - pattern: "*/src/{funTest,test}/**"


### PR DESCRIPTION
Correct license findings with curations so correct ORT report
is generated.

Signed-off-by: Thomas Steenbergen <thomas.steenbergen@here.com>