### PR TITLE
CODEOWNERS: Fix adding @tsteenbe

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 * @sschuberth @mnonnenmacher @fviernau
-*.md @tsteenbe
+*.md @sschuberth @mnonnenmacher @fviernau @tsteenbe
 /reporter-web-app/ @tsteenbe
-/spdx-utils/src/main/ @tsteenbe
+/spdx-utils/src/main/ @sschuberth @mnonnenmacher @fviernau @tsteenbe


### PR DESCRIPTION
Ownership is not additive, the last matching one takes precedence, so
all wanted reviewers must be repeated for a specific pattern.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>