### PR TITLE
NoticeReporter: remove more garbage

### DIFF
--- a/reporter/src/main/kotlin/reporters/NoticeByPackageReporter.kt
+++ b/reporter/src/main/kotlin/reporters/NoticeByPackageReporter.kt
@@ -101,6 +101,7 @@ class NoticeByPackageProcessor(input: ReporterInput) : AbstractNoticeReporter.No
             .merge()
             .removeGarbage(input.copyrightGarbage)
             .processStatements()
+            .removeGarbage(input.copyrightGarbage)
             .filter { (license, _) ->
                 input.licenseTextProvider.hasLicenseText(license).also {
                     if (!it) {
@@ -155,7 +156,10 @@ class NoticeByPackageProcessor(input: ReporterInput) : AbstractNoticeReporter.No
             addLicenseFileFindings(licenseFileFindings, archiveDir)
 
             val licensesInNoticeFiles = licenseFileFindings.values.map { it.keys }.flatten().toSet()
-            val processedFindings = licenseFindingsMap.removeGarbage(input.copyrightGarbage).processStatements()
+            val processedFindings = licenseFindingsMap
+                .removeGarbage(input.copyrightGarbage)
+                .processStatements()
+                .removeGarbage(input.copyrightGarbage)
                 .filter { (license, _) -> license !in licensesInNoticeFiles }
                 .filter { (license, _) ->
                     input.licenseTextProvider.hasLicenseText(license).also {

--- a/reporter/src/main/kotlin/reporters/NoticeSummaryReporter.kt
+++ b/reporter/src/main/kotlin/reporters/NoticeSummaryReporter.kt
@@ -79,5 +79,9 @@ class NoticeSummaryProcessor(input: ReporterInput) : AbstractNoticeReporter.Noti
     }
 
     private fun mergeFindings(model: AbstractNoticeReporter.NoticeReportModel) =
-        model.findings.values.merge().removeGarbage(input.copyrightGarbage).processStatements()
+        model.findings.values
+            .merge()
+            .removeGarbage(input.copyrightGarbage)
+            .processStatements()
+            .removeGarbage(input.copyrightGarbage)
 }


### PR DESCRIPTION
This needs to be merged after the notice reporter refactoring and the list copyrights commits so that this PR contains only 2 commits.