### PR TITLE
helper-cli: Fix compile error

### DIFF
--- a/helper-cli/src/main/kotlin/commands/ImportLicenseFindingCurationsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ImportLicenseFindingCurationsCommand.kt
@@ -34,7 +34,7 @@ import com.here.ort.model.OrtResult
 import com.here.ort.model.config.LicenseFindingCuration
 import com.here.ort.model.config.RepositoryConfiguration
 import com.here.ort.model.readValue
-import com.here.ort.model.util.FindingCurationMatcher
+import com.here.ort.model.utils.FindingCurationMatcher
 import com.here.ort.utils.PARAMETER_ORDER_MANDATORY
 import com.here.ort.utils.PARAMETER_ORDER_OPTIONAL
 


### PR DESCRIPTION
The package renaming done by 5eab6e706ef was not reflected in that import
statement and thus broke the compilation. For not yet known reason this
slipped through CI.

Signed-off-by: Frank Viernau <frank.viernau@here.com>