### PR TITLE
OrtResult: Fix a severe issue with collectLicenseFindings()

### DIFF
--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -187,7 +187,7 @@ data class OrtResult(
                 val copyrights = finding.copyrights.mapNotNullTo(sortedSetOf()) { copyrightFindings ->
                     val locations = copyrightFindings.locations.filterTo(sortedSetOf()) {
                         val path = getFilePathRelativeToAnalyzerRoot(project, it.path)
-                        excludes.paths.any { exclude -> exclude.matches(path) }
+                        excludes.paths.none { exclude -> exclude.matches(path) }
                     }
                     if (locations.isNotEmpty()) copyrightFindings.copy(locations = locations)
                     else null

--- a/reporter/src/funTest/assets/notice-by-package-reporter-expected-results
+++ b/reporter/src/funTest/assets/notice-by-package-reporter-expected-results
@@ -3,6 +3,8 @@ The applicable license information is listed below:
 
 ----
 
+Copyright 1
+
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
 "Software"), to deal in the Software without restriction, including

--- a/reporter/src/funTest/assets/notice-by-package-reporter-expected-results-with-license-files
+++ b/reporter/src/funTest/assets/notice-by-package-reporter-expected-results-with-license-files
@@ -3,6 +3,8 @@ The applicable license information is listed below:
 
 ----
 
+Copyright 1
+
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
 "Software"), to deal in the Software without restriction, including


### PR DESCRIPTION
Invert the logic for applying PathExcludes to the locations of
copyright statements so that excluded locations get filtered out.

The issue was observed in the generated copyright notices which lacked
the copyright statements which were detected in not excluded locations.

This is a fix-up of d4e577c.

Signed-off-by: Frank Viernau <frank.viernau@here.com>