### PR TITLE
analyzer: Automatically create HTTPS mirrors for disabled HTTP URLs

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
@@ -26,9 +26,9 @@ project:
       dependencies:
       - id: "PyPI::isodate:0.6.0"
         dependencies:
-        - id: "PyPI::six:1.13.0"
+        - id: "PyPI::six:1.14.0"
       - id: "PyPI::pyparsing:2.4.6"
-    - id: "PyPI::six:1.13.0"
+    - id: "PyPI::six:1.14.0"
 packages:
 - package:
     id: "PyPI::isodate:0.6.0"
@@ -153,8 +153,8 @@ packages:
       path: ""
   curations: []
 - package:
-    id: "PyPI::six:1.13.0"
-    purl: "pkg:pypi/six@1.13.0"
+    id: "PyPI::six:1.14.0"
+    purl: "pkg:pypi/six@1.14.0"
     declared_licenses:
     - "MIT"
     declared_licenses_processed:
@@ -162,14 +162,14 @@ packages:
     description: "Python 2 and 3 compatibility utilities"
     homepage_url: "https://github.com/benjaminp/six"
     binary_artifact:
-      url: "https://files.pythonhosted.org/packages/65/26/32b8464df2a97e6dd1b656ed26b2c194606c16fe163c695a992b36c11cdf/six-1.13.0-py2.py3-none-any.whl"
+      url: "https://files.pythonhosted.org/packages/65/eb/1f97cb97bfc2390a276969c6fae16075da282f5058082d4cb10c6c5c1dba/six-1.14.0-py2.py3-none-any.whl"
       hash:
-        value: "b642ef493974a23bb77f5c7e0e08b204"
+        value: "eb7d3da1d4e6554cf48ff3e69cf49b0d"
         algorithm: "MD5"
     source_artifact:
-      url: "https://files.pythonhosted.org/packages/94/3e/edcf6fef41d89187df7e38e868b2dd2182677922b600e880baad7749c865/six-1.13.0.tar.gz"
+      url: "https://files.pythonhosted.org/packages/21/9f/b251f7f8a76dec1d6651be194dfba8fb8d7781d10ab3987190de8391d08e/six-1.14.0.tar.gz"
       hash:
-        value: "e92c23c882c7d5564ce5773fe31b2771"
+        value: "21674588a57e649d1a6d977ec3122140"
         algorithm: "MD5"
     vcs:
       type: ""


### PR DESCRIPTION
Several Maven repositories have disabled HTTP access for security
reasons, see [1] and [2]. To be able to still analyze old Maven projects
that use the HTTP URLs automatically create mirrors for those
repositories pointing to the HTTPS URLs. Otherwise Maven would abort
with an exception as soon as it tries to download an artifact from any
of those repositories.

[1] https://github.com/github/security-lab/issues/21
[2] https://medium.com/p/d069d253fe23