### PR TITLE
DownloaderCommand: Fix-up the entity parameter handling

### DIFF
--- a/cli/src/main/kotlin/commands/DownloaderCommand.kt
+++ b/cli/src/main/kotlin/commands/DownloaderCommand.kt
@@ -105,7 +105,7 @@ class DownloaderCommand : CliktCommand(name = "download", help = "Fetch source c
         "--entities", "-e",
         help = "The data entities from the ORT file's analyzer result to limit downloads to. If not specified, all " +
                 "data entities are downloaded."
-    ).enum<Downloader.DataEntity>().split(",").default(emptyList())
+    ).enum<Downloader.DataEntity>().split(",").default(enumValues<Downloader.DataEntity>().asList())
 
     private val allowMovingRevisionsOption by option(
         "--allow-moving-revisions",


### PR DESCRIPTION
The default value has recently been changed to an empty list which made
the behavior inconsistent with the parameter description, see bb5e2b6.

Fix this by reverting to the previous default value.

Signed-off-by: Frank Viernau <frank.viernau@here.com>