### PR TITLE
Pip: Relax the version check for virtualenv

### DIFF
--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -82,7 +82,7 @@ object VirtualEnv : CommandLineTool {
     override fun command(workingDir: File?) = "virtualenv"
 
     // Allow to use versions that are known to work. Note that virtualenv bundles a version of pip.
-    override fun getVersionRequirement(): Requirement = Requirement.buildIvy("[15.1,16.7[")
+    override fun getVersionRequirement(): Requirement = Requirement.buildIvy("[15.1,17.0[")
 }
 
 object PythonVersion : CommandLineTool {


### PR DESCRIPTION
We mostly want to check that we have at least version 15.1 here. In order
to support current version 16.7.7 and also future releases, relax the
version check accordingly.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>