### PR TITLE
Helper-CLI: Additional params for listing licenses

### DIFF
--- a/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
@@ -110,8 +110,20 @@ internal class ListLicensesCommand : CommandWithHelp() {
     )
     private var applyLicenseFindingCurations: Boolean = false
 
+    @Parameter(
+        names = ["--repository-configuration-file"],
+        required = false,
+        order = PARAMETER_ORDER_OPTIONAL,
+        description = "Override the repository configuration contained in the ORT result."
+    )
+    private var repositoryConfigurationFile: File? = null
+
     override fun runCommand(jc: JCommander): Int {
-        val ortResult = ortResultFile.readValue<OrtResult>()
+        var ortResult = ortResultFile.readValue<OrtResult>()
+        repositoryConfigurationFile?.let {
+            ortResult = ortResult.replaceConfig(it.readValue())
+        }
+
         val sourcesDir = sourceCodeDir ?: ortResult.fetchScannedSources(packageId)
         val violatedRulesByLicense = ortResult.getViolatedRulesByLicense(packageId, Severity.ERROR)
 

--- a/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
@@ -46,7 +46,8 @@ internal class ListLicensesCommand : CommandWithHelp() {
     @Parameter(
         names = ["--ort-result-file"],
         required = true,
-        order = PARAMETER_ORDER_MANDATORY
+        order = PARAMETER_ORDER_MANDATORY,
+        description = "The ORT result file to read as input."
     )
     private lateinit var ortResultFile: File
 
@@ -54,42 +55,50 @@ internal class ListLicensesCommand : CommandWithHelp() {
         names = ["--package-id"],
         required = true,
         order = PARAMETER_ORDER_MANDATORY,
-        converter = IdentifierConverter::class
+        converter = IdentifierConverter::class,
+        description = "The target package for which the licenses shall be listed."
     )
     private lateinit var packageId: Identifier
 
     @Parameter(
         names = ["--source-code-dir"],
         required = false,
-        order = PARAMETER_ORDER_OPTIONAL
+        order = PARAMETER_ORDER_OPTIONAL,
+        description = "A directory containing the sources for the target package. These sources should match " +
+                "the provenance of the respective scan result in the ORT result. If not specified those sources " +
+                "are downloaded if needed."
     )
     private var sourceCodeDir: File? = null
 
     @Parameter(
         names = ["--only-offending"],
         required = false,
-        order = PARAMETER_ORDER_OPTIONAL
+        order = PARAMETER_ORDER_OPTIONAL,
+        description = "Only list licenses causing a rule violation of error severity in the given ORT result."
     )
     private var onlyOffending: Boolean = false
 
     @Parameter(
         names = ["--omit-excluded"],
         required = false,
-        order = PARAMETER_ORDER_OPTIONAL
+        order = PARAMETER_ORDER_OPTIONAL,
+        description = "Only list license findings for non-excluded file locations."
     )
     private var omitExcluded: Boolean = false
 
     @Parameter(
         names = ["--ignore-excluded-rule-ids"],
         required = false,
-        order = PARAMETER_ORDER_OPTIONAL
+        order = PARAMETER_ORDER_OPTIONAL,
+        description = "A comma separate list of rule names for which --omit-excluded should not have any effect."
     )
     private var ignoreExcludedRuleIds: List<String> = emptyList()
 
     @Parameter(
         names = ["--no-license-texts"],
         required = false,
-        order = PARAMETER_ORDER_OPTIONAL
+        order = PARAMETER_ORDER_OPTIONAL,
+        description = "Do not output the actual file content of file locations of license findings."
     )
     private var noLicenseTexts: Boolean = false
 

--- a/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
@@ -102,6 +102,14 @@ internal class ListLicensesCommand : CommandWithHelp() {
     )
     private var noLicenseTexts: Boolean = false
 
+    @Parameter(
+        names = ["--apply-license-finding-curations"],
+        required = false,
+        order = PARAMETER_ORDER_OPTIONAL,
+        description = "Apply the license finding curations contained in the ORT result."
+    )
+    private var applyLicenseFindingCurations: Boolean = false
+
     override fun runCommand(jc: JCommander): Int {
         val ortResult = ortResultFile.readValue<OrtResult>()
         val sourcesDir = sourceCodeDir ?: ortResult.fetchScannedSources(packageId)
@@ -112,7 +120,7 @@ internal class ListLicensesCommand : CommandWithHelp() {
         } ?: false
 
         ortResult
-            .getLicenseFindingsById(packageId)
+            .getLicenseFindingsById(packageId, applyLicenseFindingCurations)
             .filter { (license, _) -> !onlyOffending || violatedRulesByLicense.contains(license) }
             .mapValues { (license, locations) ->
                 locations.filter {

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -426,7 +426,10 @@ data class OrtResult(
     @JsonIgnore
     fun getExcludes(): Excludes = repository.config.excludes ?: Excludes()
 
-    private fun getLicenseFindingsCurations(id: Identifier): List<LicenseFindingCuration> =
+    /**
+     * Return the [LicenseFindingCuration]s associated with the given package [id].
+     */
+    fun getLicenseFindingsCurations(id: Identifier): List<LicenseFindingCuration> =
         if (projects.containsKey(id)) {
             repository.config.curations?.licenseFindings.orEmpty()
         } else {


### PR DESCRIPTION
Extend the list licenses command of the helper-cli by parameters for:
- specifying a repository configuration
- optionally applying license finding curations
