### PR TITLE
FindingCurationMatcher: Apply all matching curations

### DIFF
--- a/model/src/main/kotlin/utils/FindingCurationMatcher.kt
+++ b/model/src/main/kotlin/utils/FindingCurationMatcher.kt
@@ -64,17 +64,25 @@ class FindingCurationMatcher {
         else finding.copy(license = curation.concludedLicense)
 
     /**
-     * Applies the given [curations] to the given [findings]. In case multiple curations apply to any given finding only
-     * an arbitrary single one is applied.
+     * Applies the given [curations] to the given [findings]. In case multiple curations match any given finding all
+     * curations are applied to the original finding, thus in this case there are multiple curated findings for one
+     * finding.
      */
     fun applyAll(
         findings: Collection<LicenseFinding>,
         curations: Collection<LicenseFindingCuration>
-    ): List<LicenseFinding> =
-        findings.mapNotNull { finding ->
-            curations.find { matches(finding, it) }.let {
-                if (it != null) apply(finding, it)
-                else finding
+    ): List<LicenseFinding> {
+        val result = mutableListOf<LicenseFinding>()
+
+        findings.forEach { finding ->
+            val matchingCurations = curations.filter { matches(finding, it) }
+            if (matchingCurations.isNotEmpty()) {
+                result.addAll(matchingCurations.mapNotNull { apply(finding, it) })
+            } else {
+                result.add(finding)
             }
         }
+
+        return result
+    }
 }

--- a/model/src/test/kotlin/utils/FindingCurationMatcherTest.kt
+++ b/model/src/test/kotlin/utils/FindingCurationMatcherTest.kt
@@ -261,5 +261,43 @@ class FindingCurationMatcherTest : WordSpec() {
                 )
             }
         }
+
+        "Given two curations matching a single finding, applyAll" should {
+            "return two findings with the respective curation applied" {
+                val findings = listOf(
+                    LicenseFinding(
+                        license = "MIT",
+                        location = TextLocation(path = "some/path", startLine = 1, endLine = 1)
+                    )
+                )
+                val curations = listOf(
+                    LicenseFindingCuration(
+                        path = "some/path",
+                        detectedLicense = "MIT",
+                        reason = INCORRECT,
+                        concludedLicense = "MIT-old-style"
+                    ),
+                    LicenseFindingCuration(
+                        path = "some/path",
+                        detectedLicense = "MIT",
+                        reason = INCORRECT,
+                        concludedLicense = "Apache-2.0"
+                    )
+                )
+
+                val result = matcher.applyAll(findings, curations)
+
+                result shouldContainExactlyInAnyOrder listOf(
+                    LicenseFinding(
+                        license = "MIT-old-style",
+                        location = TextLocation(path = "some/path", startLine = 1, endLine = 1)
+                    ),
+                    LicenseFinding(
+                        license = "Apache-2.0",
+                        location = TextLocation(path = "some/path", startLine = 1, endLine = 1)
+                    )
+                )
+            }
+        }
     }
 }


### PR DESCRIPTION
When a single finding actually points to a text location containing
multiple licenses it was not possible before to express those multiple
licenses with a single or with multiple curations as SPDX
expressions are not supported with detected licenses yet and as only the
first matching curation is applied to any license finding.

Implementing support for SPDX expression would allow setting multiple
licenses to a single finding via a curation but doing the implementation
is a bigger task. Until then address this by applying all curations to
have a solution available quickly. That behavior may make sense to keep
even when SPDX expression are supported.

Signed-off-by: Frank Viernau <frank.viernau@here.com>