### PR TITLE
Git: Rewrite testing for applicable URLs to use JGit

### DIFF
--- a/downloader/build.gradle.kts
+++ b/downloader/build.gradle.kts
@@ -1,3 +1,4 @@
+val jgitVersion: String by project
 val svnkitVersion: String by project
 
 plugins {
@@ -10,5 +11,6 @@ dependencies {
 
     implementation(project(":utils"))
 
+    implementation("org.eclipse.jgit:org.eclipse.jgit:$jgitVersion")
     implementation("org.tmatesoft.svnkit:svnkit:$svnkitVersion")
 }

--- a/downloader/src/funTest/kotlin/GitWorkingTreeTest.kt
+++ b/downloader/src/funTest/kotlin/GitWorkingTreeTest.kt
@@ -21,7 +21,6 @@ package com.here.ort.downloader.vcs
 
 import com.here.ort.downloader.VersionControlSystem
 import com.here.ort.model.VcsType
-import com.here.ort.utils.Os
 import com.here.ort.utils.getUserOrtDirectory
 import com.here.ort.utils.safeDeleteRecursively
 import com.here.ort.utils.unpack
@@ -68,8 +67,7 @@ class GitWorkingTreeTest : StringSpec() {
             git.isApplicableUrl("https://bitbucket.org/paniq/masagin") shouldBe false
         }
 
-        // TODO: Investigate why this succeeds locally on Windows but seem to make AppVeyor CI hang.
-        "Git does not prompt for credentials for non-existing repositories".config(enabled = !Os.isWindows) {
+        "Git does not prompt for credentials for non-existing repositories" {
             git.isApplicableUrl("https://github.com/heremaps/foobar.git") shouldBe false
         }
 

--- a/downloader/src/main/kotlin/vcs/Git.kt
+++ b/downloader/src/main/kotlin/vcs/Git.kt
@@ -24,7 +24,6 @@ import com.here.ort.model.VcsInfo
 import com.here.ort.model.VcsType
 import com.here.ort.utils.FileMatcher
 import com.here.ort.utils.Os
-import com.here.ort.utils.ProcessCapture
 import com.here.ort.utils.collectMessagesAsString
 import com.here.ort.utils.log
 import com.here.ort.utils.safeMkdirs
@@ -35,6 +34,8 @@ import com.vdurmont.semver4j.Semver
 import java.io.File
 import java.io.IOException
 
+import org.eclipse.jgit.api.LsRemoteCommand
+
 // TODO: Make this configurable.
 const val GIT_HISTORY_DEPTH = 50
 
@@ -42,8 +43,10 @@ class Git : GitBase() {
     override val type = VcsType.GIT
     override val priority = 100
 
-    override fun isApplicableUrlInternal(vcsUrl: String) =
-        ProcessCapture("git", "-c", "credential.helper=", "-c", "core.askpass=echo", "ls-remote", vcsUrl).isSuccess
+    override fun isApplicableUrlInternal(vcsUrl: String): Boolean =
+        runCatching {
+            LsRemoteCommand(null).setRemote(vcsUrl).call().isNotEmpty()
+        }.isSuccess
 
     override fun initWorkingTree(targetDir: File, vcs: VcsInfo): WorkingTree {
         // Do not use "git clone" to have more control over what is being fetched.

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,6 +18,7 @@ flexmarkVersion = 0.50.44
 hamcrestCoreVersion = 1.3
 jacksonVersion = 2.10.1
 jcommanderVersion = 1.78
+jgitVersion = 5.6.0.201912101111-r
 kotlintestVersion = 3.4.2
 kotlinxCoroutinesVersion = 1.3.3
 kotlinxHtmlVersion = 0.6.12


### PR DESCRIPTION
This is the first step towards fully migrating to JGit to reduce external
dependencies, and it allows to again enable the test for non-existing
repositories on Windows.

Fixes #2077.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>