### PR TITLE
PathExcludeReason: Add `other` as reason

### DIFF
--- a/model/src/main/kotlin/config/PathExcludeReason.kt
+++ b/model/src/main/kotlin/config/PathExcludeReason.kt
@@ -52,6 +52,11 @@ enum class PathExcludeReason {
     OPTIONAL_COMPONENT_OF,
 
     /**
+     * Any other reason which cannot be represented by any other element of [PathExcludeReason].
+     */
+    OTHER,
+
+    /**
      * The path only contains packages or sources for packages that have to be provided by the user of distributed build
      * artifacts.
      */


### PR DESCRIPTION
In some cases no path exclude reason really matches. Introduce `other`
as additional reason which is supposed to be used mainly for not so
common reasons or edge cases.

Signed-off-by: Frank Viernau <frank.viernau@here.com>