### PR TITLE
OrtResult: Fix-up the deserialization after a rename

### DIFF
--- a/model/src/main/kotlin/AnalyzerResult.kt
+++ b/model/src/main/kotlin/AnalyzerResult.kt
@@ -29,7 +29,7 @@ import java.util.SortedSet
 /**
  * A class that merges all information from individual [ProjectAnalyzerResult]s created for each found definition file.
  */
-@JsonIgnoreProperties(value = ["has_issues"], allowGetters = true)
+@JsonIgnoreProperties(value = ["has_issues", /* Backwards-compatibility: */ "has_errors"], allowGetters = true)
 data class AnalyzerResult(
     /**
      * Sorted set of the projects, as they appear in the individual analyzer results.

--- a/model/src/main/kotlin/ScanRecord.kt
+++ b/model/src/main/kotlin/ScanRecord.kt
@@ -27,7 +27,7 @@ import java.util.SortedSet
 /**
  * A record of a single run of the scanner tool, containing the input and the scan results for all scanned packages.
  */
-@JsonIgnoreProperties(value = ["has_issues"], allowGetters = true)
+@JsonIgnoreProperties(value = ["has_issues", /* Backwards-compatibility: */ "has_errors"], allowGetters = true)
 data class ScanRecord(
     /**
      * The scanned and ignored [Scope]s for each scanned [Project] by id.


### PR DESCRIPTION
In a recent PR `error` has been renamed to `issue` accross the code
based. Deserializing OrtResults created before that rename now fails
as the 'has_errors' property is not ignored anymore, see 99152a1 and
addb4ab.

Re-add 'has_errors' to the set of ignored properties fixes the
deserialization again.

Signed-off-by: Frank Viernau <frank.viernau@here.com>