### PR TITLE
StaticHtmlReporter: Make sure projects are listed first

### DIFF
--- a/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
+++ b/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
@@ -453,7 +453,7 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
         </thead>
         <tbody>
           <tr class="ort-error" id="violation-1">
-            <td><a href="#violation-1">1</a></td><td>rule 1</td><td>Maven:junit:junit:4.12</td><td>DETECTED: EPL-1.0</td><td>
+            <td><a href="#violation-1">1</a></td><td>rule 1</td><td>Ant:junit:junit:4.12</td><td>DETECTED: EPL-1.0</td><td>
               <p>EPL-1.0 error</p>
               <details>
                 <summary>How to fix</summary>
@@ -586,7 +586,7 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
             </td>
           </tr>
           <tr class="ort-success " id="Gradle:com.here.ort.gradle.example:lib:1.0.0-pkg-2">
-            <td><a href="#Gradle:com.here.ort.gradle.example:lib:1.0.0-pkg-2">2</a></td><td>Maven:junit:junit:4.12</td><td>
+            <td><a href="#Gradle:com.here.ort.gradle.example:lib:1.0.0-pkg-2">2</a></td><td>Ant:junit:junit:4.12</td><td>
               <ul>
                 <li class="">testCompile</li>
               </ul>

--- a/reporter/src/funTest/assets/static-html-reporter-test-input.yml
+++ b/reporter/src/funTest/assets/static-html-reporter-test-input.yml
@@ -67,7 +67,7 @@ analyzer:
           - id: "Maven:org.apache.commons:commons-lang3:3.5"
       - name: "testCompile"
         dependencies:
-        - id: "Maven:junit:junit:4.12"
+        - id: "Ant:junit:junit:4.12"
           dependencies:
           - id: "Maven:org.hamcrest:hamcrest-core:1.3"
         - id: "Maven:org.apache.commons:commons-text:1.1"
@@ -91,7 +91,7 @@ analyzer:
       scopes: []
     packages:
     - package:
-        id: "Maven:junit:junit:4.12"
+        id: "Ant:junit:junit:4.12"
         purl: "pkg:maven/junit/junit@4.12"
         declared_licenses:
         - "Eclipse Public License 1.0"
@@ -321,7 +321,7 @@ scanner:
               - path: "file1.java"
                 start_line: 1
                 end_line: 1
-    - id: "Maven:junit:junit:4.12"
+    - id: "Ant:junit:junit:4.12"
       results:
       - provenance:
           download_time: "1970-01-01T00:00:00Z"
@@ -402,7 +402,7 @@ evaluator:
   end_time: "1970-01-01T00:00:00Z"
   violations:
   - rule: "rule 1"
-    pkg: "Maven:junit:junit:4.12"
+    pkg: "Ant:junit:junit:4.12"
     license: "EPL-1.0"
     license_source: "DETECTED"
     severity: "ERROR"

--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -438,8 +438,10 @@ class StaticHtmlReporter : Reporter() {
             }
 
             tbody {
-                table.rows.forEachIndexed { rowIndex, pkg ->
-                    projectRow(project.id.toCoordinates(), rowIndex + 1, pkg)
+                val projectRow = table.rows.single { it.id == project.id }
+                projectRow(project.id.toCoordinates(), 1, projectRow)
+                (table.rows - projectRow).forEachIndexed { rowIndex, pkg ->
+                    projectRow(project.id.toCoordinates(), rowIndex + 2, pkg)
                 }
             }
         }


### PR DESCRIPTION
Make sure that in the dependency table the project itself is always the
first entry.