### PR TITLE
reporter: Start reporting the reporter data model itself

### DIFF
--- a/model/src/main/kotlin/Scope.kt
+++ b/model/src/main/kotlin/Scope.kt
@@ -19,6 +19,7 @@
 
 package com.here.ort.model
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
 import java.util.SortedSet
@@ -75,4 +76,15 @@ data class Scope(
      */
     fun findReferences(id: Identifier) =
         dependencies.filter { it.id == id } + dependencies.flatMap { it.findReferences(id) }
+
+    /**
+     * Return the depth of the dependency tree rooted at the project associated with this scope.
+     */
+    @JsonIgnore
+    fun getDependencyTreeDepth(): Int {
+        fun getTreeDepthRec(dependencies: Collection<PackageReference>): Int =
+            dependencies.map { dependency -> 1 + getTreeDepthRec(dependency.dependencies) }.max() ?: 0
+
+        return getTreeDepthRec(dependencies)
+    }
 }

--- a/model/src/test/kotlin/ScopeTest.kt
+++ b/model/src/test/kotlin/ScopeTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.model
+
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.WordSpec
+
+class ScopeTest : WordSpec({
+    "getDependencyTreeDepth()" should {
+        "return 0 if it does not contain any package" {
+            val scope = Scope(name = "test", dependencies = sortedSetOf())
+
+            scope.getDependencyTreeDepth() shouldBe 0
+        }
+
+        "return 1 if it contains only direct dependencies" {
+            val scope = Scope(
+                name = "test",
+                dependencies = sortedSetOf(
+                    PackageReference(id = Identifier("a")),
+                    PackageReference(id = Identifier("b"))
+                )
+            )
+
+            scope.getDependencyTreeDepth() shouldBe 1
+        }
+
+        "return 2 if it contains a tree of height 2" {
+            val scope = Scope(
+                name = "test",
+                dependencies = sortedSetOf(
+                    PackageReference(
+                        id = Identifier("a"),
+                        dependencies = sortedSetOf(
+                            PackageReference(id = Identifier("a1"))
+                        )
+                    )
+                )
+            )
+
+            scope.getDependencyTreeDepth() shouldBe 2
+        }
+
+        "return 3 if it contains a tree of height 3" {
+            val scope = Scope(
+                name = "test",
+                dependencies = sortedSetOf(
+                    PackageReference(
+                        id = Identifier("a"),
+                        dependencies = sortedSetOf(
+                            PackageReference(
+                                id = Identifier("a1"),
+                                dependencies = sortedSetOf(
+                                    PackageReference(id = Identifier("a11")),
+                                    PackageReference(id = Identifier("a12"))
+                                )
+                            )
+                        )
+                    ),
+                    PackageReference(id = Identifier("b"))
+                )
+            )
+
+            scope.getDependencyTreeDepth() shouldBe 3
+        }
+    }
+})

--- a/reporter/src/funTest/assets/evaluated-model-test-expected-statistics.yml
+++ b/reporter/src/funTest/assets/evaluated-model-test-expected-statistics.yml
@@ -1,0 +1,21 @@
+---
+stats:
+  open_issues:
+    errors: 1
+    warnings: 0
+    hints: 0
+  open_rule_violations:
+    errors: 1
+    warnings: 1
+    hints: 1
+  dependency_tree:
+    included_projects: 1
+    excluded_projects: 1
+    included_packages: 4
+    excludes_packages: 0
+    total_tree_depth: 2
+    included_tree_depth: 2
+    included_scopes:
+    - "compile"
+    - "testCompile"
+    excluded_scopes: []

--- a/reporter/src/funTest/kotlin/reporters/EvaluatedModelYamlReporterTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/EvaluatedModelYamlReporterTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2019 Bosch Software Innovations GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.reporter.reporters
+
+import com.here.ort.model.OrtResult
+import com.here.ort.reporter.ReporterInput
+import com.here.ort.utils.test.readOrtResult
+
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.WordSpec
+
+import java.io.ByteArrayOutputStream
+import java.io.File
+
+class EvaluatedModelYamlReporterTest : WordSpec({
+    "Evaluated model" should {
+        "contain the expected stats" {
+            val expectedResult = File(
+                "src/funTest/assets/evaluated-model-test-expected-statistics.yml"
+            ).readText()
+            val ortResult = readOrtResult("src/funTest/assets/static-html-reporter-test-input.yml")
+
+            println(generateReport(ortResult))
+            generateReport(ortResult) shouldBe expectedResult
+        }
+    }
+})
+
+private fun generateReport(ortResult: OrtResult) =
+    ByteArrayOutputStream().also { outputStream ->
+        EvaluatedModelYamlReporter().generateReport(outputStream, ReporterInput(ortResult))
+    }.toString("UTF-8")

--- a/reporter/src/main/kotlin/StatisticsCalculator.kt
+++ b/reporter/src/main/kotlin/StatisticsCalculator.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.model.utils
+
+import com.here.ort.model.DependencyTreeStatistics
+import com.here.ort.model.IssueStatistics
+import com.here.ort.model.OrtResult
+import com.here.ort.model.Severity
+import com.here.ort.model.Statistics
+import com.here.ort.reporter.ResolutionProvider
+
+/**
+ * This class calculates [Statistics] for a given [OrtResult] and applicable
+ * [com.here.ort.model.config.ErrorResolution]s and applicable [com.here.ort.model.config.RuleViolationResolution]s.
+ */
+internal class StatisticsCalculator {
+    /**
+     * Return the [Statistics] for the given [ortResult].
+     */
+    fun getStatistics(ortResult: OrtResult, resolutionProvider: ResolutionProvider) = Statistics(
+        openIssues = getOpenIssuesIssues(ortResult, resolutionProvider),
+        openRuleViolations = getOpenRuleViolations(ortResult, resolutionProvider),
+        dependencyTree = DependencyTreeStatistics(
+            includedProjects = ortResult.getProjects().count { !ortResult.isExcluded(it.id) },
+            excludedProjects = ortResult.getProjects().count { ortResult.isExcluded(it.id) },
+            includedPackages = ortResult.getPackages().count { !ortResult.isExcluded(it.pkg.id) },
+            excludesPackages = ortResult.getPackages().count { ortResult.isExcluded(it.pkg.id) },
+            totalTreeDepth = getTreeDepth(ortResult),
+            includedTreeDepth = getTreeDepth(ortResult = ortResult, ignoreExcluded = true),
+            includedScopes = getIncludedScopes(ortResult).toSortedSet(),
+            excludedScopes = getExcludedScopes(ortResult).toSortedSet()
+        )
+    )
+
+    private fun getOpenRuleViolations(ortResult: OrtResult, resolutionProvider: ResolutionProvider): IssueStatistics {
+        val openPolicyViolations = ortResult
+            .getRuleViolations()
+            .filter { policyViolation -> resolutionProvider.getRuleViolationResolutionsFor(policyViolation).isEmpty() }
+
+        return IssueStatistics(
+            errors = openPolicyViolations.count { it.severity == Severity.ERROR },
+            warnings = openPolicyViolations.count { it.severity == Severity.WARNING },
+            hints = openPolicyViolations.count { it.severity == Severity.HINT }
+        )
+    }
+
+    private fun getOpenIssuesIssues(ortResult: OrtResult, resolutionProvider: ResolutionProvider): IssueStatistics {
+        val openIssues = ortResult
+            .collectErrors()
+            .filterNot { (id, _) -> ortResult.isExcluded(id) }
+            .values
+            .flatten()
+            .filter { issue -> resolutionProvider.getErrorResolutionsFor(issue).isEmpty() }
+
+        return IssueStatistics(
+            errors = openIssues.count { it.severity == Severity.ERROR },
+            warnings = openIssues.count { it.severity == Severity.WARNING },
+            hints = openIssues.count { it.severity == Severity.HINT }
+        )
+    }
+
+    private fun getTreeDepth(ortResult: OrtResult, ignoreExcluded: Boolean = false): Int =
+        ortResult
+            .getProjects()
+            .filterNot { project -> ignoreExcluded && ortResult.isExcluded(project.id) }
+            .flatMap { project -> project.scopes }
+            .filterNot { scope -> ignoreExcluded && ortResult.repository.config.excludes.isScopeExcluded(scope) }
+            .map { scope -> scope.getDependencyTreeDepth() }
+            .max() ?: 0
+
+    private fun getIncludedScopes(ortResult: OrtResult): Set<String> =
+        ortResult
+            .getProjects()
+            .filterNot { project -> ortResult.isExcluded(project.id) }
+            .flatMap { project -> project.scopes }
+            .filterNot { scope -> ortResult.repository.config.excludes.isScopeExcluded(scope) }
+            .map { scope -> scope.name }
+            .toSet()
+
+    private fun getExcludedScopes(ortResult: OrtResult): Set<String> =
+        ortResult
+            .getProjects()
+            .flatMap { project -> project.scopes }
+            .map { scope -> scope.name }
+            .toSet()
+            .let { allScopes ->
+                allScopes - getIncludedScopes(ortResult)
+            }
+}

--- a/reporter/src/main/kotlin/model/Statistics.kt
+++ b/reporter/src/main/kotlin/model/Statistics.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.model
+
+import java.util.SortedSet
+
+/**
+ * A class containing statistics for an [OrtResult].
+ */
+data class Statistics(
+    /**
+     * The number of [OrtIssue]s by severity which are not resolved and not excluded.
+     */
+    val openIssues: IssueStatistics,
+
+    /**
+     * The number of [RuleViolation]s by severity which are not resolved.
+     */
+    val openRuleViolations: IssueStatistics,
+
+    /**
+     * Statistics for the dependency tree.
+     */
+    val dependencyTree: DependencyTreeStatistics
+)
+
+/**
+ * A class containing the amount of issues per severity.
+ */
+data class IssueStatistics(
+    /**
+     * The number of issues with [Severity.ERROR] as severity.
+     */
+    val errors: Int,
+
+    /**
+     * The number of issues with [Severity.WARNING] as severity.
+     */
+    val warnings: Int,
+
+    /**
+     * The number of issues with [Severity.HINT] as severity.
+     */
+    val hints: Int
+)
+
+/**
+ * A class containing statistics about the dependency trees.
+ */
+data class DependencyTreeStatistics(
+    /**
+     * The number of included [Project]s.
+     */
+    val includedProjects: Int,
+
+    /**
+     * The number of excluded [Project]s.
+     */
+    val excludedProjects: Int,
+
+    /**
+     * The number of included [Package]s.
+     */
+    val includedPackages: Int,
+
+    /**
+     * The number of excluded [Package]s.
+     */
+    val excludesPackages: Int,
+
+    /**
+     * The total depth of the deepest tree in the forest.
+     */
+    val totalTreeDepth: Int,
+
+    /**
+     * The depth of the deepest tree in the forest disregarding excluded tree nodes.
+     */
+    val includedTreeDepth: Int,
+
+    /**
+     * The set of scopes names which have at least one not excluded corresponding [Scope].
+     */
+    val includedScopes: SortedSet<String>,
+
+    /**
+     * The set of scope names which do not have a single not excluded corresponding [Scope].
+     */
+    val excludedScopes: SortedSet<String>
+)

--- a/reporter/src/main/kotlin/model/Statistics.kt
+++ b/reporter/src/main/kotlin/model/Statistics.kt
@@ -96,7 +96,7 @@ data class DependencyTreeStatistics(
     val includedTreeDepth: Int,
 
     /**
-     * The set of scopes names which have at least one not excluded corresponding [Scope].
+     * The set of scope names which have at least one not excluded corresponding [Scope].
      */
     val includedScopes: SortedSet<String>,
 

--- a/reporter/src/main/kotlin/reporters/EvaluatedModelReporter.kt
+++ b/reporter/src/main/kotlin/reporters/EvaluatedModelReporter.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2017-2010 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.reporter.reporters
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.here.ort.model.Statistics
+
+import com.here.ort.model.jsonMapper
+import com.here.ort.model.utils.StatisticsCalculator
+import com.here.ort.model.yamlMapper
+import com.here.ort.reporter.Reporter
+import com.here.ort.reporter.ReporterInput
+
+import java.io.OutputStream
+
+/**
+ * Creates a JSON file containing the evaluated model.
+ */
+class EvaluatedModelJsonReporter : EvaluatedModelReporter(
+    reporterName = "EvaluatedModelJson",
+    defaultFileName = "evaluated-model-report.json",
+    mapper = jsonMapper
+)
+
+/**
+ * Creates a YAML file containing the evaluated model.
+ */
+class EvaluatedModelYamlReporter : EvaluatedModelReporter(
+    reporterName = "EvaluatedModelYaml",
+    defaultFileName = "evaluated-model-report.yml",
+    mapper = yamlMapper
+)
+
+/**
+ * Creates a file containing the evaluated model using the given [mapper].
+ */
+abstract class EvaluatedModelReporter(
+    reporterName: String,
+    defaultFileName: String,
+    private val mapper: ObjectMapper
+) : Reporter {
+    override val reporterName = reporterName
+    override val defaultFilename = defaultFileName
+
+    override fun generateReport(outputStream: OutputStream, input: ReporterInput) {
+        data class EvaluatedModel(
+            val stats: Statistics
+            // TODO: add the actual evaluated data model.
+        )
+
+        val evaluatedModel = EvaluatedModel(
+            stats = StatisticsCalculator().getStatistics(input.ortResult, input.resolutionProvider)
+        )
+
+        outputStream.bufferedWriter().use {
+            it.write(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(evaluatedModel))
+        }
+    }
+}

--- a/reporter/src/main/resources/META-INF/services/com.here.ort.reporter.Reporter
+++ b/reporter/src/main/resources/META-INF/services/com.here.ort.reporter.Reporter
@@ -1,4 +1,6 @@
 com.here.ort.reporter.reporters.CycloneDxReporter
+com.here.ort.reporter.reporters.EvaluatedModelJsonReporter
+com.here.ort.reporter.reporters.EvaluatedModelYamlReporter
 com.here.ort.reporter.reporters.ExcelReporter
 com.here.ort.reporter.reporters.NoticeByPackageReporter
 com.here.ort.reporter.reporters.NoticeSummaryReporter


### PR DESCRIPTION
Which for now just contains summary stats and is supposed to be extended so that a data model is shared across reporters.

Note: doing the stats first was only due to urgent needs.