### PR TITLE
Gradle: Use the "implementation" instead of "compile" configuration

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -20,5 +20,5 @@ repositories {
 val ideaExtPluginVersion = extra["ideaExtPluginVersion"]
 
 dependencies {
-    compile("gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:$ideaExtPluginVersion")
+    implementation("gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:$ideaExtPluginVersion")
 }

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -32,30 +32,30 @@ repositories {
 }
 
 dependencies {
-    compile(project(":analyzer"))
-    compile(project(":downloader"))
-    compile(project(":evaluator"))
-    compile(project(":model"))
-    compile(project(":reporter"))
-    compile(project(":scanner"))
-    compile(project(":utils"))
+    implementation(project(":analyzer"))
+    implementation(project(":downloader"))
+    implementation(project(":evaluator"))
+    implementation(project(":model"))
+    implementation(project(":reporter"))
+    implementation(project(":scanner"))
+    implementation(project(":utils"))
 
-    compile("com.beust:jcommander:$jcommanderVersion")
-    compile("io.github.config4k:config4k:$config4kVersion")
-    compile("org.apache.logging.log4j:log4j-core:$log4jCoreVersion")
-    compile("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-    compile("org.jetbrains.kotlin:kotlin-reflect")
-    compile("org.reflections:reflections:$reflectionsVersion")
+    implementation("com.beust:jcommander:$jcommanderVersion")
+    implementation("io.github.config4k:config4k:$config4kVersion")
+    implementation("org.apache.logging.log4j:log4j-core:$log4jCoreVersion")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("org.reflections:reflections:$reflectionsVersion")
 
-    testCompile(project(":test-utils"))
+    testImplementation(project(":test-utils"))
 
-    testCompile("io.kotlintest:kotlintest-core:$kotlintestVersion")
-    testCompile("io.kotlintest:kotlintest-assertions:$kotlintestVersion")
-    testCompile("io.kotlintest:kotlintest-runner-junit5:$kotlintestVersion")
+    testImplementation("io.kotlintest:kotlintest-core:$kotlintestVersion")
+    testImplementation("io.kotlintest:kotlintest-assertions:$kotlintestVersion")
+    testImplementation("io.kotlintest:kotlintest-runner-junit5:$kotlintestVersion")
 
-    funTestCompile(sourceSets["main"].output)
-    funTestCompile(sourceSets["test"].output)
+    funTestImplementation(sourceSets["main"].output)
+    funTestImplementation(sourceSets["test"].output)
 }
 
-configurations["funTestCompile"].extendsFrom(configurations.testCompile.get())
+configurations["funTestImplementation"].extendsFrom(configurations.testImplementation.get())
 configurations["funTestRuntime"].extendsFrom(configurations.testRuntime.get())

--- a/helper-cli/build.gradle.kts
+++ b/helper-cli/build.gradle.kts
@@ -30,11 +30,11 @@ repositories {
 }
 
 dependencies {
-    compile(project(":analyzer"))
-    compile(project(":downloader"))
-    compile(project(":reporter"))
-    compile(project(":utils"))
+    implementation(project(":analyzer"))
+    implementation(project(":downloader"))
+    implementation(project(":reporter"))
+    implementation(project(":utils"))
 
-    compile("com.beust:jcommander:$jcommanderVersion")
-    compile("org.apache.logging.log4j:log4j-core:$log4jCoreVersion")
+    implementation("com.beust:jcommander:$jcommanderVersion")
+    implementation("org.apache.logging.log4j:log4j-core:$log4jCoreVersion")
 }


### PR DESCRIPTION
The "compile" configuration has been generally deprecated in Gradle 6.0,
so use the "implementation" configuration instead.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>