### PR TITLE
Analyzer: Remove the default repository config file location for Git Repo projects

### DIFF
--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -21,7 +21,6 @@ package com.here.ort.analyzer
 
 import com.here.ort.analyzer.managers.Unmanaged
 import com.here.ort.downloader.VersionControlSystem
-import com.here.ort.downloader.vcs.GitRepo
 import com.here.ort.model.AnalyzerResult
 import com.here.ort.model.AnalyzerResultBuilder
 import com.here.ort.model.AnalyzerRun
@@ -36,7 +35,6 @@ import com.here.ort.model.readValue
 import com.here.ort.utils.NamedThreadFactory
 import com.here.ort.utils.ORT_CONFIG_FILENAME
 import com.here.ort.utils.log
-import com.here.ort.utils.realFile
 
 import java.io.File
 import java.time.Instant
@@ -64,7 +62,7 @@ class Analyzer(private val config: AnalyzerConfiguration) {
         val startTime = Instant.now()
 
         val actualRepositoryConfigurationFile = repositoryConfigurationFile
-            ?: locateRepositoryConfigurationFile(absoluteProjectPath)
+            ?: File(absoluteProjectPath, ORT_CONFIG_FILENAME)
 
         val repositoryConfiguration = if (actualRepositoryConfigurationFile.isFile) {
             log.info { "Using configuration file '${actualRepositoryConfigurationFile.absolutePath}'." }
@@ -182,14 +180,4 @@ class Analyzer(private val config: AnalyzerConfiguration) {
 
         return analyzerResultBuilder.build()
     }
-
-    private fun locateRepositoryConfigurationFile(absoluteProjectPath: File): File =
-        GitRepo().getWorkingTree(absoluteProjectPath).let { workingTree ->
-            if (workingTree.isValid() && workingTree.getRootPath() == absoluteProjectPath) {
-                val manifestFile = absoluteProjectPath.resolve(".repo/manifest.xml").realFile()
-                manifestFile.resolveSibling("${manifestFile.name}$ORT_CONFIG_FILENAME")
-            } else {
-                File(absoluteProjectPath, ORT_CONFIG_FILENAME)
-            }
-        }
 }

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -8,9 +8,6 @@ ORT's behavior can be customized for a specific repository by adding a `.ort.yml
 Currently, this file can only be used to configure the excludes described below, but more features are planned for the
 future.
 
-Note that for Git-Repo repositories, the default location of the configuration file is next to the manifest file. For
-example, if the manifest is `manifest.xml` the configuration should be `manifest.xml.ort.yml`.
-
 ### Excludes
 
 ORT's philosophy is to analyze and scan everything it can find to build a complete picture of a repository and its


### PR DESCRIPTION
The fact that ORT uses the manifests repository as default location for
repository configuration files can be interpreted as ORT is encouraging
to place the ort.yml files there which could put some users in the wrong
direction. Remove this to make ORT neutral about the location for Git
Repo based projects and to remove the need to maintain an additional
code path.

Note that it is still possible to use any `*.ort.yml` residing within
the `.repo/manifest` directory by just specifying it via the
`repositoryConfigurationFile` parameter.

Signed-off-by: Frank Viernau <frank.viernau@here.com>