### PR TITLE
Gradle: Upgrade the detekt plugin to version 1.2.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,8 +2,6 @@ import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 
 import com.here.ort.gradle.*
 
-import io.gitlab.arturbosch.detekt.detekt
-
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-detektPluginVersion = 1.2.0
+detektPluginVersion = 1.2.1
 dokkaPluginVersion = 0.10.0
 ideaExtPluginVersion = 0.5
 kotlinPluginVersion = 1.3.61


### PR DESCRIPTION
This now automatically provides the "detekt" extension. For details see
https://arturbosch.github.io/detekt/changelog.html#121.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>