### PR TITLE
Fix link to curations file

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -281,7 +281,7 @@ on a bigger project you will see that `ScanCode` often finds more licenses than 
 The evaluator can apply a set of rules against the scan result created above.
 ORT provides examples for the policy rules file [(rules.kts)](examples/rules.kts),
 [user-defined categorization of licenses (licenses.yml)](examples/licenses.yml) and
-[user-defined package curations (curations.yml)](examples/licenses.yml) that can be used for testing the _evaluator_. 
+[user-defined package curations (curations.yml)](examples/curations.yml) that can be used for testing the _evaluator_. 
 
 To run the example rules use:
 


### PR DESCRIPTION
There was a wrong link in paragraph 6, possibly a copy and paste error. The curations.yml link pointed to 'examples/licenses.yml'.