### PR TITLE
Subversion: Use SVNKit instead of the "svn" CLI for working tree information

### DIFF
--- a/downloader/build.gradle.kts
+++ b/downloader/build.gradle.kts
@@ -1,4 +1,4 @@
-val jacksonVersion: String by project
+val svnkitVersion: String by project
 
 plugins {
     // Apply core plugins.
@@ -10,5 +10,5 @@ dependencies {
 
     implementation(project(":utils"))
 
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
+    implementation("org.tmatesoft.svnkit:svnkit:$svnkitVersion")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,6 +32,7 @@ reflectionsVersion = 0.9.11
 retrofitVersion = 2.6.2
 semverVersion = 3.1.0
 simpleExcelVersion = 1.1
+svnkitVersion = 1.10.1
 toml4jVersion = 0.7.2
 xalanVersion = 2.7.2
 xzVersion = 1.8


### PR DESCRIPTION
This is a step towards getting rid of the "svn" CLI dependency
completely.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>