### PR TITLE
spdx-utils: Make SpdxException an unchecked exception

### DIFF
--- a/spdx-utils/src/main/kotlin/SpdxException.kt
+++ b/spdx-utils/src/main/kotlin/SpdxException.kt
@@ -19,7 +19,7 @@
 
 package com.here.ort.spdx
 
-class SpdxException : Exception {
+class SpdxException : RuntimeException {
     constructor(message: String?, cause: Throwable?) : super(message, cause)
     constructor(message: String?) : super(message)
     constructor(cause: Throwable?) : super(cause)


### PR DESCRIPTION
Derive SpdxException from RuntimeException to make it an unchecked
exception. This makes parse() more convenient to use from Java code as
SpdxException then does not need to be catched or declared as part of a
a method signature, e.g. because some preprocessing already ensured a
correct syntax of the expression.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>