### PR TITLE
Remove our custom "succeeds" extension function

### DIFF
--- a/downloader/src/main/kotlin/vcs/Cvs.kt
+++ b/downloader/src/main/kotlin/vcs/Cvs.kt
@@ -27,7 +27,6 @@ import com.here.ort.utils.CommandLineTool
 import com.here.ort.utils.ProcessCapture
 import com.here.ort.utils.safeDeleteRecursively
 import com.here.ort.utils.searchUpwardsForSubdirectory
-import com.here.ort.utils.succeeds
 import com.here.ort.utils.toHexString
 
 import java.io.File
@@ -180,8 +179,8 @@ class Cvs : VersionControlSystem(), CommandLineTool {
     }
 
     override fun updateWorkingTree(workingTree: WorkingTree, revision: String, path: String, recursive: Boolean) =
-        succeeds {
+        runCatching {
             // Checkout the working tree of the desired revision.
             run(workingTree.workingDir, "checkout", "-r", revision, path.takeUnless { it.isEmpty() } ?: ".")
-        }
+        }.isSuccess
 }

--- a/downloader/src/main/kotlin/vcs/Subversion.kt
+++ b/downloader/src/main/kotlin/vcs/Subversion.kt
@@ -27,7 +27,6 @@ import com.here.ort.model.VcsType
 import com.here.ort.utils.collectMessagesAsString
 import com.here.ort.utils.log
 import com.here.ort.utils.showStackTrace
-import com.here.ort.utils.succeeds
 
 import java.io.File
 import java.io.IOException
@@ -112,7 +111,9 @@ class Subversion : VersionControlSystem() {
         }
 
     override fun isApplicableUrlInternal(vcsUrl: String) =
-        succeeds { clientManager.wcClient.doInfo(SVNURL.parseURIEncoded(vcsUrl), SVNRevision.HEAD, SVNRevision.HEAD) }
+        runCatching {
+            clientManager.wcClient.doInfo(SVNURL.parseURIEncoded(vcsUrl), SVNRevision.HEAD, SVNRevision.HEAD)
+        }.isSuccess
 
     override fun initWorkingTree(targetDir: File, vcs: VcsInfo): WorkingTree {
         try {

--- a/utils/src/main/kotlin/Extensions.kt
+++ b/utils/src/main/kotlin/Extensions.kt
@@ -270,17 +270,18 @@ fun String.percentEncode(): String =
 /**
  * True if the string is a valid semantic version of the given [type], false otherwise.
  */
-fun String.isSemanticVersion(type: Semver.SemverType = Semver.SemverType.STRICT) = succeeds { Semver(this, type) }
+fun String.isSemanticVersion(type: Semver.SemverType = Semver.SemverType.STRICT) =
+    runCatching { Semver(this, type) }.isSuccess
 
 /**
  * True if the string is a valid [URI], false otherwise.
  */
-fun String.isValidUri() = succeeds { URI(this) }
+fun String.isValidUri() = runCatching { URI(this) }.isSuccess
 
 /**
  * True if the string is a valid [URL], false otherwise.
  */
-fun String.isValidUrl() = succeeds { URL(this) }
+fun String.isValidUrl() = runCatching { URL(this) }.isSuccess
 
 /**
  * A regular expression matching the non-linux line breaks "\r\n" and "\r".

--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -287,18 +287,6 @@ fun normalizeVcsUrl(vcsUrl: String): String {
 }
 
 /**
- * Return true if the call of [block] succeeds without throwing an exception, return false if an exception was thrown.
- */
-@Suppress("TooGenericExceptionCaught")
-inline fun succeeds(block: () -> Unit) =
-    try {
-        block()
-        true
-    } catch (e: Throwable) {
-        false
-    }
-
-/**
  * Temporarily set the specified system [properties] while executing [block]. Afterwards, previously set properties have
  * their original values restored and previously unset properties are cleared.
  */


### PR DESCRIPTION
In favor of using Kotlin's runCatching / isSuccess instead.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>