### PR TITLE
GitRepo: Re-introduce the switch for the git-repo branch

### DIFF
--- a/downloader/src/main/kotlin/vcs/GitRepo.kt
+++ b/downloader/src/main/kotlin/vcs/GitRepo.kt
@@ -34,6 +34,11 @@ import com.here.ort.utils.showStackTrace
 import java.io.File
 import java.io.IOException
 
+/**
+ * The branch of git-repo to use. This allows to override git-repo's default of using the "stable" branch.
+ */
+private const val GIT_REPO_BRANCH = "stable"
+
 class GitRepo : GitBase() {
     override val type = VcsType.GIT_REPO
     override val priority = 50
@@ -95,7 +100,8 @@ class GitRepo : GitBase() {
         // Clone all projects instead of only those in the "default" group until we support specifying groups.
         runRepoCommand(
             targetDir,
-            "init", "--groups=all", "--no-repo-verify", "--no-clone-bundle",
+            "init", "--groups=all", "--no-repo-verify",
+            "--no-clone-bundle", "--repo-branch=$GIT_REPO_BRANCH",
             "-b", manifestRevision,
             "-u", vcs.url,
             "-m", manifestPath


### PR DESCRIPTION
This has been removed by f61b87b but it turned out that there is a
preferrence to keep it, see also:

https://github.com/heremaps/oss-review-toolkit/pull/2186#issuecomment-582905816

This partially reverts commit f61b87b.

Signed-off-by: Frank Viernau <frank.viernau@here.com>