### PR TITLE
Scanner: Use the same code path for setting the container ID

### DIFF
--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -172,18 +172,21 @@ abstract class Scanner(val scannerName: String, protected val config: ScannerCon
      * the [project]s definition file.
      */
     private fun filterProjectScanResults(project: Project, resultContainer: ScanResultContainer): ScanResultContainer {
+        var filteredResults = resultContainer.results
+
         // Do not filter the results if the definition file is in the root of the repository.
         val parentPath = File(project.definitionFilePath).parentFile?.path
-            ?: return resultContainer.copy(id = project.id)
-
-        val filteredResults = resultContainer.results.map { result ->
-            if (result.provenance.sourceArtifact != null) {
-                // Do not filter the result if a source artifact was scanned.
-                result
-            } else {
-                result.filterPath(parentPath)
+        if (parentPath != null) {
+            filteredResults = resultContainer.results.map { result ->
+                if (result.provenance.sourceArtifact != null) {
+                    // Do not filter the result if a source artifact was scanned.
+                    result
+                } else {
+                    result.filterPath(parentPath)
+                }
             }
         }
+
         return ScanResultContainer(project.id, filteredResults)
     }
 }


### PR DESCRIPTION
As this avoids unwanted inconsistencies as seen in the bug which just
got fixed at that same code location.

Signed-off-by: Frank Viernau <frank.viernau@here.com>