### PR TITLE
ScannerConfiguration: Rename the "scanner" field to "options"

### DIFF
--- a/model/src/main/kotlin/config/ScannerConfiguration.kt
+++ b/model/src/main/kotlin/config/ScannerConfiguration.kt
@@ -19,6 +19,7 @@
 
 package com.here.ort.model.config
 
+import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
 import com.here.ort.utils.storage.FileArchiver
@@ -48,5 +49,6 @@ data class ScannerConfiguration(
      * Scanner specific configuration options. The key needs to match the name of the scanner class, e.g. "ScanCode"
      * for the ScanCode wrapper. See the documentation of the scanner for available options.
      */
-    val scanner: Map<String, Map<String, String>>? = null
+    @JsonAlias("scanner")
+    val options: Map<String, Map<String, String>>? = null
 )

--- a/model/src/main/resources/reference.conf
+++ b/model/src/main/resources/reference.conf
@@ -35,5 +35,9 @@ ort {
       username = username
       password = password
     }
+
+    options {
+      // A map of maps from scanner class names to scanner-specific key-value pairs.
+    }
   }
 }

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -77,6 +77,8 @@ class OrtConfigurationTest : WordSpec({
                     postgres.username shouldBe "username"
                     postgres.password shouldBe "password"
                 }
+
+                scanner.options shouldNotBe null
             }
         }
     }

--- a/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
@@ -195,7 +195,7 @@ scanner:
     archive: null
     file_based_storage: null
     postgres_storage: null
-    scanner: null
+    options: null
   results:
     scan_results:
     - id: "Gradle:com.here.ort.gradle.example:lib:1.0.0"

--- a/scanner/src/main/kotlin/scanners/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/ScanCode.kt
@@ -216,7 +216,7 @@ class ScanCode(
     override val scannerVersion = "3.0.2"
     override val resultFileExt = "json"
 
-    private val scanCodeConfiguration = config.scanner?.get("ScanCode").orEmpty()
+    private val scanCodeConfiguration = config.options?.get("ScanCode").orEmpty()
 
     private val configurationOptions = scanCodeConfiguration["commandLine"]?.split(" ")
         ?: DEFAULT_CONFIGURATION_OPTIONS

--- a/scanner/src/test/kotlin/ScanCodeTest.kt
+++ b/scanner/src/test/kotlin/ScanCodeTest.kt
@@ -771,7 +771,7 @@ class ScanCodeTest : WordSpec({
         "return the non-config values from the scanner configuration" {
             val scannerWithConfig = ScanCode(
                 "ScanCode", ScannerConfiguration(
-                    scanner = mapOf(
+                    options = mapOf(
                         "ScanCode" to mapOf(
                             "commandLine" to "--command --line",
                             "commandLineNonConfig" to "--commandLineNonConfig",
@@ -799,7 +799,7 @@ class ScanCodeTest : WordSpec({
         "contain the values from the scanner configuration" {
             val scannerWithConfig = ScanCode(
                 "ScanCode", ScannerConfiguration(
-                    scanner = mapOf(
+                    options = mapOf(
                         "ScanCode" to mapOf(
                             "commandLine" to "--command --line",
                             "commandLineNonConfig" to "--commandLineNonConfig",


### PR DESCRIPTION
The ScannerConfiguration itself is included via a "scanner" field in the
"OrtConfiguration", leading to two nested "scanner" fields, which is not
so nice. So rename this field to "options" which is a more fitting name
anyway, also see the docs for the field.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>