### PR TITLE
SpdxDeclaredLicenseMapping: Add `SEE LICENSE IN LICENSE`

### DIFF
--- a/spdx-utils/src/main/kotlin/SpdxDeclaredLicenseMapping.kt
+++ b/spdx-utils/src/main/kotlin/SpdxDeclaredLicenseMapping.kt
@@ -414,6 +414,7 @@ object SpdxDeclaredLicenseMapping {
         "Ruby's" to RUBY.toExpression(),
         "Qt Public License" to QPL_1_0.toExpression(),
         "Qt Public License (QPL)" to QPL_1_0.toExpression(),
+        "SEE LICENSE IN LICENSE" to licenseRef("unknown-license-reference", "scancode"),
         "SIL OPEN FONT LICENSE Version 1.1" to OFL_1_1.toExpression(),
         "SIL Open Font License 1.1 (OFL-1.1)" to OFL_1_1.toExpression(),
         "Simplified BSD" to BSD_2_CLAUSE.toExpression(),


### PR DESCRIPTION
Resolve ORT error that 'SEE LICENSE IN LICENSE' can not
be mapped to a valid license or SPDX expression.
This is a valid declared license per npm docs[1] for
license that have not yet been assign an SPDX id or if you
are using a custom license.

[1] https://docs.npmjs.com/files/package.json#license

Signed-off-by: Thomas Steenbergen <thomas.steenbergen@here.com>