### PR TITLE
Extensions: Make expandTilde() work in Bash on Windows

### DIFF
--- a/utils/src/main/kotlin/Extensions.kt
+++ b/utils/src/main/kotlin/Extensions.kt
@@ -53,7 +53,11 @@ fun ByteArray.toHexString(): String = joinToString("") { String.format("%02x", i
  * Return the absolute file with a leading "~" in a Unix path expanded to the current user's home directory.
  */
 fun File.expandTilde(): File =
-    File(path.replace(Regex("^~/"), "${System.getProperty("user.home")}/")).absoluteFile
+    if (System.getenv("SHELL") != null) {
+        File(path.replace(Regex("^~"), Regex.escapeReplacement(System.getProperty("user.home"))))
+    } else {
+        this
+    }.absoluteFile
 
 /**
  * Return the hexadecimal digest of the given hash [algorithm] for this [File].


### PR DESCRIPTION
On Windows the path separator is "\" so we cannot include "/" into the
pattern anymore. Instead of the presence of "/", use the "SHELL"
environment variable as the indicator whether the replacement should
happen, as "SHELL" is also set in Git for Windows' Bash and "Bash on
Ubuntu on Windows".

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>