### PR TITLE
GradleKotlinScriptTest: Temporarily disable the test on Travis

### DIFF
--- a/analyzer/src/funTest/kotlin/managers/GradleKotlinScriptTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GradleKotlinScriptTest.kt
@@ -21,6 +21,7 @@ package com.here.ort.analyzer.managers
 
 import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.yamlMapper
+import com.here.ort.utils.Ci
 import com.here.ort.utils.normalizeVcsUrl
 import com.here.ort.utils.test.DEFAULT_ANALYZER_CONFIGURATION
 import com.here.ort.utils.test.DEFAULT_REPOSITORY_CONFIGURATION
@@ -40,7 +41,7 @@ class GradleKotlinScriptTest : StringSpec() {
     private val vcsRevision = vcsDir.getRevision()
 
     init {
-        "root project dependencies are detected correctly" {
+        "root project dependencies are detected correctly".config(enabled = !Ci.isTravis) {
             val packageFile = File(projectDir, "build.gradle.kts")
             val expectedResult = patchExpectedResult(
                 File(projectDir.parentFile, "multi-kotlin-project-expected-output-root.yml"),
@@ -55,7 +56,7 @@ class GradleKotlinScriptTest : StringSpec() {
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
 
-        "core project dependencies are detected correctly" {
+        "core project dependencies are detected correctly".config(enabled = !Ci.isTravis) {
             val packageFile = File(projectDir, "core/build.gradle.kts")
             val expectedResult = patchExpectedResult(
                 File(projectDir.parentFile, "multi-kotlin-project-expected-output-core.yml"),
@@ -70,7 +71,7 @@ class GradleKotlinScriptTest : StringSpec() {
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
 
-        "cli project dependencies are detected correctly" {
+        "cli project dependencies are detected correctly".config(enabled = !Ci.isTravis) {
             val packageFile = File(projectDir, "cli/build.gradle.kts")
             val expectedResult = patchExpectedResult(
                 File(projectDir.parentFile, "multi-kotlin-project-expected-output-cli.yml"),


### PR DESCRIPTION
For unknown reasons, Travis has problems downloading
gradle-kotlin-dsl-5.1.1-20190108191351+0000-all.zip, although both
locally and on AppVeyor the test passes. So just disable it for now.

[1] https://travis-ci.com/heremaps/oss-review-toolkit/builds/135240146#L3110

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>