### PR TITLE
model: Use isolationMode() instead of the deprecated isInstancePerTest()

### DIFF
--- a/model/src/test/kotlin/utils/FindingCurationMatcherTest.kt
+++ b/model/src/test/kotlin/utils/FindingCurationMatcherTest.kt
@@ -24,6 +24,7 @@ import com.here.ort.model.TextLocation
 import com.here.ort.model.config.LicenseFindingCuration
 import com.here.ort.model.config.LicenseFindingCurationReason.INCORRECT
 
+import io.kotlintest.IsolationMode
 import io.kotlintest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.WordSpec
@@ -35,7 +36,7 @@ class FindingCurationMatcherTest : WordSpec() {
     private lateinit var finding: LicenseFinding
     private lateinit var curation: LicenseFindingCuration
 
-    override fun isInstancePerTest() = true
+    override fun isolationMode() = IsolationMode.InstancePerLeaf
 
     private fun setupFinding(license: String, path: String, startLine: Int, endLine: Int) {
         finding = LicenseFinding(

--- a/model/src/test/kotlin/utils/FindingsMatcherTest.kt
+++ b/model/src/test/kotlin/utils/FindingsMatcherTest.kt
@@ -26,6 +26,7 @@ import com.here.ort.model.TextLocation
 import com.here.ort.model.utils.FindingsMatcher.Companion.DEFAULT_TOLERANCE_LINES
 import com.here.ort.utils.FileMatcher
 
+import io.kotlintest.IsolationMode
 import io.kotlintest.matchers.beEmpty
 import io.kotlintest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotlintest.should
@@ -41,7 +42,7 @@ class FindingsMatcherTest : WordSpec() {
     private val licenseFindings = mutableListOf<LicenseFinding>()
     private val copyrightFindings = mutableListOf<CopyrightFinding>()
 
-    override fun isInstancePerTest() = true
+    override fun isolationMode() = IsolationMode.InstancePerLeaf
 
     private fun setupLicenseFinding(license: String, path: String, line: Int = 1) {
         licenseFindings.add(


### PR DESCRIPTION
Note, as these specs have no code in non-leaf tests, using
InstancePerLeaf instead of InstancePerTest should be enough.

Also see:
https://github.com/kotlintest/kotlintest/blob/master/doc/isolation_mode.md

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>