### PR TITLE
README.md: Make the Conan integration experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ Currently, the following package managers are supported:
 * [Bower](http://bower.io/) (JavaScript)
 * [Bundler](http://bundler.io/) (Ruby)
 * [Cargo](https://doc.rust-lang.org/cargo/) (Rust)
-* [Conan](https://conan.io/) (C / C++)
+* [Conan](https://conan.io/) (C / C++, *experimental* as the VCS locations often times do not contain the actual source
+  code, see #2037)
 * [dep](https://golang.github.io/dep/) (Go)
 * [DotNet](https://docs.microsoft.com/en-us/dotnet/core/tools/) (.NET, with currently some [limitations](https://github.com/heremaps/oss-review-toolkit/pull/1303#issue-253860146))
 * [Glide](https://glide.sh/) (Go)


### PR DESCRIPTION
As the VCS locations returned by that package manager often times do not
contain the actual source code for the respective package but just a
receipe to build the conan package, see #2037.

Signed-off-by: Frank Viernau <frank.viernau@here.com>