### PR TITLE
NoticeByPackageReporter: Remove a superfluous type declaration

### DIFF
--- a/reporter/src/main/kotlin/reporters/NoticeByPackageReporter.kt
+++ b/reporter/src/main/kotlin/reporters/NoticeByPackageReporter.kt
@@ -143,7 +143,7 @@ class NoticeByPackageProcessor(input: ReporterInput) : AbstractNoticeReporter.No
                     emptyMap()
                 }
             } else {
-                emptyMap<String, LicenseFindingsMap>()
+                emptyMap()
             }
 
             addLicenseFileFindings(licenseFileFindings, archiveDir)


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>