### PR TITLE
git-repo: Temporarily switch back to version 1

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -59,7 +59,7 @@ install:
   - set PATH=%PATH%;C:\msys64\usr\bin # For CVS.
   - set PATH=C:\Ruby25\bin;%PATH% # For licensee.
   # Install git-repo.
-  - ps: Start-FileDownload 'https://storage.googleapis.com/git-repo-downloads/repo' -FileName "$env:PROGRAMFILES\Git\usr\bin\repo"
+  - ps: Start-FileDownload 'https://storage.googleapis.com/git-repo-downloads/repo-1' -FileName "$env:PROGRAMFILES\Git\usr\bin\repo"
   # Install the Android SDK.
   - ps: Start-FileDownload "https://dl.google.com/android/repository/sdk-tools-windows-$env:ANDROID_SDK_VERSION.zip"
   - 7z x sdk-tools-windows-%ANDROID_SDK_VERSION%.zip -o%ANDROID_HOME% > nul

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ install:
   - curl -sSL https://github.com/commercialhaskell/stack/raw/v$STACK_VERSION/etc/scripts/get-stack.sh | sh
   - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $RUST_VERSION
   - export PATH=$PATH:$HOME/.cargo/bin
-  - curl https://storage.googleapis.com/git-repo-downloads/repo > ~/bin/repo
+  - curl https://storage.googleapis.com/git-repo-downloads/repo-1 > ~/bin/repo
   - chmod a+x ~/bin/repo
   - curl -Os https://dl.google.com/android/repository/sdk-tools-linux-$ANDROID_SDK_VERSION.zip
   - unzip -q sdk-tools-linux-$ANDROID_SDK_VERSION.zip -d $ANDROID_HOME

--- a/downloader/src/main/kotlin/vcs/GitRepo.kt
+++ b/downloader/src/main/kotlin/vcs/GitRepo.kt
@@ -37,7 +37,7 @@ import java.io.IOException
 /**
  * The branch of git-repo to use. This allows to override git-repo's default of using the "stable" branch.
  */
-private const val GIT_REPO_BRANCH = "stable"
+private const val GIT_REPO_BRANCH = "repo-1"
 
 class GitRepo : GitBase() {
     override val type = VcsType.GIT_REPO


### PR DESCRIPTION
Yesterday version 2 became the new `stable` version of git-repo and
thus ORT started using it. As result GitRepoTest started failing due to
the below issue which can be reproduced by installing the latest
(stable) git-repo launcher and then running a `repo-sync` with the
`--fetch-submodules` option.

Work around that issue by switching back to version 1 temporarily, so
that finding the proper solution can be done outside the critical path
of fixing the failing CI.

[1] .repo/repo/project.py", line 2076, in parse_gitmodules
    os.write(fd, p.stdout)

Signed-off-by: Frank Viernau <frank.viernau@here.com>