### PR TITLE
PostgresStorage: Allow to connect using SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ ort {
       schema = "schema"
       username = "username"
       password = "password"
+      sslmode = "verify-full"
     }
   }
 }
@@ -306,6 +307,10 @@ ort {
 
 The _scanner_ creates a table called `scan_results` and stores the data in a
 [jsonb](https://www.postgresql.org/docs/current/datatype-json.html) column.
+
+If you do not want to use SSL set the `sslmode` to `disabled`, other possible values are explained in the
+[documentation](https://jdbc.postgresql.org/documentation/head/ssl-client.html). For other supported configuration
+options see [PostgresStorageConfiguration.kt](model/src/main/kotlin/config/PostgresStorageConfiguration.kt).
 
 <a name="evaluator">&nbsp;</a>
 

--- a/model/src/main/kotlin/config/PostgresStorageConfiguration.kt
+++ b/model/src/main/kotlin/config/PostgresStorageConfiguration.kt
@@ -44,5 +44,34 @@ data class PostgresStorageConfiguration(
      * The password to use for authentication.
      */
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
-    val password: String = ""
+    val password: String = "",
+
+    /**
+     * The SSL mode to use, one of "disable", "allow", "prefer", "require", "verify-ca" or "verify-full".
+     * See: https://jdbc.postgresql.org/documentation/head/ssl-client.html
+     */
+    val sslmode: String = "verify-full",
+
+    /**
+     * The full path of the certificate file.
+     * See: https://jdbc.postgresql.org/documentation/head/connect.html
+     */
+    val sslcert: String? = null,
+
+    /**
+     * The full path of the key file.
+     * See: https://jdbc.postgresql.org/documentation/head/connect.html
+     */
+    val sslkey: String? = null,
+
+    /**
+     * The full path of the root certificate file.
+     * See: https://jdbc.postgresql.org/documentation/head/connect.html
+     */
+    val sslrootcert: String? = null
+
+    /**
+     * TODO: Make additional parameters configurable, see:
+     *       https://jdbc.postgresql.org/documentation/head/connect.html
+     */
 )

--- a/model/src/main/resources/reference.conf
+++ b/model/src/main/resources/reference.conf
@@ -34,6 +34,10 @@ ort {
       schema = schema
       username = username
       password = password
+      sslmode = "required"
+      sslcert = "/defaultdir/postgresql.crt"
+      sslkey = "/defaultdir/postgresql.pk8"
+      sslrootcert = "/defaultdir/root.crt"
     }
 
     options {

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -76,6 +76,10 @@ class OrtConfigurationTest : WordSpec({
                     postgres.schema shouldBe "schema"
                     postgres.username shouldBe "username"
                     postgres.password shouldBe "password"
+                    postgres.sslmode shouldBe "required"
+                    postgres.sslcert shouldBe "/defaultdir/postgresql.crt"
+                    postgres.sslkey shouldBe "/defaultdir/postgresql.pk8"
+                    postgres.sslrootcert shouldBe "/defaultdir/root.crt"
                 }
 
                 scanner.options shouldNotBe null

--- a/scanner/src/main/kotlin/ScanResultsStorage.kt
+++ b/scanner/src/main/kotlin/ScanResultsStorage.kt
@@ -103,6 +103,14 @@ abstract class ScanResultsStorage {
             properties["password"] = config.password
             properties["ApplicationName"] = "$ORT_NAME - $TOOL_NAME"
 
+            // Configure SSL, see: https://jdbc.postgresql.org/documentation/head/connect.html
+            // Note that the "ssl" property is only a fallback in case "sslmode" is not used. Since we always set
+            // "sslmode", "ssl" is not required.
+            properties["sslmode"] = config.sslmode
+            config.sslcert?.let { properties["sslcert"] = it }
+            config.sslkey?.let { properties["sslkey"] = it }
+            config.sslrootcert?.let { properties["sslrootcert"] = it }
+
             val connection = DriverManager.getConnection(config.url, properties)
 
             storage = PostgresStorage(connection, config.schema).also { it.setupDatabase() }


### PR DESCRIPTION
Allow to enable and configure SSL mode when connecting to the database
server. For details see:

https://jdbc.postgresql.org/documentation/head/connect.html
https://jdbc.postgresql.org/documentation/head/ssl-client.html