### PR TITLE
Remove superfluous trailing underscores in destructing declarations

### DIFF
--- a/analyzer/src/test/kotlin/managers/PackageManagerTest.kt
+++ b/analyzer/src/test/kotlin/managers/PackageManagerTest.kt
@@ -40,7 +40,7 @@ class PackageManagerTest : WordSpec({
 
             // The keys in expected and actual maps of definition files are different instances of package manager
             // factories. So to compare values use the package manager names as keys instead.
-            val managedFilesByName = managedFiles.mapKeys { (manager, _) ->
+            val managedFilesByName = managedFiles.mapKeys { (manager) ->
                 manager.managerName
             }
 
@@ -74,7 +74,7 @@ class PackageManagerTest : WordSpec({
 
             // The keys in expected and actual maps of definition files are different instances of package manager
             // factories. So to compare values use the package manager names as keys instead.
-            val managedFilesByName = managedFiles.mapKeys { (manager, _) ->
+            val managedFilesByName = managedFiles.mapKeys { (manager) ->
                 manager.managerName
             }
 

--- a/spdx-utils/src/test/kotlin/SpdxDeclaredLicenseMappingTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxDeclaredLicenseMappingTest.kt
@@ -28,7 +28,7 @@ import io.kotlintest.specs.WordSpec
 class SpdxDeclaredLicenseMappingTest : WordSpec({
     "The mapping" should {
         "contain only unparsable keys" {
-            val parsableLicenses = SpdxDeclaredLicenseMapping.mapping.filter { (declaredLicense, _) ->
+            val parsableLicenses = SpdxDeclaredLicenseMapping.mapping.filter { (declaredLicense) ->
                 try {
                     // Restrict parsing to SPDX license identifier strings as otherwise almost anything could be parsed,
                     // but we do want to have mappings e.g. for something like "CDDL or GPLv2 with exceptions".
@@ -44,7 +44,7 @@ class SpdxDeclaredLicenseMappingTest : WordSpec({
 
         "not contain plain SPDX license ids" {
             assertSoftly {
-                SpdxDeclaredLicenseMapping.mapping.forEach { (declaredLicense, _) ->
+                SpdxDeclaredLicenseMapping.mapping.forEach { (declaredLicense) ->
                     "\"$declaredLicense\" maps to ${SpdxLicense.forId(declaredLicense)}" shouldBe
                             "\"$declaredLicense\" maps to null"
                 }

--- a/spdx-utils/src/test/kotlin/SpdxLicenseAliasMappingTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxLicenseAliasMappingTest.kt
@@ -26,7 +26,7 @@ import io.kotlintest.specs.WordSpec
 class SpdxLicenseAliasMappingTest : WordSpec({
     "The mapping" should {
         "contain only parsable keys" {
-            val unparsableLicenses = SpdxLicenseAliasMapping.mapping.filterNot { (declaredLicense, _) ->
+            val unparsableLicenses = SpdxLicenseAliasMapping.mapping.filterNot { (declaredLicense) ->
                 try {
                     // Be as lenient as possible when parsing declared licenses as we really only want to check for
                     // general parsability here.
@@ -42,7 +42,7 @@ class SpdxLicenseAliasMappingTest : WordSpec({
 
         "not contain plain SPDX license ids" {
             assertSoftly {
-                SpdxLicenseAliasMapping.customNames.forEach { (declaredLicense, _) ->
+                SpdxLicenseAliasMapping.customNames.forEach { (declaredLicense) ->
                     "\"$declaredLicense\" maps to ${SpdxLicense.forId(declaredLicense)}" shouldBe
                             "\"$declaredLicense\" maps to null"
                 }


### PR DESCRIPTION
One purpose of destructing declarations is that you do not need to know
about all properties in the used class, but only about the ones you are
interested in. This also means you should not need to know how many
properties are in the class in total, if not required. As such, omit
optional trailing underscores in destructing declarations for
simplicity.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>