### PR TITLE
downloader: Refactor the archive types from constants into an enum

### DIFF
--- a/cli/src/main/kotlin/commands/DownloaderCommand.kt
+++ b/cli/src/main/kotlin/commands/DownloaderCommand.kt
@@ -46,7 +46,7 @@ import com.here.ort.model.RemoteArtifact
 import com.here.ort.model.VcsInfo
 import com.here.ort.model.VcsType
 import com.here.ort.model.readValue
-import com.here.ort.utils.ARCHIVE_EXTENSIONS
+import com.here.ort.utils.ArchiveType
 import com.here.ort.utils.collectMessagesAsString
 import com.here.ort.utils.encodeOrUnknown
 import com.here.ort.utils.expandTilde
@@ -143,7 +143,7 @@ class DownloaderCommand : CliktCommand(name = "download", help = "Fetch source c
                 val projectName = projectNameOption ?: projectFile.nameWithoutExtension
 
                 val dummyId = Identifier("Downloader::$projectName:")
-                val dummyPackage = if (ARCHIVE_EXTENSIONS.any { projectFile.name.endsWith(it) }) {
+                val dummyPackage = if (ArchiveType.getType(projectFile.name) != ArchiveType.NONE) {
                     Package.EMPTY.copy(id = dummyId, sourceArtifact = RemoteArtifact.EMPTY.copy(url = projectUrl))
                 } else {
                     val vcs = VcsInfo(


### PR DESCRIPTION
This makes the code more readable.

Note that there is a minor change in behavior involved in
DownloaderCommand: Before, the condition

    if (ARCHIVE_EXTENSIONS.any { projectFile.name.endsWith(it) })

was not taken for POM files, that is, in vase of an URL pointing to a
POM file, that POM file was not used as the source artifact, which is
actually wrong.

The new condition

    ArchiveType.getType(projectFile.name) != ArchiveType.NONE

distinguishes POM artifacts from other NONE archive types, and thus the
condition it now taken for POM files, and POM files are used as source
artifacts.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>