### PR TITLE
Analyzer: Fix the `Unmanaged` approach

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
@@ -51,6 +51,22 @@ analyzer:
         - id: "Maven:junit:junit:4.12"
           dependencies:
           - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+    - id: "Unmanaged::directories-jvm:d302b1e93963c81ed511e072a52e95251b5d078b"
+      definition_file_path: ""
+      declared_licenses: []
+      declared_licenses_processed: {}
+      vcs:
+        type: ""
+        url: ""
+        revision: ""
+        path: ""
+      vcs_processed:
+        type: "Git"
+        url: "https://github.com/soc/directories-jvm"
+        revision: "d302b1e93963c81ed511e072a52e95251b5d078b"
+        path: ""
+      homepage_url: ""
+      scopes: []
     packages:
     - package:
         id: "Maven:com.novocode:junit-interface:0.11"

--- a/analyzer/src/funTest/assets/projects/external/sbt-multi-project-example-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/sbt-multi-project-example-expected-output.yml
@@ -214,6 +214,22 @@ analyzer:
       - name: "compile"
         dependencies:
         - id: "Maven:org.scala-lang:scala-library:2.12.3"
+    - id: "Unmanaged::sbt-multi-project-example:31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+      definition_file_path: ""
+      declared_licenses: []
+      declared_licenses_processed: {}
+      vcs:
+        type: ""
+        url: ""
+        revision: ""
+        path: ""
+      vcs_processed:
+        type: "Git"
+        url: "https://github.com/pbassiner/sbt-multi-project-example.git"
+        revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+        path: ""
+      homepage_url: ""
+      scopes: []
     packages:
     - package:
         id: "Maven:ch.qos.logback:logback-classic:1.2.3"


### PR DESCRIPTION
The scanner module associates each copyright or license finding to the
project in whoose subtree it resides whereas the project directories are
derived from the definition file locations. Thus having a definition file
at the root of the repository guarantees that each finding gets associated
with a project.

In order to provide that mentioned guarantee the analyzer adds an
`unmanaged` project to the root directory in case it does not already
contain a definition file for an enabled package manager.

The problem is that the condition for the creation of the `unmanaged`
manager is based on the locations of the definitions files while the
logic for the association of findings uses the locations of the `mapped`
definition files. In particular when the root directory contains a
definition file but not a `mapped` definition file it is not guaranteed
anymore that all license and copyright findings appear in the scan result.
This can happen e.g. when a SBT definition file is in the root
directory. Note: it then gets mapped to one or multiple POM files none of
them located in the root directory.

Fix this by adjusting the condition for creating the `unmanaged` project
to consider the mapped instead of the non-mapped definition files.

Signed-off-by: Frank Viernau <frank.viernau@here.com>