### PR TITLE
Analyzer: Fix an issue with locateRepositoryConfigurationFile()

### DIFF
--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -180,11 +180,13 @@ class Analyzer(private val config: AnalyzerConfiguration) {
         return analyzerResultBuilder.build()
     }
 
-    private fun locateRepositoryConfigurationFile(absoluteProjectPath: File) =
-        if (GitRepo().getWorkingTree(absoluteProjectPath).isValid()) {
-            val manifestFile = absoluteProjectPath.resolve(".repo/manifest.xml").realFile()
-            manifestFile.resolveSibling("${manifestFile.name}$ORT_CONFIG_FILENAME")
-        } else {
-            File(absoluteProjectPath, ORT_CONFIG_FILENAME)
+    private fun locateRepositoryConfigurationFile(absoluteProjectPath: File): File =
+        GitRepo().getWorkingTree(absoluteProjectPath).let { workingTree ->
+            if (workingTree.isValid() && workingTree.getRootPath() == absoluteProjectPath) {
+                val manifestFile = absoluteProjectPath.resolve(".repo/manifest.xml").realFile()
+                manifestFile.resolveSibling("${manifestFile.name}$ORT_CONFIG_FILENAME")
+            } else {
+                File(absoluteProjectPath, ORT_CONFIG_FILENAME)
+            }
         }
 }


### PR DESCRIPTION
In case `absoluteProjectPath` is a subdirectory of a Git Repo project the
analyzer fails with a NoSuchFileException thrown when it accesses the
`manifest.xml`.

Fix this by executing the Git Repo specific logic only in case the root
path of that Git Repo project is being analyzed.

Signed-off-by: Frank Viernau <frank.viernau@here.com>