### PR TITLE
Configuration.md: Fix-up LicenseFindingCuration example

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -175,6 +175,8 @@ files in the `src` directory:
 
 e.g.:
 ```yaml
+curations:
+  license_findings:
   - path: "src/**/*.cpp"
     start_lines: "3"
     line_count: 11


### PR DESCRIPTION
Add required keys for LicenseFindingCuration so ORT users are can simply copy-paste the example into their .ort.yml.

Signed-off-by: Thomas Steenbergen <thomas.steenbergen@here.com>