### PR TITLE
set_gradle_proxy: Fix setting a proxy without authentication info

### DIFF
--- a/scripts/set_gradle_proxy.sh
+++ b/scripts/set_gradle_proxy.sh
@@ -28,12 +28,14 @@ writeProxyStringToGradleProps () {
     HOST=${HOST#*//}
     # Extract authentication info.
     local AUTH=${HOST%%@*}
-    # Strip authentication info.
-    HOST=${HOST#$AUTH@}
-    # Extract the user.
-    local USER=${AUTH%%:*}
-    # Extract the password.
-    local PASSWORD=${AUTH#*:}
+    if [ "$AUTH" != "$HOST" ]; then
+        # Strip authentication info.
+        HOST=${HOST#$AUTH@}
+        # Extract the user.
+        local USER=${AUTH%%:*}
+        # Extract the password.
+        local PASSWORD=${AUTH#*:}
+    fi
 
     local PORT=${PROXY##*:}
     [ "$PORT" -ge 0 ] 2>/dev/null || PORT=80


### PR DESCRIPTION
This is a fixup for a1733d1.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>