### PR TITLE
OrtResult: Add a isProject() function

### DIFF
--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -459,4 +459,10 @@ data class OrtResult(
      * Return the list of [ScanResult]s for the given [id].
      */
     fun getScanResultsForId(id: Identifier): List<ScanResult> = scanResultsById[id].orEmpty()
+
+    /**
+     * Return true if and only if the given [id] denotes a [Project] contained in this [OrtResult].
+     */
+    @Suppress("UNUSED") // This is intended to be mostly used via scripting.
+    fun isProject(id: Identifier): Boolean = getProject(id) != null
 }


### PR DESCRIPTION
This is efficient as the execution performance is determined solely by
a TreeSet look-up.

Signed-off-by: Frank Viernau <frank.viernau@here.com>