### PR TITLE
SpdxCompoundExpression: Validate also the lhs operand of WITH

### DIFF
--- a/spdx-utils/src/main/kotlin/SpdxExpression.kt
+++ b/spdx-utils/src/main/kotlin/SpdxExpression.kt
@@ -146,6 +146,11 @@ data class SpdxCompoundExpression(
     override fun validate(strictness: Strictness) {
         left.validate(strictness)
 
+        if (operator == SpdxOperator.WITH && !(left is SpdxLicenseIdExpression
+                    || left is SpdxLicenseReferenceExpression)) {
+            throw SpdxException("Argument '$left' for WITH is not a license identifier.")
+        }
+
         if (operator == SpdxOperator.WITH && right !is SpdxLicenseExceptionExpression) {
             throw SpdxException("Argument '$right' for WITH is not an SPDX license exception id.")
         }


### PR DESCRIPTION
The left-hand side operand of the `WITH` operator must be a license
identifier. Reflect that in validate().

Signed-off-by: Frank Viernau <frank.viernau@here.com>