### PR TITLE
LocalScanner: Move a return out of "try"

### DIFF
--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -145,8 +145,8 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
             Executors.newFixedThreadPool(5, NamedThreadFactory(ScanResultsStorage.storage.name)).asCoroutineDispatcher()
         val scanDispatcher = Executors.newSingleThreadExecutor(NamedThreadFactory(scannerName)).asCoroutineDispatcher()
 
-        try {
-            return coroutineScope {
+        return try {
+            coroutineScope {
                 packages.withIndex().map { (index, pkg) ->
                     val packageIndex = "(${index + 1}/${packages.size})"
 


### PR DESCRIPTION
This way it is clearer that this huge try block is actually the last
statement in the function.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>