### PR TITLE
HttpFileStorage: Use Kotlin's readBytes() instead of Java's readAllBytes()

### DIFF
--- a/utils/src/main/kotlin/storage/HttpFileStorage.kt
+++ b/utils/src/main/kotlin/storage/HttpFileStorage.kt
@@ -87,7 +87,7 @@ class HttpFileStorage(
         inputStream.use {
             val request = Request.Builder()
                 .headers(headers.toHeaders())
-                .put(it.readAllBytes().toRequestBody())
+                .put(it.readBytes().toRequestBody())
                 .url(urlForPath(path))
                 .build()
 


### PR DESCRIPTION
Java's InputStream.readAllBytes() is only available since Java 9, see
https://docs.oracle.com/javase/9/docs/api/java/io/InputStream.html#readAllBytes--

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>