### PR TITLE
PathExcludeReason: Add `TEST_OF`

### DIFF
--- a/model/src/main/kotlin/config/PathExcludeReason.kt
+++ b/model/src/main/kotlin/config/PathExcludeReason.kt
@@ -63,6 +63,12 @@ enum class PathExcludeReason {
     PROVIDED_BY,
 
     /**
+     * The path only contains files used for testing source code which are not included in distributed build
+     * artifacts.
+     */
+    TEST_OF,
+
+    /**
      * The path only contains tools used for testing source code which are not included in distributed build
      * artifacts.
      */


### PR DESCRIPTION
In SPDX 2.2 [1] the `TEST_OF` relationship was
introduced for cases where it's clear something is used
for testing but unclear whether it's code or tools.
Adding `TEST_OF` in addition to `TEST_TOOL_OF` so ORT users
have a generic reason for test directories
which may besides tools also contain code.

[1] https://github.com/spdx/spdx-spec/issues/173.

Signed-off-by: Thomas Steenbergen <thomas.steenbergen@here.com>