### PR TITLE
ScanSummary: Move a code comment to KDoc

### DIFF
--- a/model/src/main/kotlin/ScanSummary.kt
+++ b/model/src/main/kotlin/ScanSummary.kt
@@ -76,9 +76,9 @@ data class ScanSummary(
 
     /**
      * The list of issues that occurred during the scan.
+     * This property is not serialized if the list is empty to reduce the size of the result file. If there are no
+     * issues at all, [ScanRecord.hasIssues] already contains that information.
      */
-    // Do not serialize if empty to reduce the size of the result file. If there are no issues at all,
-    // [ScanRecord.hasIssues] already contains that information.
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     val issues: List<OrtIssue> = emptyList()
 ) {


### PR DESCRIPTION
For consistency with a similar comment in `AnalyzerResult` and
`ProjectAnalyzerResult`, and because it is useful to have this comment
also in the generated docs.