### PR TITLE
Yarn workspaces: Handle also scoped submodules

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces-expected-output.yml
@@ -60,36 +60,6 @@ packages:
       path: ""
   curations: []
 - package:
-    id: "NPM::pkg1:1.0.0"
-    purl: "pkg:npm/pkg1@1.0.0"
-    declared_licenses:
-    - "Apache-2.0"
-    declared_licenses_processed:
-      spdx_expression: "Apache-2.0"
-    description: ""
-    homepage_url: ""
-    binary_artifact:
-      url: ""
-      hash:
-        value: ""
-        algorithm: ""
-    source_artifact:
-      url: ""
-      hash:
-        value: ""
-        algorithm: ""
-    vcs:
-      type: "Git"
-      url: "<REPLACE_URL>"
-      revision: "<REPLACE_REVISION>"
-      path: "analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces/packages/pkg1"
-    vcs_processed:
-      type: "Git"
-      url: "<REPLACE_URL>"
-      revision: "<REPLACE_REVISION>"
-      path: "analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces/packages/pkg1"
-  curations: []
-- package:
     id: "NPM::pkg2:1.0.0"
     purl: "pkg:npm/pkg2@1.0.0"
     declared_licenses:
@@ -178,4 +148,34 @@ packages:
       url: "https://github.com/heremaps/harp.gl.git"
       revision: "0c2857f958a34ef7638384afada4fceec427d48d"
       path: "@here/harp-fetch"
+  curations: []
+- package:
+    id: "NPM:@scope1:pkg1:1.0.0"
+    purl: "pkg:npm/%40scope1/pkg1@1.0.0"
+    declared_licenses:
+    - "Apache-2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+    description: ""
+    homepage_url: ""
+    binary_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    source_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    vcs:
+      type: "Git"
+      url: "<REPLACE_URL>"
+      revision: "<REPLACE_REVISION>"
+      path: "analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces/packages/pkg1"
+    vcs_processed:
+      type: "Git"
+      url: "<REPLACE_URL>"
+      revision: "<REPLACE_REVISION>"
+      path: "analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces/packages/pkg1"
   curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces/packages/pkg1/package.json
+++ b/analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces/packages/pkg1/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pkg1",
+  "name": "@scope1/pkg1",
   "version": "1.0.0",
   "license": "Apache-2.0",
   "dependencies": {

--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -373,14 +373,18 @@ open class Npm(
         )
     }
 
-    private fun findWorkspaceSubmodules(moduleDir: File): List<File> =
-        moduleDir.resolve("node_modules").let { nodeModulesDir ->
-            if (nodeModulesDir.isDirectory) {
-                nodeModulesDir.listFiles().filter { file -> file.isSymlink() && file.isDirectory }
-            } else {
-                emptyList()
-            }
-        }
+    private fun findWorkspaceSubmodules(moduleDir: File): List<File> {
+        val nodeModulesDir = moduleDir.resolve("node_modules")
+        if (!nodeModulesDir.isDirectory) return emptyList()
+
+        val searchDirs = nodeModulesDir.listFiles().filter { file ->
+            file.isDirectory && file.name.startsWith("@")
+        } + nodeModulesDir
+
+        return searchDirs.map { dir ->
+            dir.listFiles().filter { file -> file.isSymlink() && file.isDirectory }
+        }.flatten()
+    }
 
     private fun getModuleDependencies(moduleDir: File, scopes: Set<String>): SortedSet<PackageReference> {
         val workspaceModuleDirs = findWorkspaceSubmodules(moduleDir)

--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -53,6 +53,7 @@ import com.here.ort.utils.Os
 import com.here.ort.utils.OkHttpClientHelper
 import com.here.ort.utils.OkHttpClientHelper.applyProxySettingsFromUrl
 import com.here.ort.utils.getUserHomeDirectory
+import com.here.ort.utils.isSymlink
 import com.here.ort.utils.log
 import com.here.ort.utils.realFile
 import com.here.ort.utils.stashDirectories
@@ -375,10 +376,7 @@ open class Npm(
     private fun findWorkspaceSubmodules(moduleDir: File): List<File> =
         moduleDir.resolve("node_modules").let { nodeModulesDir ->
             if (nodeModulesDir.isDirectory) {
-                nodeModulesDir.listFiles().filter { file ->
-                    val realFile = file.realFile()
-                    realFile != file && realFile.isDirectory
-                }
+                nodeModulesDir.listFiles().filter { file -> file.isSymlink() && file.isDirectory }
             } else {
                 emptyList()
             }

--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -372,8 +372,8 @@ open class Npm(
         )
     }
 
-    private fun getModuleDependencies(moduleDir: File, scopes: Set<String>): SortedSet<PackageReference> {
-        val workspaceModuleDirs = moduleDir.resolve("node_modules").let { nodeModulesDir ->
+    private fun findWorkspaceSubmodules(moduleDir: File): List<File> =
+        moduleDir.resolve("node_modules").let { nodeModulesDir ->
             if (nodeModulesDir.isDirectory) {
                 nodeModulesDir.listFiles().filter { file ->
                     val realFile = file.realFile()
@@ -383,6 +383,9 @@ open class Npm(
                 emptyList()
             }
         }
+
+    private fun getModuleDependencies(moduleDir: File, scopes: Set<String>): SortedSet<PackageReference> {
+        val workspaceModuleDirs = findWorkspaceSubmodules(moduleDir)
 
         return sortedSetOf<PackageReference>().apply {
             addAll(getPackageReferenceForModule(moduleDir, scopes)!!.dependencies)

--- a/utils/src/main/kotlin/Extensions.kt
+++ b/utils/src/main/kotlin/Extensions.kt
@@ -66,6 +66,11 @@ fun File.hash(algorithm: String = "SHA-1"): String =
     MessageDigest.getInstance(algorithm).digest(readBytes()).toHexString()
 
 /**
+ * Return true if and only if this file is a symbolic link.
+ */
+fun File.isSymlink(): Boolean = realFile() != absoluteFile
+
+/**
  * Resolve the file to the real underlying file. In contrast to Java's [File.getCanonicalFile], this also works to
  * resolve symbolic links on Windows.
  */


### PR DESCRIPTION
The logic for finding workspace submodules did not find submodules with a scope / namespace, which is the issue this PR addresses. See also the individual commit messages.