### PR TITLE
ReporterCommand: Do not write an empty output file on error

### DIFF
--- a/cli/src/main/kotlin/commands/ReporterCommand.kt
+++ b/cli/src/main/kotlin/commands/ReporterCommand.kt
@@ -153,6 +153,10 @@ class ReporterCommand : CliktCommand(
             } catch (e: Exception) {
                 e.showStackTrace()
 
+                // The "file.outputStream()" above already creates the file, so delete it here if the exception occurred
+                // before any content was written.
+                if (file.length() == 0L) file.delete()
+
                 throw UsageError("Could not create '${reporter.reporterName}' report: ${e.collectMessagesAsString()}",
                     statusCode = 1)
             }


### PR DESCRIPTION
The call to "file.outputStream()" already creates the file, which is
then still kept if the reporter later fails with an exception. Avoid
that by writing to a byte array frist.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>