### PR TITLE
Improve / align docs to the splitUrl() and normalizeVcsUrl() functions

### DIFF
--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -132,7 +132,7 @@ abstract class VersionControlSystem {
         }
 
         /**
-         * Decompose a [vcsUrl] into any contained VCS information.
+         * Decompose a string representing a [VCS URL][vcsUrl] into any contained [VCS information][VcsInfo].
          */
         fun splitUrl(vcsUrl: String) =
             VcsHost.toVcsInfo(vcsUrl)

--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -185,9 +185,7 @@ fun getUserHomeDirectory() = File(System.getProperty("user.home"))
 fun getUserOrtDirectory() = getUserHomeDirectory().resolve(".ort")
 
 /**
- * Normalize a VCS URL by converting it to a common pattern.
- *
- * @param vcsUrl The URL to normalize.
+ * Normalize a string representing a [VCS URL][vcsUrl] to a common string form.
  */
 fun normalizeVcsUrl(vcsUrl: String): String {
     var url = vcsUrl.trimEnd('/')


### PR DESCRIPTION
These functions are somewhat similar, so highlight the differences.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>