### PR TITLE
model: Rename the `util` package to `utils`

### DIFF
--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -43,7 +43,7 @@ import com.here.ort.model.config.RepositoryConfiguration
 import com.here.ort.model.config.Resolutions
 import com.here.ort.model.config.RuleViolationResolution
 import com.here.ort.model.config.ScopeExclude
-import com.here.ort.model.util.FindingCurationMatcher
+import com.here.ort.model.utils.FindingCurationMatcher
 import com.here.ort.model.yamlMapper
 import com.here.ort.utils.safeMkdirs
 import com.here.ort.utils.OkHttpClientHelper

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -28,8 +28,8 @@ import com.here.ort.model.config.PathExclude
 import com.here.ort.model.config.RepositoryConfiguration
 import com.here.ort.model.config.Resolutions
 import com.here.ort.model.config.orEmpty
-import com.here.ort.model.util.FindingCurationMatcher
-import com.here.ort.model.util.FindingsMatcher
+import com.here.ort.model.utils.FindingCurationMatcher
+import com.here.ort.model.utils.FindingsMatcher
 import com.here.ort.spdx.SpdxExpression
 import com.here.ort.utils.log
 import com.here.ort.utils.zipWithDefault

--- a/model/src/main/kotlin/utils/FindingCurationMatcher.kt
+++ b/model/src/main/kotlin/utils/FindingCurationMatcher.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package com.here.ort.model.util
+package com.here.ort.model.utils
 
 import com.here.ort.model.LicenseFinding
 import com.here.ort.model.config.LicenseFindingCuration

--- a/model/src/main/kotlin/utils/FindingsMatcher.kt
+++ b/model/src/main/kotlin/utils/FindingsMatcher.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package com.here.ort.model.util
+package com.here.ort.model.utils
 
 import com.here.ort.model.CopyrightFinding
 import com.here.ort.model.CopyrightFindings

--- a/model/src/test/kotlin/utils/FindingCurationMatcherTest.kt
+++ b/model/src/test/kotlin/utils/FindingCurationMatcherTest.kt
@@ -23,7 +23,6 @@ import com.here.ort.model.LicenseFinding
 import com.here.ort.model.TextLocation
 import com.here.ort.model.config.LicenseFindingCuration
 import com.here.ort.model.config.LicenseFindingCurationReason.INCORRECT
-import com.here.ort.model.util.FindingCurationMatcher
 
 import io.kotlintest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotlintest.shouldBe

--- a/model/src/test/kotlin/utils/FindingsMatcherTest.kt
+++ b/model/src/test/kotlin/utils/FindingsMatcherTest.kt
@@ -23,8 +23,7 @@ import com.here.ort.model.CopyrightFinding
 import com.here.ort.model.LicenseFinding
 import com.here.ort.model.LicenseFindings
 import com.here.ort.model.TextLocation
-import com.here.ort.model.util.FindingsMatcher
-import com.here.ort.model.util.FindingsMatcher.Companion.DEFAULT_TOLERANCE_LINES
+import com.here.ort.model.utils.FindingsMatcher.Companion.DEFAULT_TOLERANCE_LINES
 import com.here.ort.spdx.LicenseFileMatcher
 
 import io.kotlintest.matchers.beEmpty


### PR DESCRIPTION
In order to make the naming consistent with other utility packages
within ORT.

Signed-off-by: Frank Viernau <frank.viernau@here.com>