### PR TITLE
Travis: Add a missing colon to fix coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,5 +89,5 @@ script:
 
 after_success:
   - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
-      bash <(curl -s https://codecov.io/bash) -X gcov -f '!*/src/*/assets/*'
+      bash <(curl -s https://codecov.io/bash) -X gcov -f '!*/src/*/assets/*';
     fi


### PR DESCRIPTION
This is a fixup for b9ba83b. Coverage reporting was broken since then.
    
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>