### PR TITLE
ScanRecord: Fix-up broken de-serialization backwards compatibility

### DIFF
--- a/model/src/main/kotlin/ScanRecord.kt
+++ b/model/src/main/kotlin/ScanRecord.kt
@@ -28,7 +28,7 @@ import java.util.SortedSet
  * A record of a single run of the scanner tool, containing the input and the scan results for all scanned packages.
  */
 @JsonIgnoreProperties(
-    value = ["has_issues", /* Backwards-compatibility: */ "has_errors", "scopes"],
+    value = ["has_issues", /* Backwards-compatibility: */ "has_errors", "scanned_scopes", "scopes"],
     allowGetters = true
 )
 data class ScanRecord(


### PR DESCRIPTION
This is a fix-up for 09dfd2d which missed to also add the JSON alias
corresponding to the `scopes` property.

Signed-off-by: Frank Viernau <frank.viernau@here.com>