### PR TITLE
NoticeReporter: Prevent calling `reduce` on an empty map

### DIFF
--- a/reporter/src/main/kotlin/reporters/NoticeReporter.kt
+++ b/reporter/src/main/kotlin/reporters/NoticeReporter.kt
@@ -138,13 +138,13 @@ class NoticeReporter : Reporter() {
         buildString {
             append(noticeReport.headers.joinToString(NOTICE_SEPARATOR))
 
-            val mergedFindings = noticeReport.findings.values.reduce { left, right ->
+            val mergedFindings = noticeReport.findings.values.takeIf { it.isNotEmpty() }?.reduce { left, right ->
                 left.apply {
                     right.forEach { (license, copyrights) ->
                         getOrPut(license) { mutableSetOf() } += copyrights
                     }
                 }
-            }.removeGarbage(copyrightGarbage).processStatements()
+            }?.removeGarbage(copyrightGarbage)?.processStatements() ?: sortedMapOf()
 
             mergedFindings.forEach { (license, copyrights) ->
                 licenseTextProvider.getLicenseText(license)?.let { licenseText ->


### PR DESCRIPTION
Do not call `reduce` on an empty map to prevent it from throwing an
exception.