### PR TITLE
helper-cli: Commands for the import / export of curations

### DIFF
--- a/helper-cli/src/main/kotlin/Main.kt
+++ b/helper-cli/src/main/kotlin/Main.kt
@@ -83,6 +83,7 @@ object Main : CommandWithHelp() {
             addCommand(GenerateScopeExcludesCommand())
             addCommand(GenerateRuleViolationResolutionsCommand())
             addCommand(GenerateTimeoutErrorResolutionsCommand())
+            addCommand(ImportLicenseFindingCurationsCommand())
             addCommand(ImportPathExcludesCommand())
             addCommand(ListLicensesCommand())
             addCommand(ListPackagesCommand())

--- a/helper-cli/src/main/kotlin/Main.kt
+++ b/helper-cli/src/main/kotlin/Main.kt
@@ -75,6 +75,7 @@ object Main : CommandWithHelp() {
         val jc = JCommander(this).apply {
             programName = TOOL_NAME
 
+            addCommand(ExportLicenseFindingCurationsCommand())
             addCommand(ExportPathExcludesCommand())
             addCommand(ExtractRepositoryConfigurationCommand())
             addCommand(FormatRepositoryConfigurationCommand())

--- a/helper-cli/src/main/kotlin/commands/ExportLicenseFindingCurationsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ExportLicenseFindingCurationsCommand.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.helper.commands
+
+import com.beust.jcommander.JCommander
+import com.beust.jcommander.Parameter
+import com.beust.jcommander.Parameters
+
+import com.here.ort.helper.CommandWithHelp
+import com.here.ort.helper.common.RepositoryLicenseFindingCurations
+import com.here.ort.helper.common.getRepositoryLicenseFindingCurations
+import com.here.ort.helper.common.mergeLicenseFindingCurations
+import com.here.ort.model.OrtResult
+import com.here.ort.model.readValue
+import com.here.ort.model.yamlMapper
+import com.here.ort.utils.PARAMETER_ORDER_MANDATORY
+import com.here.ort.utils.PARAMETER_ORDER_OPTIONAL
+import com.here.ort.utils.safeMkdirs
+
+import java.io.File
+
+@Parameters(
+    commandNames = ["export-license-finding-curations"],
+    commandDescription = "Export the license finding curations to a file which maps repository URLs to the license " +
+            "finding curations for the respective repository."
+)
+internal class ExportLicenseFindingCurationsCommand : CommandWithHelp() {
+    @Parameter(
+        names = ["--license-finding-curations-file"],
+        required = true,
+        order = PARAMETER_ORDER_MANDATORY,
+        description = "The output license finding curations file."
+    )
+    private lateinit var licenseFindingCurationsFile: File
+
+    @Parameter(
+        names = ["--ort-result-file"],
+        required = true,
+        order = PARAMETER_ORDER_MANDATORY,
+        description = "The input ORT file from which the license finding curations are to be read."
+    )
+    private lateinit var ortResultFile: File
+
+    @Parameter(
+        names = ["--repository-configuration-file"],
+        required = false,
+        order = PARAMETER_ORDER_OPTIONAL,
+        description = "Override the repository configuration contained in the given input ORT file."
+    )
+    private lateinit var repositoryConfigurationFile: File
+
+    @Parameter(
+        names = ["--update-only-existing"],
+        required = false,
+        order = PARAMETER_ORDER_OPTIONAL,
+        description = "If enabled, only entries are imported for which an entry already exists which differs " +
+            "only in terms of its concluded license, comment or reason."
+    )
+    private var updateOnlyExisting = false
+
+    override fun runCommand(jc: JCommander): Int {
+        val localLicenseFindingCurations = ortResultFile
+            .readValue<OrtResult>()
+            .replaceConfig(repositoryConfigurationFile.readValue())
+            .getRepositoryLicenseFindingCurations()
+
+        val globalLicenseFindingCurations = if (licenseFindingCurationsFile.isFile) {
+            licenseFindingCurationsFile.readValue<RepositoryLicenseFindingCurations>()
+        } else {
+            mapOf()
+        }
+
+        globalLicenseFindingCurations
+            .mergeLicenseFindingCurations(localLicenseFindingCurations, updateOnlyExisting = updateOnlyExisting)
+            .writeAsYaml(licenseFindingCurationsFile)
+
+        return 0
+    }
+}
+
+/**
+ * Serialize this [RepositoryLicenseFindingCurations] to the given [targetFile] as YAML.
+ */
+private fun RepositoryLicenseFindingCurations.writeAsYaml(targetFile: File) {
+    targetFile.parentFile.apply { safeMkdirs() }
+
+    yamlMapper.writeValue(
+        targetFile,
+        mapValues { (_, curations) ->
+            curations.sortedBy { it.path.removePrefix("*").removePrefix("*") }
+        }.toSortedMap()
+    )
+}

--- a/helper-cli/src/main/kotlin/commands/ExportPathExcludesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ExportPathExcludesCommand.kt
@@ -26,7 +26,7 @@ import com.beust.jcommander.Parameters
 import com.here.ort.helper.CommandWithHelp
 import com.here.ort.helper.common.RepositoryPathExcludes
 import com.here.ort.helper.common.getRepositoryPathExcludes
-import com.here.ort.helper.common.merge
+import com.here.ort.helper.common.mergePathExcludes
 import com.here.ort.model.OrtResult
 import com.here.ort.model.readValue
 import com.here.ort.model.yamlMapper
@@ -83,7 +83,7 @@ internal class ExportPathExcludesCommand : CommandWithHelp() {
         }
 
         globalPathExcludes
-            .merge(localPathExcludes, updateOnlyExisting = updateOnlyExisting)
+            .mergePathExcludes(localPathExcludes, updateOnlyExisting = updateOnlyExisting)
             .writeAsYaml(pathExcludesFile)
 
         return 0

--- a/helper-cli/src/main/kotlin/commands/ImportLicenseFindingCurationsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ImportLicenseFindingCurationsCommand.kt
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.helper.commands
+
+import com.beust.jcommander.JCommander
+import com.beust.jcommander.Parameter
+import com.beust.jcommander.Parameters
+
+import com.here.ort.helper.CommandWithHelp
+import com.here.ort.helper.common.RepositoryLicenseFindingCurations
+import com.here.ort.helper.common.mergeLicenseFindingCurations
+import com.here.ort.helper.common.replaceLicenseFindingCurations
+import com.here.ort.helper.common.sortLicenseFindingCurations
+import com.here.ort.helper.common.writeAsYaml
+import com.here.ort.model.LicenseFinding
+import com.here.ort.model.OrtResult
+import com.here.ort.model.config.LicenseFindingCuration
+import com.here.ort.model.config.RepositoryConfiguration
+import com.here.ort.model.readValue
+import com.here.ort.model.util.FindingCurationMatcher
+import com.here.ort.utils.PARAMETER_ORDER_MANDATORY
+import com.here.ort.utils.PARAMETER_ORDER_OPTIONAL
+
+import java.io.File
+
+@Parameters(
+    commandNames = ["import-license-finding-curations"],
+    commandDescription = "Import license finding curations from a license finding curations file and merge them into " +
+            "the given repository configuration."
+)
+internal class ImportLicenseFindingCurationsCommand : CommandWithHelp() {
+    @Parameter(
+        names = ["--license-finding-curations-file"],
+        required = true,
+        order = PARAMETER_ORDER_MANDATORY,
+        description = "The input license finding curations file."
+    )
+    private lateinit var licenseFindingCurationsFile: File
+
+    @Parameter(
+        names = ["--ort-result-file"],
+        required = true,
+        order = PARAMETER_ORDER_MANDATORY,
+        description = "The ORT file containing the findings the imported curations need to match against."
+    )
+    private lateinit var ortResultFile: File
+
+    @Parameter(
+        names = ["--repository-configuration-file"],
+        required = true,
+        order = PARAMETER_ORDER_MANDATORY,
+        description = "The repository configuration file where the imported curations are to be merged into."
+    )
+    private lateinit var repositoryConfigurationFile: File
+
+    @Parameter(
+        names = ["--update-only-existing"],
+        order = PARAMETER_ORDER_OPTIONAL,
+        description = "If enabled, only entries are imported for which an entry already exists which differs " +
+                "only in terms of its concluded license, comment or reason."
+    )
+    private var updateOnlyExisting = false
+
+    private val findingCurationMatcher = FindingCurationMatcher()
+
+    override fun runCommand(jc: JCommander): Int {
+        val ortResult = ortResultFile.readValue<OrtResult>()
+        val repositoryConfiguration = if (repositoryConfigurationFile.isFile) {
+            repositoryConfigurationFile.readValue()
+        } else {
+            RepositoryConfiguration()
+        }
+
+        val allLicenseFindings = ortResult.getLicenseFindingsForAllProjects()
+
+        val importedCurations = importLicenseFindingCurations(ortResult)
+            .filter { curation ->
+                allLicenseFindings.any { finding ->
+                    findingCurationMatcher.matches(finding, curation)
+                }
+            }
+        val existingCurations = repositoryConfiguration.curations?.licenseFindings.orEmpty()
+        val curations = existingCurations.mergeLicenseFindingCurations(importedCurations, updateOnlyExisting)
+
+        repositoryConfiguration
+            .replaceLicenseFindingCurations(curations)
+            .sortLicenseFindingCurations()
+            .writeAsYaml(repositoryConfigurationFile)
+
+        return 0
+    }
+
+    private fun importLicenseFindingCurations(ortResult: OrtResult): Set<LicenseFindingCuration> {
+        val repositoryPaths = ortResult.getRepositoryPaths()
+        val licenseFindingCurations = licenseFindingCurationsFile.readValue<RepositoryLicenseFindingCurations>()
+
+        val result = mutableSetOf<LicenseFindingCuration>()
+
+        repositoryPaths.forEach { (vcsUrl, relativePaths) ->
+            licenseFindingCurations[vcsUrl]?.let { curationsForRepository ->
+                curationsForRepository.forEach { curation ->
+                    relativePaths.forEach { path ->
+                        result.add(curation.copy(path = path + '/' + curation.path))
+                    }
+                }
+            }
+        }
+
+        return result
+    }
+}
+
+private fun OrtResult.getRepositoryPaths(): Map<String, Set<String>> {
+    val result = mutableMapOf<String, MutableSet<String>>()
+
+    repository.nestedRepositories.mapValues { (path, vcsInfo) ->
+        result.getOrPut(vcsInfo.url, { mutableSetOf() }).add(path)
+    }
+
+    return result
+}
+
+private fun OrtResult.getLicenseFindingsForAllProjects(): Set<LicenseFinding> {
+    val result = mutableSetOf<LicenseFinding>()
+
+    val projectIds = getProjects().mapTo(mutableSetOf()) { it.id }
+    scanner?.results?.scanResults?.forEach { container ->
+        if (container.id in projectIds) {
+            container.results.forEach { scanResult ->
+                result.addAll(scanResult.summary.licenseFindings)
+            }
+        }
+    }
+
+    return result
+}

--- a/helper-cli/src/main/kotlin/commands/ImportPathExcludesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ImportPathExcludesCommand.kt
@@ -27,7 +27,7 @@ import com.here.ort.helper.CommandWithHelp
 import com.here.ort.helper.common.RepositoryPathExcludes
 import com.here.ort.helper.common.findFilesRecursive
 import com.here.ort.helper.common.findRepositoryPaths
-import com.here.ort.helper.common.merge
+import com.here.ort.helper.common.mergePathExcludes
 import com.here.ort.helper.common.replacePathExcludes
 import com.here.ort.helper.common.sortPathExcludes
 import com.here.ort.helper.common.writeAsYaml
@@ -86,7 +86,7 @@ internal class ImportPathExcludesCommand : CommandWithHelp() {
             allFiles.any { pathExclude.matches(it) }
         }
 
-        val pathExcludes = existingPathExcludes.merge(importedPathExcludes, updateOnlyExisting)
+        val pathExcludes = existingPathExcludes.mergePathExcludes(importedPathExcludes, updateOnlyExisting)
 
         repositoryConfiguration
             .replacePathExcludes(pathExcludes)

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -382,7 +382,7 @@ internal fun RepositoryConfiguration.writeAsYaml(targetFile: File) {
 }
 
 /**
- * Merge the given [RepositoryPathExcludes]s replacing entries with equal [PathExclude.pattern].
+ * Merge the given [RepositoryPathExcludes] replacing entries with equal [PathExclude.pattern].
  * If the given [updateOnlyExisting] is true then only entries with matching [PathExclude.pattern] are merged.
  */
 internal fun RepositoryPathExcludes.merge(other: RepositoryPathExcludes, updateOnlyExisting: Boolean = false):

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -385,7 +385,10 @@ internal fun RepositoryConfiguration.writeAsYaml(targetFile: File) {
  * Merge the given [RepositoryPathExcludes] replacing entries with equal [PathExclude.pattern].
  * If the given [updateOnlyExisting] is true then only entries with matching [PathExclude.pattern] are merged.
  */
-internal fun RepositoryPathExcludes.merge(other: RepositoryPathExcludes, updateOnlyExisting: Boolean = false):
+internal fun RepositoryPathExcludes.mergePathExcludes(
+    other: RepositoryPathExcludes,
+    updateOnlyExisting: Boolean = false
+):
         RepositoryPathExcludes {
     val result: MutableMap<String, MutableMap<String, PathExclude>> = mutableMapOf()
 
@@ -423,7 +426,7 @@ internal fun RepositoryPathExcludes.merge(other: RepositoryPathExcludes, updateO
  * Merge the given [PathExclude]s replacing entries with equal [PathExclude.pattern].
  * If the given [updateOnlyExisting] is true then only entries with matching [PathExclude.pattern] are merged.
  */
-internal fun Collection<PathExclude>.merge(
+internal fun Collection<PathExclude>.mergePathExcludes(
     other: Collection<PathExclude>,
     updateOnlyExisting: Boolean = false
 ): List<PathExclude> {

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -296,7 +296,7 @@ fun OrtResult.getScanIssues(omitExcluded: Boolean = false): List<OrtIssue> {
 }
 
 /**
- * Return all path excludes from this [Ortresult] represented as [RepositoryPathExcludes].
+ * Return all path excludes from this [OrtResult] represented as [RepositoryPathExcludes].
  */
 internal fun OrtResult.getRepositoryPathExcludes(): RepositoryPathExcludes {
     fun isDefinitionsFile(pathExclude: PathExclude) = PackageManager.ALL.any {

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -37,6 +37,7 @@ import com.here.ort.model.Severity
 import com.here.ort.model.TextLocation
 import com.here.ort.model.VcsInfo
 import com.here.ort.model.config.AnalyzerConfiguration
+import com.here.ort.model.config.Curations
 import com.here.ort.model.config.Excludes
 import com.here.ort.model.config.LicenseFindingCuration
 import com.here.ort.model.config.PathExclude
@@ -336,6 +337,13 @@ internal fun OrtResult.getUnresolvedRuleViolations(): List<RuleViolation> {
 }
 
 /**
+ * Return a copy with the [LicenseFindingCuration]s replaced by the given scope excludes.
+ */
+internal fun RepositoryConfiguration.replaceLicenseFindingCurations(
+    curations: List<LicenseFindingCuration>
+): RepositoryConfiguration = copy(curations = (this.curations ?: Curations()).copy(licenseFindings = curations))
+
+/**
  * Return a copy with the [PathExclude]s replaced by the given scope excludes.
  */
 internal fun RepositoryConfiguration.replacePathExcludes(pathExcludes: List<PathExclude>): RepositoryConfiguration =
@@ -502,6 +510,37 @@ internal fun Collection<PathExclude>.mergePathExcludes(
     other.forEach {
         if (!updateOnlyExisting || result.containsKey(it.pattern)) {
             result[it.pattern] = it
+        }
+    }
+
+    return result.values.toList()
+}
+
+/**
+ * Merge the given [LicenseFindingCuration]s replacing entries with equal [LicenseFindingCuration.path],
+ * [LicenseFindingCuration.startLines], [LicenseFindingCuration.lineCount] and [LicenseFindingCuration.detectedLicense].
+ * If the given [updateOnlyExisting] is true then only entries replacing existing ones are merged.
+ */
+internal fun Collection<LicenseFindingCuration>.mergeLicenseFindingCurations(
+    other: Collection<LicenseFindingCuration>,
+    updateOnlyExisting: Boolean = false
+): List<LicenseFindingCuration> {
+    data class HashKey(
+        val path: String,
+        val startLines: List<Int> = emptyList(),
+        val lineCount: Int? = null,
+        val detectedLicense: String?
+    )
+
+    fun LicenseFindingCuration.hashKey(): HashKey = HashKey(path, startLines, lineCount, detectedLicense)
+
+    val result = mutableMapOf<HashKey, LicenseFindingCuration>()
+
+    associateByTo(result) { it.hashKey() }
+
+    other.forEach {
+        if (!updateOnlyExisting || result.containsKey(it.hashKey())) {
+            result[it.hashKey()] = it
         }
     }
 

--- a/model/src/main/kotlin/config/Curations.kt
+++ b/model/src/main/kotlin/config/Curations.kt
@@ -29,5 +29,5 @@ data class Curations(
      * Curations for license findings.
      */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val licenseFindings: List<LicenseFindingCuration>
+    val licenseFindings: List<LicenseFindingCuration> = emptyList()
 )


### PR DESCRIPTION
Curations can now be exported to a file mapping repository URLs to curations.
This can be helpful for managing a global curations file with commonly used entries.