### PR TITLE
ReportTableModelMapper: Fix a null pointer exception

### DIFF
--- a/reporter/src/main/kotlin/reporters/ReportTableModelMapper.kt
+++ b/reporter/src/main/kotlin/reporters/ReportTableModelMapper.kt
@@ -23,6 +23,7 @@ import com.here.ort.model.Identifier
 import com.here.ort.model.OrtIssue
 import com.here.ort.model.OrtResult
 import com.here.ort.model.RuleViolation
+import com.here.ort.model.VcsInfo
 import com.here.ort.reporter.ResolutionProvider
 import com.here.ort.reporter.reporters.ReportTableModel.DependencyRow
 import com.here.ort.reporter.reporters.ReportTableModel.IssueRow
@@ -114,7 +115,7 @@ class ReportTableModelMapper(private val resolutionProvider: ResolutionProvider)
 
                 DependencyRow(
                     id = id,
-                    vcsInfo = ortResult.getUncuratedPackageById(id)!!.vcsProcessed,
+                    vcsInfo = ortResult.getUncuratedPackageById(id)?.vcsProcessed ?: VcsInfo.EMPTY,
                     scopes = scopes,
                     concludedLicense = concludedLicense,
                     declaredLicenses = declaredLicenses,


### PR DESCRIPTION
Do not fail if the uncurated package for an identifier cannot be found
and use an empty `VcsInfo` instead. The package can be missing if there
was an issue in the analyzer.

This is a fixup for 6747eae.