### PR TITLE
DownloaderCommand: Log an error summary

### DIFF
--- a/cli/src/main/kotlin/commands/DownloaderCommand.kt
+++ b/cli/src/main/kotlin/commands/DownloaderCommand.kt
@@ -161,8 +161,7 @@ class DownloaderCommand : CliktCommand(name = "download", help = "Fetch source c
             }
         }
 
-        var error = false
-
+        val errorMessages = mutableListOf<String>()
         packages.forEach { pkg ->
             try {
                 val absoluteOutputDir = outputDir.expandTilde()
@@ -198,12 +197,16 @@ class DownloaderCommand : CliktCommand(name = "download", help = "Fetch source c
             } catch (e: DownloadException) {
                 e.showStackTrace()
 
-                log.error { "Could not download '${pkg.id.toCoordinates()}': ${e.collectMessagesAsString()}" }
+                val errorMessage = "Could not download '${pkg.id.toCoordinates()}': ${e.collectMessagesAsString()}"
+                errorMessages += errorMessage
 
-                error = true
+                log.error { errorMessage }
             }
         }
 
-        if (error) throw UsageError("An error occurred.", statusCode = 2)
+        if (errorMessages.isNotEmpty()) {
+            log.error { "Error Summary:\n\n${errorMessages.joinToString("\n\n")}" }
+            throw UsageError("${errorMessages.size} error(s) occurred.", statusCode = 2)
+        }
     }
 }


### PR DESCRIPTION
As the log can be potentially quite long it seems convenient to have the
errors summarized at the very end of the logs.

Signed-off-by: Frank Viernau <frank.viernau@here.com>