### PR TITLE
Work around a classpath issue when running ORT on Windows

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -14,6 +14,15 @@ application {
     mainClassName = "com.here.ort.Main"
 }
 
+tasks.named<CreateStartScripts>("startScripts") {
+    doLast {
+        // Work around the command line length limit on Windows when passing the classpath to Java, see
+        // https://github.com/gradle/gradle/issues/1989#issuecomment-395001392.
+        windowsScript.writeText(windowsScript.readText().replace(Regex("set CLASSPATH=.*"),
+            "set CLASSPATH=%APP_HOME%\\\\lib\\\\*"))
+    }
+}
+
 repositories {
     jcenter()
 

--- a/helper-cli/build.gradle.kts
+++ b/helper-cli/build.gradle.kts
@@ -12,6 +12,15 @@ application {
     mainClassName = "com.here.ort.helper.Main"
 }
 
+tasks.named<CreateStartScripts>("startScripts") {
+    doLast {
+        // Work around the command line length limit on Windows when passing the classpath to Java, see
+        // https://github.com/gradle/gradle/issues/1989#issuecomment-395001392.
+        windowsScript.writeText(windowsScript.readText().replace(Regex("set CLASSPATH=.*"),
+            "set CLASSPATH=%APP_HOME%\\\\lib\\\\*"))
+    }
+}
+
 repositories {
     jcenter()
 


### PR DESCRIPTION
Our classpath of dependencies got too long to be passed to Java on the
command line on Windows. Work around the issue by using a wildcard
instead of listing all JARs individually as suggested at

https://github.com/gradle/gradle/issues/1989#issuecomment-395001392

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>