### PR TITLE
Run cheap checks first in CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -77,12 +77,13 @@ build_script:
   - if not exist %HOME%\.gradle mkdir %HOME%\.gradle
   - echo org.gradle.daemon=false>>%HOME%\.gradle\gradle.properties
   - echo org.gradle.java.home=C:/Program Files/Java/jdk9>>%HOME%\.gradle\gradle.properties
+  - gradlew --stacktrace checkCopyright detekt
 
 test_script:
   - if "%APPVEYOR_SCHEDULED_BUILD%"=="True" (
-      gradlew --stacktrace dokkaJar check
+      gradlew --stacktrace dokkaJar test funTest
     ) else (
-      gradlew --stacktrace -Dkotlintest.tags.exclude=ExpensiveTag check
+      gradlew --stacktrace -Dkotlintest.tags.exclude=ExpensiveTag test funTest
     )
 
 on_finish:

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,12 +77,17 @@ install:
   - conan user # Create the conan data directory. Automatic detection of your arch, compiler, etc.
   - pip install --user pipenv==$PYTHON_PIPENV_VERSION
 
+before_script:
+  - mkdir -p $HOME/.gradle
+  - echo "org.gradle.daemon=false" >> $HOME/.gradle/gradle.properties
+
 script:
   - set -o pipefail
+  - ./gradlew --stacktrace checkCopyright detekt
   - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
-      ./gradlew --no-daemon --stacktrace -Dkotlintest.tags.exclude=ScanCodeTag check jacocoReport | tee log.txt;
+      ./gradlew --stacktrace -Dkotlintest.tags.exclude=ScanCodeTag test funTest jacocoReport | tee log.txt;
     else
-      ./gradlew --no-daemon --scan --stacktrace -Dkotlintest.tags.exclude=ExpensiveTag check jacocoReport | tee log.txt;
+      ./gradlew --scan --stacktrace -Dkotlintest.tags.exclude=ExpensiveTag test funTest jacocoReport | tee log.txt;
     fi
   - if grep -A1 ".+Test.+STARTED$" log.txt | grep -q "^:"; then
       echo "Some tests seemingly have been aborted.";


### PR DESCRIPTION
To fail early if there are e.g. detekt issues. Otherwise finishing detekt
can actually take quite long when run in parallel with other compute
intensive (test) tasks.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>