### PR TITLE
Bundler: Whitelist Bundler 2.1.x

### DIFF
--- a/analyzer/src/main/kotlin/managers/Bundler.kt
+++ b/analyzer/src/main/kotlin/managers/Bundler.kt
@@ -83,7 +83,7 @@ class Bundler(
 
     override fun command(workingDir: File?) = if (Os.isWindows) "bundle.bat" else "bundle"
 
-    override fun getVersionRequirement(): Requirement = Requirement.buildIvy("[1.16,2.1[")
+    override fun getVersionRequirement(): Requirement = Requirement.buildIvy("[1.16,2.2[")
 
     override fun beforeResolution(definitionFiles: List<File>) =
         // We do not actually depend on any features specific to a version of Bundler, but we still want to stick to


### PR DESCRIPTION
As Bundler 2.1.4 is now what Travis uses.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>