### PR TITLE
FindingsMatcher: Prepare for changing the algorithm

### DIFF
--- a/model/src/main/kotlin/utils/FindingsMatcher.kt
+++ b/model/src/main/kotlin/utils/FindingsMatcher.kt
@@ -62,7 +62,7 @@ class FindingsMatcher(
     private fun getClosestCopyrightStatements(
         copyrights: List<CopyrightFinding>,
         licenseStartLine: Int
-    ): Set<CopyrightFindings> {
+    ): Set<CopyrightFinding> {
         require(copyrights.map { it.location.path }.distinct().size <= 1) {
             "Given copyright statements must all point to the same file."
         }
@@ -71,7 +71,7 @@ class FindingsMatcher(
             (it.location.startLine - licenseStartLine).absoluteValue <= toleranceLines
         }
 
-        return closestCopyrights.mapTo(mutableSetOf()) { it.toCopyrightFindings() }
+        return closestCopyrights.toSet()
     }
 
     private fun CopyrightFinding.toCopyrightFindings() =
@@ -103,12 +103,12 @@ class FindingsMatcher(
         // If there are multiple license findings in a single file, search for the closest copyright statements
         // for each of these, if any.
         val copyrightsForLicenses = mutableMapOf<String, MutableSet<CopyrightFindings>>()
-        licenses.forEach {
+        licenses.forEach { (license, location) ->
             val closestCopyrights = getClosestCopyrightStatements(
                 copyrights = copyrights,
-                licenseStartLine = it.location.startLine
-            )
-            copyrightsForLicenses.getOrPut(it.license) { mutableSetOf() } += closestCopyrights
+                licenseStartLine = location.startLine
+            ).map { it.toCopyrightFindings() }
+            copyrightsForLicenses.getOrPut(license) { mutableSetOf() } += closestCopyrights
         }
 
         return copyrightsForLicenses

--- a/model/src/main/kotlin/utils/FindingsMatcher.kt
+++ b/model/src/main/kotlin/utils/FindingsMatcher.kt
@@ -88,7 +88,7 @@ class FindingsMatcher(
     /**
      * Associate copyright findings to license findings within a single file.
      */
-    private fun associateFileFindings(
+    private fun matchFileFindings(
         licenses: List<LicenseFinding>,
         copyrights: List<CopyrightFinding>,
         rootLicenses: Collection<String>
@@ -137,7 +137,7 @@ class FindingsMatcher(
         paths.forEach { path ->
             val licenses = licenseFindingsByPath[path].orEmpty()
             val copyrights = copyrightFindingsByPath[path].orEmpty()
-            val findings = associateFileFindings(licenses, copyrights, rootLicenses)
+            val findings = matchFileFindings(licenses, copyrights, rootLicenses)
 
             findings.forEach { (license, copyrightFindings) ->
                 copyrightsForLicenses.getOrPut(license) { mutableSetOf() } += copyrightFindings

--- a/model/src/main/kotlin/utils/FindingsMatcher.kt
+++ b/model/src/main/kotlin/utils/FindingsMatcher.kt
@@ -128,11 +128,11 @@ class FindingsMatcher(
         val paths = (licenseFindingsByPath.keys + copyrightFindingsByPath.keys).toSet()
         val rootLicenses = getRootLicenses(licenseFindings)
 
-        val locationsForLicenses = licenseFindings
+        val locationsByLicense = licenseFindings
             .groupBy({ it.license }, { it.location })
             .mapValuesTo(mutableMapOf()) { it.value.toSortedSet() }
 
-        val copyrightsForLicenses = mutableMapOf<String, MutableSet<CopyrightFinding>>()
+        val copyrightsByLicense = mutableMapOf<String, MutableSet<CopyrightFinding>>()
 
         paths.forEach { path ->
             val licenses = licenseFindingsByPath[path].orEmpty()
@@ -140,15 +140,15 @@ class FindingsMatcher(
             val findings = matchFileFindings(licenses, copyrights, rootLicenses)
 
             findings.forEach { (license, copyrightFindings) ->
-                copyrightsForLicenses.getOrPut(license) { mutableSetOf() } += copyrightFindings
+                copyrightsByLicense.getOrPut(license) { mutableSetOf() } += copyrightFindings
             }
         }
 
-        return (copyrightsForLicenses.keys + locationsForLicenses.keys).mapTo(mutableSetOf()) { license ->
+        return (copyrightsByLicense.keys + locationsByLicense.keys).mapTo(mutableSetOf()) { license ->
             LicenseFindings(
                 license,
-                locationsForLicenses[license] ?: sortedSetOf(),
-                copyrightsForLicenses[license].orEmpty().toCopyrightFindings().toSortedSet()
+                locationsByLicense[license] ?: sortedSetOf(),
+                copyrightsByLicense[license].orEmpty().toCopyrightFindings().toSortedSet()
             )
         }
     }

--- a/model/src/main/kotlin/utils/FindingsMatcher.kt
+++ b/model/src/main/kotlin/utils/FindingsMatcher.kt
@@ -92,13 +92,11 @@ class FindingsMatcher(
             "The given license and copyright findings must all point to the same file."
         }
 
-        val allCopyrightStatements = copyrights.toSet()
-
         // If there is no license finding but copyright findings, associate them with all root licenses.
-        if (licenses.isEmpty()) return rootLicenses.associateBy({ it }, { allCopyrightStatements })
+        if (licenses.isEmpty()) return rootLicenses.associateBy({ it }, { copyrights.toSet() })
 
         // If there is only a single license finding, associate all copyright findings with that license.
-        if (licenses.size == 1) return licenses.associateBy({ it.license }, { allCopyrightStatements })
+        if (licenses.size == 1) return licenses.associateBy({ it.license }, { copyrights.toSet() })
 
         // If there are multiple license findings in a single file, search for the closest copyright statements
         // for each of these, if any.


### PR DESCRIPTION
This PR is intended to consist of only non-functional changes which prepare changing the actual matching algorithm. In order to no break things accidentally it seems to be good to have a green test run at this point.

