### PR TITLE
Yarn: Bump the supported version to the latest stable 1.x release

### DIFF
--- a/analyzer/src/main/kotlin/managers/Yarn.kt
+++ b/analyzer/src/main/kotlin/managers/Yarn.kt
@@ -55,7 +55,7 @@ class Yarn(
 
     override fun command(workingDir: File?) = if (Os.isWindows) "yarn.cmd" else "yarn"
 
-    override fun getVersionRequirement(): Requirement = Requirement.buildNPM("1.3.* - 1.21.*")
+    override fun getVersionRequirement(): Requirement = Requirement.buildNPM("1.3.* - 1.22.*")
 
     override fun mapDefinitionFiles(definitionFiles: List<File>) = mapDefinitionFilesForYarn(definitionFiles).toList()
 


### PR DESCRIPTION
Support for Yarn 2.x is pending, see
https://github.com/heremaps/oss-review-toolkit/issues/2283.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>