### PR TITLE
Gradle: Upgrade Kotlin to version 1.3.70

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 detektPluginVersion = 1.6.0
 dokkaPluginVersion = 0.10.1
 ideaExtPluginVersion = 0.6.1
-kotlinPluginVersion = 1.3.61
+kotlinPluginVersion = 1.3.70
 reckonPluginVersion = 0.12.0
 svntoolsPluginVersion = 2.2.1
 versionsPluginVersion = 0.28.0


### PR DESCRIPTION
See https://blog.jetbrains.com/kotlin/2020/03/kotlin-1-3-70-released/.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>