### PR TITLE
Cargo: Fix the buggy getResolvedVersion() function

### DIFF
--- a/analyzer/src/main/kotlin/managers/Cargo.kt
+++ b/analyzer/src/main/kotlin/managers/Cargo.kt
@@ -219,7 +219,9 @@ class Cargo(
         // resolved and the dependency should not appear in the dependency tree.
         // See: https://doc.rust-lang.org/cargo/commands/cargo-metadata.html
         val dependency = node["dependencies"].find {
-            it.textValue().startsWith(dependencyName)
+            val text = it.textValue()
+            require(text.indexOf(' ') != -1) { "Unexpected format while parsing dependency JSON node." }
+            text.substringBefore(' ') == dependencyName
         }
 
         return dependency?.textValue()?.split(' ')?.get(1)


### PR DESCRIPTION
Checking whether the given dependencyName is a string prefix of the
actual dependency name is a to broad condition for finding the right
JSON node. In particular when the dependency tree contains two packages
where one packages' name is a prefix of the others', then the condition
is evaluated to true while it should yield false.

Adjusting the condition to check for equality which fixes that issue.

Signed-off-by: Frank Viernau <frank.viernau@here.com>