### PR TITLE
JGit SSH-Agent

### DIFF
--- a/downloader/build.gradle.kts
+++ b/downloader/build.gradle.kts
@@ -19,6 +19,7 @@
  */
 
 val jgitVersion: String by project
+val jSchAgentProxyVersion: String by project
 val svnkitVersion: String by project
 
 plugins {
@@ -31,6 +32,7 @@ dependencies {
 
     implementation(project(":utils"))
 
+    implementation("com.jcraft:jsch.agentproxy.jsch:$jSchAgentProxyVersion")
     implementation("org.eclipse.jgit:org.eclipse.jgit:$jgitVersion")
     implementation("org.tmatesoft.svnkit:svnkit:$svnkitVersion")
 }

--- a/downloader/src/main/kotlin/vcs/Git.kt
+++ b/downloader/src/main/kotlin/vcs/Git.kt
@@ -56,7 +56,9 @@ class Git : GitBase() {
         init {
             // Configure JGit to connect to the SSH-Agent if it is available.
             val sessionFactory = object : JschConfigSessionFactory() {
-                override fun configure(hc: OpenSshConfig.Host, session: Session) {}
+                override fun configure(hc: OpenSshConfig.Host, session: Session) {
+                    session.setConfig("StrictHostKeyChecking", "no")
+                }
 
                 override fun createDefaultJSch(fs: FS): JSch {
                     val jSch = super.createDefaultJSch(fs)

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,6 +38,7 @@ hamcrestCoreVersion = 1.3
 jacksonVersion = 2.10.2
 jcommanderVersion = 1.78
 jgitVersion = 5.6.0.201912101111-r
+jSchAgentProxyVersion = 0.0.7
 kotlintestVersion = 3.4.2
 kotlinxCoroutinesVersion = 1.3.3
 kotlinxHtmlVersion = 0.6.12


### PR DESCRIPTION
Configure JGit to use the SSH-Agent if available and disable strict host key checking for JGit.