### PR TITLE
Gradle: Set the idle timout for the Gradle Daemon to 10 seconds

### DIFF
--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -47,6 +47,7 @@ import com.here.ort.utils.temporaryProperties
 
 import java.io.File
 import java.util.Properties
+import java.util.concurrent.TimeUnit
 
 import org.apache.maven.project.ProjectBuildingException
 
@@ -57,6 +58,7 @@ import org.eclipse.aether.repository.WorkspaceReader
 import org.eclipse.aether.repository.WorkspaceRepository
 
 import org.gradle.tooling.GradleConnector
+import org.gradle.tooling.internal.consumer.DefaultGradleConnector
 
 /**
  * The [Gradle](https://gradle.org/) package manager for Java.
@@ -135,10 +137,13 @@ class Gradle(
             }
         }
 
-        val gradleConnection = GradleConnector
-            .newConnector()
-            .forProjectDirectory(definitionFile.parentFile)
-            .connect()
+        val gradleConnector = GradleConnector.newConnector()
+
+        if (gradleConnector is DefaultGradleConnector) {
+            gradleConnector.daemonMaxIdleTime(10, TimeUnit.SECONDS)
+        }
+
+        val gradleConnection = gradleConnector.forProjectDirectory(definitionFile.parentFile).connect()
 
         return temporaryProperties(*gradleSystemProperties.toTypedArray()) {
             gradleConnection.use { connection ->


### PR DESCRIPTION
The Gradle Tooling API always uses the Gradle Daemon. The default idle
timeout for the Gradle Daemon is 3 hours [1]. Set it to 10 seconds
instead to make sure the Daemon is stopped shortly after the analyzer
has finished analyzing Gradle projects to make sure the runtime is
completely isolated from previous builds [2].

[1] https://docs.gradle.org/current/userguide/build_environment.html
[2] https://docs.gradle.org/current/userguide/gradle_daemon.html#sec:disabling_the_daemon