### PR TITLE
Utils: Use explicit underscores in a destructing declaration

### DIFF
--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -397,7 +397,7 @@ internal fun RepositoryConfiguration.sortPathExcludes(): RepositoryConfiguration
 internal fun RepositoryConfiguration.sortScopeExcludes(): RepositoryConfiguration =
     copy(
         excludes = excludes?.let {
-            val scopes = it.scopes.sortedBy { (pattern) ->
+            val scopes = it.scopes.sortedBy { (pattern, _, _) ->
                 pattern.removePrefix(".*")
             }
             it.copy(scopes = scopes)


### PR DESCRIPTION
As we decided to keep them, see the related discussion in
https://github.com/heremaps/oss-review-toolkit/pull/2029.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>