### PR TITLE
JitPack: Exclude dokkaJavadoc tasks to save build time

### DIFF
--- a/.jitpack.yml
+++ b/.jitpack.yml
@@ -2,5 +2,6 @@ jdk:
   - openjdk8
 
 install:
+  # Exclude dokkaJavadoc tasks to save build time.
   # Exclude the reporter-web-app from the build because there are issues installing Yarn on JitPack.
-  - ./gradlew --no-daemon --stacktrace -x reporter-web-app:yarnBuild publishToMavenLocal
+  - ./gradlew --no-daemon --stacktrace -x dokkaJavadoc -x :reporter-web-app:yarnBuild publishToMavenLocal


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>