### PR TITLE
helper-cli: Use exit code 2 in case of command failures

### DIFF
--- a/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
@@ -123,7 +123,7 @@ internal class ListLicensesCommand : CommandWithHelp() {
         var ortResult = ortResultFile.readValue<OrtResult>()
         if (ortResult.getPackageOrProject(packageId) == null) {
             println("Could not find a package for the given id `$packageId`.")
-            return -1
+            return 2
         }
 
         repositoryConfigurationFile?.let {


### PR DESCRIPTION
This is to use a non-negative value to comply with POSIX and
to align with the `cli` module, see be2a4b02 and also

  https://stackoverflow.com/questions/47265667/return-code-on-failure-positive-or-negative/47266617#47266617

Signed-off-by: Frank Viernau <frank.viernau@here.com>