### PR TITLE
Subversion: Reimplement all remaining operations using SVNKit

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
@@ -1619,8 +1619,8 @@ analyzer:
           path: ""
         vcs_processed:
           type: "Subversion"
-          url: "http://svn.sonatype.org/spice/tags/oss-parent-7"
-          revision: ""
+          url: "http://svn.sonatype.org/spice"
+          revision: "tags/oss-parent-7"
           path: ""
       curations: []
     - package:

--- a/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
@@ -592,8 +592,8 @@ packages:
       path: ""
     vcs_processed:
       type: "Subversion"
-      url: "http://svn.apache.org/repos/asf/logging/log4j/tags/v1_2_17_rc3"
-      revision: ""
+      url: "http://svn.apache.org/repos/asf/logging/log4j"
+      revision: "tags/v1_2_17_rc3"
       path: ""
   curations: []
 - package:

--- a/docker/run/Dockerfile
+++ b/docker/run/Dockerfile
@@ -65,7 +65,6 @@ RUN apt-get update && \
         cvs \
         git \
         mercurial \
-        subversion \
         # Install package managers (in versions known to work).
         bundler=$BUNDLER_VERSION \
         cargo=$CARGO_VERSION \

--- a/downloader/src/funTest/kotlin/BeanUtilsTest.kt
+++ b/downloader/src/funTest/kotlin/BeanUtilsTest.kt
@@ -69,7 +69,10 @@ class BeanUtilsTest : StringSpec() {
             )
 
             val downloadResult = Downloader().download(pkg, outputDir)
+
+            downloadResult.downloadDirectory.walkTopDown().onEnter { it.name != ".svn" }.count() shouldBe 302
             downloadResult.sourceArtifact shouldBe null
+
             downloadResult.vcsInfo shouldNotBe null
             with(downloadResult.vcsInfo!!) {
                 type shouldBe VcsType.SUBVERSION
@@ -78,17 +81,6 @@ class BeanUtilsTest : StringSpec() {
                 resolvedRevision shouldBe "928490"
                 path shouldBe vcsFromCuration.path
             }
-
-            val tagsBeanUtils183Dir = File(downloadResult.downloadDirectory, "tags/BEANUTILS_1_8_3")
-
-            tagsBeanUtils183Dir.isDirectory shouldBe true
-            tagsBeanUtils183Dir.walkTopDown().count() shouldBe 302
-
-            val workingTree = VersionControlSystem.forDirectory(tagsBeanUtils183Dir)
-
-            workingTree shouldNotBe null
-            workingTree!!.isValid() shouldBe true
-            workingTree.getRevision() shouldBe "928490"
         }
     }
 }

--- a/downloader/src/funTest/kotlin/SubversionWorkingTreeTest.kt
+++ b/downloader/src/funTest/kotlin/SubversionWorkingTreeTest.kt
@@ -88,7 +88,7 @@ class SubversionWorkingTreeTest : StringSpec() {
                 "plugins",
                 "rel-0.15",
                 "subdocs"
-            )
+            ).map { "branches/$it" }
 
             val workingTree = svn.getWorkingTree(zipContentDir)
             workingTree.listRemoteBranches().joinToString("\n") shouldBe expectedBranches.joinToString("\n")
@@ -121,7 +121,7 @@ class SubversionWorkingTreeTest : StringSpec() {
                 "prest-0.3.10",
                 "prest-0.3.11",
                 "start"
-            )
+            ).map { "tags/$it" }
 
             val workingTree = svn.getWorkingTree(zipContentDir)
             workingTree.listRemoteTags().joinToString("\n") shouldBe expectedTags.joinToString("\n")

--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -153,6 +153,18 @@ abstract class VersionControlSystem {
                         VcsInfo(VcsType.GIT, url, revision, null, "")
                     }
 
+                    vcsUrl.contains("svn") -> {
+                        val branchOrTagPattern = Regex("(.+)/(branches|tags)/([^/]+)/?(.*)")
+                        branchOrTagPattern.matchEntire(vcsUrl)?.let { match ->
+                            VcsInfo(
+                                type = VcsType.SUBVERSION,
+                                url = match.groupValues[1],
+                                revision = "${match.groupValues[2]}/${match.groupValues[3]}",
+                                path = match.groupValues[4]
+                            )
+                        } ?: VcsInfo(VcsType.NONE, vcsUrl, "")
+                    }
+
                     else -> VcsInfo(VcsType.NONE, vcsUrl, "")
                 }
     }

--- a/downloader/src/main/kotlin/vcs/Subversion.kt
+++ b/downloader/src/main/kotlin/vcs/Subversion.kt
@@ -22,41 +22,32 @@ package com.here.ort.downloader.vcs
 import com.here.ort.downloader.DownloadException
 import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.downloader.WorkingTree
-import com.here.ort.model.Package
+import com.here.ort.model.VcsInfo
 import com.here.ort.model.VcsType
-import com.here.ort.utils.CommandLineTool
+import com.here.ort.utils.collectMessagesAsString
 import com.here.ort.utils.log
+import com.here.ort.utils.showStackTrace
 import com.here.ort.utils.succeeds
 
 import java.io.File
 import java.io.IOException
-import java.util.regex.Pattern
+import java.nio.file.Paths
 
+import org.tmatesoft.svn.core.SVNDepth
 import org.tmatesoft.svn.core.SVNException
 import org.tmatesoft.svn.core.SVNURL
 import org.tmatesoft.svn.core.wc.SVNClientManager
 import org.tmatesoft.svn.core.wc.SVNRevision
+import org.tmatesoft.svn.util.Version
 
-class Subversion : VersionControlSystem(), CommandLineTool {
+class Subversion : VersionControlSystem() {
     private val clientManager = SVNClientManager.newInstance()
-    private val versionRegex = Pattern.compile("svn, [Vv]ersion (?<version>[\\d.]+) \\(r\\d+\\)")
 
     override val type = VcsType.SUBVERSION
     override val priority = 10
     override val latestRevisionNames = listOf("HEAD")
 
-    override fun command(workingDir: File?) = "svn"
-
-    override fun getVersion() =
-        getVersion { output ->
-            versionRegex.matcher(output.lineSequence().first()).let {
-                if (it.matches()) {
-                    it.group("version")
-                } else {
-                    ""
-                }
-            }
-        }
+    override fun getVersion() = Version.getVersionString()
 
     override fun getWorkingTree(vcsDirectory: File) =
         object : WorkingTree(vcsDirectory, type) {
@@ -99,7 +90,7 @@ class Subversion : VersionControlSystem(), CommandLineTool {
                         /*fetchLocks =*/ false,
                         /*recursive =*/ false
                     ) { dirEntry ->
-                        if (dirEntry.name.isNotEmpty()) refs += dirEntry.relativePath
+                        if (dirEntry.name.isNotEmpty()) refs += "$namespace/${dirEntry.relativePath}"
                     }
                 } catch (e: SVNException) {
                     throw IOException("Unable to list remote refs for $type repository at $remoteUrl.")
@@ -123,89 +114,99 @@ class Subversion : VersionControlSystem(), CommandLineTool {
     override fun isApplicableUrlInternal(vcsUrl: String) =
         succeeds { clientManager.wcClient.doInfo(SVNURL.parseURIEncoded(vcsUrl), SVNRevision.HEAD, SVNRevision.HEAD) }
 
-    private fun guessTagAndPath(targetDir: File, pkg: Package): Pair<String, String> {
-        // The path to the tag (including the tag name), relative to the repository root.
-        val tagPath: String
+    override fun initWorkingTree(targetDir: File, vcs: VcsInfo): WorkingTree {
+        try {
+            clientManager.updateClient.doCheckout(
+                SVNURL.parseURIEncoded(vcs.url),
+                targetDir,
+                SVNRevision.HEAD,
+                SVNRevision.HEAD,
+                SVNDepth.EMPTY,
+                /* allowUnversionedObstructions = */ false
+            )
+        } catch (e: SVNException) {
+            e.showStackTrace()
 
-        // The path within the tag to limit the working directory to, relative to the repository root.
-        val path: String
+            throw DownloadException("Unable to initialize the $type working tree at '$targetDir' from ${vcs.url}.", e)
+        }
 
-        val tagsMarker = "tags/"
-        val tagsIndex = pkg.vcsProcessed.path.indexOf(tagsMarker)
-        val isTagsPath = tagsIndex == 0 || (tagsIndex > 0 && pkg.vcsProcessed.path[tagsIndex - 1] == '/')
-        if (isTagsPath) {
-            log.info {
-                "Ignoring the $type revision '${pkg.vcsProcessed.revision}' as the path points to a tag."
+        return getWorkingTree(targetDir)
+    }
+
+    private fun updateEmptyPath(workingTree: WorkingTree, revision: SVNRevision, path: String) {
+        val pathIterator = Paths.get(path).iterator()
+        var currentPath = workingTree.workingDir
+
+        while (pathIterator.hasNext()) {
+            clientManager.updateClient.doUpdate(
+                currentPath,
+                revision,
+                SVNDepth.EMPTY,
+                /* allowUnversionedObstructions = */ false,
+                /* depthIsSticky = */ true
+            )
+
+            currentPath = currentPath.resolve(pathIterator.next().toFile())
+        }
+    }
+
+    override fun updateWorkingTree(workingTree: WorkingTree, revision: String, path: String, recursive: Boolean) =
+        try {
+            revision.toLongOrNull()?.let { numericRevision ->
+                // This code path updates the working tree to a numeric revision.
+                val svnRevision = SVNRevision.create(numericRevision)
+
+                // First update the (empty) working tree to the desired revision along the requested path.
+                updateEmptyPath(workingTree, svnRevision, path)
+
+                // Then deepen only the requested path in the desired revision.
+                clientManager.updateClient.apply { isIgnoreExternals = !recursive }.doUpdate(
+                    workingTree.workingDir.resolve(path),
+                    svnRevision,
+                    SVNDepth.INFINITY,
+                    /* allowUnversionedObstructions = */ false,
+                    /* depthIsSticky = */ true
+                )
+            } ?: run {
+                // This code path updates the working tree to a symbolic revision.
+                val svnUrl = SVNURL.parseURIEncoded(
+                    "${workingTree.getRemoteUrl()}/$revision"
+                )
+
+                // First switch the (empty) working tree to the requested branch / tag.
+                clientManager.updateClient.doSwitch(
+                    workingTree.workingDir,
+                    svnUrl,
+                    SVNRevision.HEAD,
+                    SVNRevision.HEAD,
+                    SVNDepth.EMPTY,
+                    /* allowUnversionedObstructions = */ false,
+                    /* depthIsSticky = */ true,
+                    /* ignoreAncestry = */ true
+                )
+
+                // Then update the working tree in the current revision along the requested path, and ...
+                updateEmptyPath(workingTree, SVNRevision.HEAD, path)
+
+                // finally deepen only the requested path in the current revision.
+                clientManager.updateClient.apply { isIgnoreExternals = !recursive }.doUpdate(
+                    workingTree.workingDir.resolve(path),
+                    SVNRevision.HEAD,
+                    SVNDepth.INFINITY,
+                    /* allowUnversionedObstructions = */ false,
+                    /* depthIsSticky = */ true
+                )
             }
 
-            val tagsPathIndex = pkg.vcsProcessed.path.indexOf('/', tagsIndex + tagsMarker.length)
-
-            tagPath = pkg.vcsProcessed.path.let {
-                if (tagsPathIndex < 0) it else it.substring(0, tagsPathIndex)
-            }
-            path = pkg.vcsProcessed.path
-        } else {
-            log.info { "Trying to guess a $type revision for version '${pkg.id.version}'." }
-
-            val revision = try {
-                getWorkingTree(targetDir).guessRevisionName(pkg.id.name, pkg.id.version)
-            } catch (e: IOException) {
-                // Enrich the IOException with a more specific message.
-                throw IOException("Unable to determine a revision to checkout.", e)
-            }
+            true
+        } catch (e: SVNException) {
+            e.showStackTrace()
 
             log.warn {
-                "Using guessed $type revision '$revision' for version '${pkg.id.version}'. This might cause " +
-                        "the downloaded source code to not match the package version."
+                "Failed to update the $type working tree at '${workingTree.workingDir}' to revision '$revision':\n" +
+                        "${e.collectMessagesAsString()}"
             }
 
-            tagPath = "tags/$revision"
-            path = "$tagPath/${pkg.vcsProcessed.path}"
+            false
         }
-
-        return Pair(tagPath, path)
-    }
-
-    override fun download(
-        pkg: Package, targetDir: File, allowMovingRevisions: Boolean,
-        recursive: Boolean
-    ): WorkingTree {
-        log.info { "Using $type version ${getVersion()}." }
-
-        return try {
-            // Create an empty working tree of the latest revision to allow sparse checkouts.
-            run(targetDir, "checkout", pkg.vcsProcessed.url, "--depth", "empty", ".")
-
-            var revision = pkg.vcsProcessed.revision.takeIf { it.isNotBlank() } ?: "HEAD"
-
-            val workingTree = getWorkingTree(targetDir)
-            if (allowMovingRevisions || isFixedRevision(workingTree, revision)) {
-                if (pkg.vcsProcessed.path.isBlank()) {
-                    // Deepen everything as we do not know whether the revision is contained in branches, tags or trunk.
-                    run(targetDir, "update", "-r", revision, "--set-depth", "infinity")
-                    workingTree
-                } else {
-                    // Deepen only the given path.
-                    run(
-                        targetDir, "update", "-r", revision, "--depth", "infinity", "--parents",
-                        pkg.vcsProcessed.path
-                    )
-
-                    // Only return that part of the working tree that has the right revision.
-                    getWorkingTree(File(targetDir, pkg.vcsProcessed.path))
-                }
-            } else {
-                val (tagPath, path) = guessTagAndPath(targetDir, pkg)
-
-                // In Subversion, tags are not symbolic names for revisions but names of directories containing
-                // snapshots. Checking out a tag just is a sparse checkout of that path.
-                run(targetDir, "update", "--depth", "infinity", "--parents", path)
-
-                // Only return that part of the working tree that has the right revision.
-                getWorkingTree(File(targetDir, tagPath))
-            }
-        } catch (e: IOException) {
-            throw DownloadException("$type failed to download from ${pkg.vcsProcessed.url}.", e)
-        }
-    }
 }

--- a/downloader/src/test/kotlin/VersionControlSystemTest.kt
+++ b/downloader/src/test/kotlin/VersionControlSystemTest.kt
@@ -116,6 +116,58 @@ class VersionControlSystemTest : WordSpec({
             )
             actual shouldBe expected
         }
+
+        "separate an SVN branch into the revision" {
+            val actual = VersionControlSystem.splitUrl(
+                "http://svn.osdn.net/svnroot/tortoisesvn/branches/1.13.x"
+            )
+            val expected = VcsInfo(
+                type = VcsType.SUBVERSION,
+                url = "http://svn.osdn.net/svnroot/tortoisesvn",
+                revision = "branches/1.13.x",
+                path = ""
+            )
+            actual shouldBe expected
+        }
+
+        "separate branch and path from an SVN URL" {
+            val actual = VersionControlSystem.splitUrl(
+                "http://svn.osdn.net/svnroot/tortoisesvn/branches/1.13.x/src/gpl.txt"
+            )
+            val expected = VcsInfo(
+                type = VcsType.SUBVERSION,
+                url = "http://svn.osdn.net/svnroot/tortoisesvn",
+                revision = "branches/1.13.x",
+                path = "src/gpl.txt"
+            )
+            actual shouldBe expected
+        }
+
+        "separate an SVN tag into the revision" {
+            val actual = VersionControlSystem.splitUrl(
+                "http://svn.terracotta.org/svn/ehcache/tags/ehcache-parent-2.21"
+            )
+            val expected = VcsInfo(
+                type = VcsType.SUBVERSION,
+                url = "http://svn.terracotta.org/svn/ehcache",
+                revision = "tags/ehcache-parent-2.21",
+                path = ""
+            )
+            actual shouldBe expected
+        }
+
+        "separate tag and path from an SVN URL" {
+            val actual = VersionControlSystem.splitUrl(
+                "http://svn.terracotta.org/svn/ehcache/tags/ehcache-parent-2.21/pom.xml"
+            )
+            val expected = VcsInfo(
+                type = VcsType.SUBVERSION,
+                url = "http://svn.terracotta.org/svn/ehcache",
+                revision = "tags/ehcache-parent-2.21",
+                path = "pom.xml"
+            )
+            actual shouldBe expected
+        }
     }
 
     "splitUrl for Bitbucket" should {


### PR DESCRIPTION
This also changes the (so far broken) semantics of the Subversion
implementation. Previously, when downloading a Subversion branch / tag,
it had to be specified as the path. However, the fact that Subversion
organizes branches / tags as paths is an implementation detail that the
user should not need to care about when using the ORT downloader.

The new implementation treats branch / tag names as symbolic revisions.
That is, if the user wants to download a branch, the VCS revision should
be set to "branches/<branch name>", or "tags/<tag name>" for a tag. A
branch / tag name requires the "branches/" / "tags/" prefix in order to
distinguish branches and tags with the same name.

Note that this changes requires any existing VCS curations for
Subversion branches / tags to be updated by moving the path to the
revision field.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>