### PR TITLE
XZCompressedLocalFileStorage: Fall back to reading an uncompressed file

### DIFF
--- a/utils/src/test/kotlin/storage/XZCompressedLocalFileStorageTest.kt
+++ b/utils/src/test/kotlin/storage/XZCompressedLocalFileStorageTest.kt
@@ -36,9 +36,20 @@ class XZCompressedLocalFileStorageTest : StringSpec() {
     }
 
     init {
-        "Written data can be read back" {
+        "Can read written compressed data" {
             storage { storage, _ ->
-                storage.write("existing-file", "content".byteInputStream())
+                storage.write("new-file", "content".byteInputStream())
+
+                val content = storage.read("new-file").bufferedReader().use(BufferedReader::readText)
+
+                content shouldBe "content"
+            }
+        }
+
+        "Can read existing uncompressed data" {
+            storage { storage, directory ->
+                val file = directory.resolve("existing-file")
+                file.writeText("content")
 
                 val content = storage.read("existing-file").bufferedReader().use(BufferedReader::readText)
 


### PR DESCRIPTION
This way any existing uncompressed files, like scan results, are reused
instead of being recreated.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>