### PR TITLE
Consistently use `issue` instead of `error` throughout the whole codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ interface (for scripted use).
 
 The toolkit consists of the following tools:
 
-* [_Analyzer_](#analyzer) - determines dependencies of a project. Supports multiple package managers and sub-projects. No
-  changes to the projects are required.
+* [_Analyzer_](#analyzer) - determines dependencies of a project. Supports multiple package managers and sub-projects.
+  No changes to the projects are required.
 * [_Downloader_](#downloader) - fetches the source code referred to by the Analyzer result.
-* [_Scanner_](#scanner) - wraps existing license / copyright scanners to detect findings in local source code directories.
+* [_Scanner_](#scanner) - wraps existing license / copyright scanners to detect findings in local source code
+  directories.
 * [_Evaluator_](#evaluator) - evaluates license findings against customizable policy rules.
 * [_Reporter_](#reporter) - presents results in various formats such as visual reports, open source notices or
   Bill-Of-Materials (BOMs) to easily identify dependencies, licenses, copyrights or policy rule violations.
@@ -55,9 +56,9 @@ The following tools are [planned](https://github.com/heremaps/oss-review-toolkit
 
 ## From binaries
 
-Preliminary binary artifacts for ORT are currently available via [JitPack](https://jitpack.io/#heremaps/oss-review-toolkit).
-Please note that due to limitations with the JitPack build environment, the reporter is not able to create the Web App
-report.
+Preliminary binary artifacts for ORT are currently available via
+[JitPack](https://jitpack.io/#heremaps/oss-review-toolkit). Please note that due to limitations with the JitPack build
+environment, the reporter is not able to create the Web App report.
 
 ## From sources
 
@@ -111,8 +112,9 @@ dependencies) or to run ORT natively (in which case some additional requirements
 
 ## Run using Docker
 
-After you have built the image as [described above](#build-using-docker), simply run `docker run <DOCKER_ARGS> ort <ORT_ARGS>`. You typically use `<DOCKER_ARGS>` to mount the project
-directory to analyze into the container for ORT to access it, like:
+After you have built the image as [described above](#build-using-docker), simply run
+`docker run <DOCKER_ARGS> ort <ORT_ARGS>`. You typically use `<DOCKER_ARGS>` to mount the project directory to analyze
+into the container for ORT to access it, like:
 
     docker run -v /workspace:/project ort --info analyze -f JSON -i /project -o /project/ort/analyzer
 
@@ -139,8 +141,9 @@ or
 
 ## Running on CI
 
-A basic ORT pipeline (using the _analyzer_, _scanner_ and _reporter_) can easily be run on [Jenkins CI](https://jenkins.io/)
-by using the [Jenkinsfile](./Jenkinsfile) in a (declarative) [pipeline](https://jenkins.io/doc/book/pipeline/) job.
+A basic ORT pipeline (using the _analyzer_, _scanner_ and _reporter_) can easily be run on
+[Jenkins CI](https://jenkins.io/) by using the [Jenkinsfile](./Jenkinsfile) in a (declarative)
+[pipeline](https://jenkins.io/doc/book/pipeline/) job.
 
 ## Getting started
 
@@ -163,10 +166,10 @@ Please see the documentation below for details about the ORT configuration.
 
 [![Analyzer](./logos/analyzer.png)](./analyzer/src/main/kotlin)
 
-The _analyzer_ is a Software Composition Analysis (SCA) tool that determines the dependencies of software projects inside
-the specified input directory (`-i`). It does so by querying the detected package managers; **no modifications** to your
-existing project source code, like applying build system plugins, are necessary for that to work. The tree of transitive
-dependencies per project is written out as part of an
+The _analyzer_ is a Software Composition Analysis (SCA) tool that determines the dependencies of software projects
+inside the specified input directory (`-i`). It does so by querying the detected package managers; **no modifications**
+to your existing project source code, like applying build system plugins, are necessary for that to work. The tree of
+transitive dependencies per project is written out as part of an
 [OrtResult](https://github.com/heremaps/oss-review-toolkit/blob/master/model/src/main/kotlin/OrtResult.kt) in YAML (or
 JSON, see `-f`) format to a file named `analyzer-result.yml` in the specified output directory (`-o`). The output file
 exactly documents the status quo of all package-related meta-data. It can be further processed or manually edited before
@@ -180,14 +183,17 @@ Currently, the following package managers are supported:
 * [Conan](https://conan.io/) (C / C++, *experimental* as the VCS locations often times do not contain the actual source
   code, see #2037)
 * [dep](https://golang.github.io/dep/) (Go)
-* [DotNet](https://docs.microsoft.com/en-us/dotnet/core/tools/) (.NET, with currently some [limitations](https://github.com/heremaps/oss-review-toolkit/pull/1303#issue-253860146))
+* [DotNet](https://docs.microsoft.com/en-us/dotnet/core/tools/) (.NET, with currently some
+  [limitations](https://github.com/heremaps/oss-review-toolkit/pull/1303#issue-253860146))
 * [Glide](https://glide.sh/) (Go)
 * [Godep](https://github.com/tools/godep) (Go)
-* [GoMod](https://github.com/golang/go/wiki/Modules) (Go, *experimental* as only proxy-based source artifacts but no VCS locations are supported)
+* [GoMod](https://github.com/golang/go/wiki/Modules) (Go, *experimental* as only proxy-based source artifacts but no VCS
+  locations are supported)
 * [Gradle](https://gradle.org/) (Java)
 * [Maven](http://maven.apache.org/) (Java)
 * [NPM](https://www.npmjs.com/) (Node.js)
-* [NuGet](https://www.nuget.org/) (.NET, with currently some [limitations](https://github.com/heremaps/oss-review-toolkit/pull/1303#issue-253860146))
+* [NuGet](https://www.nuget.org/) (.NET, with currently some
+  [limitations](https://github.com/heremaps/oss-review-toolkit/pull/1303#issue-253860146))
 * [Composer](https://getcomposer.org/) (PHP)
 * [PIP](https://pip.pypa.io/) (Python)
 * [Pipenv](https://pipenv.readthedocs.io/) (Python)
@@ -200,9 +206,10 @@ Currently, the following package managers are supported:
 
 [![Downloader](./logos/downloader.png)](./downloader/src/main/kotlin)
 
-Taking an ORT result file with an _analyzer_ result as the input (`-a`), the _downloader_ retrieves the source code of all
-contained packages to the specified output directory (`-o`). The _downloader_ takes care of things like normalizing URLs
-and using the [appropriate VCS tool](./downloader/src/main/kotlin/vcs) to checkout source code from version control.
+Taking an ORT result file with an _analyzer_ result as the input (`-a`), the _downloader_ retrieves the source code of
+all contained packages to the specified output directory (`-o`). The _downloader_ takes care of things like normalizing
+URLs and using the [appropriate VCS tool](./downloader/src/main/kotlin/vcs) to checkout source code from version
+control.
 
 Currently, the following Version Control Systems are supported:
 
@@ -227,7 +234,8 @@ Currently, the following license scanners are supported:
 * [Licensee](https://github.com/benbalter/licensee)
 * [ScanCode](https://github.com/nexB/scancode-toolkit)
 
-For a comparison of some of these, see this [Bachelor Thesis](https://osr.cs.fau.de/2019/08/07/final-thesis-a-comparison-study-of-open-source-license-crawler/).
+For a comparison of some of these, see this
+[Bachelor Thesis](https://osr.cs.fau.de/2019/08/07/final-thesis-a-comparison-study-of-open-source-license-crawler/).
 
 ## Storage Backends
 
@@ -300,16 +308,16 @@ The _scanner_ creates a table called `scan_results` and stores the data in a
 
 [![Evaluator](./logos/evaluator.png)](./evaluator/src/main/kotlin)
 
-The _evaluator_ is used to perform custom license policy checks on scan results. The rules to check against are implemented
-as scripts (currently Kontlin scripts, with a dedicated DSL, but support for other scripting can be added as well.
-See [rules.kts](./docs/examples/rules.kts) for an example file.
+The _evaluator_ is used to perform custom license policy checks on scan results. The rules to check against are
+implemented as scripts (currently Kontlin scripts, with a dedicated DSL, but support for other scripting can be added as
+well. See [rules.kts](./docs/examples/rules.kts) for an example file.
 
 <a name="reporter">&nbsp;</a>
 
 [![Reporter](./logos/reporter.png)](./reporter/src/main/kotlin)
 
-The _reporter_ generates human-readable reports from the scan result file generated by the _scanner_ (`-s`). It is designed
-to support multiple output formats.
+The _reporter_ generates human-readable reports from the scan result file generated by the _scanner_ (`-s`). It is
+designed to support multiple output formats.
 
 Currently, the following report formats are supported (reporter names are case-insensitive):
 
@@ -326,8 +334,9 @@ Currently, the following report formats are supported (reporter names are case-i
 ORT is written in [Kotlin](https://kotlinlang.org/) and uses [Gradle](https://gradle.org/) as the build system, with
 [Kotlin script](https://docs.gradle.org/current/userguide/kotlin_dsl.html) instead of Groovy as the DSL.
 
-When developing on the command line, use the committed [Gradle wrapper](https://docs.gradle.org/current/userguide/gradle_wrapper.html)
-to bootstrap Gradle in the configured version and execute any given tasks. The most important tasks for this project are:
+When developing on the command line, use the committed
+[Gradle wrapper](https://docs.gradle.org/current/userguide/gradle_wrapper.html) to bootstrap Gradle in the configured
+version and execute any given tasks. The most important tasks for this project are:
 
 | Task        | Purpose                                                           |
 | ----------- | ----------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Please see the documentation below for details about the ORT configuration.
   and resolutions to address issues found within a project's code repository.
 * [The curations.yml file](docs/config-file-curations-yml.md) - curations correct invalid or missing package metadata
   and set the concluded license for packages.
-* [The resolutions.yml file](docs/config-file-resolution-yml.md) - resolutions allow *resolving* any errors
+* [The resolutions.yml file](docs/config-file-resolution-yml.md) - resolutions allow *resolving* any issues
   or policy rule violations by providing a reason why they are acceptable and can be ignored.
 
 # Details on the tools

--- a/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
@@ -192,6 +192,6 @@ analyzer:
           revision: ""
           path: ""
       curations: []
-    has_errors: false
+    has_issues: false
 scanner: null
 evaluator: null

--- a/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
@@ -8899,7 +8899,7 @@ analyzer:
           revision: ""
           path: "types/node"
       curations: []
-    errors:
+    issues:
       'NPM::submodules/test-data-npm/long.js/package.json:':
       - timestamp: "1970-01-01T00:00:00Z"
         source: "NPM"
@@ -8908,6 +8908,6 @@ analyzer:
           \ results in unstable versions of dependencies. To allow this, enable support\
           \ for dynamic versions."
         severity: "ERROR"
-    has_errors: true
+    has_issues: true
 scanner: null
 evaluator: null

--- a/analyzer/src/funTest/assets/projects/external/sbt-multi-project-example-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/sbt-multi-project-example-expected-output.yml
@@ -1168,6 +1168,6 @@ analyzer:
           revision: ""
           path: ""
       curations: []
-    has_errors: false
+    has_issues: false
 scanner: null
 evaluator: null

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
@@ -586,6 +586,6 @@ analyzer:
           - "curated license a"
           - "curated license b"
           comment: "Declared license in pom.xml is wrong."
-    has_errors: true
+    has_issues: true
 scanner: null
 evaluator: null

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
@@ -195,7 +195,7 @@ analyzer:
       - name: "compile"
         dependencies:
         - id: "Unknown:org.apache.commons:commons-text:1.1"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
@@ -205,7 +205,7 @@ analyzer:
       - name: "compileClasspath"
         dependencies:
         - id: "Unknown:org.apache.commons:commons-text:1.1"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
@@ -217,7 +217,7 @@ analyzer:
       - name: "default"
         dependencies:
         - id: "Unknown:org.apache.commons:commons-text:1.1"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
@@ -227,7 +227,7 @@ analyzer:
       - name: "runtime"
         dependencies:
         - id: "Unknown:org.apache.commons:commons-text:1.1"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
@@ -237,7 +237,7 @@ analyzer:
       - name: "runtimeClasspath"
         dependencies:
         - id: "Unknown:org.apache.commons:commons-text:1.1"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
@@ -249,14 +249,14 @@ analyzer:
       - name: "testCompile"
         dependencies:
         - id: "Unknown:junit:junit:4.12"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency junit:junit:4.12 because no repositories are defined."
             severity: "ERROR"
         - id: "Unknown:org.apache.commons:commons-text:1.1"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
@@ -266,14 +266,14 @@ analyzer:
       - name: "testCompileClasspath"
         dependencies:
         - id: "Unknown:junit:junit:4.12"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency junit:junit:4.12 because no repositories are defined."
             severity: "ERROR"
         - id: "Unknown:org.apache.commons:commons-text:1.1"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
@@ -285,14 +285,14 @@ analyzer:
       - name: "testRuntime"
         dependencies:
         - id: "Unknown:junit:junit:4.12"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency junit:junit:4.12 because no repositories are defined."
             severity: "ERROR"
         - id: "Unknown:org.apache.commons:commons-text:1.1"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
@@ -302,14 +302,14 @@ analyzer:
       - name: "testRuntimeClasspath"
         dependencies:
         - id: "Unknown:junit:junit:4.12"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency junit:junit:4.12 because no repositories are defined."
             severity: "ERROR"
         - id: "Unknown:org.apache.commons:commons-text:1.1"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
@@ -195,7 +195,7 @@ analyzer:
       - name: "compile"
         dependencies:
         - id: "Unknown:org.apache.commons:commons-text:1.1"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
@@ -205,7 +205,7 @@ analyzer:
       - name: "compileClasspath"
         dependencies:
         - id: "Unknown:org.apache.commons:commons-text:1.1"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
@@ -217,7 +217,7 @@ analyzer:
       - name: "default"
         dependencies:
         - id: "Unknown:org.apache.commons:commons-text:1.1"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
@@ -227,7 +227,7 @@ analyzer:
       - name: "runtime"
         dependencies:
         - id: "Unknown:org.apache.commons:commons-text:1.1"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
@@ -237,7 +237,7 @@ analyzer:
       - name: "runtimeClasspath"
         dependencies:
         - id: "Unknown:org.apache.commons:commons-text:1.1"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
@@ -249,14 +249,14 @@ analyzer:
       - name: "testCompile"
         dependencies:
         - id: "Unknown:junit:junit:4.12"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency junit:junit:4.12 because no repositories are defined."
             severity: "ERROR"
         - id: "Unknown:org.apache.commons:commons-text:1.1"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
@@ -266,14 +266,14 @@ analyzer:
       - name: "testCompileClasspath"
         dependencies:
         - id: "Unknown:junit:junit:4.12"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency junit:junit:4.12 because no repositories are defined."
             severity: "ERROR"
         - id: "Unknown:org.apache.commons:commons-text:1.1"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
@@ -285,14 +285,14 @@ analyzer:
       - name: "testRuntime"
         dependencies:
         - id: "Unknown:junit:junit:4.12"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency junit:junit:4.12 because no repositories are defined."
             severity: "ERROR"
         - id: "Unknown:org.apache.commons:commons-text:1.1"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
@@ -302,14 +302,14 @@ analyzer:
       - name: "testRuntimeClasspath"
         dependencies:
         - id: "Unknown:junit:junit:4.12"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency junit:junit:4.12 because no repositories are defined."
             severity: "ERROR"
         - id: "Unknown:org.apache.commons:commons-text:1.1"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
@@ -565,6 +565,6 @@ analyzer:
           revision: ""
           path: ""
       curations: []
-    has_errors: true
+    has_issues: true
 scanner: null
 evaluator: null

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
@@ -23,7 +23,7 @@ project:
   - name: "compile"
     dependencies:
     - id: "Unknown:org.apache.commons:commons-text:1.1"
-      errors:
+      issues:
       - timestamp: "1970-01-01T00:00:00Z"
         source: "Gradle"
         message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
@@ -33,7 +33,7 @@ project:
   - name: "compileClasspath"
     dependencies:
     - id: "Unknown:org.apache.commons:commons-text:1.1"
-      errors:
+      issues:
       - timestamp: "1970-01-01T00:00:00Z"
         source: "Gradle"
         message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
@@ -45,7 +45,7 @@ project:
   - name: "default"
     dependencies:
     - id: "Unknown:org.apache.commons:commons-text:1.1"
-      errors:
+      issues:
       - timestamp: "1970-01-01T00:00:00Z"
         source: "Gradle"
         message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
@@ -55,7 +55,7 @@ project:
   - name: "runtime"
     dependencies:
     - id: "Unknown:org.apache.commons:commons-text:1.1"
-      errors:
+      issues:
       - timestamp: "1970-01-01T00:00:00Z"
         source: "Gradle"
         message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
@@ -65,7 +65,7 @@ project:
   - name: "runtimeClasspath"
     dependencies:
     - id: "Unknown:org.apache.commons:commons-text:1.1"
-      errors:
+      issues:
       - timestamp: "1970-01-01T00:00:00Z"
         source: "Gradle"
         message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
@@ -77,14 +77,14 @@ project:
   - name: "testCompile"
     dependencies:
     - id: "Unknown:junit:junit:4.12"
-      errors:
+      issues:
       - timestamp: "1970-01-01T00:00:00Z"
         source: "Gradle"
         message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
           \ dependency junit:junit:4.12 because no repositories are defined."
         severity: "ERROR"
     - id: "Unknown:org.apache.commons:commons-text:1.1"
-      errors:
+      issues:
       - timestamp: "1970-01-01T00:00:00Z"
         source: "Gradle"
         message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
@@ -94,14 +94,14 @@ project:
   - name: "testCompileClasspath"
     dependencies:
     - id: "Unknown:junit:junit:4.12"
-      errors:
+      issues:
       - timestamp: "1970-01-01T00:00:00Z"
         source: "Gradle"
         message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
           \ dependency junit:junit:4.12 because no repositories are defined."
         severity: "ERROR"
     - id: "Unknown:org.apache.commons:commons-text:1.1"
-      errors:
+      issues:
       - timestamp: "1970-01-01T00:00:00Z"
         source: "Gradle"
         message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
@@ -113,14 +113,14 @@ project:
   - name: "testRuntime"
     dependencies:
     - id: "Unknown:junit:junit:4.12"
-      errors:
+      issues:
       - timestamp: "1970-01-01T00:00:00Z"
         source: "Gradle"
         message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
           \ dependency junit:junit:4.12 because no repositories are defined."
         severity: "ERROR"
     - id: "Unknown:org.apache.commons:commons-text:1.1"
-      errors:
+      issues:
       - timestamp: "1970-01-01T00:00:00Z"
         source: "Gradle"
         message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
@@ -130,14 +130,14 @@ project:
   - name: "testRuntimeClasspath"
     dependencies:
     - id: "Unknown:junit:junit:4.12"
-      errors:
+      issues:
       - timestamp: "1970-01-01T00:00:00Z"
         source: "Gradle"
         message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
           \ dependency junit:junit:4.12 because no repositories are defined."
         severity: "ERROR"
     - id: "Unknown:org.apache.commons:commons-text:1.1"
-      errors:
+      issues:
       - timestamp: "1970-01-01T00:00:00Z"
         source: "Gradle"
         message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-unsupported-version.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-unsupported-version.yml
@@ -17,6 +17,6 @@ project:
   homepage_url: ""
   scopes: []
 packages: []
-errors:
+issues:
 - "This project uses the unsupported Gradle version 3.2.1. At least Gradle 3.3 is\
   \ required."

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output-no-lockfile.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output-no-lockfile.yml
@@ -17,7 +17,7 @@ project:
   homepage_url: ""
   scopes: []
 packages: []
-errors:
+issues:
 - timestamp: "1970-01-01T00:00:00Z"
   source: "NPM"
   message: "Resolving dependencies for 'package.json' failed with: IllegalArgumentException:\

--- a/analyzer/src/funTest/assets/projects/synthetic/pub-expected-output-no-lockfile.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pub-expected-output-no-lockfile.yml
@@ -17,7 +17,7 @@ project:
   homepage_url: ""
   scopes: []
 packages: []
-errors:
+issues:
 - timestamp: "2019-06-12T09:56:14.808Z"
   source: "Pub"
   message: "IllegalArgumentException: No lock file found in /Users/mahille/Development/Kotlin/oss-review-toolkit/analyzer/src/funTest/assets/projects/synthetic/pub/no-lockfile,\

--- a/analyzer/src/funTest/assets/projects/synthetic/pub-expected-output-project-with-flutter.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pub-expected-output-project-with-flutter.yml
@@ -14283,7 +14283,7 @@ packages:
       revision: ""
       path: ""
   curations: []
-errors:
+issues:
 - timestamp: "1970-01-01T00:00:00Z"
   source: "Pub"
   message: "Cannot get iOS dependencies for package 'flutter_crashlytics'. Support\

--- a/analyzer/src/funTest/kotlin/integration/AbstractIntegrationSpec.kt
+++ b/analyzer/src/funTest/kotlin/integration/AbstractIntegrationSpec.kt
@@ -60,9 +60,9 @@ abstract class AbstractIntegrationSpec : StringSpec() {
     protected open val managedFilesForTest by lazy { expectedManagedFiles }
 
     /**
-     * The list of package identifiers for which errors are expected.
+     * The list of package identifiers for which issues are expected.
      */
-    protected open val identifiersWithExpectedErrors = setOf<Identifier>()
+    protected open val identifiersWithExpectedIssues = setOf<Identifier>()
 
     /**
      * The temporary parent directory for downloads.
@@ -126,7 +126,7 @@ abstract class AbstractIntegrationSpec : StringSpec() {
                     result.project.vcsProcessed.url shouldBe pkg.vcs.url
                     result.project.scopes shouldNot beEmpty()
                     result.packages shouldNot beEmpty()
-                    result.collectErrors().keys should containExactly(identifiersWithExpectedErrors)
+                    result.collectIssues().keys should containExactly(identifiersWithExpectedIssues)
                 }
             }
         }

--- a/analyzer/src/funTest/kotlin/managers/BowerTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/BowerTest.kt
@@ -56,7 +56,7 @@ class BowerTest : StringSpec() {
             val result = createBower().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
-            result!!.errors should beEmpty()
+            result!!.issues should beEmpty()
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
     }

--- a/analyzer/src/funTest/kotlin/managers/BundlerTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/BundlerTest.kt
@@ -73,8 +73,8 @@ class BundlerTest : WordSpec() {
                     project.definitionFilePath shouldBe
                             "analyzer/src/funTest/assets/projects/synthetic/bundler/no-lockfile/Gemfile"
                     packages.size shouldBe 0
-                    errors.size shouldBe 1
-                    errors.first().message should haveSubstring("IllegalArgumentException: No lockfile found in")
+                    issues.size shouldBe 1
+                    issues.first().message should haveSubstring("IllegalArgumentException: No lockfile found in")
                 }
             }
 

--- a/analyzer/src/funTest/kotlin/managers/CargoSubcrateTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/CargoSubcrateTest.kt
@@ -56,7 +56,7 @@ class CargoSubcrateTest : StringSpec() {
             val result = createCargo().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
-            result!!.errors should beEmpty()
+            result!!.issues should beEmpty()
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
 
@@ -75,7 +75,7 @@ class CargoSubcrateTest : StringSpec() {
             val result = createCargo().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
-            result!!.errors should beEmpty()
+            result!!.issues should beEmpty()
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
 
@@ -94,7 +94,7 @@ class CargoSubcrateTest : StringSpec() {
             val result = createCargo().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
-            result!!.errors should beEmpty()
+            result!!.issues should beEmpty()
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
     }

--- a/analyzer/src/funTest/kotlin/managers/CargoTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/CargoTest.kt
@@ -56,7 +56,7 @@ class CargoTest : StringSpec() {
             val result = createCargo().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
-            result!!.errors should beEmpty()
+            result!!.issues should beEmpty()
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
     }

--- a/analyzer/src/funTest/kotlin/managers/ConanTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/ConanTest.kt
@@ -63,7 +63,7 @@ class ConanTest : StringSpec() {
             val result = createConan().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
-            result!!.errors should beEmpty()
+            result!!.issues should beEmpty()
             patchActualResult(yamlMapper.writeValueAsString(result)) shouldBe expectedResult
         }
 
@@ -81,7 +81,7 @@ class ConanTest : StringSpec() {
             val result = createConan().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
-            result!!.errors should beEmpty()
+            result!!.issues should beEmpty()
             patchActualResult(yamlMapper.writeValueAsString(result)) shouldBe expectedResult
         }
     }

--- a/analyzer/src/funTest/kotlin/managers/DotNetTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/DotNetTest.kt
@@ -65,7 +65,7 @@ class DotNetTest : StringSpec() {
             val result = createDotNet().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
-            result!!.errors should beEmpty()
+            result!!.issues should beEmpty()
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
     }

--- a/analyzer/src/funTest/kotlin/managers/GoDepTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GoDepTest.kt
@@ -60,8 +60,8 @@ class GoDepTest : WordSpec() {
                     project.definitionFilePath shouldBe
                             "analyzer/src/funTest/assets/projects/synthetic/godep/no-lockfile/Gopkg.toml"
                     packages.size shouldBe 0
-                    errors.size shouldBe 1
-                    errors.first().message should haveSubstring("IllegalArgumentException: No lockfile found in")
+                    issues.size shouldBe 1
+                    issues.first().message should haveSubstring("IllegalArgumentException: No lockfile found in")
                 }
             }
 
@@ -74,7 +74,7 @@ class GoDepTest : WordSpec() {
                 with(result!!) {
                     project shouldNotBe Project.EMPTY
                     packages.size shouldBe 4
-                    errors.size shouldBe 0
+                    issues.size shouldBe 0
                 }
             }
 

--- a/analyzer/src/funTest/kotlin/managers/GoModTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GoModTest.kt
@@ -56,7 +56,7 @@ class GoModTest : StringSpec() {
             val result = createGoMod().resolveDependencies(listOf(definitionFile))[definitionFile]
 
             result shouldNotBe null
-            result!!.errors should beEmpty()
+            result!!.issues should beEmpty()
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
     }

--- a/analyzer/src/funTest/kotlin/managers/GradleAndroidTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GradleAndroidTest.kt
@@ -52,7 +52,7 @@ class GradleAndroidTest : StringSpec() {
             val result = createGradle().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
-            result!!.errors shouldBe emptyList()
+            result!!.issues shouldBe emptyList()
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
 
@@ -67,7 +67,7 @@ class GradleAndroidTest : StringSpec() {
             val result = createGradle().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
-            result!!.errors shouldBe emptyList()
+            result!!.issues shouldBe emptyList()
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
 
@@ -82,7 +82,7 @@ class GradleAndroidTest : StringSpec() {
             val result = createGradle().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
-            result!!.errors shouldBe emptyList()
+            result!!.issues shouldBe emptyList()
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
     }

--- a/analyzer/src/funTest/kotlin/managers/GradleKotlinScriptTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GradleKotlinScriptTest.kt
@@ -51,7 +51,7 @@ class GradleKotlinScriptTest : StringSpec() {
             val result = createGradle().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
-            result!!.errors shouldBe emptyList()
+            result!!.issues shouldBe emptyList()
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
 
@@ -66,7 +66,7 @@ class GradleKotlinScriptTest : StringSpec() {
             val result = createGradle().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
-            result!!.errors shouldBe emptyList()
+            result!!.issues shouldBe emptyList()
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
 
@@ -81,7 +81,7 @@ class GradleKotlinScriptTest : StringSpec() {
             val result = createGradle().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
-            result!!.errors shouldBe emptyList()
+            result!!.issues shouldBe emptyList()
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
     }

--- a/analyzer/src/funTest/kotlin/managers/GradleLibraryTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GradleLibraryTest.kt
@@ -51,7 +51,7 @@ class GradleLibraryTest : StringSpec() {
             val result = createGradle().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
-            result!!.errors shouldBe emptyList()
+            result!!.issues shouldBe emptyList()
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
 
@@ -66,7 +66,7 @@ class GradleLibraryTest : StringSpec() {
             val result = createGradle().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
-            result!!.errors shouldBe emptyList()
+            result!!.issues shouldBe emptyList()
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
 
@@ -81,7 +81,7 @@ class GradleLibraryTest : StringSpec() {
             val result = createGradle().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
-            result!!.errors shouldBe emptyList()
+            result!!.issues shouldBe emptyList()
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
     }

--- a/analyzer/src/funTest/kotlin/managers/GradleTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GradleTest.kt
@@ -68,7 +68,7 @@ class GradleTest : StringSpec() {
             val result = createGradle().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
-            result!!.errors shouldBe emptyList()
+            result!!.issues shouldBe emptyList()
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
 
@@ -83,7 +83,7 @@ class GradleTest : StringSpec() {
             val result = createGradle().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
-            result!!.errors shouldBe emptyList()
+            result!!.issues shouldBe emptyList()
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
 
@@ -98,7 +98,7 @@ class GradleTest : StringSpec() {
             val result = createGradle().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
-            result!!.errors shouldBe emptyList()
+            result!!.issues shouldBe emptyList()
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
 
@@ -113,7 +113,7 @@ class GradleTest : StringSpec() {
             val result = createGradle().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
-            result!!.errors shouldBe emptyList()
+            result!!.issues shouldBe emptyList()
             patchActualResult(yamlMapper.writeValueAsString(result)) shouldBe expectedResult
         }
 
@@ -189,7 +189,7 @@ class GradleTest : StringSpec() {
                 val result = createGradle().resolveDependencies(listOf(packageFile))[packageFile]
 
                 result shouldNotBe null
-                result!!.errors shouldBe emptyList()
+                result!!.issues shouldBe emptyList()
                 yamlMapper.writeValueAsString(result) shouldBe expectedResult
             }
         }

--- a/analyzer/src/funTest/kotlin/managers/NuGetTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/NuGetTest.kt
@@ -65,7 +65,7 @@ class NuGetTest : StringSpec() {
             val result = createNuGet().resolveDependencies(listOf(packageFile))[packageFile]
 
             result shouldNotBe null
-            result!!.errors should beEmpty()
+            result!!.issues should beEmpty()
             yamlMapper.writeValueAsString(result) shouldBe expectedResult
         }
     }

--- a/analyzer/src/funTest/kotlin/managers/PhpComposerTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/PhpComposerTest.kt
@@ -70,8 +70,8 @@ class PhpComposerTest : StringSpec() {
                 project.definitionFilePath shouldBe
                         "analyzer/src/funTest/assets/projects/synthetic/php-composer/no-lockfile/composer.json"
                 packages.size shouldBe 0
-                errors.size shouldBe 1
-                errors.first().message should haveSubstring("IllegalArgumentException: No lockfile found in")
+                issues.size shouldBe 1
+                issues.first().message should haveSubstring("IllegalArgumentException: No lockfile found in")
             }
         }
 

--- a/analyzer/src/funTest/kotlin/managers/PubTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/PubTest.kt
@@ -120,8 +120,8 @@ class PubTest : WordSpec() {
                     project.definitionFilePath shouldBe
                             "analyzer/src/funTest/assets/projects/synthetic/pub/no-lockfile/pubspec.yaml"
                     packages.size shouldBe 0
-                    errors.size shouldBe 1
-                    errors.first().message should haveSubstring("IllegalArgumentException: No lockfile found in")
+                    issues.size shouldBe 1
+                    issues.first().message should haveSubstring("IllegalArgumentException: No lockfile found in")
                 }
             }
         }

--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -154,7 +154,7 @@ class Analyzer(private val config: AnalyzerConfiguration) {
                                 results.mapValues { entry ->
                                     ProjectAnalyzerResult(
                                         project = entry.value.project,
-                                        errors = entry.value.errors,
+                                        issues = entry.value.issues,
                                         packages = entry.value.packages.map { curatedPackage ->
                                             val curations = provider.getCurationsFor(curatedPackage.pkg.id)
                                             curations.fold(curatedPackage) { cur, packageCuration ->

--- a/analyzer/src/main/kotlin/managers/GoDep.kt
+++ b/analyzer/src/main/kotlin/managers/GoDep.kt
@@ -105,14 +105,14 @@ class GoDep(
             val revision = project.getValue("revision")
             val version = project.getValue("version")
 
-            val errors = mutableListOf<OrtIssue>()
+            val issues = mutableListOf<OrtIssue>()
 
             val vcsProcessed = try {
                 resolveVcsInfo(name, revision, gopath)
             } catch (e: IOException) {
                 e.showStackTrace()
 
-                errors += createAndLogIssue(
+                issues += createAndLogIssue(
                     source = managerName,
                     message = "Could not resolve VCS information for project '$name': ${e.collectMessagesAsString()}"
                 )
@@ -133,7 +133,7 @@ class GoDep(
 
             packages += pkg
 
-            packageRefs += pkg.toReference(linkage = PackageLinkage.STATIC, errors = errors)
+            packageRefs += pkg.toReference(linkage = PackageLinkage.STATIC, issues = issues)
         }
 
         val scope = Scope("default", packageRefs.toSortedSet())

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -281,7 +281,7 @@ class Gradle(
         } else {
             val type = dependency.pomFile?.let { "Maven" } ?: "Unknown"
             val id = Identifier(type, dependency.groupId, dependency.artifactId, dependency.version)
-            PackageReference(id, dependencies = transitiveDependencies.toSortedSet(), errors = issues)
+            PackageReference(id, dependencies = transitiveDependencies.toSortedSet(), issues = issues)
         }
     }
 }

--- a/analyzer/src/main/kotlin/managers/Maven.kt
+++ b/analyzer/src/main/kotlin/managers/Maven.kt
@@ -211,7 +211,7 @@ class Maven(
             return PackageReference(
                 Identifier(managerName, node.artifact.groupId, node.artifact.artifactId, node.artifact.version),
                 dependencies = sortedSetOf(),
-                errors = listOf(
+                issues = listOf(
                     createAndLogIssue(
                         source = managerName,
                         message = "Could not get package information for dependency '$identifier': " +

--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -421,7 +421,7 @@ open class Npm(
                         "specific to a different platform."
             )
 
-            return PackageReference(id, errors = listOf(issue))
+            return PackageReference(id, issues = listOf(issue))
         } else {
             // Skip the package name directory when going up.
             var parentModulesDir = startModulesDir.parentFile.parentFile

--- a/analyzer/src/main/kotlin/managers/PhpComposer.kt
+++ b/analyzer/src/main/kotlin/managers/PhpComposer.kt
@@ -203,7 +203,7 @@ class PhpComposer(
                 e.showStackTrace()
 
                 packageInfo.toReference(
-                    errors = listOf(
+                    issues = listOf(
                         createAndLogIssue(
                             source = managerName,
                             message = "Could not resolve dependencies of '$packageName': ${e.collectMessagesAsString()}"

--- a/analyzer/src/main/kotlin/managers/Pub.kt
+++ b/analyzer/src/main/kotlin/managers/Pub.kt
@@ -468,7 +468,7 @@ class Pub(
                         packages[item.pkg.id] = item.pkg
                     }
 
-                    issues += result.errors
+                    issues += result.issues
                 }
 
                 // As this package contains flutter, trigger CocoaPods manually for it.
@@ -477,7 +477,7 @@ class Pub(
                         packages[item.pkg.id] = item.pkg
                     }
 
-                    issues += result.errors
+                    issues += result.issues
                 }
             }
         }

--- a/analyzer/src/main/kotlin/managers/Pub.kt
+++ b/analyzer/src/main/kotlin/managers/Pub.kt
@@ -294,7 +294,7 @@ class Pub(
                         e.showStackTrace()
 
                         packageInfo.toReference(
-                            errors = listOf(
+                            issues = listOf(
                                 createAndLogIssue(
                                     source = managerName,
                                     message = "Could not resolve dependencies of '$packageName': " +

--- a/analyzer/src/main/kotlin/managers/utils/DotNetSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/DotNetSupport.kt
@@ -82,7 +82,7 @@ fun PackageManager.resolveDotNetDependencies(
     return ProjectAnalyzerResult(
         project,
         packages = support.packages.mapTo(sortedSetOf()) { it.toCuratedPackage() },
-        errors = support.errors
+        issues = support.issues
     )
 }
 
@@ -152,7 +152,7 @@ class DotNetSupport(packageReferencesMap: Map<String, String>) {
     }
 
     val packages = mutableListOf<Package>()
-    val errors = mutableListOf<OrtIssue>()
+    val issues = mutableListOf<OrtIssue>()
     val scope = Scope("dependencies", sortedSetOf())
 
     // Maps an (id, version) pair to a (nupkg URL, catalog entry) pair.
@@ -221,7 +221,7 @@ class DotNetSupport(packageReferencesMap: Map<String, String>) {
         val packageJsonNode = preparePackageReference(packageID, version)
 
         if (packageJsonNode == null) {
-            errors += createAndLogIssue(
+            issues += createAndLogIssue(
                 source = "nuget-API",
                 message = "$packageID:$version can not be found on Nugets RestAPI."
             )

--- a/analyzer/src/test/kotlin/managers/utils/DotNetSupportTest.kt
+++ b/analyzer/src/test/kotlin/managers/utils/DotNetSupportTest.kt
@@ -54,7 +54,7 @@ class DotNetSupportTest : StringSpec() {
             )
 
             dotNetSupport.scope shouldBe resultScope
-            dotNetSupport.errors.map { it.copy(timestamp = Instant.EPOCH) } shouldBe resultErrors
+            dotNetSupport.issues.map { it.copy(timestamp = Instant.EPOCH) } shouldBe resultErrors
         }
 
         "dependencies are detected correctly" {

--- a/docs/config-file-copyright-garbage-yml.md
+++ b/docs/config-file-copyright-garbage-yml.md
@@ -7,7 +7,7 @@ You can use [examples/copyright-garbage.yml](examples/copyright-garbage.yml) as 
 ### When to Use
 
 No scanner is perfect and many detect code statements or binary code as copyright holders,
-`copyright-garbage.yml` provides a way to clean to clean up such errors across all scans.
+`copyright-garbage.yml` provides a way to clean up such errors across all scans.
 
 ## Command Line
 

--- a/docs/config-file-curations-yml.md
+++ b/docs/config-file-curations-yml.md
@@ -27,7 +27,8 @@ a license finding curation in the [.ort.yml](config-file-ort-yml.md#curations) f
 In order to discover the source code of the dependencies of a package, ORT relies on the package metadata. Often the
 metadata contains information on how to locate the source code, but not always. In many cases, the metadata of packages
 provides no VCS information, it points to outdated repositories or the repositories are not correctly tagged.
-Because it is not always possible to fix this information in upstream packages, ORT offers a curation mechanism for metadata.
+Because it is not always possible to fix this information in upstream packages, ORT offers a curation mechanism for
+metadata.
 
 These curations can be configured in a YAML file that is passed to the _analyzer_. The data from the curations file
 amends the metadata provided by the packages themselves. This way, it is possible to fix broken VCS URLs or provide the
@@ -73,7 +74,8 @@ cli/build/install/ort/bin/ort analyze
 In the future we will integrate [ClearlyDefined](https://clearlydefined.io/) as a source for curated metadata. Until
 then, and also for curations for internal packages that cannot be published, the curations file can be used.
 
-To test curations you can also pass the `curations.yml` file to the `--package-curations-file` option of the _evaluator_:
+To test curations you can also pass the `curations.yml` file to the `--package-curations-file` option of the
+_evaluator_:
 
 ```bash
 cli/build/install/ort/bin/ort evaluate

--- a/docs/config-file-ort-yml.md
+++ b/docs/config-file-ort-yml.md
@@ -28,9 +28,9 @@ Exclusions apply to paths (files/directories) or scopes. Examples of currently s
 ORT's philosophy is to analyze and scan everything it can find to build a complete picture of a repository
 and its dependencies.
 
-However, the users may not be interested in the results for components that are not included in their released artifacts,
-for example build files, documentation, examples or test code. To support such use cases, ORT provides a mechanism
-to mark files, directories or scopes included in the repository as excluded.
+However, the users may not be interested in the results for components that are not included in their released
+artifacts, for example build files, documentation, examples or test code. To support such use cases, ORT provides a
+mechanism to mark files, directories or scopes included in the repository as excluded.
 
 Note that the excluded parts are analyzed and scanned, but are treated differently in the reports ORT generates:
 
@@ -66,7 +66,9 @@ For how to write a glob pattern, please see this
 The path exclude above has the following effects:
 
 * All projects found below the `test-data` directory are marked as excluded.
-* License findings in files below the `test-data` directory are marked as excluded. This can be used in [evaluator rules](getting-started.md#6-running-the-evaluator) to for instance change the severity from error to warning.
+* License findings in files below the `test-data` directory are marked as excluded. This can be used in
+  [evaluator rules](getting-started.md#6-running-the-evaluator) to for instance change the severity from error to
+  warning.
 
 ```yaml
 excludes:
@@ -125,8 +127,8 @@ Note that you must verify that the scopes defined in the examples below match th
 
 ### When to Use Curations
 
-Project-specific curations should be used when you want to correct the licenses detected in the source code of the project.
-If you need to correct the license findings for a third-party dependency then add a curation to
+Project-specific curations should be used when you want to correct the licenses detected in the source code of the
+project. If you need to correct the license findings for a third-party dependency then add a curation to
 [curations.yml](config-file-curations-yml.md).
 
 ### Curating License Findings
@@ -225,7 +227,8 @@ resolutions:
     comment: "A comment further explaining why the reason above is applicable."
 ```
 
-Where the list of available options for `reason` is defined in [RuleViolationResolutionReason.kt](../model/src/main/kotlin/config/RuleViolationResolutionReason.kt)
+Where the list of available options for `reason` is defined in
+[RuleViolationResolutionReason.kt](../model/src/main/kotlin/config/RuleViolationResolutionReason.kt).
 
 For example, to confirm you acquired a commercial Qt license for your project, your `.ort.yml` could include:
 

--- a/docs/config-file-ort-yml.md
+++ b/docs/config-file-ort-yml.md
@@ -6,7 +6,7 @@ to the root of the source code repository.
 * [excludes](#excludes) - Mark [files, directories](#excluding-paths).
   or [package manager scopes](#excluding-scopes) as not included in released artifacts
 * [license finding curations](#curations): Overwrite scan results to correct identified licenses.
-* [resolutions](#resolutions) - Resolve any error or policy rule violations.
+* [resolutions](#resolutions) - Resolve any issues or policy rule violations.
 
 The sections below explain each in futher detail. Prefer to learn by example? See the [.ort.yml](../.ort.yml)
 for OSS Review Toolkit itself.
@@ -34,7 +34,7 @@ to mark files, directories or scopes included in the repository as excluded.
 
 Note that the excluded parts are analyzed and scanned, but are treated differently in the reports ORT generates:
 
-* The error summary does not show errors in the excluded parts.
+* The issue summary does not show issues in the excluded parts.
 * The excluded parts are grayed out.
 * The reason for the exclusion is shown next to the result.
 
@@ -166,8 +166,8 @@ If a resolution is not project-specific than add it to [resolutions.yml](./confi
 so that it is applied to each scan.
 
 ### Resolution Basics
-Resolutions allow you to *resolve* errors or policy rule violations by marking them as acceptable.
-A resolution is applied to specific errors or violations via the regular expression specified
+Resolutions allow you to *resolve* issues or policy rule violations by marking them as acceptable.
+A resolution is applied to specific issues or violations via the regular expression specified
 in the `message` of a resolution.
 
 To be able to show why a resolution is acceptable, each resolution must include an explanation. 
@@ -176,32 +176,32 @@ The explanation consists of:
 * `reason` -- an identifier selected from a predefined list of options. 
 * `comment` -- free text, providing an explanation and optionally a link to further information.
 
-### Resolving Errors
+### Resolving Issues
 
-If the ORT results show errors, the best approach is usually to fix them and run the scan again.
-However, sometimes it is not possible, for example if an error occurs in the license scan
+If the ORT results show issues, the best approach is usually to fix them and run the scan again.
+However, sometimes it is not possible, for example if an issue occurs in the license scan
 of a third-party dependency which cannot be fixed or updated.
 
-In such situations, you can *resolve* the error in any future scan by adding a resolution
+In such situations, you can *resolve* the issue in any future scan by adding a resolution
 to the `.ort.yml` to mark it as acceptable.
 
-The code below shows the structure of an error resolution in the `.ort.yml` file:
+The code below shows the structure of an issue resolution in the `.ort.yml` file:
 
 ```yaml
 resolutions:
-  errors:
+  issues:
   - message: "A regular expression matching the error message."
-    reason: "One of ErrorResolutionReason e.g BUILD_TOOL_ISSUE,CANT_FIX_ISSUE."
+    reason: "One of IssueResolutionReason e.g BUILD_TOOL_ISSUE,CANT_FIX_ISSUE."
     comment: "A comment further explaining why the reason above is acceptable."
 ```
 Where the list of available options for `reason` is defined in
-[ErrorResolutionReason.kt](../model/src/main/kotlin/config/ErrorResolutionReason.kt)
+[IssueResolutionReason.kt](../model/src/main/kotlin/config/IssueResolutionReason.kt)
 
-For example, to ignore an error related to a build tool problem, your `.ort.yml` could include:
+For example, to ignore an issue related to a build tool problem, your `.ort.yml` could include:
 
 ```yaml
 resolutions:
-  errors:
+  issues:
   - message: "Does not have X.*"
     reason: "BUILD_TOOL_ISSUE"
     comment: "Error caused by a known issue for which a fix is being implemented, see https://github.com/..."

--- a/docs/config-file-resolutions-yml.md
+++ b/docs/config-file-resolutions-yml.md
@@ -1,6 +1,6 @@
 # The `resolutions.yml` file
 
-Resolutions allow you to *resolve* errors or policy rule violations
+Resolutions allow you to *resolve* issues or policy rule violations
 by providing a reason why they are acceptable and can be ignored.
 
 You can use [examples/resolutions.yml](examples/resolutions.yml) as the base configuration file for your scans.
@@ -16,7 +16,7 @@ Resolutions are only taken into account by the _reporter_, while the _analyzer_ 
 
 ## Resolution Basics
 
-A resolution is applied to specific errors or violations via the regular expression specified
+A resolution is applied to specific issues or violations via the regular expression specified
 in the `message` of a resolution.
 
 To be able to show why a resolution is acceptable, each resolution must include an explanation. 
@@ -25,30 +25,30 @@ The explanation consists of:
 * `reason` -- an identifier selected from a predefined list of options. 
 * `comment` -- free text, providing an explanation and optionally a link to further information.
 
-## Resolving Errors
+## Resolving Issues
 
-If the ORT results contain errors, the best approach is usually to fix them and run the scan again. 
-However, sometimes it is not possible, for example if an error occurs in the license scan
+If the ORT results contain issues, the best approach is usually to fix them and run the scan again. 
+However, sometimes it is not possible, for example if an issue occurs in the license scan
 of a third-party dependency which cannot be fixed or updated.
 
-In such situations, you can *resolve* the error in any future scan by adding a resolution
+In such situations, you can *resolve* the issue in any future scan by adding a resolution
 to the `resolutions.yml` to mark it as acceptable.
 
-The code below shows the structure of an error resolution in the `resolutions.yml` file:
+The code below shows the structure of an issue resolution in the `resolutions.yml` file:
 
 ```yaml
-errors:
+issues:
 - message: "A regular expression matching the error message."
-  reason: "One of ErrorResolutionReason e.g. BUILD_TOOL_ISSUE,CANT_FIX_ISSUE,SCANNER_ISSUE."
+  reason: "One of IssueResolutionReason e.g. BUILD_TOOL_ISSUE,CANT_FIX_ISSUE,SCANNER_ISSUE."
   comment: "A comment further explaining why the reason above is acceptable."
 ```
 Where the list of available options for `reason` is defined in
-[ErrorResolutionReason.kt](../model/src/main/kotlin/config/ErrorResolutionReason.kt)
+[IssueResolutionReason.kt](../model/src/main/kotlin/config/IssueResolutionReason.kt)
 
-For example, to ignore an error related to a build tool problem, your `resolutions.yml` could include:
+For example, to ignore an issue related to a build tool problem, your `resolutions.yml` could include:
 
 ```yaml
-errors:
+issues:
 - message: "Does not have X.*"
   reason: "BUILD_TOOL_ISSUE"
   comment: "Error caused by a known issue for which fix is being implemented, see https://github.com/..."

--- a/docs/config-file-resolutions-yml.md
+++ b/docs/config-file-resolutions-yml.md
@@ -59,7 +59,8 @@ issues:
 Resolutions should not be used to resolve license policy rule violations as they do not
 the change generated open source notices.
 To resolve a license policy rule violation either add a local `license_findings` curation
-to the [.ort.yml file](./config-file-ort-yml.md) if the finding is in your code repository or add a curation to the [curations.yml](config-file-curations-yml.md) if the violation occurs in a third-party dependency.
+to the [.ort.yml file](./config-file-ort-yml.md) if the finding is in your code repository or add a curation to the
+[curations.yml](config-file-curations-yml.md) if the violation occurs in a third-party dependency.
 
 The code below shows the structure of a policy rule violation resolution in the `resolutions.yml`file:
 
@@ -70,9 +71,11 @@ rule_violations:
   comment: "A comment further explaining why the reason above is applicable."
 ```
 
-Where the list of available options for `reason` is defined in [RuleViolationResolutionReason.kt](../model/src/main/kotlin/config/RuleViolationResolutionReason.kt)
+Where the list of available options for `reason` is defined in
+[RuleViolationResolutionReason.kt](../model/src/main/kotlin/config/RuleViolationResolutionReason.kt).
 
-For example, to confirm your organization has acquired an org-wide Qt commercial license, your `resolutions.yml` could include:
+For example, to confirm your organization has acquired an org-wide Qt commercial license, your `resolutions.yml` could
+include:
 
 ```yaml
 rule_violations:

--- a/docs/examples/resolutions.yml
+++ b/docs/examples/resolutions.yml
@@ -1,5 +1,5 @@
 ---
-# This file contains global resolutions for issues and rule violations occuring in the OSS scan.
+# This file contains global resolutions for issues and rule violations occurring in the OSS scan.
 # These resolutions are applied to all scanned projects, so make sure to only
 # add resolutions that are not specific to a project. Project specific
 # resolutions can be configured in the .ort.yml file of the project.

--- a/docs/examples/resolutions.yml
+++ b/docs/examples/resolutions.yml
@@ -28,4 +28,4 @@ issues:
 rule_violations:
 - message: "^$"
   reason: "CANT_FIX_EXCEPTION"
-  comment: "An rule violation resolution which resolves only errors with an empty rule message."
+  comment: "A rule violation resolution which resolves only rule violations with an empty message."

--- a/docs/examples/resolutions.yml
+++ b/docs/examples/resolutions.yml
@@ -1,5 +1,5 @@
 ---
-# This file contains global resolutions for errors and rule violations occuring in the OSS scan.
+# This file contains global resolutions for issues and rule violations occuring in the OSS scan.
 # These resolutions are applied to all scanned projects, so make sure to only
 # add resolutions that are not specific to a project. Project specific
 # resolutions can be configured in the .ort.yml file of the project.
@@ -7,16 +7,16 @@
 # For detailed documentation, see:
 # https://github.com/heremaps/oss-review-toolkit/blob/master/docs/config-file-resolutions-yml.md
 
-# Structure of error resolution:
+# Structure of issue resolution:
 #
-# errors:
+# issues:
 # - message: "A regular expression matching the error message."
 #   reason: "One of: BUILD_TOOL_ISSUE|CANT_FIX_ISSUE|SCANNER_ISSUE"
 #   comment: "A comment further explaining why the reason above is applicable."
-errors:
+issues:
 - message: "^$"
   reason: "CANT_FIX_ISSUE"
-  comment: "An error resolution which resolves only errors with an empty error message."
+  comment: "An issue resolution which resolves only issues with an empty message."
 
 # Structure of policy rule violation resolution:
 #

--- a/docs/examples/rules.kts
+++ b/docs/examples/rules.kts
@@ -204,5 +204,5 @@ val ruleSet = ruleSet(ortResult) {
 }
 
 
-// Populate the list of policy rule violation errors to return
+// Populate the list of policy rule violations to return.
 ruleViolations += ruleSet.violations

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -238,7 +238,8 @@ cli/build/install/ort/bin/ort scan --help
 The `mime-types` package has only one dependency in the `depenencies` scope, but a lot of dependencies in the
 `devDependencies` scope. Scanning all of the `devDependencies` would take a lot of time, so we will only run the
 scanner on the `dependencies` scope in this tutorial. If you also want to scan the `devDependencies` it is strongly
-advised to configure a cache for the scan results as documented in the [README](../README.md) to speed up repeated scans.
+advised to configure a cache for the scan results as documented in the [README](../README.md) to speed up repeated
+scans.
 
 ```bash
 $ cli/build/install/ort/bin/ort scan -i [analyzer-output-path]/analyzer-result.yml -o [scanner-output-path] --scopes dependencies
@@ -255,8 +256,8 @@ Writing scan result to '[scanner-output-path]/scan-result.yml'.
 ```
 
 The `scanner` writes a new ORT result file to `[scanner-output-path]/scan-result.yml` containing the scan results in
-addition to the analyzer result from the input. This way belonging results are stored in the same place for traceability.
-If the input file already contained scan results they are replaced by the new scan results in the output.
+addition to the analyzer result from the input. This way belonging results are stored in the same place for
+traceability. If the input file already contained scan results they are replaced by the new scan results in the output.
 
 As you can see when checking the `scan-result.yml` file, the licenses detected by `ScanCode` match the licenses declared
 by the packages. This is because we scanned a small and well-maintained package in this example, but if you run the scan
@@ -296,8 +297,9 @@ Created 'WebApp' report: [reporter-output-path]/scan-report-web-app.html
 Created 'NoticeByPackage' report: [reporter-output-path]/NOTICE_BY_PACKAGE
 ```
 
-If you do not want to run the _evaluator_ you can pass the _scanner_ result e.g. `[scanner-output-path/scan-result.yml` to the `reporter` instead. To learn how you can customize generated notices see
-[notice-pre-processor-kts.md](notice-pre-processor-kts.md)
+If you do not want to run the _evaluator_ you can pass the _scanner_ result e.g. `[scanner-output-path/scan-result.yml`
+to the `reporter` instead. To learn how you can customize generated notices see
+[notice-pre-processor-kts.md](notice-pre-processor-kts.md).
 
 ## 8. Curating Package Metadata or License Findings
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -175,7 +175,7 @@ analyzer:
           dependencies:
           - id: "NPM::builtin-modules:1.1.1"
           - id: "NPM::contains-path:0.1.0"
-            # If an error occurred during the dependency analysis of this package there would be an additional "errors"
+            # If an issue occurred during the dependency analysis of this package there would be an additional "issues"
             # array.
 # ...
 # Detailed metadata about each package from the dependency trees.
@@ -209,10 +209,10 @@ analyzer:
           path: ""
       curations: []
 # ...
-# Finally a list of project related errors that happened during dependency analysis. Fortunately empty in this case.
-    errors: {}
-# A field to quickly check if the analyzer result contains any errors.
-    has_errors: false
+# Finally a list of project related issues that happened during dependency analysis. Fortunately empty in this case.
+    issues: {}
+# A field to quickly check if the analyzer result contains any issues.
+    has_issues: false
 ```
 
 ## 5. Run the scanner
@@ -311,5 +311,5 @@ ORT provides a variety of mechanisms to fix a variety of issues, for details see
   and resolutions to address issues found within a project's code repository.
 * [The curations.yml file](docs/config-file-curations-yml.md) - curations correct invalid or missing package metadata
   and set the concluded license for packages.
-* [The resolutions.yml file](docs/config-file-resolution-yml.md) - resolutions allow *resolving* any errors
+* [The resolutions.yml file](docs/config-file-resolution-yml.md) - resolutions allow *resolving* any issues
   or policy rule violations by providing a reason why they are acceptable and can be ignored.

--- a/docs/how-to-add-support-for-new-package-manager.md
+++ b/docs/how-to-add-support-for-new-package-manager.md
@@ -4,7 +4,8 @@ The sections below outline the steps needed to add support for a new package man
 
 ## 1. Initial Questions / Requirements
 
-Before you start any implementation work, determine whether the package manager meets the minimal requirements to provide the data needed for OSS Review Toolkit to work.
+Before you start any implementation work, determine whether the package manager meets the minimal requirements to
+provide the data needed for OSS Review Toolkit to work.
 
 Answers to the questions below should help you. 
 

--- a/evaluator/src/test/kotlin/EvaluatorTest.kt
+++ b/evaluator/src/test/kotlin/EvaluatorTest.kt
@@ -53,7 +53,7 @@ class EvaluatorTest : WordSpec() {
         }
 
         "evaluate" should {
-            "return no errors for an empty script" {
+            "return no rule violations for an empty script" {
                 val result = Evaluator(OrtResult.EMPTY).run("")
 
                 result.violations should beEmpty()
@@ -68,7 +68,7 @@ class EvaluatorTest : WordSpec() {
                 result.violations should beEmpty()
             }
 
-            "contain rule errors in the result" {
+            "contain rule violations in the result" {
                 val result = Evaluator(OrtResult.EMPTY).run(
                     """
                     ruleViolations += RuleViolation(

--- a/helper-cli/src/main/kotlin/commands/GenerateTimeoutErrorResolutionsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/GenerateTimeoutErrorResolutionsCommand.kt
@@ -26,7 +26,7 @@ import com.beust.jcommander.Parameters
 import com.here.ort.helper.CommandWithHelp
 import com.here.ort.helper.common.getScanIssues
 import com.here.ort.model.OrtResult
-import com.here.ort.model.config.ErrorResolution
+import com.here.ort.model.config.IssueResolution
 import com.here.ort.model.config.ErrorResolutionReason
 import com.here.ort.model.config.Resolutions
 import com.here.ort.model.readValue
@@ -63,7 +63,7 @@ internal class GenerateTimeoutErrorResolutionsCommand : CommandWithHelp() {
         names = ["--resolutions-file"],
         required = false,
         order = PARAMETER_ORDER_OPTIONAL,
-        description = "A file containing error resolutions to be used in addition to the ones contained in the given " +
+        description = "A file containing issue resolutions to be used in addition to the ones contained in the given " +
                 "ORT file."
     )
     private var resolutionsFile: File? = null
@@ -72,7 +72,7 @@ internal class GenerateTimeoutErrorResolutionsCommand : CommandWithHelp() {
         names = ["--omit-excluded"],
         required = false,
         order = PARAMETER_ORDER_OPTIONAL,
-        description = "Only generate error resolutions for non-excluded projects or packages."
+        description = "Only generate issue resolutions for non-excluded projects or packages."
     )
     private var omitExcluded: Boolean = false
 
@@ -98,11 +98,11 @@ internal class GenerateTimeoutErrorResolutionsCommand : CommandWithHelp() {
             .getScanIssues(omitExcluded)
             .filter {
                 it.message.startsWith("ERROR: Timeout")
-                        && resolutionProvider.getErrorResolutionsFor(it).isEmpty()
+                        && resolutionProvider.getIssueResolutionsFor(it).isEmpty()
             }
 
         val generatedResolutions = timeoutIssues.map {
-            ErrorResolution(
+            IssueResolution(
                 message = it.message,
                 reason = ErrorResolutionReason.SCANNER_ISSUE,
                 comment = "TODO"

--- a/helper-cli/src/main/kotlin/commands/GenerateTimeoutErrorResolutionsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/GenerateTimeoutErrorResolutionsCommand.kt
@@ -27,7 +27,7 @@ import com.here.ort.helper.CommandWithHelp
 import com.here.ort.helper.common.getScanIssues
 import com.here.ort.model.OrtResult
 import com.here.ort.model.config.IssueResolution
-import com.here.ort.model.config.ErrorResolutionReason
+import com.here.ort.model.config.IssueResolutionReason
 import com.here.ort.model.config.Resolutions
 import com.here.ort.model.readValue
 import com.here.ort.model.yamlMapper
@@ -104,7 +104,7 @@ internal class GenerateTimeoutErrorResolutionsCommand : CommandWithHelp() {
         val generatedResolutions = timeoutIssues.map {
             IssueResolution(
                 message = it.message,
-                reason = ErrorResolutionReason.SCANNER_ISSUE,
+                reason = IssueResolutionReason.SCANNER_ISSUE,
                 comment = "TODO"
             )
         }.distinct().sortedBy { it.message }

--- a/helper-cli/src/main/kotlin/commands/RemoveConfigurationEntriesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/RemoveConfigurationEntriesCommand.kt
@@ -27,7 +27,7 @@ import com.here.ort.helper.CommandWithHelp
 import com.here.ort.helper.common.findFilesRecursive
 import com.here.ort.helper.common.minimize
 import com.here.ort.helper.common.replacePathExcludes
-import com.here.ort.helper.common.replaceErrorResolutions
+import com.here.ort.helper.common.replaceIssueResolutions
 import com.here.ort.helper.common.replaceRuleViolationResolutions
 import com.here.ort.helper.common.replaceScopeExcludes
 import com.here.ort.helper.common.writeAsYaml
@@ -76,7 +76,7 @@ internal class RemoveConfigurationEntriesCommand : CommandWithHelp() {
     private lateinit var sourceCodeDir: File
 
     @Parameter(
-        description = "A file containing error resolutions.",
+        description = "A file containing issue resolutions.",
         names = ["--resolutions-file"],
         order = PARAMETER_ORDER_OPTIONAL
     )
@@ -108,24 +108,24 @@ internal class RemoveConfigurationEntriesCommand : CommandWithHelp() {
                 add(it)
             }
         }
-        val notGloballyResolvedErrors = ortResult.collectIssues().values.flatten().filter {
-            resolutionProvider.getErrorResolutionsFor(it).isEmpty()
+        val notGloballyResolvedIssues = ortResult.collectIssues().values.flatten().filter {
+            resolutionProvider.getIssueResolutionsFor(it).isEmpty()
         }
-        val errorResolutions = ortResult.getResolutions().errors.filter { resolution ->
-            notGloballyResolvedErrors.any { resolution.matches(it) }
+        val issueResolutions = ortResult.getResolutions().issues.filter { resolution ->
+            notGloballyResolvedIssues.any { resolution.matches(it) }
         }
 
         repositoryConfiguration
             .replacePathExcludes(pathExcludes)
             .replaceScopeExcludes(scopeExcludes)
-            .replaceErrorResolutions(errorResolutions)
+            .replaceIssueResolutions(issueResolutions)
             .replaceRuleViolationResolutions(ruleViolationResolutions)
             .writeAsYaml(repositoryConfigurationFile)
 
         buildString {
             val removedPathExcludes = repositoryConfiguration.excludes.paths.size - pathExcludes.size
             val removedScopeExcludes = repositoryConfiguration.excludes.scopes.size - scopeExcludes.size
-            val removedErrorResolutions = repositoryConfiguration.resolutions.errors.size - errorResolutions.size
+            val removedIssueResolutions = repositoryConfiguration.resolutions.issues.size - issueResolutions.size
             val removedRuleViolationResolutions = repositoryConfiguration.resolutions.ruleViolations.size -
                     ruleViolationResolutions.size
 
@@ -133,7 +133,7 @@ internal class RemoveConfigurationEntriesCommand : CommandWithHelp() {
             appendln()
             appendln("  path excludes             : $removedPathExcludes")
             appendln("  scope excludes            : $removedScopeExcludes")
-            appendln("  error resolutions         : $removedErrorResolutions")
+            appendln("  issue resolutions         : $removedIssueResolutions")
             appendln("  rule violation resolutions: $removedRuleViolationResolutions")
         }.let { println(it) }
 

--- a/helper-cli/src/main/kotlin/commands/RemoveConfigurationEntriesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/RemoveConfigurationEntriesCommand.kt
@@ -108,7 +108,7 @@ internal class RemoveConfigurationEntriesCommand : CommandWithHelp() {
                 add(it)
             }
         }
-        val notGloballyResolvedErrors = ortResult.collectErrors().values.flatten().filter {
+        val notGloballyResolvedErrors = ortResult.collectIssues().values.flatten().filter {
             resolutionProvider.getErrorResolutionsFor(it).isEmpty()
         }
         val errorResolutions = ortResult.getResolutions().errors.filter { resolution ->

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -360,7 +360,7 @@ fun OrtResult.getScanIssues(omitExcluded: Boolean = false): List<OrtIssue> {
     scanner?.results?.scanResults?.forEach { container ->
         if (!omitExcluded || !isExcluded(container.id)) {
             container.results.forEach { scanResult ->
-                result.addAll(scanResult.summary.errors)
+                result.addAll(scanResult.summary.issues)
             }
         }
     }

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -37,7 +37,7 @@ import com.here.ort.model.Severity
 import com.here.ort.model.TextLocation
 import com.here.ort.model.VcsInfo
 import com.here.ort.model.config.AnalyzerConfiguration
-import com.here.ort.model.config.ErrorResolution
+import com.here.ort.model.config.IssueResolution
 import com.here.ort.model.config.LicenseFindingCuration
 import com.here.ort.model.config.PathExclude
 import com.here.ort.model.config.RepositoryConfiguration
@@ -410,11 +410,11 @@ internal fun OrtResult.getUnresolvedRuleViolations(): List<RuleViolation> {
 }
 
 /**
- * Return a copy with the [ErrorResolution]s replaced by the given [errorResolutions].
+ * Return a copy with the [IssueResolution]s replaced by the given [issueResolutions].
  */
-internal fun RepositoryConfiguration.replaceErrorResolutions(
-    errorResolutions: List<ErrorResolution>
-): RepositoryConfiguration = copy(resolutions = resolutions.copy(errors = errorResolutions))
+internal fun RepositoryConfiguration.replaceIssueResolutions(
+    issueResolutions: List<IssueResolution>
+): RepositoryConfiguration = copy(resolutions = resolutions.copy(issues = issueResolutions))
 
 /**
  * Return a copy with the [LicenseFindingCuration]s replaced by the given scope excludes.

--- a/model/src/main/kotlin/AnalyzerResult.kt
+++ b/model/src/main/kotlin/AnalyzerResult.kt
@@ -76,9 +76,9 @@ data class AnalyzerResult(
         }
 
         packages.forEach { curatedPackage ->
-            val errors = curatedPackage.pkg.collectErrors()
-            if (errors.isNotEmpty()) {
-                collectedIssues.getOrPut(curatedPackage.pkg.id) { mutableSetOf() } += errors
+            val issues = curatedPackage.pkg.collectIssues()
+            if (issues.isNotEmpty()) {
+                collectedIssues.getOrPut(curatedPackage.pkg.id) { mutableSetOf() } += issues
             }
         }
 

--- a/model/src/main/kotlin/AnalyzerResult.kt
+++ b/model/src/main/kotlin/AnalyzerResult.kt
@@ -91,7 +91,7 @@ data class AnalyzerResult(
     @Suppress("UNUSED") // Not used in code, but shall be serialized.
     val hasIssues by lazy {
         issues.any { it.value.isNotEmpty() }
-                || projects.any { it.scopes.any { it.dependencies.any { it.hasErrors() } } }
+                || projects.any { it.scopes.any { it.dependencies.any { it.hasIssues() } } }
     }
 }
 

--- a/model/src/main/kotlin/AnalyzerResult.kt
+++ b/model/src/main/kotlin/AnalyzerResult.kt
@@ -129,8 +129,8 @@ class AnalyzerResultBuilder {
             } else {
                 projects += projectAnalyzerResult.project
                 packages += projectAnalyzerResult.packages
-                if (projectAnalyzerResult.errors.isNotEmpty()) {
-                    issues[projectAnalyzerResult.project.id] = projectAnalyzerResult.errors
+                if (projectAnalyzerResult.issues.isNotEmpty()) {
+                    issues[projectAnalyzerResult.project.id] = projectAnalyzerResult.issues
                 }
             }
         }

--- a/model/src/main/kotlin/AnalyzerResult.kt
+++ b/model/src/main/kotlin/AnalyzerResult.kt
@@ -70,8 +70,8 @@ data class AnalyzerResult(
         val collectedIssues = issues.mapValuesTo(mutableMapOf()) { it.value.toMutableSet() }
 
         projects.forEach { project ->
-            project.collectErrors().forEach { (id, errors) ->
-                collectedIssues.getOrPut(id) { mutableSetOf() } += errors
+            project.collectIssues().forEach { (id, issues) ->
+                collectedIssues.getOrPut(id) { mutableSetOf() } += issues
             }
         }
 

--- a/model/src/main/kotlin/AnalyzerResult.kt
+++ b/model/src/main/kotlin/AnalyzerResult.kt
@@ -19,6 +19,7 @@
 
 package com.here.ort.model
 
+import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 
@@ -28,7 +29,7 @@ import java.util.SortedSet
 /**
  * A class that merges all information from individual [ProjectAnalyzerResult]s created for each found definition file.
  */
-@JsonIgnoreProperties(value = ["has_errors"], allowGetters = true)
+@JsonIgnoreProperties(value = ["has_issues"], allowGetters = true)
 data class AnalyzerResult(
     /**
      * Sorted set of the projects, as they appear in the individual analyzer results.
@@ -41,13 +42,14 @@ data class AnalyzerResult(
     val packages: SortedSet<CuratedPackage>,
 
     /**
-     * The lists of errors that occurred within the analyzed projects themselves. Errors related to project
+     * The lists of [OrtIssue]s that occurred within the analyzed projects themselves. Issues related to project
      * dependencies are contained in the dependencies of the project's scopes.
+     * This property is not serialized if the map is empty to reduce the size of the result file. If there are no issues
+     * at all, [AnalyzerResult.hasIssues] already contains that information.
      */
-    // Do not serialize if empty to reduce the size of the result file. If there are no errors at all,
-    // [AnalyzerResult.hasErrors] already contains that information.
+    @JsonAlias("errors")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val errors: SortedMap<Identifier, List<OrtIssue>> = sortedMapOf()
+    val issues: SortedMap<Identifier, List<OrtIssue>> = sortedMapOf()
 ) {
     companion object {
         /**
@@ -57,38 +59,38 @@ data class AnalyzerResult(
         val EMPTY = AnalyzerResult(
             projects = sortedSetOf(),
             packages = sortedSetOf(),
-            errors = sortedMapOf()
+            issues = sortedMapOf()
         )
     }
 
     /**
-     * Return a map of all de-duplicated errors associated by [Identifier].
+     * Return a map of all de-duplicated [OrtIssue]s associated by [Identifier].
      */
-    fun collectErrors(): Map<Identifier, Set<OrtIssue>> {
-        val collectedErrors = errors.mapValuesTo(mutableMapOf()) { it.value.toMutableSet() }
+    fun collectIssues(): Map<Identifier, Set<OrtIssue>> {
+        val collectedIssues = issues.mapValuesTo(mutableMapOf()) { it.value.toMutableSet() }
 
         projects.forEach { project ->
             project.collectErrors().forEach { (id, errors) ->
-                collectedErrors.getOrPut(id) { mutableSetOf() } += errors
+                collectedIssues.getOrPut(id) { mutableSetOf() } += errors
             }
         }
 
         packages.forEach { curatedPackage ->
             val errors = curatedPackage.pkg.collectErrors()
             if (errors.isNotEmpty()) {
-                collectedErrors.getOrPut(curatedPackage.pkg.id) { mutableSetOf() } += errors
+                collectedIssues.getOrPut(curatedPackage.pkg.id) { mutableSetOf() } += errors
             }
         }
 
-        return collectedErrors
+        return collectedIssues
     }
 
     /**
-     * True if there were any errors during the analysis, false otherwise.
+     * True if there were any issues during the analysis, false otherwise.
      */
     @Suppress("UNUSED") // Not used in code, but shall be serialized.
-    val hasErrors by lazy {
-        errors.any { it.value.isNotEmpty() }
+    val hasIssues by lazy {
+        issues.any { it.value.isNotEmpty() }
                 || projects.any { it.scopes.any { it.dependencies.any { it.hasErrors() } } }
     }
 }
@@ -96,9 +98,9 @@ data class AnalyzerResult(
 class AnalyzerResultBuilder {
     private val projects = sortedSetOf<Project>()
     private val packages = sortedSetOf<CuratedPackage>()
-    private val errors = sortedMapOf<Identifier, List<OrtIssue>>()
+    private val issues = sortedMapOf<Identifier, List<OrtIssue>>()
 
-    fun build() = AnalyzerResult(projects, packages, errors)
+    fun build() = AnalyzerResult(projects, packages, issues)
 
     fun addResult(projectAnalyzerResult: ProjectAnalyzerResult) =
         also {
@@ -114,7 +116,7 @@ class AnalyzerResultBuilder {
                     "${it.vcsProcessed.url}/${it.definitionFilePath}"
                 }
 
-                val error = createAndLogIssue(
+                val issue = createAndLogIssue(
                     source = "analyzer",
                     message = "Multiple projects with the same id '${existingProject.id.toCoordinates()}' " +
                             "found. Not adding the project defined in '$incomingDefinitionFileUrl' to the " +
@@ -122,13 +124,13 @@ class AnalyzerResultBuilder {
                             "'$existingDefinitionFileUrl'."
                 )
 
-                val projectErrors = errors.getOrDefault(existingProject.id, emptyList())
-                errors[existingProject.id] = projectErrors + error
+                val projectIssues = issues.getOrDefault(existingProject.id, emptyList())
+                issues[existingProject.id] = projectIssues + issue
             } else {
                 projects += projectAnalyzerResult.project
                 packages += projectAnalyzerResult.packages
                 if (projectAnalyzerResult.errors.isNotEmpty()) {
-                    errors[projectAnalyzerResult.project.id] = projectAnalyzerResult.errors
+                    issues[projectAnalyzerResult.project.id] = projectAnalyzerResult.errors
                 }
             }
         }

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -167,7 +167,7 @@ data class OrtResult(
      */
     fun collectErrors(): Map<Identifier, Set<OrtIssue>> {
         val analyzerErrors = analyzer?.result?.collectIssues().orEmpty()
-        val scannerErrors = scanner?.results?.collectErrors().orEmpty()
+        val scannerErrors = scanner?.results?.collectIssues().orEmpty()
         return analyzerErrors.zipWithDefault(scannerErrors, emptySet()) { left, right -> left + right }
     }
 

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -166,7 +166,7 @@ data class OrtResult(
      * Return a map of all de-duplicated errors associated by [Identifier].
      */
     fun collectErrors(): Map<Identifier, Set<OrtIssue>> {
-        val analyzerErrors = analyzer?.result?.collectErrors().orEmpty()
+        val analyzerErrors = analyzer?.result?.collectIssues().orEmpty()
         val scannerErrors = scanner?.results?.collectErrors().orEmpty()
         return analyzerErrors.zipWithDefault(scannerErrors, emptySet()) { left, right -> left + right }
     }

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -163,12 +163,12 @@ data class OrtResult(
     }
 
     /**
-     * Return a map of all de-duplicated errors associated by [Identifier].
+     * Return a map of all de-duplicated [OrtIssue]s associated by [Identifier].
      */
-    fun collectErrors(): Map<Identifier, Set<OrtIssue>> {
-        val analyzerErrors = analyzer?.result?.collectIssues().orEmpty()
-        val scannerErrors = scanner?.results?.collectIssues().orEmpty()
-        return analyzerErrors.zipWithDefault(scannerErrors, emptySet()) { left, right -> left + right }
+    fun collectIssues(): Map<Identifier, Set<OrtIssue>> {
+        val analyzerIssues = analyzer?.result?.collectIssues().orEmpty()
+        val scannerIssues = scanner?.results?.collectIssues().orEmpty()
+        return analyzerIssues.zipWithDefault(scannerIssues, emptySet()) { left, right -> left + right }
     }
 
     private fun collectLicenseFindings(

--- a/model/src/main/kotlin/Package.kt
+++ b/model/src/main/kotlin/Package.kt
@@ -150,7 +150,7 @@ data class Package(
     /**
      * Check if this package contains any erroneous data.
      */
-    fun collectErrors() =
+    fun collectIssues() =
         declaredLicensesProcessed.unmapped.map { unmappedLicense ->
             OrtIssue(
                 severity = Severity.ERROR,

--- a/model/src/main/kotlin/Package.kt
+++ b/model/src/main/kotlin/Package.kt
@@ -166,12 +166,12 @@ data class Package(
     fun toCuratedPackage() = CuratedPackage(this, emptyList())
 
     /**
-     * Return a [PackageReference] to refer to this [Package] with optional [dependencies] and [errors].
+     * Return a [PackageReference] to refer to this [Package] with optional [dependencies] and [issues].
      */
     fun toReference(
         linkage: PackageLinkage? = null,
         dependencies: SortedSet<PackageReference>? = null,
-        errors: List<OrtIssue>? = null
+        issues: List<OrtIssue>? = null
     ): PackageReference {
         var ref = PackageReference(id)
 
@@ -183,8 +183,8 @@ data class Package(
             ref = ref.copy(dependencies = dependencies)
         }
 
-        if (errors != null) {
-            ref = ref.copy(errors = errors)
+        if (issues != null) {
+            ref = ref.copy(issues = issues)
         }
 
         return ref

--- a/model/src/main/kotlin/PackageReference.kt
+++ b/model/src/main/kotlin/PackageReference.kt
@@ -19,6 +19,7 @@
 
 package com.here.ort.model
 
+import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonInclude
 
 import java.util.SortedSet
@@ -57,21 +58,22 @@ data class PackageReference(
     val dependencies: SortedSet<PackageReference> = sortedSetOf(),
 
     /**
-     * A list of errors that occurred handling this [PackageReference].
+     * A list of [OrtIssue]s that occurred handling this [PackageReference].
      */
-    val errors: List<OrtIssue> = emptyList()
+    @JsonAlias("errors")
+    val issues: List<OrtIssue> = emptyList()
 ) : Comparable<PackageReference> {
     /**
      * Return the set of [PackageReference]s this [PackageReference] transitively depends on, up to and including a
      * depth of [maxDepth] where counting starts at 0 (for the [PackageReference] itself) and 1 are direct dependencies
-     * etc. A value below 0 means to not limit the depth. If [includeErroneous] is true, [PackageReference]s with errors
-     * (but not their dependencies without errors) are excluded, otherwise they are included.
+     * etc. A value below 0 means to not limit the depth. If [includeErroneous] is true, [PackageReference]s with issues
+     * (but not their dependencies without issues) are excluded, otherwise they are included.
      */
     fun collectDependencies(maxDepth: Int = -1, includeErroneous: Boolean = true): SortedSet<PackageReference> =
         dependencies.fold(sortedSetOf<PackageReference>()) { refs, ref ->
             refs.also {
                 if (maxDepth != 0) {
-                    if (ref.errors.isEmpty() || includeErroneous) it += ref
+                    if (ref.issues.isEmpty() || includeErroneous) it += ref
                     it += ref.collectDependencies(maxDepth - 1, includeErroneous)
                 }
             }
@@ -95,9 +97,9 @@ data class PackageReference(
         dependencies.filter { it.id == id } + dependencies.flatMap { it.findReferences(id) }
 
     /**
-     * Return whether this package reference or any of its dependencies has errors.
+     * Return whether this package reference or any of its dependencies has issues.
      */
-    fun hasErrors(): Boolean = errors.isNotEmpty() || dependencies.any { it.hasErrors() }
+    fun hasIssues(): Boolean = issues.isNotEmpty() || dependencies.any { it.hasIssues() }
 
     /**
      * Apply the provided [transform] to each node in the dependency tree represented by this [PackageReference] and

--- a/model/src/main/kotlin/Project.kt
+++ b/model/src/main/kotlin/Project.kt
@@ -114,8 +114,8 @@ data class Project(
         val collectedErrors = mutableMapOf<Identifier, MutableSet<OrtIssue>>()
 
         fun addErrors(pkgRef: PackageReference) {
-            if (pkgRef.errors.isNotEmpty()) {
-                collectedErrors.getOrPut(pkgRef.id) { mutableSetOf() } += pkgRef.errors
+            if (pkgRef.issues.isNotEmpty()) {
+                collectedErrors.getOrPut(pkgRef.id) { mutableSetOf() } += pkgRef.issues
             }
 
             pkgRef.dependencies.forEach { addErrors(it) }
@@ -147,7 +147,7 @@ data class Project(
 
         fun addErrors(pkgRef: PackageReference) {
             if (pkgRef.id == id) {
-                collectedErrors += pkgRef.errors
+                collectedErrors += pkgRef.issues
             }
 
             pkgRef.dependencies.forEach { addErrors(it) }

--- a/model/src/main/kotlin/ProjectAnalyzerResult.kt
+++ b/model/src/main/kotlin/ProjectAnalyzerResult.kt
@@ -66,7 +66,7 @@ data class ProjectAnalyzerResult(
 
         fun addIssues(pkgReference: PackageReference) {
             val issuesForPkg = collectedIssues.getOrPut(pkgReference.id) { mutableListOf() }
-            issuesForPkg += pkgReference.errors
+            issuesForPkg += pkgReference.issues
 
             pkgReference.dependencies.forEach { addIssues(it) }
         }

--- a/model/src/main/kotlin/ProjectAnalyzerResult.kt
+++ b/model/src/main/kotlin/ProjectAnalyzerResult.kt
@@ -39,12 +39,12 @@ data class ProjectAnalyzerResult(
     val packages: SortedSet<CuratedPackage>,
 
     /**
-     * The list of errors that occurred during dependency resolution. Defaults to an empty list.
+     * The list of issues that occurred during dependency resolution. Defaults to an empty list.
+     * This property is not serialized if the list is empty for consistency with the issue properties in other classes,
+     * even if this class is not serialized as part of an [OrtResult].
      */
-    // Do not serialize if empty for consistency with the error properties in other classes, even if this class is
-    // not serialized as part of an [OrtResult].
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val errors: List<OrtIssue> = emptyList()
+    val issues: List<OrtIssue> = emptyList()
 ) {
     init {
         // Perform a sanity check to ensure we have no references to non-existing packages.
@@ -61,30 +61,30 @@ data class ProjectAnalyzerResult(
         }
     }
 
-    fun collectErrors(): Map<Identifier, List<OrtIssue>> {
-        val collectedErrors = mutableMapOf<Identifier, MutableList<OrtIssue>>()
+    fun collectIssues(): Map<Identifier, List<OrtIssue>> {
+        val collectedIssues = mutableMapOf<Identifier, MutableList<OrtIssue>>()
 
-        fun addErrors(pkgReference: PackageReference) {
-            val errorsForPkg = collectedErrors.getOrPut(pkgReference.id) { mutableListOf() }
-            errorsForPkg += pkgReference.errors
+        fun addIssues(pkgReference: PackageReference) {
+            val issuesForPkg = collectedIssues.getOrPut(pkgReference.id) { mutableListOf() }
+            issuesForPkg += pkgReference.errors
 
-            pkgReference.dependencies.forEach { addErrors(it) }
+            pkgReference.dependencies.forEach { addIssues(it) }
         }
 
         for (scope in project.scopes) {
             for (dependency in scope.dependencies) {
-                addErrors(dependency)
+                addIssues(dependency)
             }
         }
 
         return mutableMapOf<Identifier, List<OrtIssue>>().apply {
-            if (errors.isNotEmpty()) {
-                this[project.id] = errors.toMutableList()
+            if (issues.isNotEmpty()) {
+                this[project.id] = issues.toMutableList()
             }
 
-            collectedErrors.forEach { (pkgId, errors) ->
-                if (errors.isNotEmpty()) {
-                    this[pkgId] = errors.distinct()
+            collectedIssues.forEach { (pkgId, issues) ->
+                if (issues.isNotEmpty()) {
+                    this[pkgId] = issues.distinct()
                 }
             }
         }

--- a/model/src/main/kotlin/ScanRecord.kt
+++ b/model/src/main/kotlin/ScanRecord.kt
@@ -54,7 +54,7 @@ data class ScanRecord(
 
         scanResults.forEach { container ->
             container.results.forEach { result ->
-                collectedIssues.getOrPut(container.id) { mutableSetOf() } += result.summary.errors
+                collectedIssues.getOrPut(container.id) { mutableSetOf() } += result.summary.issues
             }
         }
 
@@ -65,5 +65,5 @@ data class ScanRecord(
      * True if any of the [scanResults] contain [OrtIssue]s.
      */
     @Suppress("UNUSED") // Not used in code, but shall be serialized.
-    val hasIssues by lazy { scanResults.any { it.results.any { it.summary.errors.isNotEmpty() } } }
+    val hasIssues by lazy { scanResults.any { it.results.any { it.summary.issues.isNotEmpty() } } }
 }

--- a/model/src/main/kotlin/ScanRecord.kt
+++ b/model/src/main/kotlin/ScanRecord.kt
@@ -27,7 +27,7 @@ import java.util.SortedSet
 /**
  * A record of a single run of the scanner tool, containing the input and the scan results for all scanned packages.
  */
-@JsonIgnoreProperties(value = ["has_errors"], allowGetters = true)
+@JsonIgnoreProperties(value = ["has_issues"], allowGetters = true)
 data class ScanRecord(
     /**
      * The scanned and ignored [Scope]s for each scanned [Project] by id.
@@ -47,23 +47,23 @@ data class ScanRecord(
     val storageStats: AccessStatistics
 ) {
     /**
-     * Return a map of all de-duplicated errors associated by [Identifier].
+     * Return a map of all de-duplicated [OrtIssue]s associated by [Identifier].
      */
-    fun collectErrors(): Map<Identifier, Set<OrtIssue>> {
-        val collectedErrors = mutableMapOf<Identifier, MutableSet<OrtIssue>>()
+    fun collectIssues(): Map<Identifier, Set<OrtIssue>> {
+        val collectedIssues = mutableMapOf<Identifier, MutableSet<OrtIssue>>()
 
         scanResults.forEach { container ->
             container.results.forEach { result ->
-                collectedErrors.getOrPut(container.id) { mutableSetOf() } += result.summary.errors
+                collectedIssues.getOrPut(container.id) { mutableSetOf() } += result.summary.errors
             }
         }
 
-        return collectedErrors
+        return collectedIssues
     }
 
     /**
-     * True if any of the [scanResults] contain errors.
+     * True if any of the [scanResults] contain [OrtIssue]s.
      */
     @Suppress("UNUSED") // Not used in code, but shall be serialized.
-    val hasErrors by lazy { scanResults.any { it.results.any { it.summary.errors.isNotEmpty() } } }
+    val hasIssues by lazy { scanResults.any { it.results.any { it.summary.errors.isNotEmpty() } } }
 }

--- a/model/src/main/kotlin/ScanSummary.kt
+++ b/model/src/main/kotlin/ScanSummary.kt
@@ -19,7 +19,6 @@
 
 package com.here.ort.model
 
-import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
@@ -44,19 +43,16 @@ data class ScanSummary(
     /**
      * The time when the scan started.
      */
-    @JsonAlias("startTime")
     val startTime: Instant,
 
     /**
      * The time when the scan finished.
      */
-    @JsonAlias("endTime")
     val endTime: Instant,
 
     /**
      * The number of scanned files.
      */
-    @JsonAlias("fileCount")
     val fileCount: Int,
 
     /**

--- a/model/src/main/kotlin/Scope.kt
+++ b/model/src/main/kotlin/Scope.kt
@@ -48,14 +48,14 @@ data class Scope(
     /**
      * Return the set of [PackageReference]s in this [Scope], up to and including a depth of [maxDepth] where counting
      * starts at 0 (for the [Scope] itself) and 1 are direct dependencies etc. A value below 0 means to not limit the
-     * depth. If [includeErroneous] is true, [PackageReference]s with errors (but not their dependencies without errors)
+     * depth. If [includeErroneous] is true, [PackageReference]s with issues (but not their dependencies without issues)
      * are excluded, otherwise they are included.
      */
     fun collectDependencies(maxDepth: Int = -1, includeErroneous: Boolean = true) =
         dependencies.fold(sortedSetOf<PackageReference>()) { refs, ref ->
             refs.also {
                 if (maxDepth != 0) {
-                    if (ref.errors.isEmpty() || includeErroneous) it += ref
+                    if (ref.issues.isEmpty() || includeErroneous) it += ref
                     it += ref.collectDependencies(maxDepth - 1, includeErroneous)
                 }
             }

--- a/model/src/main/kotlin/config/IssueResolution.kt
+++ b/model/src/main/kotlin/config/IssueResolution.kt
@@ -37,7 +37,7 @@ data class IssueResolution(
     /**
      * The reason why the issue is resolved.
      */
-    val reason: ErrorResolutionReason,
+    val reason: IssueResolutionReason,
 
     /**
      * A comment to further explain why the [reason] is applicable here.

--- a/model/src/main/kotlin/config/IssueResolution.kt
+++ b/model/src/main/kotlin/config/IssueResolution.kt
@@ -24,18 +24,18 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.here.ort.model.OrtIssue
 
 /**
- * Defines the resolution of an error. This can be used to silence false positives, or errors that have been identified
- * as not being relevant.
+ * Defines the resolution of an [OrtIssue]. This can be used to silence false positives, or issues that have been
+ * identified as not being relevant.
  */
-data class ErrorResolution(
+data class IssueResolution(
     /**
-     * A regular expression string to match the messages of errors to resolve. Will be converted to a [Regex] using
+     * A regular expression string to match the messages of issues to resolve. Will be converted to a [Regex] using
      * [RegexOption.DOT_MATCHES_ALL].
      */
     val message: String,
 
     /**
-     * The reason why the errors is resolved.
+     * The reason why the issue is resolved.
      */
     val reason: ErrorResolutionReason,
 
@@ -48,7 +48,7 @@ data class ErrorResolution(
     private val regex = Regex(message, RegexOption.DOT_MATCHES_ALL)
 
     /**
-     * True if [message] matches the message of [error].
+     * True if [message] matches the message of [issue].
      */
-    fun matches(error: OrtIssue) = regex.matches(error.message)
+    fun matches(issue: OrtIssue) = regex.matches(issue.message)
 }

--- a/model/src/main/kotlin/config/IssueResolutionReason.kt
+++ b/model/src/main/kotlin/config/IssueResolutionReason.kt
@@ -19,19 +19,24 @@
 
 package com.here.ort.model.config
 
-enum class ErrorResolutionReason {
+import com.here.ort.model.OrtIssue
+
+/**
+ * Possible reasons for resolving an [OrtIssue] using a [IssueResolution].
+ */
+enum class IssueResolutionReason {
     /**
-     * The error originates from the build tool used by the project.
+     * The issue originates from the build tool used by the project.
      */
     BUILD_TOOL_ISSUE,
 
     /**
-     * The error can not be fixed, e.g. because it requires a change to be made by a third party that is not responsive.
+     * The issue can not be fixed, e.g. because it requires a change to be made by a third party that is not responsive.
      */
     CANT_FIX_ISSUE,
 
     /**
-     * The error is due to an irrelevant scanner issue, such as time out on a large file that is not distributed.
+     * The issue is due to an irrelevant scanner issue, such as time out on a large file that is not distributed.
      */
     SCANNER_ISSUE
 }

--- a/model/src/main/kotlin/config/RepositoryConfiguration.kt
+++ b/model/src/main/kotlin/config/RepositoryConfiguration.kt
@@ -56,7 +56,7 @@ class ExcludesFilter {
 @Suppress("EqualsWithHashCodeExist") // The class is not supposed to be used with hashing.
 class ResolutionsFilter {
     override fun equals(other: Any?): Boolean =
-        if (other is Resolutions) other.errors.isEmpty() && other.ruleViolations.isEmpty() else false
+        if (other is Resolutions) other.issues.isEmpty() && other.ruleViolations.isEmpty() else false
 }
 
 @Suppress("EqualsWithHashCodeExist") // The class is not supposed to be used with hashing.

--- a/model/src/main/kotlin/config/Resolutions.kt
+++ b/model/src/main/kotlin/config/Resolutions.kt
@@ -31,8 +31,9 @@ data class Resolutions(
     /**
      * Resolutions for issues with the analysis or scan of the projects in this repository and their dependencies.
      */
+    @JsonAlias("errors")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val errors: List<ErrorResolution> = emptyList(),
+    val issues: List<IssueResolution> = emptyList(),
 
     /**
      * Resolutions for license policy violations.
@@ -46,7 +47,7 @@ data class Resolutions(
      */
     fun merge(other: Resolutions) =
         Resolutions(
-            errors = (errors + other.errors).distinct(),
+            issues = (issues + other.issues).distinct(),
             ruleViolations = (ruleViolations + other.ruleViolations).distinct()
         )
 }

--- a/model/src/test/assets/deprecated-license-findings-scan-result.yml
+++ b/model/src/test/assets/deprecated-license-findings-scan-result.yml
@@ -39,14 +39,14 @@ results:
                 - path: "copyright path 1.2"
                   start_line: 1
                   end_line: 2
-      errors:
+      issues:
         - timestamp: "1970-01-01T00:00:00Z"
           source: "source-11"
-          message: "error-11"
+          message: "issue-11"
           severity: "ERROR"
         - timestamp: "1970-01-01T00:00:00Z"
           source: "source-12"
-          message: "error-12"
+          message: "issue-12"
           severity: "ERROR"
     raw_result: "key 1"
   - provenance:
@@ -88,13 +88,13 @@ results:
                 - path: "path 2.2"
                   start_line: 1
                   end_line: 1
-      errors:
+      issues:
         - timestamp: "1970-01-01T00:00:00Z"
           source: "source-21"
-          message: "error-21"
+          message: "issue-21"
           severity: "ERROR"
         - timestamp: "1970-01-01T00:00:00Z"
           source: "source-22"
-          message: "error-22"
+          message: "issue-22"
           severity: "ERROR"
     raw_result: "key 2"

--- a/model/src/test/assets/expected-scan-results.yml
+++ b/model/src/test/assets/expected-scan-results.yml
@@ -39,14 +39,14 @@ results:
         path: "copyright path 1.2"
         start_line: 1
         end_line: 2
-    errors:
+    issues:
     - timestamp: "1970-01-01T00:00:00Z"
       source: "source-11"
-      message: "error-11"
+      message: "issue-11"
       severity: "ERROR"
     - timestamp: "1970-01-01T00:00:00Z"
       source: "source-12"
-      message: "error-12"
+      message: "issue-12"
       severity: "ERROR"
   raw_result: "key 1"
 - provenance:
@@ -88,13 +88,13 @@ results:
         path: "path/to/another/file"
         start_line: 3
         end_line: 4
-    errors:
+    issues:
     - timestamp: "1970-01-01T00:00:00Z"
       source: "source-21"
-      message: "error-21"
+      message: "issue-21"
       severity: "ERROR"
     - timestamp: "1970-01-01T00:00:00Z"
       source: "source-22"
-      message: "error-22"
+      message: "issue-22"
       severity: "ERROR"
   raw_result: "key 2"

--- a/model/src/test/kotlin/AnalyzerResultTest.kt
+++ b/model/src/test/kotlin/AnalyzerResultTest.kt
@@ -29,18 +29,18 @@ import io.kotlintest.shouldBe
 import io.kotlintest.specs.WordSpec
 
 class AnalyzerResultTest : WordSpec() {
-    private val error1 = OrtIssue(source = "source-1", message = "message-1")
-    private val error2 = OrtIssue(source = "source-2", message = "message-2")
-    private val error3 = OrtIssue(source = "source-3", message = "message-3")
-    private val error4 = OrtIssue(source = "source-4", message = "message-4")
+    private val issue1 = OrtIssue(source = "source-1", message = "message-1")
+    private val issue2 = OrtIssue(source = "source-2", message = "message-2")
+    private val issue3 = OrtIssue(source = "source-3", message = "message-3")
+    private val issue4 = OrtIssue(source = "source-4", message = "message-4")
 
     private val package1 = Package.EMPTY.copy(id = Identifier("type-1", "namespace-1", "package-1", "version-1"))
     private val package2 = Package.EMPTY.copy(id = Identifier("type-2", "namespace-2", "package-2", "version-2"))
     private val package3 = Package.EMPTY.copy(id = Identifier("type-3", "namespace-3", "package-3", "version-3"))
 
-    private val pkgRef1 = package1.toReference(errors = listOf(error1))
+    private val pkgRef1 = package1.toReference(errors = listOf(issue1))
     private val pkgRef2 = package2.toReference(
-        dependencies = sortedSetOf(package3.toReference(errors = listOf(error2)))
+        dependencies = sortedSetOf(package3.toReference(errors = listOf(issue2)))
     )
 
     private val scope1 = Scope("scope-1", sortedSetOf(pkgRef1))
@@ -57,12 +57,12 @@ class AnalyzerResultTest : WordSpec() {
 
     private val analyzerResult1 = ProjectAnalyzerResult(
         project1, sortedSetOf(package1.toCuratedPackage()),
-        listOf(error3, error4)
+        listOf(issue3, issue4)
     )
     private val analyzerResult2 = ProjectAnalyzerResult(
         project2,
         sortedSetOf(package1.toCuratedPackage(), package2.toCuratedPackage(), package3.toCuratedPackage()),
-        listOf(error4)
+        listOf(issue4)
     )
 
     init {
@@ -80,22 +80,22 @@ class AnalyzerResultTest : WordSpec() {
             }
         }
 
-        "collectErrors" should {
-            "find all errors" {
+        "collectIssues" should {
+            "find all issues" {
                 val analyzerResult = AnalyzerResultBuilder()
                     .addResult(analyzerResult1)
                     .addResult(analyzerResult2)
                     .build()
 
-                analyzerResult.collectErrors() shouldBe mapOf(
-                    package1.id to setOf(error1),
-                    package3.id to setOf(error2),
-                    project1.id to setOf(error3, error4),
-                    project2.id to setOf(error4)
+                analyzerResult.collectIssues() shouldBe mapOf(
+                    package1.id to setOf(issue1),
+                    package3.id to setOf(issue2),
+                    project1.id to setOf(issue3, issue4),
+                    project2.id to setOf(issue4)
                 )
             }
 
-            "contain declared license errors" {
+            "contain declared license issues" {
                 val invalidProjectLicense = sortedSetOf("invalid project license")
                 val invalidPackageLicense = sortedSetOf("invalid package license")
                 val analyzerResult = AnalyzerResult(
@@ -114,21 +114,21 @@ class AnalyzerResultTest : WordSpec() {
                     )
                 )
 
-                val errors = analyzerResult.collectErrors()
+                val issues = analyzerResult.collectIssues()
 
-                errors.getValue(project1.id).let { projectErrors ->
-                    projectErrors should haveSize(1)
-                    projectErrors.first().severity shouldBe Severity.ERROR
-                    projectErrors.first().source shouldBe project1.id.toCoordinates()
-                    projectErrors.first().message shouldBe "The declared license 'invalid project license' could not " +
+                issues.getValue(project1.id).let { projectIssues ->
+                    projectIssues should haveSize(1)
+                    projectIssues.first().severity shouldBe Severity.ERROR
+                    projectIssues.first().source shouldBe project1.id.toCoordinates()
+                    projectIssues.first().message shouldBe "The declared license 'invalid project license' could not " +
                             "be mapped to a valid license or parsed as an SPDX expression."
                 }
 
-                errors.getValue(package1.id).let { packageErrors ->
-                    packageErrors should haveSize(1)
-                    packageErrors.first().severity shouldBe Severity.ERROR
-                    packageErrors.first().source shouldBe package1.id.toCoordinates()
-                    packageErrors.first().message shouldBe "The declared license 'invalid package license' could not " +
+                issues.getValue(package1.id).let { packageIssues ->
+                    packageIssues should haveSize(1)
+                    packageIssues.first().severity shouldBe Severity.ERROR
+                    packageIssues.first().source shouldBe package1.id.toCoordinates()
+                    packageIssues.first().message shouldBe "The declared license 'invalid package license' could not " +
                             "be mapped to a valid license or parsed as an SPDX expression."
                 }
             }
@@ -146,7 +146,7 @@ class AnalyzerResultTest : WordSpec() {
                     package1.toCuratedPackage(), package2.toCuratedPackage(),
                     package3.toCuratedPackage()
                 )
-                mergedResults.errors shouldBe
+                mergedResults.issues shouldBe
                         sortedMapOf(project1.id to analyzerResult1.errors, project2.id to analyzerResult2.errors)
             }
         }

--- a/model/src/test/kotlin/AnalyzerResultTest.kt
+++ b/model/src/test/kotlin/AnalyzerResultTest.kt
@@ -38,9 +38,9 @@ class AnalyzerResultTest : WordSpec() {
     private val package2 = Package.EMPTY.copy(id = Identifier("type-2", "namespace-2", "package-2", "version-2"))
     private val package3 = Package.EMPTY.copy(id = Identifier("type-3", "namespace-3", "package-3", "version-3"))
 
-    private val pkgRef1 = package1.toReference(errors = listOf(issue1))
+    private val pkgRef1 = package1.toReference(issues = listOf(issue1))
     private val pkgRef2 = package2.toReference(
-        dependencies = sortedSetOf(package3.toReference(errors = listOf(issue2)))
+        dependencies = sortedSetOf(package3.toReference(issues = listOf(issue2)))
     )
 
     private val scope1 = Scope("scope-1", sortedSetOf(pkgRef1))

--- a/model/src/test/kotlin/AnalyzerResultTest.kt
+++ b/model/src/test/kotlin/AnalyzerResultTest.kt
@@ -147,7 +147,7 @@ class AnalyzerResultTest : WordSpec() {
                     package3.toCuratedPackage()
                 )
                 mergedResults.issues shouldBe
-                        sortedMapOf(project1.id to analyzerResult1.errors, project2.id to analyzerResult2.errors)
+                        sortedMapOf(project1.id to analyzerResult1.issues, project2.id to analyzerResult2.issues)
             }
         }
     }

--- a/model/src/test/kotlin/AnalyzerRunTest.kt
+++ b/model/src/test/kotlin/AnalyzerRunTest.kt
@@ -40,7 +40,7 @@ class AnalyzerRunTest : StringSpec() {
                 result:
                   projects: []
                   packages: []
-                  has_errors: false
+                  has_issues: false
             """.trimIndent()
 
             val analyzerRun = yamlMapper.readValue<AnalyzerRun>(yaml)
@@ -63,7 +63,7 @@ class AnalyzerRunTest : StringSpec() {
                 result:
                   projects: []
                   packages: []
-                  has_errors: false
+                  has_issues: false
             """.trimIndent()
 
             val analyzerRun = yamlMapper.readValue<AnalyzerRun>(yaml)

--- a/model/src/test/kotlin/PackageReferenceTest.kt
+++ b/model/src/test/kotlin/PackageReferenceTest.kt
@@ -71,14 +71,14 @@ class PackageReferenceTest : WordSpec() {
                     val name = "${it.id.name}_suffix"
                     it.copy(
                         id = it.id.copy(name = name),
-                        errors = listOf(OrtIssue(source = "test", message = "error $name"))
+                        issues = listOf(OrtIssue(source = "test", message = "issue $name"))
                     )
                 }
 
                 modifiedTree.traverse {
                     it.id.name should endWith("_suffix")
-                    it.errors should haveSize(1)
-                    it.errors.first().message shouldBe "error ${it.id.name}"
+                    it.issues should haveSize(1)
+                    it.issues.first().message shouldBe "issue ${it.id.name}"
                     it
                 }
             }

--- a/model/src/test/kotlin/ProjectAnalyzerResultTest.kt
+++ b/model/src/test/kotlin/ProjectAnalyzerResultTest.kt
@@ -60,10 +60,10 @@ class ProjectAnalyzerResultTest : StringSpec({
                                             version = "version2"
                                         ),
                                         dependencies = sortedSetOf(),
-                                        errors = listOf(issue1, issue2)
+                                        issues = listOf(issue1, issue2)
                                     )
                                 ),
-                                errors = listOf(issue3, issue4)
+                                issues = listOf(issue3, issue4)
                             ),
                             PackageReference(
                                 Identifier(
@@ -73,7 +73,7 @@ class ProjectAnalyzerResultTest : StringSpec({
                                     version = "version3"
                                 ),
                                 dependencies = sortedSetOf(),
-                                errors = listOf(issue5, issue6)
+                                issues = listOf(issue5, issue6)
                             )
                         )
                     )

--- a/model/src/test/kotlin/ProjectAnalyzerResultTest.kt
+++ b/model/src/test/kotlin/ProjectAnalyzerResultTest.kt
@@ -23,15 +23,15 @@ import io.kotlintest.shouldBe
 import io.kotlintest.specs.StringSpec
 
 class ProjectAnalyzerResultTest : StringSpec({
-    "collectErrors should find all errors" {
-        val error1 = OrtIssue(source = "source-1", message = "error-1")
-        val error2 = OrtIssue(source = "source-2", message = "error-2")
-        val error3 = OrtIssue(source = "source-3", message = "error-3")
-        val error4 = OrtIssue(source = "source-4", message = "error-4")
-        val error5 = OrtIssue(source = "source-5", message = "error-5")
-        val error6 = OrtIssue(source = "source-6", message = "error-6")
-        val error7 = OrtIssue(source = "source-7", message = "error-7")
-        val error8 = OrtIssue(source = "source-8", message = "error-8")
+    "collectIssues should find all issues" {
+        val issue1 = OrtIssue(source = "source-1", message = "issue-1")
+        val issue2 = OrtIssue(source = "source-2", message = "issue-2")
+        val issue3 = OrtIssue(source = "source-3", message = "issue-3")
+        val issue4 = OrtIssue(source = "source-4", message = "issue-4")
+        val issue5 = OrtIssue(source = "source-5", message = "issue-5")
+        val issue6 = OrtIssue(source = "source-6", message = "issue-6")
+        val issue7 = OrtIssue(source = "source-7", message = "issue-7")
+        val issue8 = OrtIssue(source = "source-8", message = "issue-8")
 
         val result = ProjectAnalyzerResult(
             project = Project(
@@ -60,10 +60,10 @@ class ProjectAnalyzerResultTest : StringSpec({
                                             version = "version2"
                                         ),
                                         dependencies = sortedSetOf(),
-                                        errors = listOf(error1, error2)
+                                        errors = listOf(issue1, issue2)
                                     )
                                 ),
-                                errors = listOf(error3, error4)
+                                errors = listOf(issue3, issue4)
                             ),
                             PackageReference(
                                 Identifier(
@@ -73,21 +73,21 @@ class ProjectAnalyzerResultTest : StringSpec({
                                     version = "version3"
                                 ),
                                 dependencies = sortedSetOf(),
-                                errors = listOf(error5, error6)
+                                errors = listOf(issue5, issue6)
                             )
                         )
                     )
                 )
             ),
             packages = sortedSetOf(),
-            errors = listOf(error7, error8)
+            issues = listOf(issue7, issue8)
         )
 
-        val errors = result.collectErrors()
-        errors.size shouldBe 4
-        errors[Identifier("type:namespace:name:version")] shouldBe listOf(error7, error8)
-        errors[Identifier("type1:namespace1:name1:version1")] shouldBe listOf(error3, error4)
-        errors[Identifier("type2:namespace2:name2:version2")] shouldBe listOf(error1, error2)
-        errors[Identifier("type3:namespace3:name3:version3")] shouldBe listOf(error5, error6)
+        val issues = result.collectIssues()
+        issues.size shouldBe 4
+        issues[Identifier("type:namespace:name:version")] shouldBe listOf(issue7, issue8)
+        issues[Identifier("type1:namespace1:name1:version1")] shouldBe listOf(issue3, issue4)
+        issues[Identifier("type2:namespace2:name2:version2")] shouldBe listOf(issue1, issue2)
+        issues[Identifier("type3:namespace3:name3:version3")] shouldBe listOf(issue5, issue6)
     }
 })

--- a/model/src/test/kotlin/ProjectTest.kt
+++ b/model/src/test/kotlin/ProjectTest.kt
@@ -68,15 +68,15 @@ class ProjectTest : WordSpec({
         }
     }
 
-    "collectErrors" should {
-        "find all errors" {
+    "collectIssues" should {
+        "find all issues" {
             val analyzerResultsFile = File(
                 "../analyzer/src/funTest/assets/projects/synthetic/" +
                         "gradle-expected-output-lib-without-repo.yml"
             )
             val project = analyzerResultsFile.readValue<ProjectAnalyzerResult>().project
 
-            project.collectErrors() shouldBe mapOf(
+            project.collectIssues() shouldBe mapOf(
                 Identifier("Unknown:org.apache.commons:commons-text:1.1") to setOf(
                     OrtIssue(
                         Instant.EPOCH,

--- a/model/src/test/kotlin/ScanResultContainerTest.kt
+++ b/model/src/test/kotlin/ScanResultContainerTest.kt
@@ -54,10 +54,10 @@ class ScanResultContainerTest : WordSpec() {
     private val scannerStartTime2 = downloadTime2 + Duration.ofMinutes(1)
     private val scannerEndTime2 = scannerStartTime2 + Duration.ofMinutes(1)
 
-    private val error11 = OrtIssue(source = "source-11", message = "error-11")
-    private val error12 = OrtIssue(source = "source-12", message = "error-12")
-    private val error21 = OrtIssue(source = "source-21", message = "error-21")
-    private val error22 = OrtIssue(source = "source-22", message = "error-22")
+    private val issue11 = OrtIssue(source = "source-11", message = "issue-11")
+    private val issue12 = OrtIssue(source = "source-12", message = "issue-12")
+    private val issue21 = OrtIssue(source = "source-21", message = "issue-21")
+    private val issue22 = OrtIssue(source = "source-22", message = "issue-22")
 
     private val scanSummary1 = ScanSummary(
         scannerStartTime1,
@@ -84,7 +84,7 @@ class ScanResultContainerTest : WordSpec() {
                 TextLocation("copyright path 1.2", 1, 2)
             )
          ),
-        mutableListOf(error11, error12)
+        mutableListOf(issue11, issue12)
     )
     private val scanSummary2 = ScanSummary(
         scannerStartTime2,
@@ -106,7 +106,7 @@ class ScanResultContainerTest : WordSpec() {
             CopyrightFinding("copyright 3", TextLocation("path/to/file", 1, 2)),
             CopyrightFinding("copyright 4", TextLocation("path/to/another/file", 3, 4))
         ),
-        mutableListOf(error21, error22)
+        mutableListOf(issue21, issue22)
     )
 
     private val rawResult1 = jsonMapper.readTree("\"key 1\": \"value 1\"")

--- a/model/src/test/kotlin/ScannerRunTest.kt
+++ b/model/src/test/kotlin/ScannerRunTest.kt
@@ -42,7 +42,7 @@ class ScannerRunTest : StringSpec() {
                   storage_stats:
                     num_reads: 0
                     num_hits: 0
-                  has_errors: false
+                  has_issues: false
             """.trimIndent()
 
             val scannerRun = yamlMapper.readValue<ScannerRun>(yaml)
@@ -67,7 +67,7 @@ class ScannerRunTest : StringSpec() {
                   storage_stats:
                     num_reads: 0
                     num_hits: 0
-                  has_errors: false
+                  has_issues: false
             """.trimIndent()
 
             val scannerRun = yamlMapper.readValue<ScannerRun>(yaml)

--- a/model/src/test/kotlin/config/RepositoryConfigurationTest.kt
+++ b/model/src/test/kotlin/config/RepositoryConfigurationTest.kt
@@ -95,9 +95,9 @@ class RepositoryConfigurationTest : WordSpec() {
                     comment shouldBe "issue comment"
                 }
 
-                val evalErrors = repositoryConfiguration.resolutions.ruleViolations
-                evalErrors should haveSize(1)
-                with(evalErrors.first()) {
+                val ruleViolations = repositoryConfiguration.resolutions.ruleViolations
+                ruleViolations should haveSize(1)
+                with(ruleViolations.first()) {
                     message shouldBe "rule message"
                     reason shouldBe RuleViolationResolutionReason.PATENT_GRANT_EXCEPTION
                     comment shouldBe "rule comment"

--- a/model/src/test/kotlin/config/RepositoryConfigurationTest.kt
+++ b/model/src/test/kotlin/config/RepositoryConfigurationTest.kt
@@ -91,7 +91,7 @@ class RepositoryConfigurationTest : WordSpec() {
                 issues should haveSize(1)
                 with(issues.first()) {
                     message shouldBe "message"
-                    reason shouldBe ErrorResolutionReason.CANT_FIX_ISSUE
+                    reason shouldBe IssueResolutionReason.CANT_FIX_ISSUE
                     comment shouldBe "issue comment"
                 }
 

--- a/model/src/test/kotlin/config/RepositoryConfigurationTest.kt
+++ b/model/src/test/kotlin/config/RepositoryConfigurationTest.kt
@@ -57,10 +57,10 @@ class RepositoryConfigurationTest : WordSpec() {
                         reason: "TEST_DEPENDENCY_OF"
                         comment: "scope comment"
                     resolutions:
-                      errors:
+                      issues:
                       - message: "message"
                         reason: "CANT_FIX_ISSUE"
-                        comment: "error comment"
+                        comment: "issue comment"
                       rule_violations:
                       - message: "rule message"
                         reason: "PATENT_GRANT_EXCEPTION"
@@ -87,12 +87,12 @@ class RepositoryConfigurationTest : WordSpec() {
                     comment shouldBe "scope comment"
                 }
 
-                val errors = repositoryConfiguration.resolutions.errors
-                errors should haveSize(1)
-                with(errors.first()) {
+                val issues = repositoryConfiguration.resolutions.issues
+                issues should haveSize(1)
+                with(issues.first()) {
                     message shouldBe "message"
                     reason shouldBe ErrorResolutionReason.CANT_FIX_ISSUE
-                    comment shouldBe "error comment"
+                    comment shouldBe "issue comment"
                 }
 
                 val evalErrors = repositoryConfiguration.resolutions.ruleViolations

--- a/reporter-web-app/public/index.html
+++ b/reporter-web-app/public/index.html
@@ -13516,7 +13516,7 @@
         },
         "curations" : [ ]
       } ],
-      "has_errors" : false
+      "has_issues" : false
     }
   },
   "scanner" : {
@@ -61322,7 +61322,7 @@
         "num_reads" : 294,
         "num_hits" : 248
       },
-      "has_errors" : false
+      "has_issues" : false
     }
   },
   "evaluator" : {

--- a/reporter-web-app/src/App.css
+++ b/reporter-web-app/src/App.css
@@ -11,7 +11,7 @@ h1, h2, h3, h4 {
     margin: 1em 0em 1em 0em;
 }
 
-th: {
+th {
     padding-right: 10px;
 }
 

--- a/reporter-web-app/src/App.css
+++ b/reporter-web-app/src/App.css
@@ -57,7 +57,7 @@ tr.ant-table-expanded-row, tr.ant-table-expanded-row:hover {
     width: auto;
 }
 
-// Styling specific for last item in SummaryView Timeline
+/* Styling specific for last item in SummaryView Timeline */
 .ant-timeline-item-last {
     padding-bottom: 1em;
 }

--- a/reporter-web-app/src/components/IssuesTable.js
+++ b/reporter-web-app/src/components/IssuesTable.js
@@ -21,21 +21,21 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Icon, Table } from 'antd';
 
-// Generates the HTML to display errors as a Table
-const ErrorsTable = (props) => {
+// Generates the HTML to display issues as a Table
+const IssuesTable = (props) => {
     const {
-        errors,
+        issues,
         expandedRowRender,
         showPackageColumn
     } = props;
 
-    // If return null to prevent React render error
-    if (!errors) {
+    // If return null to prevent React render issue
+    if (!issues) {
         return null;
     }
 
     const columns = [];
-    const totalErrors = errors.length;
+    const totalIssues = issues.length;
 
     columns.push({
         align: 'right',
@@ -105,10 +105,10 @@ const ErrorsTable = (props) => {
     return (
         <Table
             columns={columns}
-            dataSource={errors}
+            dataSource={issues}
             expandedRowRender={expandedRowRender}
             locale={{
-                emptyText: 'No errors'
+                emptyText: 'No issues'
             }}
             pagination={
                 {
@@ -118,25 +118,25 @@ const ErrorsTable = (props) => {
                     position: 'bottom',
                     showQuickJumper: true,
                     showSizeChanger: true,
-                    showTotal: (total, range) => `${range[0]}-${range[1]} of ${total} errors`
+                    showTotal: (total, range) => `${range[0]}-${range[1]} of ${total} issues`
                 }
             }
             rowKey="key"
-            showHeader={totalErrors > 1}
+            showHeader={totalIssues > 1}
             size="small"
         />
     );
 };
 
-ErrorsTable.propTypes = {
-    errors: PropTypes.array.isRequired,
+IssuesTable.propTypes = {
+    issues: PropTypes.array.isRequired,
     expandedRowRender: PropTypes.func,
     showPackageColumn: PropTypes.bool
 };
 
-ErrorsTable.defaultProps = {
+IssuesTable.defaultProps = {
     expandedRowRender: null,
     showPackageColumn: false
 };
 
-export default ErrorsTable;
+export default IssuesTable;

--- a/reporter-web-app/src/components/PackageCollapse.js
+++ b/reporter-web-app/src/components/PackageCollapse.js
@@ -23,7 +23,7 @@ import PropTypes from 'prop-types';
 import {
     Collapse
 } from 'antd';
-import ErrorsTable from './ErrorsTable';
+import IssuesTable from './IssuesTable';
 import PackageDetails from './PackageDetails';
 import PackageLicenses from './PackageLicenses';
 import PackagePaths from './PackagePaths';
@@ -32,19 +32,19 @@ import ViolationsTable from './ViolationsTable';
 
 const { Panel } = Collapse;
 
-// Generates the HTML for packages errors
+// Generates the HTML for packages issues
 const PackageCollapse = (props) => {
     const {
         pkg,
         filterScanFindings,
         includeLicenses,
-        includeErrors,
+        includeIssues,
         includeViolations,
         includePaths,
         includeScanFindings,
         showDetails,
         showLicenses,
-        showErrors,
+        showIssues,
         showViolations,
         showPaths,
         showScanFindings,
@@ -61,7 +61,7 @@ const PackageCollapse = (props) => {
         defaultActiveKey.push('2');
     }
 
-    if (showErrors) {
+    if (showIssues) {
         defaultActiveKey.push('3');
     }
 
@@ -95,12 +95,12 @@ const PackageCollapse = (props) => {
                 )
             }
             {
-                includeErrors
-                && pkg.hasErrors(webAppOrtResult)
+                includeIssues
+                && pkg.hasIssues(webAppOrtResult)
                 && (
-                    <Panel header="Package Errors" key="3">
-                        <ErrorsTable
-                            errors={pkg.getErrors(webAppOrtResult)}
+                    <Panel header="Package Issues" key="3">
+                        <IssuesTable
+                            issues={pkg.getIssues(webAppOrtResult)}
                             showPackageColumn={false}
                         />
                     </Panel>
@@ -149,13 +149,13 @@ PackageCollapse.propTypes = {
     filterScanFindings: PropTypes.object,
     pkg: PropTypes.object.isRequired,
     includeLicenses: PropTypes.bool,
-    includeErrors: PropTypes.bool,
+    includeIssues: PropTypes.bool,
     includeViolations: PropTypes.bool,
     includePaths: PropTypes.bool,
     includeScanFindings: PropTypes.bool,
     showDetails: PropTypes.bool,
     showLicenses: PropTypes.bool,
-    showErrors: PropTypes.bool,
+    showIssues: PropTypes.bool,
     showViolations: PropTypes.bool,
     showPaths: PropTypes.bool,
     showScanFindings: PropTypes.bool,
@@ -168,13 +168,13 @@ PackageCollapse.defaultProps = {
         value: []
     },
     includeLicenses: true,
-    includeErrors: true,
+    includeIssues: true,
     includeViolations: true,
     includePaths: true,
     includeScanFindings: true,
     showDetails: true,
     showLicenses: true,
-    showErrors: true,
+    showIssues: true,
     showViolations: true,
     showPaths: false,
     showScanFindings: false

--- a/reporter-web-app/src/components/PackagePaths.js
+++ b/reporter-web-app/src/components/PackagePaths.js
@@ -23,7 +23,7 @@ import PropTypes from 'prop-types';
 
 const { Step } = Steps;
 
-// Generates the HTML for packages errors
+// Generates the HTML for packages issues
 const PackagePaths = (props) => {
     const { pkg, webAppOrtResult } = props;
     const { id, paths } = pkg;

--- a/reporter-web-app/src/components/SummaryView.js
+++ b/reporter-web-app/src/components/SummaryView.js
@@ -23,7 +23,7 @@ import PropTypes from 'prop-types';
 import {
     Col, Row, Tabs
 } from 'antd';
-import ErrorsTable from './ErrorsTable';
+import IssuesTable from './IssuesTable';
 import SummaryViewLicenses from './SummaryViewLicenses';
 import SummaryViewTimeline from './SummaryViewTimeline';
 import PackageCollapse from './PackageCollapse';
@@ -65,7 +65,7 @@ class SummaryView extends React.Component {
                 </Row>
                 <Row>
                     <Col span={22} offset={1}>
-                        {(webAppOrtResult.hasErrors() || webAppOrtResult.hasViolations())
+                        {(webAppOrtResult.hasIssues() || webAppOrtResult.hasViolations())
                             && (
                                 <Tabs tabPosition="top" className="ort-summary-issues">
                                     { webAppOrtResult.hasViolations()
@@ -89,11 +89,11 @@ class SummaryView extends React.Component {
                                                                     type: ['LICENSE'],
                                                                     value: [violation.license]
                                                                 }}
-                                                                includeErrors
+                                                                includeIssues
                                                                 includeScanFindings
                                                                 includeViolations={false}
                                                                 showDetails={false}
-                                                                showErrors={false}
+                                                                showIssues={false}
                                                                 showLicenses
                                                                 showScanFindings
                                                                 webAppOrtResult={webAppOrtResult}
@@ -106,24 +106,24 @@ class SummaryView extends React.Component {
                                             </TabPane>
                                         )
                                     }
-                                    { webAppOrtResult.hasErrors()
+                                    { webAppOrtResult.hasIssues()
                                         && (
                                             <TabPane
                                                 tab={(
                                                     <span>
-                                                        Errors (
-                                                        {webAppOrtResult.errors.length}
+                                                        Issues (
+                                                        {webAppOrtResult.issues.length}
                                                         )
                                                     </span>
                                                 )}
                                                 key="2"
                                             >
-                                                <ErrorsTable
+                                                <IssuesTable
                                                     expandedRowRender={
-                                                        error => (
+                                                        issue => (
                                                             <PackageCollapse
-                                                                pkg={webAppOrtResult.getPackageById(error.pkg)}
-                                                                includeErrors={false}
+                                                                pkg={webAppOrtResult.getPackageById(issue.pkg)}
+                                                                includeIssues={false}
                                                                 includeScanFindings={false}
                                                                 includeViolations={false}
                                                                 showDetails
@@ -133,7 +133,7 @@ class SummaryView extends React.Component {
                                                             />
                                                         )
                                                     }
-                                                    errors={webAppOrtResult.errors}
+                                                    issues={webAppOrtResult.issues}
                                                     showPackageColumn
                                                 />
                                             </TabPane>

--- a/reporter-web-app/src/components/SummaryViewTimeline.js
+++ b/reporter-web-app/src/components/SummaryViewTimeline.js
@@ -29,7 +29,7 @@ const SummaryViewTimeline = (props) => {
     const {
         declaredLicenses,
         detectedLicenses,
-        errors,
+        issues,
         levels,
         packagesMap,
         projectsMap,
@@ -38,7 +38,7 @@ const SummaryViewTimeline = (props) => {
         violations
     } = webAppOrtResult;
     const { revision, type, url } = vcsProcessed;
-    const hasErrors = webAppOrtResult.hasErrors();
+    const hasIssues = webAppOrtResult.hasIssues();
     const hasViolations = webAppOrtResult.hasViolations();
 
     if (!revision || !type || !url) {
@@ -132,7 +132,7 @@ const SummaryViewTimeline = (props) => {
                 dot={(
                     <Icon
                         type={
-                            (hasErrors || hasViolations)
+                            (hasIssues || hasViolations)
                                 ? 'exclamation-circle-o' : 'check-circle-o'
                         }
                         style={
@@ -140,25 +140,25 @@ const SummaryViewTimeline = (props) => {
                         }
                     />
                 )}
-                color={(hasErrors || hasViolations) ? 'red' : 'green'}
+                color={(hasIssues || hasViolations) ? 'red' : 'green'}
             >
                 {
-                    hasErrors && !hasViolations
+                    hasIssues && !hasViolations
                     && (
                         <span className="ort-error">
                             <b>
                                 Completed scan with
                                 {' '}
-                                {errors.length}
+                                {issues.length}
                                 {' '}
-                                error
-                                { errors.length > 1 && 's'}
+                                issue
+                                { issues.length > 1 && 's'}
                             </b>
                         </span>
                     )
                 }
                 {
-                    !hasErrors && hasViolations
+                    !hasIssues && hasViolations
                     && (
                         <span className="ort-error">
                             <b>
@@ -173,16 +173,16 @@ const SummaryViewTimeline = (props) => {
                     )
                 }
                 {
-                    hasErrors && hasViolations
+                    hasIssues && hasViolations
                     && (
                         <span className="ort-error">
                             <b>
                                 Completed scan with
                                 {' '}
-                                {errors.length}
+                                {issues.length}
                                 {' '}
-                                error
-                                { errors.length > 1 && 's'}
+                                issue
+                                { issues.length > 1 && 's'}
                                 {' '}
                                 and
                                 {' '}
@@ -195,7 +195,7 @@ const SummaryViewTimeline = (props) => {
                     )
                 }
                 {
-                    !hasErrors && !hasViolations
+                    !hasIssues && !hasViolations
                     && (
                         <span className="ort-success">
                             <b>

--- a/reporter-web-app/src/components/TableView.js
+++ b/reporter-web-app/src/components/TableView.js
@@ -39,14 +39,14 @@ class TableView extends React.Component {
             {
                 align: 'right',
                 filters: (() => [
-                    { text: 'Errors', value: 'errors' },
+                    { text: 'Issues', value: 'issues' },
                     { text: 'Violations', value: 'violations' }
                 ])(),
                 filterMultiple: true,
-                key: 'errors',
+                key: 'issues',
                 onFilter: (value, pkg) => {
-                    if (value === 'errors') {
-                        return pkg.hasErrors(webAppOrtResult);
+                    if (value === 'issues') {
+                        return pkg.hasIssues(webAppOrtResult);
                     }
 
                     if (value === 'violations') {
@@ -56,7 +56,7 @@ class TableView extends React.Component {
                     return false;
                 },
                 render: (pkg) => {
-                    if (pkg.hasErrors(webAppOrtResult) || pkg.hasViolations(webAppOrtResult)) {
+                    if (pkg.hasIssues(webAppOrtResult) || pkg.hasViolations(webAppOrtResult)) {
                         return (
                             <Icon
                                 type="exclamation-circle"

--- a/reporter-web-app/src/components/TreeView.js
+++ b/reporter-web-app/src/components/TreeView.js
@@ -174,7 +174,7 @@ class TreeView extends React.Component {
             <Drawer
                 title={
                     (() => {
-                        if (selectedPackage.hasErrors(webAppOrtResult)
+                        if (selectedPackage.hasIssues(webAppOrtResult)
                         || selectedPackage.hasViolations(webAppOrtResult)) {
                             return (
                                 <span>

--- a/reporter-web-app/src/models/AnalyzerResult.js
+++ b/reporter-web-app/src/models/AnalyzerResult.js
@@ -26,10 +26,10 @@ class AnalyzerResult {
 
     #packages = [];
 
-    #errors = new Map();
+    #issues = new Map();
 
     constructor(obj) {
-        this.hasErrors = false;
+        this.hasIssues = false;
 
         if (obj instanceof Object) {
             if (obj.projects) {
@@ -40,16 +40,16 @@ class AnalyzerResult {
                 this.packages = obj.packages;
             }
 
-            if (obj.errors) {
-                this.errors = obj.errors;
+            if (obj.issues) {
+                this.issues = obj.issues;
             }
 
-            if (obj.has_errors) {
-                this.hasErrors = obj.has_errors;
+            if (obj.has_issues) {
+                this.hasIssues = obj.has_issues;
             }
 
-            if (obj.hasErrors) {
-                this.hasErrors = obj.hasErrors;
+            if (obj.hasIssues) {
+                this.hasIssues = obj.hasIssues;
             }
         }
     }
@@ -74,13 +74,13 @@ class AnalyzerResult {
         }
     }
 
-    get errors() {
-        return this.#errors;
+    get issues() {
+        return this.#issues;
     }
 
-    set errors(obj) {
+    set issues(obj) {
         Object.keys(obj).forEach((key) => {
-            this.#errors.set(key, new OrtIssue(obj[key]));
+            this.#issues.set(key, new OrtIssue(obj[key]));
         });
     }
 }

--- a/reporter-web-app/src/models/PackageReference.js
+++ b/reporter-web-app/src/models/PackageReference.js
@@ -26,7 +26,7 @@ class PackageReference {
 
     #dependencies = [];
 
-    #errors = [];
+    #issues = [];
 
     constructor(obj) {
         if (obj instanceof Object) {
@@ -64,13 +64,13 @@ class PackageReference {
         }
     }
 
-    get errors() {
-        return this.#errors;
+    get issues() {
+        return this.#issues;
     }
 
-    set errors(val) {
+    set issues(val) {
         for (let i = 0, len = val.length; i < len; i++) {
-            this.#errors.push(new OrtIssue(val[i]));
+            this.#issues.push(new OrtIssue(val[i]));
         }
     }
 }

--- a/reporter-web-app/src/models/ScanRecord.js
+++ b/reporter-web-app/src/models/ScanRecord.js
@@ -29,7 +29,7 @@ class ScanRecord {
     #storageStats = new AccessStatistics();
 
     constructor(obj) {
-        this.hasErrors = false;
+        this.hasIssues = false;
 
         if (obj instanceof Object) {
             if (obj.scopes) {
@@ -60,12 +60,12 @@ class ScanRecord {
                 this.storageStats = obj.storageStats;
             }
 
-            if (obj.has_errors) {
-                this.hasErrors = obj.has_errors;
+            if (obj.has_issues) {
+                this.hasIssues = obj.has_issues;
             }
 
-            if (obj.hasErrors) {
-                this.hasErrors = obj.hasErrors;
+            if (obj.hasIssues) {
+                this.hasIssues = obj.hasIssues;
             }
         }
     }

--- a/reporter-web-app/src/models/ScanSummary.js
+++ b/reporter-web-app/src/models/ScanSummary.js
@@ -26,7 +26,7 @@ class ScanSummary {
 
     #endTime = '';
 
-    #errors = [];
+    #issues = [];
 
     #fileCount = 0;
 
@@ -70,8 +70,8 @@ class ScanSummary {
                 this.copyrightFindings = obj.copyrights;
             }
 
-            if (obj.errors) {
-                this.errors = obj.errors;
+            if (obj.issues) {
+                this.issues = obj.issues;
             }
         }
     }
@@ -108,13 +108,13 @@ class ScanSummary {
         }
     }
 
-    get errors() {
-        return this.#errors;
+    get issues() {
+        return this.#issues;
     }
 
-    set errors(val) {
+    set issues(val) {
         for (let i = 0, len = val.length; i < len; i++) {
-            this.#errors.push(new OrtIssue(val[i]));
+            this.#issues.push(new OrtIssue(val[i]));
         }
     }
 

--- a/reporter-web-app/src/models/WebAppOrtResult.js
+++ b/reporter-web-app/src/models/WebAppOrtResult.js
@@ -31,7 +31,7 @@ class WebAppOrtResult extends OrtResult {
 
     #detectedLicenses;
 
-    #errors = [];
+    #issues = [];
 
     #levels = new Set();
 
@@ -92,7 +92,7 @@ class WebAppOrtResult extends OrtResult {
                 for (let j = 0, lenScanResultContainer = scanResultContainer.length; j < lenScanResultContainer; j++) {
                     const scanResult = scanResultContainer[j];
                     const { scanner, summary } = scanResult;
-                    const { errors } = summary;
+                    const { issues } = summary;
                     const scannerId = `${scanner.name}-${scanner.version}`;
 
                     if (!this.#scannersUsed.has(scannerId)) {
@@ -100,12 +100,12 @@ class WebAppOrtResult extends OrtResult {
                         scannersIndex.set(scannerId, j);
                     }
 
-                    if (errors !== 0) {
-                        for (let k = 0, len = errors.length; k < len; k++) {
-                            const webAppOrtIssue = new WebAppOrtIssueScanner(errors[k]);
+                    if (issues !== 0) {
+                        for (let k = 0, len = issues.length; k < len; k++) {
+                            const webAppOrtIssue = new WebAppOrtIssueScanner(issues[k]);
                             webAppOrtIssue.pkg = id;
 
-                            this.#errors.push(webAppOrtIssue);
+                            this.#issues.push(webAppOrtIssue);
                         }
                     }
                 }
@@ -153,8 +153,8 @@ class WebAppOrtResult extends OrtResult {
         this.#detectedLicenses = set;
     }
 
-    get errors() {
-        return this.#errors;
+    get issues() {
+        return this.#issues;
     }
 
     get levels() {
@@ -239,9 +239,9 @@ class WebAppOrtResult extends OrtResult {
         return this.#violations;
     }
 
-    addError(err) {
+    addIssue(err) {
         if (err instanceof WebAppOrtIssueAnalyzer || err instanceof WebAppOrtIssueScanner) {
-            this.#errors.push(err);
+            this.#issues.push(err);
         }
     }
 
@@ -337,8 +337,8 @@ class WebAppOrtResult extends OrtResult {
         return this.analyzer.result.projects;
     }
 
-    hasErrors() {
-        return this.errors.length > 0;
+    hasIssues() {
+        return this.issues.length > 0;
     }
 
     hasProjectId(id) {

--- a/reporter-web-app/src/models/WebAppPackage.js
+++ b/reporter-web-app/src/models/WebAppPackage.js
@@ -32,7 +32,7 @@ class WebAppPackage extends Package {
 
     #detectedLicenses = new Set();
 
-    #errors;
+    #issues;
 
     #key;
 
@@ -198,16 +198,16 @@ class WebAppPackage extends Package {
         return null;
     }
 
-    getErrors(webAppOrtResult) {
-        if (!this.#errors) {
+    getIssues(webAppOrtResult) {
+        if (!this.#issues) {
             if (webAppOrtResult) {
-                this.#errors = webAppOrtResult.errors.filter(
-                    error => error.pkg === this.id
+                this.#issues = webAppOrtResult.issues.filter(
+                    issue => issue.pkg === this.id
                 );
             }
         }
 
-        return this.#errors;
+        return this.#issues;
     }
 
     getScanSummaryForScannerId(webAppOrtResult, scannerId) {
@@ -279,12 +279,12 @@ class WebAppPackage extends Package {
         return this.#violations;
     }
 
-    hasErrors(webAppOrtResult) {
-        if (!this.#errors) {
-            this.getErrors(webAppOrtResult);
+    hasIssues(webAppOrtResult) {
+        if (!this.#issues) {
+            this.getIssues(webAppOrtResult);
         }
 
-        return this.#errors.length;
+        return this.#issues.length;
     }
 
     hasCurations() {

--- a/reporter-web-app/src/models/config/IssueResolution.js
+++ b/reporter-web-app/src/models/config/IssueResolution.js
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-class ErrorResolution {
+class IssueResolution {
     constructor(obj) {
         this.message = '';
         this.reason = '';
@@ -33,4 +33,4 @@ class ErrorResolution {
     }
 }
 
-export default ErrorResolution;
+export default IssueResolution;

--- a/reporter-web-app/src/models/config/Resolutions.js
+++ b/reporter-web-app/src/models/config/Resolutions.js
@@ -17,18 +17,18 @@
  * License-Filename: LICENSE
  */
 
-import ErrorResolution from './ErrorResolution';
+import IssueResolution from './IssueResolution';
 import RuleViolationResolution from './RuleViolationResolution';
 
 class Resolutions {
-    #errors = [];
+    #issues = [];
 
     #resolutions = [];
 
     constructor(obj) {
         if (obj instanceof Object) {
-            if (obj.errors) {
-                this.errors = obj.errors;
+            if (obj.issues) {
+                this.issues = obj.issues;
             }
 
             if (obj.resolutions) {
@@ -37,13 +37,13 @@ class Resolutions {
         }
     }
 
-    get errors() {
-        return this.#errors;
+    get issues() {
+        return this.#issues;
     }
 
-    set errors(val) {
+    set issues(val) {
         for (let i = 0, len = val.length; i < len; i++) {
-            this.#errors.push(new ErrorResolution(val[i]));
+            this.#issues.push(new IssueResolution(val[i]));
         }
     }
 

--- a/reporter-web-app/src/sagas/processOrtResultData.js
+++ b/reporter-web-app/src/sagas/processOrtResultData.js
@@ -40,7 +40,7 @@ function recursiveAnalyzerResultProcessor(
 ) {
     const treeId = parentTreeId === '' ? `${childIndex}` : `${parentTreeId}-${childIndex}`;
     const children = [];
-    const { dependencies, errors, scopes } = pkg;
+    const { dependencies, issues, scopes } = pkg;
     const id = pkg.id || pkg.name;
     const level = path.length;
     const scanResultContainer = webAppOrtResult.getScanResultContainerForPackageId(id);
@@ -131,14 +131,14 @@ function recursiveAnalyzerResultProcessor(
     webAppPkgTreeNodeWithNoChildren.children = [];
     webAppOrtResult.addPackageToPackagesTreeFlatArray(webAppPkgTreeNodeWithNoChildren, true);
 
-    if (errors && errors.length !== 0) {
-        for (let i = 0, len = errors.length; i < len; i++) {
-            const error = errors[i];
-            const webAppOrtIssueAnalyzer = new WebAppOrtIssueAnalyzer(error);
+    if (issues && issues.length !== 0) {
+        for (let i = 0, len = issues.length; i < len; i++) {
+            const issue = issues[i];
+            const webAppOrtIssueAnalyzer = new WebAppOrtIssueAnalyzer(issue);
 
             webAppOrtIssueAnalyzer.pkg = id;
 
-            webAppOrtResult.addError(webAppOrtIssueAnalyzer);
+            webAppOrtResult.addIssue(webAppOrtIssueAnalyzer);
         }
     }
 

--- a/reporter/src/funTest/assets/NPM-is-windows-1.0.2-scan-result.json
+++ b/reporter/src/funTest/assets/NPM-is-windows-1.0.2-scan-result.json
@@ -6863,10 +6863,10 @@
         },
         "curations" : [ ]
       } ],
-      "errors" : {
+      "issues" : {
         "NPM::is-windows:1.0.2" : [ ]
       },
-      "has_errors" : false
+      "has_issues" : false
     }
   },
   "scanner" : {

--- a/reporter/src/funTest/assets/NPM-is-windows-1.0.2-scan-result.json
+++ b/reporter/src/funTest/assets/NPM-is-windows-1.0.2-scan-result.json
@@ -16059,7 +16059,7 @@
         "num_reads" : 154,
         "num_hits" : 0
       },
-      "has_errors" : false
+      "has_issues" : false
     }
   },
   "evaluator" : null

--- a/reporter/src/funTest/assets/gradle-all-dependencies-result.yml
+++ b/reporter/src/funTest/assets/gradle-all-dependencies-result.yml
@@ -541,6 +541,6 @@ analyzer:
           revision: ""
           path: ""
       curations: []
-    has_errors: true
+    has_issues: true
 scanner: null
 evaluator: null

--- a/reporter/src/funTest/assets/gradle-all-dependencies-result.yml
+++ b/reporter/src/funTest/assets/gradle-all-dependencies-result.yml
@@ -171,7 +171,7 @@ analyzer:
       - name: "compile"
         dependencies:
         - id: "Unknown:org.apache.commons:commons-text:1.1"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
@@ -181,7 +181,7 @@ analyzer:
       - name: "compileClasspath"
         dependencies:
         - id: "Unknown:org.apache.commons:commons-text:1.1"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
@@ -193,7 +193,7 @@ analyzer:
       - name: "default"
         dependencies:
         - id: "Unknown:org.apache.commons:commons-text:1.1"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
@@ -203,7 +203,7 @@ analyzer:
       - name: "runtime"
         dependencies:
         - id: "Unknown:org.apache.commons:commons-text:1.1"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
@@ -213,7 +213,7 @@ analyzer:
       - name: "runtimeClasspath"
         dependencies:
         - id: "Unknown:org.apache.commons:commons-text:1.1"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
@@ -225,14 +225,14 @@ analyzer:
       - name: "testCompile"
         dependencies:
         - id: "Unknown:junit:junit:4.12"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency junit:junit:4.12 because no repositories are defined."
             severity: "ERROR"
         - id: "Unknown:org.apache.commons:commons-text:1.1"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
@@ -242,14 +242,14 @@ analyzer:
       - name: "testCompileClasspath"
         dependencies:
         - id: "Unknown:junit:junit:4.12"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency junit:junit:4.12 because no repositories are defined."
             severity: "ERROR"
         - id: "Unknown:org.apache.commons:commons-text:1.1"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
@@ -261,14 +261,14 @@ analyzer:
       - name: "testRuntime"
         dependencies:
         - id: "Unknown:junit:junit:4.12"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency junit:junit:4.12 because no repositories are defined."
             severity: "ERROR"
         - id: "Unknown:org.apache.commons:commons-text:1.1"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
@@ -278,14 +278,14 @@ analyzer:
       - name: "testRuntimeClasspath"
         dependencies:
         - id: "Unknown:junit:junit:4.12"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency junit:junit:4.12 because no repositories are defined."
             severity: "ERROR"
         - id: "Unknown:org.apache.commons:commons-text:1.1"
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\

--- a/reporter/src/funTest/assets/npm-test-with-exclude-scan-results.yml
+++ b/reporter/src/funTest/assets/npm-test-with-exclude-scan-results.yml
@@ -363,7 +363,7 @@ analyzer:
           revision: "51d15eaa03e53aaedd3002dc67814355073e8a55"
           path: ""
       curations: []
-    has_errors: false
+    has_issues: false
 scanner:
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"

--- a/reporter/src/funTest/assets/npm-test-with-exclude-scan-results.yml
+++ b/reporter/src/funTest/assets/npm-test-with-exclude-scan-results.yml
@@ -753,5 +753,5 @@ scanner:
     storage_stats:
       num_reads: 11
       num_hits: 0
-    has_errors: true
+    has_issues: true
 evaluator: null

--- a/reporter/src/funTest/assets/npm-test-with-exclude-scan-results.yml
+++ b/reporter/src/funTest/assets/npm-test-with-exclude-scan-results.yml
@@ -670,7 +670,7 @@ scanner:
           end_time: "2018-08-21T16:20:45.663Z"
           file_count: 0
           license_findings: []
-          errors:
+          issues:
           - timestamp: "2018-08-21T16:20:45.663Z"
             source: "ScanCode"
             message: "DownloadException: No source artifact URL provided for 'NPM::npm-excludes-test-project:1.0.0'."

--- a/reporter/src/funTest/assets/npm-test-without-exclude-scan-results.yml
+++ b/reporter/src/funTest/assets/npm-test-without-exclude-scan-results.yml
@@ -665,7 +665,7 @@ scanner:
           end_time: "2018-08-21T16:20:45.663Z"
           file_count: 0
           license_findings: []
-          errors:
+          issues:
           - timestamp: "2018-08-21T16:20:45.663Z"
             source: "ScanCode"
             message: "DownloadException: No source artifact URL provided for 'NPM::npm-excludes-test-project:1.0.0'."

--- a/reporter/src/funTest/assets/npm-test-without-exclude-scan-results.yml
+++ b/reporter/src/funTest/assets/npm-test-without-exclude-scan-results.yml
@@ -358,7 +358,7 @@ analyzer:
           revision: "51d15eaa03e53aaedd3002dc67814355073e8a55"
           path: ""
       curations: []
-    has_errors: false
+    has_issues: false
 scanner:
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"

--- a/reporter/src/funTest/assets/npm-test-without-exclude-scan-results.yml
+++ b/reporter/src/funTest/assets/npm-test-without-exclude-scan-results.yml
@@ -748,5 +748,5 @@ scanner:
     storage_stats:
       num_reads: 11
       num_hits: 0
-    has_errors: true
+    has_issues: true
 evaluator: null

--- a/reporter/src/funTest/assets/static-html-reporter-test-input.yml
+++ b/reporter/src/funTest/assets/static-html-reporter-test-input.yml
@@ -216,7 +216,7 @@ analyzer:
           revision: ""
           path: ""
       curations: []
-    has_errors: false
+    has_issues: false
 scanner:
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"

--- a/reporter/src/funTest/assets/static-html-reporter-test-input.yml
+++ b/reporter/src/funTest/assets/static-html-reporter-test-input.yml
@@ -396,7 +396,7 @@ scanner:
     storage_stats:
       num_reads: 5
       num_hits: 0
-    has_errors: true
+    has_issues: true
 evaluator:
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"

--- a/reporter/src/funTest/assets/static-html-reporter-test-input.yml
+++ b/reporter/src/funTest/assets/static-html-reporter-test-input.yml
@@ -272,7 +272,7 @@ scanner:
               - path: "fake_path"
                 start_line: 206
                 end_line: 206
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "FileCounter"
             message: "DownloadException: No source artifact URL provided for 'Gradle:com.here.ort.gradle.example:lib:1.0.0'.\n\

--- a/reporter/src/main/kotlin/DefaultResolutionProvider.kt
+++ b/reporter/src/main/kotlin/DefaultResolutionProvider.kt
@@ -31,20 +31,20 @@ class DefaultResolutionProvider : ResolutionProvider {
         this.resolutions = this.resolutions.merge(resolutions)
     }
 
-    override fun getErrorResolutionsFor(issue: OrtIssue) = resolutions.errors.filter { it.matches(issue) }
+    override fun getIssueResolutionsFor(issue: OrtIssue) = resolutions.issues.filter { it.matches(issue) }
 
     override fun getRuleViolationResolutionsFor(violation: RuleViolation) =
         resolutions.ruleViolations.filter { it.matches(violation) }
 
     override fun getResolutionsFor(ortResult: OrtResult): Resolutions {
-        val errorResolutions = ortResult.collectIssues().values.flatten().let { errors ->
-            resolutions.errors.filter { resolution -> errors.any { resolution.matches(it) } }
+        val issueResolutions = ortResult.collectIssues().values.flatten().let { issues ->
+            resolutions.issues.filter { resolution -> issues.any { resolution.matches(it) } }
         }
 
         val ruleViolationResolutions = ortResult.evaluator?.violations?.let { violations ->
             resolutions.ruleViolations.filter { resolution -> violations.any { resolution.matches(it) } }
         }.orEmpty()
 
-        return Resolutions(errorResolutions, ruleViolationResolutions)
+        return Resolutions(issueResolutions, ruleViolationResolutions)
     }
 }

--- a/reporter/src/main/kotlin/DefaultResolutionProvider.kt
+++ b/reporter/src/main/kotlin/DefaultResolutionProvider.kt
@@ -37,7 +37,7 @@ class DefaultResolutionProvider : ResolutionProvider {
         resolutions.ruleViolations.filter { it.matches(violation) }
 
     override fun getResolutionsFor(ortResult: OrtResult): Resolutions {
-        val errorResolutions = ortResult.collectErrors().values.flatten().let { errors ->
+        val errorResolutions = ortResult.collectIssues().values.flatten().let { errors ->
             resolutions.errors.filter { resolution -> errors.any { resolution.matches(it) } }
         }
 

--- a/reporter/src/main/kotlin/ResolutionProvider.kt
+++ b/reporter/src/main/kotlin/ResolutionProvider.kt
@@ -36,12 +36,13 @@ interface ResolutionProvider {
     fun getIssueResolutionsFor(issue: OrtIssue): List<IssueResolution>
 
     /**
-     * Get all rule violation resolutions that match [error].
+     * Get all rule violation resolutions that match [violation].
      */
     fun getRuleViolationResolutionsFor(violation: RuleViolation): List<RuleViolationResolution>
 
     /**
-     * Get a [Resolutions] object that contains all resolutions which apply to errors contained in [ortResult].
+     * Get a [Resolutions] object that contains all resolutions which apply to [OrtIssue]s or [RuleViolation]s contained
+     * in [ortResult].
      */
     fun getResolutionsFor(ortResult: OrtResult): Resolutions
 }

--- a/reporter/src/main/kotlin/ResolutionProvider.kt
+++ b/reporter/src/main/kotlin/ResolutionProvider.kt
@@ -22,7 +22,7 @@ package com.here.ort.reporter
 import com.here.ort.model.OrtIssue
 import com.here.ort.model.OrtResult
 import com.here.ort.model.RuleViolation
-import com.here.ort.model.config.ErrorResolution
+import com.here.ort.model.config.IssueResolution
 import com.here.ort.model.config.Resolutions
 import com.here.ort.model.config.RuleViolationResolution
 
@@ -31,9 +31,9 @@ import com.here.ort.model.config.RuleViolationResolution
  */
 interface ResolutionProvider {
     /**
-     * Get all error resolutions that match [error].
+     * Get all issue resolutions that match [issue].
      */
-    fun getErrorResolutionsFor(issue: OrtIssue): List<ErrorResolution>
+    fun getIssueResolutionsFor(issue: OrtIssue): List<IssueResolution>
 
     /**
      * Get all rule violation resolutions that match [error].

--- a/reporter/src/main/kotlin/StatisticsCalculator.kt
+++ b/reporter/src/main/kotlin/StatisticsCalculator.kt
@@ -63,7 +63,7 @@ internal class StatisticsCalculator {
 
     private fun getOpenIssuesIssues(ortResult: OrtResult, resolutionProvider: ResolutionProvider): IssueStatistics {
         val openIssues = ortResult
-            .collectErrors()
+            .collectIssues()
             .filterNot { (id, _) -> ortResult.isExcluded(id) }
             .values
             .flatten()

--- a/reporter/src/main/kotlin/StatisticsCalculator.kt
+++ b/reporter/src/main/kotlin/StatisticsCalculator.kt
@@ -35,7 +35,7 @@ internal class StatisticsCalculator {
      * Return the [Statistics] for the given [ortResult].
      */
     fun getStatistics(ortResult: OrtResult, resolutionProvider: ResolutionProvider) = Statistics(
-        openIssues = getOpenIssuesIssues(ortResult, resolutionProvider),
+        openIssues = getOpenIssues(ortResult, resolutionProvider),
         openRuleViolations = getOpenRuleViolations(ortResult, resolutionProvider),
         dependencyTree = DependencyTreeStatistics(
             includedProjects = ortResult.getProjects().count { !ortResult.isExcluded(it.id) },
@@ -61,7 +61,7 @@ internal class StatisticsCalculator {
         )
     }
 
-    private fun getOpenIssuesIssues(ortResult: OrtResult, resolutionProvider: ResolutionProvider): IssueStatistics {
+    private fun getOpenIssues(ortResult: OrtResult, resolutionProvider: ResolutionProvider): IssueStatistics {
         val openIssues = ortResult
             .collectIssues()
             .filterNot { (id, _) -> ortResult.isExcluded(id) }

--- a/reporter/src/main/kotlin/StatisticsCalculator.kt
+++ b/reporter/src/main/kotlin/StatisticsCalculator.kt
@@ -67,7 +67,7 @@ internal class StatisticsCalculator {
             .filterNot { (id, _) -> ortResult.isExcluded(id) }
             .values
             .flatten()
-            .filter { issue -> resolutionProvider.getErrorResolutionsFor(issue).isEmpty() }
+            .filter { issue -> resolutionProvider.getIssueResolutionsFor(issue).isEmpty() }
 
         return IssueStatistics(
             errors = openIssues.count { it.severity == Severity.ERROR },

--- a/reporter/src/main/kotlin/reporters/ReportTableModelMapper.kt
+++ b/reporter/src/main/kotlin/reporters/ReportTableModelMapper.kt
@@ -106,7 +106,7 @@ class ReportTableModelMapper(private val resolutionProvider: ResolutionProvider)
                 val detectedLicenses = licenseFindings[id]?.toSortedMap(compareBy { it.license }) ?: sortedMapOf()
 
                 val analyzerIssues = project.collectErrors(id).toMutableList()
-                analyzerResult.errors[id]?.let {
+                analyzerResult.issues[id]?.let {
                     analyzerIssues += it
                 }
 

--- a/reporter/src/main/kotlin/reporters/ReportTableModelMapper.kt
+++ b/reporter/src/main/kotlin/reporters/ReportTableModelMapper.kt
@@ -111,7 +111,7 @@ class ReportTableModelMapper(private val resolutionProvider: ResolutionProvider)
                 }
 
                 val scanIssues = scanResult?.results?.flatMap {
-                    it.summary.errors
+                    it.summary.issues
                 }?.distinct().orEmpty()
 
                 val packageForId = ortResult.getPackage(id)?.pkg ?: ortResult.getProject(id)?.toPackage()

--- a/reporter/src/main/kotlin/reporters/ReportTableModelMapper.kt
+++ b/reporter/src/main/kotlin/reporters/ReportTableModelMapper.kt
@@ -105,7 +105,7 @@ class ReportTableModelMapper(private val resolutionProvider: ResolutionProvider)
                 val declaredLicenses = ortResult.getDeclaredLicensesForId(id)
                 val detectedLicenses = licenseFindings[id]?.toSortedMap(compareBy { it.license }) ?: sortedMapOf()
 
-                val analyzerIssues = project.collectErrors(id).toMutableList()
+                val analyzerIssues = project.collectIssues(id).toMutableList()
                 analyzerResult.issues[id]?.let {
                     analyzerIssues += it
                 }

--- a/reporter/src/main/kotlin/reporters/ReportTableModelMapper.kt
+++ b/reporter/src/main/kotlin/reporters/ReportTableModelMapper.kt
@@ -41,7 +41,7 @@ private fun Collection<ResolvableIssue>.filterUnresolved() = filter { !it.isReso
  */
 class ReportTableModelMapper(private val resolutionProvider: ResolutionProvider) {
     private fun OrtIssue.toResolvableIssue(): ResolvableIssue {
-        val resolutions = resolutionProvider.getErrorResolutionsFor(this)
+        val resolutions = resolutionProvider.getIssueResolutionsFor(this)
         return ResolvableIssue(
             source = this@toResolvableIssue.source,
             description = this@toResolvableIssue.toString(),

--- a/scanner/src/funTest/assets/analyzer-result.yml
+++ b/scanner/src/funTest/assets/analyzer-result.yml
@@ -160,7 +160,6 @@ analyzer:
           revision: ""
           path: ""
       curations: []
-    errors: {}
-    has_errors: false
+    has_issues: false
 scanner: null
 evaluator: null

--- a/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
@@ -219,7 +219,7 @@ scanner:
           package_verification_code: ""
           licenses: []
           copyrights: []
-          errors:
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "FileCounter"
             message: "Could not download 'Gradle:com.here.ort.gradle.example:lib:1.0.0':\

--- a/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
@@ -181,7 +181,7 @@ analyzer:
           revision: ""
           path: ""
       curations: []
-    has_errors: false
+    has_issues: false
 scanner:
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"

--- a/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
@@ -313,5 +313,5 @@ scanner:
     storage_stats:
       num_reads: 5
       num_hits: 0
-    has_errors: true
+    has_issues: true
 evaluator: null

--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -225,7 +225,7 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
                                         packageVerificationCode = "",
                                         licenseFindings = sortedSetOf(),
                                         copyrightFindings = sortedSetOf(),
-                                        errors = listOf(issue)
+                                        issues = listOf(issue)
                                     ),
                                     rawResult = EMPTY_JSON_NODE
                                 )
@@ -299,7 +299,7 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
                     packageVerificationCode = "",
                     licenseFindings = sortedSetOf(),
                     copyrightFindings = sortedSetOf(),
-                    errors = listOf(
+                    issues = listOf(
                         createAndLogIssue(
                             source = scannerName,
                             message = "Could not download '${pkg.id.toCoordinates()}': ${e.collectMessagesAsString()}"
@@ -333,8 +333,8 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
                 message = addResult.message ?: "Could not add result to scan results storage for unknown reason.",
                 severity = Severity.WARNING
             )
-            val errors = scanResult.summary.errors + issue
-            val summary = scanResult.summary.copy(errors = errors)
+            val issues = scanResult.summary.issues + issue
+            val summary = scanResult.summary.copy(issues = issues)
             scanResult.copy(summary = summary)
         }
     }
@@ -388,7 +388,7 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
                 packageVerificationCode = "",
                 licenseFindings = sortedSetOf(),
                 copyrightFindings = sortedSetOf(),
-                errors = listOf(
+                issues = listOf(
                     createAndLogIssue(
                         source = scannerName,
                         message = "Could not scan path '$absoluteInputPath': ${e.collectMessagesAsString()}"

--- a/scanner/src/main/kotlin/scanners/Askalono.kt
+++ b/scanner/src/main/kotlin/scanners/Askalono.kt
@@ -177,7 +177,7 @@ class Askalono(name: String, config: ScannerConfiguration) : LocalScanner(name, 
             packageVerificationCode = calculatePackageVerificationCode(scanPath),
             licenseFindings = licenseFindings,
             copyrightFindings = sortedSetOf(),
-            errors = mutableListOf()
+            issues = mutableListOf()
         )
     }
 }

--- a/scanner/src/main/kotlin/scanners/BoyterLc.kt
+++ b/scanner/src/main/kotlin/scanners/BoyterLc.kt
@@ -178,7 +178,7 @@ class BoyterLc(name: String, config: ScannerConfiguration) : LocalScanner(name, 
             packageVerificationCode = calculatePackageVerificationCode(scanPath),
             licenseFindings = licenseFindings,
             copyrightFindings = sortedSetOf(),
-            errors = mutableListOf()
+            issues = mutableListOf()
         )
     }
 }

--- a/scanner/src/main/kotlin/scanners/FileCounter.kt
+++ b/scanner/src/main/kotlin/scanners/FileCounter.kt
@@ -85,7 +85,7 @@ class FileCounter(name: String, config: ScannerConfiguration) : LocalScanner(nam
             packageVerificationCode = calculatePackageVerificationCode(scanPath),
             licenseFindings = sortedSetOf(),
             copyrightFindings = sortedSetOf(),
-            errors = mutableListOf()
+            issues = mutableListOf()
         )
     }
 }

--- a/scanner/src/main/kotlin/scanners/Licensee.kt
+++ b/scanner/src/main/kotlin/scanners/Licensee.kt
@@ -156,7 +156,7 @@ class Licensee(name: String, config: ScannerConfiguration) : LocalScanner(name, 
             packageVerificationCode = calculatePackageVerificationCode(scanPath),
             licenseFindings = licenseFindings,
             copyrightFindings = sortedSetOf(),
-            errors = mutableListOf()
+            issues = mutableListOf()
         )
     }
 }

--- a/scanner/src/main/kotlin/scanners/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/ScanCode.kt
@@ -147,17 +147,17 @@ class ScanCode(
         )
 
         /**
-         * Map messages about unknown errors to a more compact form. Return true if solely memory errors occurred,
+         * Map messages about unknown issues to a more compact form. Return true if solely memory errors occurred,
          * return false otherwise.
          */
-        internal fun mapUnknownErrors(errors: MutableList<OrtIssue>): Boolean {
-            if (errors.isEmpty()) {
+        internal fun mapUnknownIssues(issues: MutableList<OrtIssue>): Boolean {
+            if (issues.isEmpty()) {
                 return false
             }
 
             var onlyMemoryErrors = true
 
-            val mappedErrors = errors.map { fullError ->
+            val mappedIssues = issues.map { fullError ->
                 UNKNOWN_ERROR_REGEX.matcher(fullError.message).let { matcher ->
                     if (matcher.matches()) {
                         val file = matcher.group("file")
@@ -176,8 +176,8 @@ class ScanCode(
                 }
             }
 
-            errors.clear()
-            errors += mappedErrors.distinctBy { it.message }
+            issues.clear()
+            issues += mappedIssues.distinctBy { it.message }
 
             return onlyMemoryErrors
         }
@@ -186,14 +186,14 @@ class ScanCode(
          * Map messages about timeout errors to a more compact form. Return true if solely timeout errors occurred,
          * return false otherwise.
          */
-        internal fun mapTimeoutErrors(errors: MutableList<OrtIssue>): Boolean {
-            if (errors.isEmpty()) {
+        internal fun mapTimeoutErrors(issues: MutableList<OrtIssue>): Boolean {
+            if (issues.isEmpty()) {
                 return false
             }
 
             var onlyTimeoutErrors = true
 
-            val mappedErrors = errors.map { fullError ->
+            val mappedIssues = issues.map { fullError ->
                 TIMEOUT_ERROR_REGEX.matcher(fullError.message).let { matcher ->
                     if (matcher.matches() && matcher.group("timeout") == TIMEOUT.toString()) {
                         val file = matcher.group("file")
@@ -205,8 +205,8 @@ class ScanCode(
                 }
             }
 
-            errors.clear()
-            errors += mappedErrors.distinctBy { it.message }
+            issues.clear()
+            issues += mappedIssues.distinctBy { it.message }
 
             return onlyTimeoutErrors
         }
@@ -327,14 +327,14 @@ class ScanCode(
         val result = getRawResult(resultsFile)
         val summary = generateSummary(startTime, endTime, path, result)
 
-        val errors = summary.errors.toMutableList()
+        val issues = summary.issues.toMutableList()
 
-        val hasOnlyMemoryErrors = mapUnknownErrors(errors)
-        val hasOnlyTimeoutErrors = mapTimeoutErrors(errors)
+        val hasOnlyMemoryErrors = mapUnknownIssues(issues)
+        val hasOnlyTimeoutErrors = mapTimeoutErrors(issues)
 
         with(process) {
             if (isSuccess || hasOnlyMemoryErrors || hasOnlyTimeoutErrors) {
-                return ScanResult(Provenance(), getDetails(), summary.copy(errors = errors), result)
+                return ScanResult(Provenance(), getDetails(), summary.copy(issues = issues), result)
             } else {
                 throw ScanException(errorMessage)
             }
@@ -368,7 +368,7 @@ class ScanCode(
             packageVerificationCode = calculatePackageVerificationCode(scanPath),
             licenseFindings = getLicenseFindings(result).toSortedSet(),
             copyrightFindings = getCopyrightFindings(result).toSortedSet(),
-            errors = getErrors(result)
+            issues = getIssues(result)
         )
 
     /**
@@ -391,7 +391,7 @@ class ScanCode(
         return name
     }
 
-    private fun getErrors(result: JsonNode): List<OrtIssue> =
+    private fun getIssues(result: JsonNode): List<OrtIssue> =
         result["files"]?.flatMap { file ->
             val path = file["path"].textValue()
             file["scan_errors"].map {

--- a/scanner/src/test/kotlin/ScanCodeTest.kt
+++ b/scanner/src/test/kotlin/ScanCodeTest.kt
@@ -66,10 +66,10 @@ class ScanCodeTest : WordSpec({
             val resultFile = File("src/test/assets/esprima-2.7.3_scancode-2.2.1.post277.4d68f9377.json")
             val result = scanner.getRawResult(resultFile)
             val summary = scanner.generateSummary(Instant.now(), Instant.now(), resultFile, result)
-            val errors = summary.errors.toMutableList()
+            val issues = summary.issues.toMutableList()
 
-            ScanCode.mapTimeoutErrors(errors) shouldBe true
-            errors.joinToString("\n") { it.message } shouldBe listOf(
+            ScanCode.mapTimeoutErrors(issues) shouldBe true
+            issues.joinToString("\n") { it.message } shouldBe listOf(
                 "ERROR: Timeout after 300 seconds while scanning file " +
                         "'test/3rdparty/syntax/angular-1.2.5.tokens'.",
                 "ERROR: Timeout after 300 seconds while scanning file " +
@@ -103,7 +103,7 @@ class ScanCodeTest : WordSpec({
             val result = scanner.getRawResult(resultFile)
             val summary = scanner.generateSummary(Instant.now(), Instant.now(), resultFile, result)
 
-            ScanCode.mapTimeoutErrors(summary.errors.toMutableList()) shouldBe false
+            ScanCode.mapTimeoutErrors(summary.issues.toMutableList()) shouldBe false
         }
     }
 
@@ -112,10 +112,10 @@ class ScanCodeTest : WordSpec({
             val resultFile = File("src/test/assets/very-long-json-lines_scancode-2.2.1.post277.4d68f9377.json")
             val result = scanner.getRawResult(resultFile)
             val summary = scanner.generateSummary(Instant.now(), Instant.now(), resultFile, result)
-            val errors = summary.errors.toMutableList()
+            val issues = summary.issues.toMutableList()
 
-            ScanCode.mapUnknownErrors(errors) shouldBe true
-            errors.joinToString("\n") { it.message } shouldBe listOf(
+            ScanCode.mapUnknownIssues(issues) shouldBe true
+            issues.joinToString("\n") { it.message } shouldBe listOf(
                 "ERROR: MemoryError while scanning file 'data.json'."
             ).joinToString("\n")
         }
@@ -124,10 +124,10 @@ class ScanCodeTest : WordSpec({
             val resultFile = File("src/test/assets/kotlin-annotation-processing-gradle-1.2.21_scancode.json")
             val result = scanner.getRawResult(resultFile)
             val summary = scanner.generateSummary(Instant.now(), Instant.now(), resultFile, result)
-            val errors = summary.errors.toMutableList()
+            val issues = summary.issues.toMutableList()
 
-            ScanCode.mapUnknownErrors(errors) shouldBe false
-            errors.joinToString("\n") { it.message } shouldBe listOf(
+            ScanCode.mapUnknownIssues(issues) shouldBe false
+            issues.joinToString("\n") { it.message } shouldBe listOf(
                 "ERROR: AttributeError while scanning file 'compiler/testData/cli/js-dce/withSourceMap.js.map' " +
                         "('NoneType' object has no attribute 'splitlines')."
             ).joinToString("\n")
@@ -138,7 +138,7 @@ class ScanCodeTest : WordSpec({
             val result = scanner.getRawResult(resultFile)
             val summary = scanner.generateSummary(Instant.now(), Instant.now(), resultFile, result)
 
-            ScanCode.mapUnknownErrors(summary.errors.toMutableList()) shouldBe false
+            ScanCode.mapUnknownIssues(summary.issues.toMutableList()) shouldBe false
         }
     }
 


### PR DESCRIPTION
Several properties and functions related to handling `OrtIssue`s still used the term `error` instead of `issue`, mainly in code that was created before the `Error` class was renamed to `OrtIssue` in f42f5b8. Change that to consistently use `issue` and make sure that old `OrtResult`s can still be deserialized.