### PR TITLE
docs: Align scope exclude examples with helper-cli

### DIFF
--- a/docs/config-file-ort-yml.md
+++ b/docs/config-file-ort-yml.md
@@ -95,7 +95,7 @@ excludes:
   scopes:
   - pattern: "test.*"
     reason: "TEST_DEPENDENCY_OF"
-    comment: "Scope with dependencies only used for testing. Not included in released artifacts."
+    comment: "Packages for testing only."
 ```
 
 The above example excludes all of the following scopes for all projects: `testAnnotationProcessor`,`testApi`,

--- a/docs/examples/bower.ort.yml
+++ b/docs/examples/bower.ort.yml
@@ -2,4 +2,4 @@ excludes:
   scopes:
   - pattern: "devDependencies"
     reason: "DEV_DEPENDENCY_OF"
-    comment: "Scope with dependencies only used for development. Not included in released artifacts in the context of this project."
+    comment: "Packages for development and testing only."

--- a/docs/examples/bundler.ort.yml
+++ b/docs/examples/bundler.ort.yml
@@ -2,4 +2,4 @@ excludes:
   scopes:
   - pattern: "test"
     reason: "TEST_DEPENDENCY_OF"
-    comment: "Scope with dependencies only used for testing. Not included in released artifacts in the context of this project."
+    comment: "Packages for testing only."

--- a/docs/examples/cargo.ort.yml
+++ b/docs/examples/cargo.ort.yml
@@ -2,7 +2,7 @@ excludes:
   scopes:
   - pattern: "build-dependencies"
     reason: "BUILD_DEPENDENCY_OF"
-    comment: "Scope with dependencies only used for building the source code. Not included in released artifacts in the context of this project."
+    comment: "Packages for building the code only."
   - pattern: "dev-dependencies"
     reason: "DEV_DEPENDENCY_OF"
-    comment: "Scope with dependencies only used for development. Not included in released artifacts in the context of this project."
+    comment: "Packages for development only."

--- a/docs/examples/go-mod.ort.yml
+++ b/docs/examples/go-mod.ort.yml
@@ -2,4 +2,4 @@ excludes:
   scopes:
     - pattern: "all"
       reason: "DEV_DEPENDENCY_OF"
-      comment: "Scope with dependencies used to build all targets including non-released artifacts like tests."
+      comment: "Packages to build all targets including tests only."

--- a/docs/examples/gradle-android.ort.yml
+++ b/docs/examples/gradle-android.ort.yml
@@ -2,7 +2,7 @@ excludes:
   scopes:
   - pattern: "test.*"
     reason: "TEST_DEPENDENCY_OF"
-    comment: "Scope with dependencies only used for testing. Not included in released artifacts in the context of this project."
+    comment: "Packages for testing only."
   - pattern: ".*Test.*"
     reason: "TEST_DEPENDENCY_OF"
-    comment: "Scope with dependencies only used for testing. Not included in released artifacts in the context of this project."
+    comment: "Packages for testing only."

--- a/docs/examples/gradle.ort.yml
+++ b/docs/examples/gradle.ort.yml
@@ -2,4 +2,4 @@ excludes:
   scopes:
   - pattern: "test.*"
     reason: "TEST_DEPENDENCY_OF"
-    comment: "Scope with dependencies only used for testing. Not included in released artifacts in the context of this project."
+    comment: "Packages for testing only."

--- a/docs/examples/maven.ort.yml
+++ b/docs/examples/maven.ort.yml
@@ -2,7 +2,7 @@ excludes:
   scopes:
   - pattern: "provided"
     reason: "PROVIDED_DEPENDENCY_OF"
-    comment: "Scope with dependencies provided by the JDK or container at runtime. Not included in released artifacts in the context of this project."
+    comment: "Packages provided at runtime by the JDK or container only."
   - pattern: "test"
     reason: "TEST_DEPENDENCY_OF"
-    comment: "Scope with dependencies only used for development. Not included in released artifacts in the context of this project."
+    comment: "Packages for testing only."

--- a/docs/examples/npm.ort.yml
+++ b/docs/examples/npm.ort.yml
@@ -2,4 +2,4 @@ excludes:
   scopes:
   - pattern: "devDependencies"
     reason: "DEV_DEPENDENCY_OF"
-    comment: "Scope with dependencies only used for development. Not included in released artifacts in the context of this project."
+    comment: "Packages for development only."

--- a/docs/examples/php-composer.ort.yml
+++ b/docs/examples/php-composer.ort.yml
@@ -2,4 +2,4 @@ excludes:
   scopes:
   - pattern: "require-dev"
     reason: "DEV_DEPENDENCY_OF"
-    comment: "Scope with dependencies only used for development. Not included in released artifacts in the context of this project."
+    comment: "Packages for development only."

--- a/docs/examples/sbt.ort.yml
+++ b/docs/examples/sbt.ort.yml
@@ -2,7 +2,7 @@ excludes:
   scopes:
   - pattern: "provided"
     reason: "PROVIDED_DEPENDENCY_OF"
-    comment: "Scope with dependencies provided by the JDK or container at runtime. Not included in released artifacts in the context of this project."
+    comment: "Packages provided at runtime by the JDK or container only."
   - pattern: "test"
     reason: "TEST_DEPENDENCY_OFF"
-    comment: "Scope with dependencies only used for testing. Not included in released artifacts in the context of this project."
+    comment: "Packages for testing only."

--- a/docs/examples/stack.ort.yml
+++ b/docs/examples/stack.ort.yml
@@ -2,7 +2,7 @@ excludes:
   scopes:
   - pattern: "bench"
     reason: "TEST_DEPENDENCY_OF"
-    comment: "Scope with dependencies only used for benchmarking. Not included in released artifacts in the context of this project."
+    comment: "Packages used for benchmark testing only."
   - pattern: "test"
     reason: "TEST_DEPENDENCY_OF"
-    comment: "Scope with dependencies only used for testing. Not included in released artifacts in the context of this project."
+    comment: "Packages for testing only."

--- a/docs/examples/yarn.ort.yml
+++ b/docs/examples/yarn.ort.yml
@@ -2,4 +2,4 @@ excludes:
   scopes:
   - pattern: "devDependencies"
     reason: "DEV_DEPENDENCY_OF"
-    comment: "Scope with dependencies only used for development. Not included in released artifacts in the context of this project."
+    comment: "Packages for development only."


### PR DESCRIPTION
Update comments for scope excludes examples so they are aligned with
those in the helper-cli's .ort.yml generation, see 9c6b442.

Signed-off-by: Thomas Steenbergen <thomas.steenbergen@here.com>