### PR TITLE
Scanner: Fix the message if an ORT result file cannot be found

### DIFF
--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -88,7 +88,7 @@ abstract class Scanner(val scannerName: String, protected val config: ScannerCon
         scopesToScan: Set<String> = emptySet()
     ): OrtResult {
         require(ortResultFile.isFile) {
-            "Provided path for the configuration does not refer to a file: ${ortResultFile.absolutePath}"
+            "The provided ORT result file '${ortResultFile.canonicalPath}' does not exit."
         }
 
         val startTime = Instant.now()


### PR DESCRIPTION
This is not a configuration file, but an ORT result file. Also use the
canonical path instead of just the absolute path to resolve e.g.
intermediate "..".

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>