### PR TITLE
AppVeyor: Temporarily move GPG executables away

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -71,6 +71,10 @@ install:
   - flutter config --no-analytics
   - flutter doctor
   - pip install pipenv==%PYTHON_PIPENV_VERSION%
+  # Work around an issue with GPG failing to connect to its agent in GitRepoTest
+  # as seen at https://ci.appveyor.com/project/heremaps/oss-review-toolkit/builds/30228453#L3030.
+  - mv C:\msys64\usr\bin\gpg.exe C:\msys64\usr\bin\gpg.exe.orig
+  - mv "C:\Program Files\Git\usr\bin\gpg.exe" "C:\Program Files\Git\usr\bin\gpg.exe.orig"
 
 # Do something useful here to override the default MSBuild (which would fail otherwise).
 build_script:


### PR DESCRIPTION
This is a work-around for GPG failing to connect to its agent in
GitRepoTest [1]. A better work-around in the repo tool is pending review
at [2].

[1] https://ci.appveyor.com/project/heremaps/oss-review-toolkit/builds/30228453#L3030
[2] https://gerrit-review.googlesource.com/c/git-repo/+/251108

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>