### PR TITLE
Jenkinsfile: Allow to trigger an optional downstream job afterwards

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,6 +55,12 @@ pipeline {
             description: 'Log message level',
             choices: ['--info', '--debug', '']
         )
+
+        string(
+            name: 'DOWNSTREAM_JOB',
+            description: 'Name of an optional downstream job to trigger',
+            defaultValue: ''
+        )
     }
 
     stages {
@@ -171,6 +177,22 @@ pipeline {
                         fingerprint: true
                     )
                 }
+            }
+        }
+
+        stage('Trigger downstream job') {
+            agent any
+
+            when {
+                beforeAgent true
+
+                expression {
+                    !params.DOWNSTREAM_JOB.allWhitespace
+                }
+            }
+
+            steps {
+                build job: params.DOWNSTREAM_JOB, wait: false
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -143,7 +143,9 @@ or
 
 A basic ORT pipeline (using the _analyzer_, _scanner_ and _reporter_) can easily be run on
 [Jenkins CI](https://jenkins.io/) by using the [Jenkinsfile](./Jenkinsfile) in a (declarative)
-[pipeline](https://jenkins.io/doc/book/pipeline/) job.
+[pipeline](https://jenkins.io/doc/book/pipeline/) job. The job accepts various parameters that are translated to ORT
+command line arguments. Additionally, one can trigger a downstream job which e.g. further processes scan results. Note
+that it is the downstream job's responsibility to copy any artifacts it needs from the upstream job.
 
 ## Getting started
 


### PR DESCRIPTION
E.g. to further process scan results with some user-specific logic. It
is the downstream job's responsibility to copy the artifacts it needs
from the upstream job, e.g. by accessing the Cause instance via Groovy
DSL.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>