### PR TITLE
updated pipdeptree version from 0.13.0 to 0.13.2

### DIFF
--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -63,7 +63,7 @@ import okhttp3.Request
 // The lowest version that supports "--prefer-binary".
 const val PIP_VERSION = "18.0"
 
-const val PIPDEPTREE_VERSION = "0.13.0"
+const val PIPDEPTREE_VERSION = "0.13.2"
 private val PHONY_DEPENDENCIES = mapOf(
     "pipdeptree" to "", // A dependency of pipdeptree itself.
     "pkg-resources" to "0.0.0", // Added by a bug with some Ubuntu distributions.


### PR DESCRIPTION
Signed-off-by: Craig Barnes <craig.barnes@here.com>

When analyzer is run using the Pip module there is the following error

> Traceback (most recent call last):
>   File "/tmp/ort3241966459477721899generated-virtualenv/lib/python3.7/site-packages/pipdeptree.py", line 17, in <module>
>     from pip._internal import get_installed_distributions
> ImportError: cannot import name 'get_installed_distributions' from 'pip._internal' (/tmp/ort3241966459477721899generated-virtualenv/lib/python3.7/site-packages/pip/_internal/__init__.py)
> 
> During handling of the above exception, another exception occurred:
> 
> Traceback (most recent call last):
>   File "/tmp/ort3241966459477721899generated-virtualenv/bin/pipdeptree", line 7, in <module>
>     from pipdeptree import main
>   File "/tmp/ort3241966459477721899generated-virtualenv/lib/python3.7/site-packages/pipdeptree.py", line 20, in <module>
>     from pip import get_installed_distributions, FrozenRequirement
> ImportError: cannot import name 'get_installed_distributions' from 'pip' (/tmp/ort3241966459477721899generated-virtualenv/lib/python3.7/site-packages/pip/__init__.py)

 
Looking at some post online it seems that the internal pip functions have changed and get_installed_distributions is not available anymore. The fix is to use a newer version of
pipdeptree. After this change the anaylzer has found the packages in my requirements.txt