### PR TITLE
mailmap: Account for Sebastian's new email address at Bosch

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -7,6 +7,7 @@ Jeff McAffer <jeffmcaffer@github.com> <jeff.mcaffer@microsoft.com>
 Johannes Tigges <johannes.tigges@here.com> <lenucksi@users.noreply.github.com>
 Martin Nonnenmacher <martin.nonnenmacher@here.com> <mnonnenmacher@users.noreply.github.com>
 Piotr Nowakowski <piotr.nowakowski@meelogic.com>
-Sebastian Schuberth <sebastian.schuberth@bosch-si.com> <sebastian.schuberth@here.com>
-Sebastian Schuberth <sebastian.schuberth@bosch-si.com> <sschuberth@gmail.com>
-Sebastian Schuberth <sebastian.schuberth@bosch-si.com> <sschuberth@users.noreply.github.com>
+Sebastian Schuberth <sebastian.schuberth@bosch.io> <sebastian.schuberth@bosch-si.com>
+Sebastian Schuberth <sebastian.schuberth@bosch.io> <sebastian.schuberth@here.com>
+Sebastian Schuberth <sebastian.schuberth@bosch.io> <sschuberth@gmail.com>
+Sebastian Schuberth <sebastian.schuberth@bosch.io> <sschuberth@users.noreply.github.com>


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>