### PR TITLE
ScanSummary: Add a field for the SPDX package verification code

### DIFF
--- a/model/src/main/kotlin/ScanSummary.kt
+++ b/model/src/main/kotlin/ScanSummary.kt
@@ -60,6 +60,13 @@ data class ScanSummary(
     val fileCount: Int,
 
     /**
+     * The [SPDX package verification code](https://spdx.org/spdx_specification_2_0_html#h.2p2csry), calculated from
+     * all files in the package. Note that if the scanner is configured to ignore certain files they will still be
+     * included in the calculation of this code.
+     */
+    val packageVerificationCode: String,
+
+    /**
      * The license findings.
      */
     @JsonProperty("licenses")
@@ -103,10 +110,13 @@ class ScanSummaryDeserializer : StdDeserializer<ScanSummary>(OrtIssue::class.jav
         val licenseFindings = node.readValues("licenses", LicenseFinding::class)
         val copyrightFindings = node.readValues("copyrights", CopyrightFinding::class)
 
+        // TODO: Remove the fallback value for packageVerification code once any ORT feature depends on its existence,
+        //       as it is only there for backward compatibility.
         return ScanSummary(
             startTime = node.readValue("start_time")!!,
             endTime = node.readValue("end_time")!!,
             fileCount = node.readValue("file_count")!!,
+            packageVerificationCode = node.readValue<String>("package_verification_code").orEmpty(),
             licenseFindings = (licenseFindings + legacyLicenseFindings).toSortedSet(),
             copyrightFindings = (copyrightFindings + legacyCopyrightFindings).toSortedSet(),
             errors = node.readValues("errors", OrtIssue::class)

--- a/model/src/test/assets/expected-scan-results.yml
+++ b/model/src/test/assets/expected-scan-results.yml
@@ -16,6 +16,7 @@ results:
     start_time: "1970-01-02T00:01:00Z"
     end_time: "1970-01-02T00:02:00Z"
     file_count: 1
+    package_verification_code: "packageVerificationCode"
     licenses:
     - license: "license 1.1"
       location:
@@ -64,6 +65,7 @@ results:
     start_time: "1970-01-03T00:01:00Z"
     end_time: "1970-01-03T00:02:00Z"
     file_count: 2
+    package_verification_code: "packageVerificationCode"
     licenses:
     - license: "license 2.1"
       location:

--- a/model/src/test/kotlin/ScanResultContainerTest.kt
+++ b/model/src/test/kotlin/ScanResultContainerTest.kt
@@ -63,6 +63,7 @@ class ScanResultContainerTest : WordSpec() {
         scannerStartTime1,
         scannerEndTime1,
         1,
+        "packageVerificationCode",
         sortedSetOf(
             LicenseFinding(
                 "license 1.1",
@@ -89,6 +90,7 @@ class ScanResultContainerTest : WordSpec() {
         scannerStartTime2,
         scannerEndTime2,
         2,
+        "packageVerificationCode",
         sortedSetOf(
             LicenseFinding(
                 "license 2.1",

--- a/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
@@ -215,6 +215,7 @@ scanner:
           start_time: "1970-01-01T00:00:00Z"
           end_time: "1970-01-01T00:00:00Z"
           file_count: 0
+          package_verification_code: ""
           licenses: []
           copyrights: []
           errors:
@@ -244,6 +245,7 @@ scanner:
           start_time: "1970-01-01T00:00:00Z"
           end_time: "1970-01-01T00:00:00Z"
           file_count: 234
+          package_verification_code: "a86513854c8896d354a2d84f51beeaf9b378c233"
           licenses: []
           copyrights: []
     - id: "Maven:org.apache.commons:commons-lang3:3.5"
@@ -263,6 +265,7 @@ scanner:
           start_time: "1970-01-01T00:00:00Z"
           end_time: "1970-01-01T00:00:00Z"
           file_count: 168
+          package_verification_code: "bff2d5982a9b1985295c372b3ae2f90a7a860747"
           licenses: []
           copyrights: []
     - id: "Maven:org.apache.commons:commons-text:1.1"
@@ -282,6 +285,7 @@ scanner:
           start_time: "1970-01-01T00:00:00Z"
           end_time: "1970-01-01T00:00:00Z"
           file_count: 80
+          package_verification_code: "78daf07d29c2b84b09766a98c1728b2daeeb59e6"
           licenses: []
           copyrights: []
     - id: "Maven:org.hamcrest:hamcrest-core:1.3"
@@ -301,6 +305,7 @@ scanner:
           start_time: "1970-01-01T00:00:00Z"
           end_time: "1970-01-01T00:00:00Z"
           file_count: 47
+          package_verification_code: "a42897bec728695ae0e3ecdcc891ced065dae355"
           licenses: []
           copyrights: []
     storage_stats:

--- a/scanner/src/funTest/kotlin/storages/AbstractStorageTest.kt
+++ b/scanner/src/funTest/kotlin/storages/AbstractStorageTest.kt
@@ -102,6 +102,7 @@ abstract class AbstractStorageTest : StringSpec() {
         scannerStartTime1,
         scannerEndTime1,
         1,
+        "packageVerificationCode",
         sortedSetOf(
             LicenseFinding("license 1.1", DUMMY_TEXT_LOCATION),
             LicenseFinding("license 1.2", DUMMY_TEXT_LOCATION)
@@ -113,6 +114,7 @@ abstract class AbstractStorageTest : StringSpec() {
         scannerStartTime2,
         scannerEndTime2,
         0,
+        "packageVerificationCode",
         sortedSetOf(),
         sortedSetOf(),
         mutableListOf()

--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -231,6 +231,7 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
                                         startTime = now,
                                         endTime = now,
                                         fileCount = 0,
+                                        packageVerificationCode = "",
                                         licenseFindings = sortedSetOf(),
                                         copyrightFindings = sortedSetOf(),
                                         errors = listOf(
@@ -311,6 +312,7 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
                     startTime = now,
                     endTime = now,
                     fileCount = 0,
+                    packageVerificationCode = "",
                     licenseFindings = sortedSetOf(),
                     copyrightFindings = sortedSetOf(),
                     errors = listOf(OrtIssue(source = scannerName, message = e.collectMessagesAsString()))
@@ -387,6 +389,7 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
                 startTime = now,
                 endTime = now,
                 fileCount = 0,
+                packageVerificationCode = "",
                 licenseFindings = sortedSetOf(),
                 copyrightFindings = sortedSetOf(),
                 errors = listOf(OrtIssue(source = scannerName, message = e.collectMessagesAsString()))

--- a/scanner/src/main/kotlin/scanners/Askalono.kt
+++ b/scanner/src/main/kotlin/scanners/Askalono.kt
@@ -33,6 +33,7 @@ import com.here.ort.scanner.AbstractScannerFactory
 import com.here.ort.scanner.HTTP_CACHE_PATH
 import com.here.ort.scanner.LocalScanner
 import com.here.ort.scanner.ScanException
+import com.here.ort.spdx.calculatePackageVerificationCode
 import com.here.ort.utils.CommandLineTool
 import com.here.ort.utils.Os
 import com.here.ort.utils.OkHttpClientHelper
@@ -169,6 +170,7 @@ class Askalono(name: String, config: ScannerConfiguration) : LocalScanner(name, 
             startTime = startTime,
             endTime = endTime,
             fileCount = result.size(),
+            packageVerificationCode = calculatePackageVerificationCode(scanPath),
             licenseFindings = licenseFindings,
             copyrightFindings = sortedSetOf(),
             errors = mutableListOf()

--- a/scanner/src/main/kotlin/scanners/BoyterLc.kt
+++ b/scanner/src/main/kotlin/scanners/BoyterLc.kt
@@ -33,6 +33,7 @@ import com.here.ort.scanner.AbstractScannerFactory
 import com.here.ort.scanner.HTTP_CACHE_PATH
 import com.here.ort.scanner.LocalScanner
 import com.here.ort.scanner.ScanException
+import com.here.ort.spdx.calculatePackageVerificationCode
 import com.here.ort.utils.CommandLineTool
 import com.here.ort.utils.Os
 import com.here.ort.utils.OkHttpClientHelper
@@ -170,6 +171,7 @@ class BoyterLc(name: String, config: ScannerConfiguration) : LocalScanner(name, 
             startTime = startTime,
             endTime = endTime,
             fileCount = result.size(),
+            packageVerificationCode = calculatePackageVerificationCode(scanPath),
             licenseFindings = licenseFindings,
             copyrightFindings = sortedSetOf(),
             errors = mutableListOf()

--- a/scanner/src/main/kotlin/scanners/FileCounter.kt
+++ b/scanner/src/main/kotlin/scanners/FileCounter.kt
@@ -29,6 +29,7 @@ import com.here.ort.model.config.ScannerConfiguration
 import com.here.ort.model.jsonMapper
 import com.here.ort.scanner.AbstractScannerFactory
 import com.here.ort.scanner.LocalScanner
+import com.here.ort.spdx.calculatePackageVerificationCode
 
 import java.io.File
 import java.time.Instant
@@ -64,7 +65,7 @@ class FileCounter(name: String, config: ScannerConfiguration) : LocalScanner(nam
         val endTime = Instant.now()
 
         val result = getRawResult(resultsFile)
-        val summary = generateSummary(startTime, endTime, result)
+        val summary = generateSummary(startTime, endTime, path, result)
         return ScanResult(Provenance(), getDetails(), summary, result)
     }
 
@@ -75,12 +76,13 @@ class FileCounter(name: String, config: ScannerConfiguration) : LocalScanner(nam
             EMPTY_JSON_NODE
         }
 
-    private fun generateSummary(startTime: Instant, endTime: Instant, result: JsonNode): ScanSummary {
+    private fun generateSummary(startTime: Instant, endTime: Instant, scanPath: File, result: JsonNode): ScanSummary {
         val fileCount = result["file_count"].intValue()
         return ScanSummary(
             startTime = startTime,
             endTime = endTime,
             fileCount = fileCount,
+            packageVerificationCode = calculatePackageVerificationCode(scanPath),
             licenseFindings = sortedSetOf(),
             copyrightFindings = sortedSetOf(),
             errors = mutableListOf()

--- a/scanner/src/main/kotlin/scanners/Licensee.kt
+++ b/scanner/src/main/kotlin/scanners/Licensee.kt
@@ -32,6 +32,7 @@ import com.here.ort.model.jsonMapper
 import com.here.ort.scanner.AbstractScannerFactory
 import com.here.ort.scanner.LocalScanner
 import com.here.ort.scanner.ScanException
+import com.here.ort.spdx.calculatePackageVerificationCode
 import com.here.ort.utils.Ci
 import com.here.ort.utils.CommandLineTool
 import com.here.ort.utils.Os
@@ -148,6 +149,7 @@ class Licensee(name: String, config: ScannerConfiguration) : LocalScanner(name, 
             startTime = startTime,
             endTime = endTime,
             fileCount = matchedFiles.count(),
+            packageVerificationCode = calculatePackageVerificationCode(scanPath),
             licenseFindings = licenseFindings,
             copyrightFindings = sortedSetOf(),
             errors = mutableListOf()

--- a/scanner/src/main/kotlin/scanners/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/ScanCode.kt
@@ -39,6 +39,7 @@ import com.here.ort.scanner.ScanException
 import com.here.ort.scanner.ScanResultsStorage
 import com.here.ort.spdx.NON_LICENSE_FILENAMES
 import com.here.ort.spdx.SpdxLicense
+import com.here.ort.spdx.calculatePackageVerificationCode
 import com.here.ort.utils.CommandLineTool
 import com.here.ort.utils.ORT_CONFIG_FILENAME
 import com.here.ort.utils.Os
@@ -324,7 +325,7 @@ class ScanCode(
         }
 
         val result = getRawResult(resultsFile)
-        val summary = generateSummary(startTime, endTime, result)
+        val summary = generateSummary(startTime, endTime, path, result)
 
         val errors = summary.errors.toMutableList()
 
@@ -359,11 +360,12 @@ class ScanCode(
         return result["files_count"]?.intValue() ?: 0
     }
 
-    internal fun generateSummary(startTime: Instant, endTime: Instant, result: JsonNode) =
+    internal fun generateSummary(startTime: Instant, endTime: Instant, scanPath: File, result: JsonNode) =
         ScanSummary(
             startTime = startTime,
             endTime = endTime,
             fileCount = getFileCount(result),
+            packageVerificationCode = calculatePackageVerificationCode(scanPath),
             licenseFindings = getLicenseFindings(result).toSortedSet(),
             copyrightFindings = getCopyrightFindings(result).toSortedSet(),
             errors = getErrors(result)

--- a/scanner/src/test/kotlin/ScanCodeTest.kt
+++ b/scanner/src/test/kotlin/ScanCodeTest.kt
@@ -43,9 +43,10 @@ class ScanCodeTest : WordSpec({
         "be correctly summarized" {
             val resultFile = File("src/test/assets/mime-types-2.1.18_scancode-2.9.7.json")
             val result = scanner.getRawResult(resultFile)
-            val summary = scanner.generateSummary(Instant.now(), Instant.now(), result)
+            val summary = scanner.generateSummary(Instant.now(), Instant.now(), resultFile, result)
 
             summary.fileCount shouldBe 10
+            summary.packageVerificationCode shouldBe "9e3fdffc51568b300a457228055f8dc8a99fc64b"
         }
     }
 
@@ -53,9 +54,10 @@ class ScanCodeTest : WordSpec({
         "be correctly summarized" {
             val resultFile = File("src/test/assets/mime-types-2.1.18_scancode-3.0.2.json")
             val result = scanner.getRawResult(resultFile)
-            val summary = scanner.generateSummary(Instant.now(), Instant.now(), result)
+            val summary = scanner.generateSummary(Instant.now(), Instant.now(), resultFile, result)
 
             summary.fileCount shouldBe 10
+            summary.packageVerificationCode shouldBe "8ec22f05b1a7006ae667901ae0853beff197c576"
         }
     }
 
@@ -63,7 +65,7 @@ class ScanCodeTest : WordSpec({
         "return true for scan results with only timeout errors" {
             val resultFile = File("src/test/assets/esprima-2.7.3_scancode-2.2.1.post277.4d68f9377.json")
             val result = scanner.getRawResult(resultFile)
-            val summary = scanner.generateSummary(Instant.now(), Instant.now(), result)
+            val summary = scanner.generateSummary(Instant.now(), Instant.now(), resultFile, result)
             val errors = summary.errors.toMutableList()
 
             ScanCode.mapTimeoutErrors(errors) shouldBe true
@@ -99,7 +101,7 @@ class ScanCodeTest : WordSpec({
         "return false for scan results without errors" {
             val resultFile = File("src/test/assets/esprima-2.7.3_scancode-2.2.1.json")
             val result = scanner.getRawResult(resultFile)
-            val summary = scanner.generateSummary(Instant.now(), Instant.now(), result)
+            val summary = scanner.generateSummary(Instant.now(), Instant.now(), resultFile, result)
 
             ScanCode.mapTimeoutErrors(summary.errors.toMutableList()) shouldBe false
         }
@@ -109,7 +111,7 @@ class ScanCodeTest : WordSpec({
         "return true for scan results with only memory errors" {
             val resultFile = File("src/test/assets/very-long-json-lines_scancode-2.2.1.post277.4d68f9377.json")
             val result = scanner.getRawResult(resultFile)
-            val summary = scanner.generateSummary(Instant.now(), Instant.now(), result)
+            val summary = scanner.generateSummary(Instant.now(), Instant.now(), resultFile, result)
             val errors = summary.errors.toMutableList()
 
             ScanCode.mapUnknownErrors(errors) shouldBe true
@@ -121,7 +123,7 @@ class ScanCodeTest : WordSpec({
         "return false for scan results with other unknown errors" {
             val resultFile = File("src/test/assets/kotlin-annotation-processing-gradle-1.2.21_scancode.json")
             val result = scanner.getRawResult(resultFile)
-            val summary = scanner.generateSummary(Instant.now(), Instant.now(), result)
+            val summary = scanner.generateSummary(Instant.now(), Instant.now(), resultFile, result)
             val errors = summary.errors.toMutableList()
 
             ScanCode.mapUnknownErrors(errors) shouldBe false
@@ -134,7 +136,7 @@ class ScanCodeTest : WordSpec({
         "return false for scan results without errors" {
             val resultFile = File("src/test/assets/esprima-2.7.3_scancode-2.2.1.json")
             val result = scanner.getRawResult(resultFile)
-            val summary = scanner.generateSummary(Instant.now(), Instant.now(), result)
+            val summary = scanner.generateSummary(Instant.now(), Instant.now(), resultFile, result)
 
             ScanCode.mapUnknownErrors(summary.errors.toMutableList()) shouldBe false
         }
@@ -514,8 +516,9 @@ class ScanCodeTest : WordSpec({
                 )
             )
 
-            val result = scanner.getRawResult(File("src/test/assets/esprima-2.7.3_scancode-2.2.1.json"))
-            val summary = scanner.generateSummary(Instant.now(), Instant.now(), result)
+            val resultFile = File("src/test/assets/esprima-2.7.3_scancode-2.2.1.json")
+            val result = scanner.getRawResult(resultFile)
+            val summary = scanner.generateSummary(Instant.now(), Instant.now(), resultFile, result)
 
             summary.licenseFindings shouldContainExactlyInAnyOrder expectedLicenseFindings
         }
@@ -699,8 +702,9 @@ class ScanCodeTest : WordSpec({
                 )
             )
 
-            val result = scanner.getRawResult(File("src/test/assets/esprima-2.7.3_scancode-2.2.1.json"))
-            val summary = scanner.generateSummary(Instant.now(), Instant.now(), result)
+            val resultFile = File("src/test/assets/esprima-2.7.3_scancode-2.2.1.json")
+            val result = scanner.getRawResult(resultFile)
+            val summary = scanner.generateSummary(Instant.now(), Instant.now(), resultFile, result)
 
             summary.copyrightFindings shouldContainExactlyInAnyOrder expectedCopyrightFindings
         }
@@ -710,7 +714,7 @@ class ScanCodeTest : WordSpec({
             val result = scanner.getRawResult(resultFile)
 
             val actualFindings = scanner
-                .generateSummary(Instant.now(), Instant.now(), result)
+                .generateSummary(Instant.now(), Instant.now(), resultFile, result)
                 .licenseFindings
 
             actualFindings.distinctBy { it.license } should haveSize(1)
@@ -734,7 +738,7 @@ class ScanCodeTest : WordSpec({
             val result = scanner.getRawResult(resultFile)
 
             val actualFindings = scanner
-                .generateSummary(Instant.now(), Instant.now(), result)
+                .generateSummary(Instant.now(), Instant.now(), resultFile, result)
                 .copyrightFindings
 
             actualFindings.map { it.statement }.distinct() shouldContainExactlyInAnyOrder listOf(

--- a/spdx-utils/src/main/kotlin/SpdxUtils.kt
+++ b/spdx-utils/src/main/kotlin/SpdxUtils.kt
@@ -37,9 +37,9 @@ val NON_LICENSE_FILENAMES = listOf(
 private fun ByteArray.toHexString(): String = joinToString("") { String.format("%02x", it) }
 
 /**
- * Calculate the [SPDX package verification code][1] for a list of known SHA1s of files.
+ * Calculate the [SPDX package verification code][1] for a list of [known SHA1s][sha1sums] of files.
  *
- * [1]: https://spdx.github.io/spdx-spec/chapters/3-package-information.html#39-package-verification-code-
+ * [1]: https://spdx.org/spdx_specification_2_0_html#h.2p2csry
  */
 @JvmName("calculatePackageVerificationCodeForStrings")
 fun calculatePackageVerificationCode(sha1sums: List<String>): String =
@@ -48,9 +48,9 @@ fun calculatePackageVerificationCode(sha1sums: List<String>): String =
     }.digest().toHexString()
 
 /**
- * Calculate the [SPDX package verification code][1] for a list of files.
+ * Calculate the [SPDX package verification code][1] for a list of [files].
  *
- * [1]: https://spdx.github.io/spdx-spec/chapters/3-package-information.html#39-package-verification-code-
+ * [1]: https://spdx.org/spdx_specification_2_0_html#h.2p2csry
  */
 @JvmName("calculatePackageVerificationCodeForFiles")
 fun calculatePackageVerificationCode(files: List<File>) =
@@ -59,6 +59,16 @@ fun calculatePackageVerificationCode(files: List<File>) =
             file.inputStream().use { digest.digest(it.readBytes()).toHexString() }
         })
     }
+
+/**
+ * Calculate the [SPDX package verification code][1] for all files in a [directory]. If [directory] points to a file
+ * instead of a directory the verification code for the single file is returned.
+ *
+ * [1]: https://spdx.org/spdx_specification_2_0_html#h.2p2csry
+ */
+@JvmName("calculatePackageVerificationCodeForDirectory")
+fun calculatePackageVerificationCode(directory: File) =
+    calculatePackageVerificationCode(directory.walkTopDown().filter { it.isFile }.toList())
 
 /**
  * A Kotlin-style convenience function to replace EnumSet.of() and EnumSet.noneOf().

--- a/spdx-utils/src/main/kotlin/SpdxUtils.kt
+++ b/spdx-utils/src/main/kotlin/SpdxUtils.kt
@@ -32,43 +32,81 @@ val NON_LICENSE_FILENAMES = listOf(
 )
 
 /**
+ * A list of directories used by version control systems to store metadata.
+ */
+private val VCS_DIRECTORIES = listOf(
+    ".git",
+    ".hg",
+    ".svn",
+    "CVS"
+)
+
+/**
  * Return a string of hexadecimal digits representing the bytes in the array.
  */
 private fun ByteArray.toHexString(): String = joinToString("") { String.format("%02x", it) }
 
 /**
- * Calculate the [SPDX package verification code][1] for a list of [known SHA1s][sha1sums] of files.
+ * Calculate the [SPDX package verification code][1] for a list of [known SHA1s][sha1sums] of files and [excludes].
  *
  * [1]: https://spdx.org/spdx_specification_2_0_html#h.2p2csry
  */
 @JvmName("calculatePackageVerificationCodeForStrings")
-fun calculatePackageVerificationCode(sha1sums: List<String>): String =
-    sha1sums.sorted().fold(MessageDigest.getInstance("SHA-1")) { digest, sha1sum ->
+fun calculatePackageVerificationCode(sha1sums: List<String>, excludes: List<String> = emptyList()): String {
+    val sha1sum = sha1sums.sorted().fold(MessageDigest.getInstance("SHA-1")) { digest, sha1sum ->
         digest.apply { update(sha1sum.toByteArray()) }
     }.digest().toHexString()
 
+    return if (excludes.isEmpty()) {
+        sha1sum
+    } else {
+        "$sha1sum (excludes: ${excludes.joinToString()})"
+    }
+}
+
 /**
- * Calculate the [SPDX package verification code][1] for a list of [files].
+ * Calculate the [SPDX package verification code][1] for a list of [files] and paths of [excludes].
  *
  * [1]: https://spdx.org/spdx_specification_2_0_html#h.2p2csry
  */
 @JvmName("calculatePackageVerificationCodeForFiles")
-fun calculatePackageVerificationCode(files: List<File>) =
-    MessageDigest.getInstance("SHA-1").let { digest ->
-        calculatePackageVerificationCode(files.map { file ->
+fun calculatePackageVerificationCode(files: List<File>, excludes: List<String> = emptyList()): String {
+    val digest = MessageDigest.getInstance("SHA-1")
+    return calculatePackageVerificationCode(
+        files.map { file ->
             file.inputStream().use { digest.digest(it.readBytes()).toHexString() }
-        })
-    }
+        },
+        excludes
+    )
+}
 
 /**
  * Calculate the [SPDX package verification code][1] for all files in a [directory]. If [directory] points to a file
  * instead of a directory the verification code for the single file is returned.
+ * All files with the extension ".spdx" are automatically excluded from the generated code. Additionally files from the
+ * following VCS directories are excluded:
+ * * .git/
+ * * .hg/
+ * * .svn/
+ * * CVS/
  *
  * [1]: https://spdx.org/spdx_specification_2_0_html#h.2p2csry
  */
 @JvmName("calculatePackageVerificationCodeForDirectory")
-fun calculatePackageVerificationCode(directory: File) =
-    calculatePackageVerificationCode(directory.walkTopDown().filter { it.isFile }.toList())
+fun calculatePackageVerificationCode(directory: File): String {
+    val (excludes, files) = directory.walkTopDown()
+        .filter { it.isFile }
+        .partition { it.extension == "spdx" }
+    // Sort the list of files to show the files in a directory before the files in its subdirectories. This can be
+    // omitted once breadth-first search is available in Kotlin: https://github.com/JetBrains/kotlin/pull/2232
+    val filteredFiles = files.filter {
+        val relativePath = it.relativeTo(directory).invariantSeparatorsPath
+        VCS_DIRECTORIES.none { vcs -> relativePath.startsWith("$vcs/") }
+    }
+    val sortedExcludes = excludes.map { "./${it.relativeTo(directory).invariantSeparatorsPath}" }
+        .sortedWith(compareBy({ it.count { char -> char == '/' } }, { it }))
+    return calculatePackageVerificationCode(filteredFiles, sortedExcludes)
+}
 
 /**
  * A Kotlin-style convenience function to replace EnumSet.of() and EnumSet.noneOf().

--- a/spdx-utils/src/test/kotlin/SpdxUtilsTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxUtilsTest.kt
@@ -92,6 +92,21 @@ class SpdxUtilsTest : WordSpec() {
 
                 calculatePackageVerificationCode(files) shouldBe "378d5a37b5b10b90535e32a190014d2a8d25354a"
             }
+
+            "work for a given file" {
+                val file = setupTempFile("file", "file")
+
+                calculatePackageVerificationCode(file) shouldBe "81e250a78cc6386afc25fa57ad6eaee31394019b"
+            }
+
+            "work for a given directory" {
+                setupTempFile("fileA", "fileA")
+                setupTempFile("fileB", "fileB")
+                tempDir!!.resolve("dir").mkdir()
+                setupTempFile("dir/fileC", "fileC")
+
+                calculatePackageVerificationCode(tempDir!!) shouldBe "15d3fa138d9302ec9a1584180b5eba0d342b60fa"
+            }
         }
 
         "getLicenseText" should {

--- a/spdx-utils/src/test/kotlin/SpdxUtilsTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxUtilsTest.kt
@@ -49,7 +49,7 @@ class SpdxUtilsTest : WordSpec() {
 
     init {
         "calculatePackageVerificationCode" should {
-            "work for given SHA1s" {
+            "work for given SHA1s and excludes" {
                 val sha1sums = listOf(
                     "0811bcab4e7a186f4d0d08d44cc5f06d721e7f6d",
                     "f7a535db519cf832c1119fecdf1ea0514f583886",
@@ -81,16 +81,24 @@ class SpdxUtilsTest : WordSpec() {
                     "310fc965173381a02fbe83a889f7c858c4499862"
                 )
 
+                val excludes = listOf("./package.spdx")
+
                 calculatePackageVerificationCode(sha1sums) shouldBe "1a74d8321c452522ec516a46893e6a42f36b5953"
+                calculatePackageVerificationCode(sha1sums, excludes) shouldBe
+                        "1a74d8321c452522ec516a46893e6a42f36b5953 (excludes: ./package.spdx)"
             }
 
-            "work for given files" {
+            "work for given files and excludes" {
                 val files = listOf(
                     setupTempFile("fileA", "Hello"),
                     setupTempFile("fileB", "World")
                 )
 
+                val excludes = listOf("./package.spdx")
+
                 calculatePackageVerificationCode(files) shouldBe "378d5a37b5b10b90535e32a190014d2a8d25354a"
+                calculatePackageVerificationCode(files, excludes) shouldBe
+                        "378d5a37b5b10b90535e32a190014d2a8d25354a (excludes: ./package.spdx)"
             }
 
             "work for a given file" {
@@ -102,10 +110,28 @@ class SpdxUtilsTest : WordSpec() {
             "work for a given directory" {
                 setupTempFile("fileA", "fileA")
                 setupTempFile("fileB", "fileB")
+                setupTempFile("package.spdx", "content")
                 tempDir!!.resolve("dir").mkdir()
                 setupTempFile("dir/fileC", "fileC")
+                setupTempFile("dir/package.spdx", "content")
 
-                calculatePackageVerificationCode(tempDir!!) shouldBe "15d3fa138d9302ec9a1584180b5eba0d342b60fa"
+                calculatePackageVerificationCode(tempDir!!) shouldBe
+                        "15d3fa138d9302ec9a1584180b5eba0d342b60fa (excludes: ./package.spdx, ./dir/package.spdx)"
+            }
+
+            "exclude VCS directories" {
+                setupTempFile("file", "file")
+                tempDir!!.resolve(".git").mkdir()
+                tempDir!!.resolve(".hg").mkdir()
+                tempDir!!.resolve(".svn").mkdir()
+                tempDir!!.resolve("CVS").mkdir()
+                setupTempFile(".git/git", "git")
+                setupTempFile(".hg/hg", "hg")
+                setupTempFile(".svn/svn", "svn")
+                setupTempFile("CVS/cvs", "cvs")
+
+                calculatePackageVerificationCode(tempDir!!) shouldBe
+                        "81e250a78cc6386afc25fa57ad6eaee31394019b"
             }
         }
 


### PR DESCRIPTION
Calculate the SPDX package verification code [1] in all scanners and add
it to the `ScanSummary`.

Also fix some broken links in `SpdxUtils` along the way.

[1] https://spdx.org/spdx_specification_2_0_html#h.2p2csry