### PR TITLE
Gradle: Add a task to list all dependencies of all projects

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -336,3 +336,12 @@ tasks.register("check") {
 
     dependsOn(checkCopyright)
 }
+
+tasks.register("allDependencies") {
+    val dependenciesTasks = allprojects.map { it.tasks.named("dependencies").get() }
+    dependsOn(dependenciesTasks)
+
+    dependenciesTasks.zipWithNext().forEach { (a, b) ->
+        b.mustRunAfter(a)
+    }
+}


### PR DESCRIPTION
Because for some reason calling "./gradlew dependencies" does not work
as a task selector to execute all "dependencies" tasks in all projects,
but it executes only in the root project.

Ensure deterministic output by requiring to run tasks after each other
in always the same order.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>