### PR TITLE
utils: Add *.licence to the list of license file patterns

### DIFF
--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -42,6 +42,7 @@ val LICENSE_FILENAMES = listOf(
     "license*",
     "licence*",
     "*.license",
+    "*.licence",
     "unlicense",
     "unlicence",
     "copying*",


### PR DESCRIPTION
Add *.licence for consistency, as for the other patterns also both
AE and BE spellings are in the list.