### PR TITLE
Upgrade Gradle to version 6.0

### DIFF
--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -67,7 +67,8 @@ class Gradle(
     name: String,
     analysisRoot: File,
     analyzerConfig: AnalyzerConfiguration,
-    repoConfig: RepositoryConfiguration
+    repoConfig: RepositoryConfiguration,
+    private val gradleVersion: String? = null
 ) : PackageManager(name, analysisRoot, analyzerConfig, repoConfig) {
     class Factory : AbstractPackageManagerFactory<Gradle>("Gradle") {
         // Gradle prefers Groovy ".gradle" files over Kotlin ".gradle.kts" files, but "build" files have to come before
@@ -138,6 +139,10 @@ class Gradle(
         }
 
         val gradleConnector = GradleConnector.newConnector()
+
+        if (gradleVersion != null) {
+            gradleConnector.useGradleVersion(gradleVersion)
+        }
 
         if (gradleConnector is DefaultGradleConnector) {
             gradleConnector.daemonMaxIdleTime(10, TimeUnit.SECONDS)

--- a/analyzer/src/main/kotlin/managers/Pub.kt
+++ b/analyzer/src/main/kotlin/managers/Pub.kt
@@ -54,6 +54,7 @@ import java.io.File
 import java.io.IOException
 import java.util.SortedSet
 
+private const val GRADLE_VERSION = "5.6.4"
 const val PUB_LOCK_FILE = "pubspec.lock"
 
 /**
@@ -319,12 +320,13 @@ class Pub(
         // Check for build.gradle failed, no Gradle scan required.
         if (!packageFile.isFile) return null
 
-        log.info { "Analyzing Android dependencies for package '$packageName'." }
+        log.info { "Analyzing Android dependencies for package '$packageName' using Gradle version $GRADLE_VERSION." }
 
         return if (analyzerResultCacheAndroid.containsKey(packageName)) {
             analyzerResultCacheAndroid[packageName]
         } else {
-            Gradle("Gradle", androidDir, analyzerConfig, repoConfig)
+            // Use the latest 5.x Gradle version as Flutter / its Android Gradle plugin does not support Gradle 6 yet.
+            Gradle("Gradle", androidDir, analyzerConfig, repoConfig, GRADLE_VERSION)
                 .resolveDependencies(listOf(packageFile))[packageFile]
                 ?.also {
                     analyzerResultCacheAndroid[packageName] = it

--- a/analyzer/src/main/kotlin/managers/Pub.kt
+++ b/analyzer/src/main/kotlin/managers/Pub.kt
@@ -55,7 +55,7 @@ import java.io.IOException
 import java.util.SortedSet
 
 private const val GRADLE_VERSION = "5.6.4"
-const val PUB_LOCK_FILE = "pubspec.lock"
+private const val PUB_LOCK_FILE = "pubspec.lock"
 
 /**
  * The [Pub](https://https://pub.dev/) package manager for Dart / Flutter.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.0-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
See https://docs.gradle.org/6.0/release-notes.html.

Flutter by default uses the Gradle version that runs the build, which in
this case is the Gradle Tooling API and as of now Gradle 6. However, as
Flutter / the Android Gradle plugin version used by Flutter does not
support Gradle 6 yet, we need a way to downgrade the Gradle version used
for analysis. Introduce a constructor parameter to the Gradle package
manager to explicitly specify the Gradle version to use to solve exactly
that issue.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>