### PR TITLE
GitRepo: Use the default branch of git-repo again

### DIFF
--- a/downloader/src/main/kotlin/vcs/GitRepo.kt
+++ b/downloader/src/main/kotlin/vcs/GitRepo.kt
@@ -34,11 +34,6 @@ import com.here.ort.utils.showStackTrace
 import java.io.File
 import java.io.IOException
 
-/**
- * The branch of git-repo to use. This allows to override git-repo's default of using the "stable" branch.
- */
-private const val GIT_REPO_BRANCH = "master"
-
 class GitRepo : GitBase() {
     override val type = VcsType.GIT_REPO
     override val priority = 50
@@ -100,8 +95,7 @@ class GitRepo : GitBase() {
         // Clone all projects instead of only those in the "default" group until we support specifying groups.
         runRepoCommand(
             targetDir,
-            "init", "--groups=all", "--no-repo-verify",
-            "--no-clone-bundle", "--repo-branch=$GIT_REPO_BRANCH",
+            "init", "--groups=all", "--no-repo-verify", "--no-clone-bundle",
             "-b", manifestRevision,
             "-u", vcs.url,
             "-m", manifestPath


### PR DESCRIPTION
ORT started using the master branch instead of the (default) stable
branch as master contained some fixes which had not been integrated into
stable back then, see c0eb030. As both fixes mentioned in that commit
meanwhile got integrated into stable there is no need anymore to use the
master branch.

Installing the repo launcher command via [1], as we do on Travis CI,
actually installs the released launcher command which comes from the
stable branch. As of the recent bump of the major version [2] of that
launcher command on the master branch, calling [3] refuses to work and
asks to update the launcher command to version 2.x first.

Revert back to using the stable branch in order to fix that issue and
thus make ORTs git-repo integration work again.

[1] curl https://storage.googleapis.com/git-repo-downloads/repo > ~/bin/repo
[2] https://gerrit.googlesource.com/git-repo/+/ee451f035d258e40ce8f995c0826061228a7d292
[3] repo init --repo-branch=master

Signed-off-by: Frank Viernau <frank.viernau@here.com>