### PR TITLE
Scanner: Stop accidentally dropping scan results

### DIFF
--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -173,7 +173,8 @@ abstract class Scanner(val scannerName: String, protected val config: ScannerCon
      */
     private fun filterProjectScanResults(project: Project, resultContainer: ScanResultContainer): ScanResultContainer {
         // Do not filter the results if the definition file is in the root of the repository.
-        val parentPath = File(project.definitionFilePath).parentFile?.path ?: return resultContainer
+        val parentPath = File(project.definitionFilePath).parentFile?.path
+            ?: return resultContainer.copy(id = project.id)
 
         val filteredResults = resultContainer.results.map { result ->
             if (result.provenance.sourceArtifact != null) {


### PR DESCRIPTION
In case the IDs of the given project and result container differ
and the definition file of that project is in the root directory,
filterProjectScanResults() returns a scan result container whose ID
does not match the ID of the given project. As consequence the scan
result lacks all license and copyright findings for that project.
Even worse the whole ORT result may lack those findings as the
unfiltered scan result container may get ditched in line 152.

Fix this by setting the ID of the returned container properly.

Signed-off-by: Frank Viernau <frank.viernau@here.com>