### PR TITLE
Gradle: Use exclusive repository content to speed up artifact lookup

### DIFF
--- a/analyzer/build.gradle.kts
+++ b/analyzer/build.gradle.kts
@@ -32,7 +32,15 @@ plugins {
 }
 
 repositories {
-    maven("https://repo.gradle.org/gradle/libs-releases-local/")
+    exclusiveContent {
+        forRepository {
+            maven("https://repo.gradle.org/gradle/libs-releases-local/")
+        }
+
+        filter {
+            includeGroup("org.gradle")
+        }
+    }
 }
 
 dependencies {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -34,7 +34,16 @@ plugins {
 
 repositories {
     jcenter()
-    maven("https://plugins.gradle.org/m2/")
+
+    exclusiveContent {
+        forRepository {
+            maven("https://plugins.gradle.org/m2/")
+        }
+
+        filter {
+            includeGroupByRegex(".*gradle\\.plugin.*")
+        }
+    }
 }
 
 val ideaExtPluginVersion = extra["ideaExtPluginVersion"]

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -48,7 +48,15 @@ repositories {
 
     // Need to repeat the analyzer's custom repository definition here, see
     // https://github.com/gradle/gradle/issues/4106.
-    maven("https://repo.gradle.org/gradle/libs-releases-local/")
+    exclusiveContent {
+        forRepository {
+            maven("https://repo.gradle.org/gradle/libs-releases-local/")
+        }
+
+        filter {
+            includeGroup("org.gradle")
+        }
+    }
 }
 
 dependencies {

--- a/helper-cli/build.gradle.kts
+++ b/helper-cli/build.gradle.kts
@@ -45,7 +45,15 @@ repositories {
 
     // Need to repeat the analyzer's custom repository definition here, see
     // https://github.com/gradle/gradle/issues/4106.
-    maven("https://repo.gradle.org/gradle/libs-releases-local/")
+    exclusiveContent {
+        forRepository {
+            maven("https://repo.gradle.org/gradle/libs-releases-local/")
+        }
+
+        filter {
+            includeGroup("org.gradle")
+        }
+    }
 }
 
 dependencies {

--- a/reporter/build.gradle.kts
+++ b/reporter/build.gradle.kts
@@ -49,7 +49,15 @@ sourceSets.named("main") {
 }
 
 repositories {
-    maven("http://www.robotooling.com/maven/")
+    exclusiveContent {
+        forRepository {
+            maven("http://www.robotooling.com/maven/")
+        }
+
+        filter {
+            includeGroup("bad.robot")
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
This feature was introduced in Gradle 6.2, see
https://docs.gradle.org/6.2/release-notes.html#declaring-exclusive-repository-content

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>