### PR TITLE
Gradle: Upgrade the idea-ext plugin to version 0.6.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@
 
 detektPluginVersion = 1.5.1
 dokkaPluginVersion = 0.10.1
-ideaExtPluginVersion = 0.5
+ideaExtPluginVersion = 0.6.1
 kotlinPluginVersion = 1.3.61
 reckonPluginVersion = 0.12.0
 svntoolsPluginVersion = 2.2.1


### PR DESCRIPTION
Unfortunately, no release notes are available. Note that the currently
latest version 0.7 does not work without significant code changes on
our side.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>