### PR TITLE
model: Fix the "utils" project to be an API dependency

### DIFF
--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -13,12 +13,11 @@ plugins {
 
 dependencies {
     api(project(":spdx-utils"))
+    api(project(":utils"))
 
     api("com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion")
     api("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion")
     api("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion")
-
-    implementation(project(":utils"))
 
     implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion")


### PR DESCRIPTION
E.g. ProcessedDeclaredLicense from "utils" is part of the model API, so
it has to be an API dependency.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>