### PR TITLE
Downloader: Force deletion of VCS left-overs

### DIFF
--- a/downloader/src/main/kotlin/Downloader.kt
+++ b/downloader/src/main/kotlin/Downloader.kt
@@ -249,7 +249,7 @@ class Downloader {
                 }
 
                 // Clean up any files left from the failed VCS download (i.e. a ".git" directory).
-                outputDirectory.safeDeleteRecursively()
+                outputDirectory.safeDeleteRecursively(force = true)
                 outputDirectory.safeMkdirs()
 
                 val fallbackTarget = target.copy(vcsProcessed = target.vcsProcessed.copy(url = vcsUrlNoCredentials))


### PR DESCRIPTION
Git creates its pack files with read-onyl attribute set on Windows,
which requires to apply force when deleting them.

Also see e.g. the discussion at
https://github.com/libgit2/libgit2sharp/issues/1354#issuecomment-277968633.

Fixes #2072.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>