### PR TITLE
scanner: Use the backend storage name in case of a FileBasedStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ ort {
       backend {
         localFileStorage {
           directory = "/tmp/ort/scan-results"
+          compression = false
         }
       }
     }

--- a/model/src/main/kotlin/config/FileStorageConfiguration.kt
+++ b/model/src/main/kotlin/config/FileStorageConfiguration.kt
@@ -23,6 +23,7 @@ import com.here.ort.utils.expandTilde
 import com.here.ort.utils.storage.FileStorage
 import com.here.ort.utils.storage.HttpFileStorage
 import com.here.ort.utils.storage.LocalFileStorage
+import com.here.ort.utils.storage.XZCompressedLocalFileStorage
 
 /**
  * The configuration model for a [FileStorage]. Only one of the storage options can be configured.
@@ -50,7 +51,12 @@ data class FileStorageConfiguration(
             HttpFileStorage(httpFileStorageConfiguration.url, httpFileStorageConfiguration.headers)
         } ?: localFileStorage!!.let { localFileStorageConfiguration ->
             val directory = localFileStorageConfiguration.directory.expandTilde()
-            LocalFileStorage(directory)
+
+            if (localFileStorageConfiguration.compression) {
+                XZCompressedLocalFileStorage(directory)
+            } else {
+                LocalFileStorage(directory)
+            }
         }
     }
 }

--- a/model/src/main/kotlin/config/LocalFileStorageConfiguration.kt
+++ b/model/src/main/kotlin/config/LocalFileStorageConfiguration.kt
@@ -29,5 +29,10 @@ data class LocalFileStorageConfiguration(
     /**
      * The directory to use as a storage root.
      */
-    val directory: File
+    val directory: File,
+
+    /**
+     * Whether to use compression for storing files or not.
+     */
+    val compression: Boolean
 )

--- a/model/src/main/resources/reference.conf
+++ b/model/src/main/resources/reference.conf
@@ -7,6 +7,7 @@ ort {
       storage {
         localFileStorage {
           directory = ~/.ort/scanner/archive
+          compression = false
         }
       }
     }
@@ -23,6 +24,7 @@ ort {
 
         localFileStorage {
           directory = ~/.ort/scanner/results
+          compression = false
         }
       }
     }

--- a/reporter/src/funTest/kotlin/reporters/NoticeByPackageReporterTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/NoticeByPackageReporterTest.kt
@@ -390,7 +390,8 @@ class NoticeByPackageReporterTest : WordSpec({
                         patterns = LICENSE_FILENAMES,
                         storage = FileStorageConfiguration(
                             localFileStorage = LocalFileStorageConfiguration(
-                                archiveDir
+                                directory = archiveDir,
+                                compression = false
                             )
                         )
                     )

--- a/scanner/src/main/kotlin/ScanResultsStorage.kt
+++ b/scanner/src/main/kotlin/ScanResultsStorage.kt
@@ -127,7 +127,7 @@ abstract class ScanResultsStorage {
     /**
      * The name to refer to this storage implementation.
      */
-    val name: String = javaClass.simpleName
+    open val name: String = javaClass.simpleName
 
     /**
      * The access statistics for the scan result storage.

--- a/scanner/src/main/kotlin/storages/FileBasedStorage.kt
+++ b/scanner/src/main/kotlin/storages/FileBasedStorage.kt
@@ -47,6 +47,8 @@ class FileBasedStorage(
      */
     private val backend: FileStorage
 ) : ScanResultsStorage() {
+    override val name = "${javaClass.simpleName} with ${backend.javaClass.simpleName} backend"
+
     override fun readFromStorage(id: Identifier): ScanResultContainer {
         val path = storagePath(id)
 


### PR DESCRIPTION
As this is more specific and distinguishes e.g. LocalFileStorage from
XZCompressedLocalFileStorage.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>