### PR TITLE
OrtMain: Exit the process before returning from main()

### DIFF
--- a/cli/src/main/kotlin/OrtMain.kt
+++ b/cli/src/main/kotlin/OrtMain.kt
@@ -49,6 +49,7 @@ import java.io.File
 
 import org.apache.logging.log4j.Level
 import org.apache.logging.log4j.core.config.Configurator
+import kotlin.system.exitProcess
 
 const val TOOL_NAME = "ort"
 
@@ -202,5 +203,6 @@ fun fixupUserHomeProperty() {
  */
 fun main(args: Array<String>) {
     fixupUserHomeProperty()
-    return OrtMain().main(args)
+    OrtMain().main(args)
+    exitProcess(0)
 }


### PR DESCRIPTION
As of the migration from `JCommander` to `clikt` the exit codes from the
ORT commands are propagated via exceptions to clikt which then calls
exitProcess(). In case no such exception has been thrown exitProcess()
is not called anymore as of bb5e2b6. As a consequence the process keeps
alive in case threads (other than the main thread) are still running.
The problem indeed happens e.g. with the analyzer command.

Adding this missing call as a fix-up for bb5e2b6.