### PR TITLE
model: Improve the naming of the fields for scanned / ignored scopes

### DIFF
--- a/evaluator/src/test/kotlin/TestData.kt
+++ b/evaluator/src/test/kotlin/TestData.kt
@@ -178,7 +178,7 @@ val ortResult = OrtResult(
         environment = Environment(),
         config = ScannerConfiguration(),
         results = ScanRecord(
-            scannedScopes = sortedSetOf(),
+            scopes = sortedSetOf(),
             scanResults = sortedSetOf(),
             storageStats = AccessStatistics()
         )

--- a/model/src/main/kotlin/ProjectScanScopes.kt
+++ b/model/src/main/kotlin/ProjectScanScopes.kt
@@ -19,6 +19,8 @@
 
 package com.here.ort.model
 
+import com.fasterxml.jackson.annotation.JsonAlias
+
 import java.util.SortedSet
 
 /**
@@ -33,13 +35,15 @@ data class ProjectScanScopes(
     /**
      * The dependencies from these [Scope]s of the [Project] were scanned.
      */
-    val scannedScopes: SortedSet<String>,
+    @JsonAlias("scanned_scopes")
+    val scanned: SortedSet<String>,
 
     /**
      * The dependencies from these [Scope]s of the [Project] were not scanned, except if they are also a dependency
      * of any of the [scannedScopes].
      */
-    val ignoredScopes: SortedSet<String>
+    @JsonAlias("ignored_scopes")
+    val ignored: SortedSet<String>
 ) : Comparable<ProjectScanScopes> {
     /**
      * A comparison function to sort project scan results by their identifier.

--- a/model/src/main/kotlin/ScanRecord.kt
+++ b/model/src/main/kotlin/ScanRecord.kt
@@ -32,7 +32,8 @@ data class ScanRecord(
     /**
      * The scanned and ignored [Scope]s for each scanned [Project] by id.
      */
-    val scannedScopes: SortedSet<ProjectScanScopes>,
+    @JsonAlias("scanned_scopes")
+    val scopes: SortedSet<ProjectScanScopes>,
 
     /**
      * The [ScanResult]s for all [Package]s.

--- a/model/src/test/kotlin/ScannerRunTest.kt
+++ b/model/src/test/kotlin/ScannerRunTest.kt
@@ -37,7 +37,7 @@ class ScannerRunTest : StringSpec() {
                 config:
                   scanner: null
                 results:
-                  scanned_scopes: []
+                  scopes: []
                   scan_results: []
                   storage_stats:
                     num_reads: 0
@@ -62,7 +62,7 @@ class ScannerRunTest : StringSpec() {
                 config:
                   scanner: null
                 results:
-                  scanned_scopes: []
+                  scopes: []
                   scan_results: []
                   storage_stats:
                     num_reads: 0

--- a/reporter-web-app/public/index.html
+++ b/reporter-web-app/public/index.html
@@ -13543,10 +13543,10 @@
       "scanner" : null
     },
     "results" : {
-      "scanned_scopes" : [ {
+      "scopes" : [ {
         "id" : "NPM::mime-types:2.1.24",
-        "scanned_scopes" : [ "dependencies", "devDependencies" ],
-        "ignored_scopes" : [ ]
+        "scanned" : [ "dependencies", "devDependencies" ],
+        "ignored" : [ ]
       } ],
       "scan_results" : [ {
         "id" : "NPM::acorn-jsx:5.0.2",

--- a/reporter-web-app/src/models/ProjectScanScopes.js
+++ b/reporter-web-app/src/models/ProjectScanScopes.js
@@ -30,6 +30,10 @@ class ProjectScanScopes {
                 this.id = obj.id;
             }
 
+            if (obj.scopes) {
+                this.scannedScopes = obj.scopes;
+            }
+
             if (obj.scanned_scopes) {
                 this.scannedScopes = obj.scanned_scopes;
             }

--- a/reporter-web-app/src/models/ScanRecord.js
+++ b/reporter-web-app/src/models/ScanRecord.js
@@ -32,6 +32,10 @@ class ScanRecord {
         this.hasErrors = false;
 
         if (obj instanceof Object) {
+            if (obj.scopes) {
+                this.scannedScopes = obj.scopes;
+            }
+
             if (obj.scanned_scopes) {
                 this.scannedScopes = obj.scanned_scopes;
             }

--- a/reporter/src/funTest/assets/NPM-is-windows-1.0.2-scan-result.json
+++ b/reporter/src/funTest/assets/NPM-is-windows-1.0.2-scan-result.json
@@ -6889,10 +6889,10 @@
       "scanner" : null
     },
     "results" : {
-      "scanned_scopes" : [ {
+      "scopes" : [ {
         "id" : "NPM::is-windows:1.0.2",
-        "scanned_scopes" : [ "dependencies", "devDependencies" ],
-        "ignored_scopes" : [ ]
+        "scanned" : [ "dependencies", "devDependencies" ],
+        "ignored" : [ ]
       } ],
       "scan_results" : [ {
         "id" : "NPM::ansi-green:0.1.1",

--- a/reporter/src/funTest/assets/npm-test-with-exclude-scan-results.yml
+++ b/reporter/src/funTest/assets/npm-test-with-exclude-scan-results.yml
@@ -378,12 +378,12 @@ scanner:
     postgres_storage: null
     scanner: null
   results:
-    scanned_scopes:
+    scopes:
     - id: "NPM::npm-excludes-test-project:1.0.0"
-      scanned_scopes:
+      scanned:
       - "dependencies"
       - "devDependencies"
-      ignored_scopes: []
+      ignored: []
     scan_results:
     - id: "NPM::boolbase:1.0.0"
       results:

--- a/reporter/src/funTest/assets/npm-test-without-exclude-scan-results.yml
+++ b/reporter/src/funTest/assets/npm-test-without-exclude-scan-results.yml
@@ -373,12 +373,12 @@ scanner:
     postgres_storage: null
     scanner: null
   results:
-    scanned_scopes:
+    scopes:
     - id: "NPM::npm-excludes-test-project:1.0.0"
-      scanned_scopes:
+      scanned:
       - "dependencies"
       - "devDependencies"
-      ignored_scopes: []
+      ignored: []
     scan_results:
     - id: "NPM::boolbase:1.0.0"
       results:

--- a/reporter/src/funTest/assets/static-html-reporter-test-input.yml
+++ b/reporter/src/funTest/assets/static-html-reporter-test-input.yml
@@ -231,12 +231,12 @@ scanner:
     postgres_storage: null
     scanner: null
   results:
-    scanned_scopes:
+    scopes:
     - id: "Gradle:com.here.ort.gradle.example:lib:1.0.0"
-      scanned_scopes:
+      scanned:
       - "compile"
       - "testCompile"
-      ignored_scopes: []
+      ignored: []
     scan_results:
     - id: "Gradle:com.here.ort.gradle.example:lib:1.0.0"
       results:

--- a/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
@@ -196,12 +196,12 @@ scanner:
     postgres_storage: null
     scanner: null
   results:
-    scanned_scopes:
+    scopes:
     - id: "Gradle:com.here.ort.gradle.example:lib:1.0.0"
-      scanned_scopes:
+      scanned:
       - "compile"
       - "testCompile"
-      ignored_scopes: []
+      ignored: []
     scan_results:
     - id: "Gradle:com.here.ort.gradle.example:lib:1.0.0"
       results:


### PR DESCRIPTION
Previously, the YAML output looked like

    scanned_scopes:
    - id: "Gradle:com.here.ort.gradle.example:lib:1.0.0"
      scanned_scopes:
      - "compile"
      - "testCompile"
      ignored_scopes: []

which is confusing due to its nested duplicate "scanned_scopes" field.
Simplify the structure to be

    scopes:
    - id: "Gradle:com.here.ort.gradle.example:lib:1.0.0"
      scanned:
      - "compile"
      - "testCompile"
      ignored: []

but maintain backwards-compatibility through aliases.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>