### PR TITLE
LicenseView: Use upper case for static constants

### DIFF
--- a/evaluator/src/main/kotlin/LicenseView.kt
+++ b/evaluator/src/main/kotlin/LicenseView.kt
@@ -32,12 +32,12 @@ class LicenseView(vararg licenseSources: List<LicenseSource>) {
         /**
          * Return all licenses.
          */
-        val All = LicenseView(listOf(LicenseSource.DECLARED, LicenseSource.DETECTED, LicenseSource.CONCLUDED))
+        val ALL = LicenseView(listOf(LicenseSource.DECLARED, LicenseSource.DETECTED, LicenseSource.CONCLUDED))
 
         /**
          * Return only the concluded licenses if they exist, otherwise return declared and detected licenses.
          */
-        val ConcludedOrRest = LicenseView(
+        val CONCLUDED_OR_REST = LicenseView(
             listOf(LicenseSource.CONCLUDED),
             listOf(LicenseSource.DECLARED, LicenseSource.DETECTED)
         )
@@ -46,7 +46,7 @@ class LicenseView(vararg licenseSources: List<LicenseSource>) {
          * Return only the concluded licenses if they exist, or return only the declared licenses if they exist, or
          * return the detected licenses.
          */
-        val ConcludedOrDeclaredOrDetected = LicenseView(
+        val CONCLUDED_OR_DECLARED_OR_DETECTED = LicenseView(
             listOf(LicenseSource.CONCLUDED),
             listOf(LicenseSource.DECLARED),
             listOf(LicenseSource.DETECTED)
@@ -55,7 +55,7 @@ class LicenseView(vararg licenseSources: List<LicenseSource>) {
         /**
          * Return only the concluded licenses if they exist, otherwise return detected licenses.
          */
-        val ConcludedOrDetected = LicenseView(
+        val CONCLUDED_OR_DETECTED = LicenseView(
             listOf(LicenseSource.CONCLUDED),
             listOf(LicenseSource.DETECTED)
         )
@@ -63,17 +63,17 @@ class LicenseView(vararg licenseSources: List<LicenseSource>) {
         /**
          * Return only the concluded licenses.
          */
-        val OnlyConcluded = LicenseView(listOf(LicenseSource.CONCLUDED))
+        val ONLY_CONCLUDED = LicenseView(listOf(LicenseSource.CONCLUDED))
 
         /**
          * Return only the declared licenses.
          */
-        val OnlyDeclared = LicenseView(listOf(LicenseSource.DECLARED))
+        val ONLY_DECLARED = LicenseView(listOf(LicenseSource.DECLARED))
 
         /**
          * Return only the detected licenses.
          */
-        val OnlyDetected = LicenseView(listOf(LicenseSource.DETECTED))
+        val ONLY_DETECTED = LicenseView(listOf(LicenseSource.DETECTED))
     }
 
     private val licenseSources = licenseSources.toList()

--- a/evaluator/src/main/resources/rules/no_gpl_declared.kts
+++ b/evaluator/src/main/resources/rules/no_gpl_declared.kts
@@ -15,7 +15,7 @@ val ruleSet = ruleSet(ortResult) {
     // Define a rule that is executed for each package.
     packageRule("NO_GPL") {
         // Define a rule that is executed for each license of the package.
-        licenseRule("NO_GPL", LicenseView.All) {
+        licenseRule("NO_GPL", LicenseView.ALL) {
             require {
                 +isGpl()
             }

--- a/evaluator/src/test/kotlin/LicenseViewTest.kt
+++ b/evaluator/src/test/kotlin/LicenseViewTest.kt
@@ -28,7 +28,7 @@ import io.kotlintest.specs.WordSpec
 class LicenseViewTest : WordSpec({
     "All" should {
         "return the correct licenses" {
-            val view = LicenseView.All
+            val view = LicenseView.ALL
 
             view.licenses(packageWithoutLicense, emptyList()) shouldBe emptyList()
 
@@ -84,7 +84,7 @@ class LicenseViewTest : WordSpec({
 
     "ConcludedOrRest" should {
         "return the correct licenses" {
-            val view = LicenseView.ConcludedOrRest
+            val view = LicenseView.CONCLUDED_OR_REST
 
             view.licenses(
                 packageWithoutLicense,
@@ -153,7 +153,7 @@ class LicenseViewTest : WordSpec({
 
     "ConcludedOrDeclaredOrDetected" should {
         "return the correct licenses" {
-            val view = LicenseView.ConcludedOrDeclaredOrDetected
+            val view = LicenseView.CONCLUDED_OR_DECLARED_OR_DETECTED
 
             view.licenses(
                 packageWithoutLicense,
@@ -220,7 +220,7 @@ class LicenseViewTest : WordSpec({
 
     "ConcludedOrDetected" should {
         "return the correct licenses" {
-            val view = LicenseView.ConcludedOrDetected
+            val view = LicenseView.CONCLUDED_OR_DETECTED
             view.licenses(
                 packageWithoutLicense,
                 emptyList()
@@ -283,7 +283,7 @@ class LicenseViewTest : WordSpec({
 
     "OnlyConcluded" should {
         "return only the concluded licenses" {
-            val view = LicenseView.OnlyConcluded
+            val view = LicenseView.ONLY_CONCLUDED
             view.licenses(
                 packageWithoutLicense,
                 emptyList()
@@ -340,7 +340,7 @@ class LicenseViewTest : WordSpec({
 
     "OnlyDeclared" should {
         "return only the declared licenses" {
-            val view = LicenseView.OnlyDeclared
+            val view = LicenseView.ONLY_DECLARED
 
             view.licenses(
                 packageWithoutLicense,
@@ -398,7 +398,7 @@ class LicenseViewTest : WordSpec({
 
     "OnlyDetected" should {
         "return only the detected licenses" {
-            val view = LicenseView.OnlyDetected
+            val view = LicenseView.ONLY_DETECTED
 
             view.licenses(
                 packageWithoutLicense,

--- a/evaluator/src/test/kotlin/RuleSetTest.kt
+++ b/evaluator/src/test/kotlin/RuleSetTest.kt
@@ -61,7 +61,7 @@ class RuleSetTest : WordSpec() {
                             -isExcluded()
                         }
 
-                        licenseRule("test", LicenseView.All) {
+                        licenseRule("test", LicenseView.ALL) {
                             require {
                                 +isSpdxLicense()
                             }
@@ -107,7 +107,7 @@ class RuleSetTest : WordSpec() {
                             -isStaticallyLinked()
                         }
 
-                        licenseRule("test", LicenseView.All) {
+                        licenseRule("test", LicenseView.ALL) {
                             require {
                                 +isSpdxLicense()
                             }


### PR DESCRIPTION
In order to re-align with the naming commonly used in ORT. This follows
up on 53734d4.

Signed-off-by: Frank Viernau <frank.viernau@here.com>