### PR TITLE
ClearlyDefinedPackageCurationProvider: Add missing provider mappings

### DIFF
--- a/analyzer/src/main/kotlin/curation/ClearlyDefinedPackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/curation/ClearlyDefinedPackageCurationProvider.kt
@@ -47,8 +47,8 @@ fun Identifier.toClearlyDefinedTypeAndProvider(): Pair<ComponentType, Provider> 
         "Bundler" -> ComponentType.GEM to Provider.RUBYGEMS
         "Cargo" -> ComponentType.CRATE to Provider.CRATES_IO
         "CocoaPods" -> ComponentType.POD to Provider.COCOAPODS
-        "nuget" -> ComponentType.NUGET to Provider.NUGET
-        "GoDep" -> ComponentType.GIT to Provider.GITHUB
+        "DotNet", "nuget" -> ComponentType.NUGET to Provider.NUGET
+        "GoDep", "GoMod" -> ComponentType.GIT to Provider.GITHUB
         "Maven" -> ComponentType.MAVEN to Provider.MAVEN_CENTRAL
         "NPM" -> ComponentType.NPM to Provider.NPM_JS
         "PhpComposer" -> ComponentType.COMPOSER to Provider.PACKAGIST


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>