### PR TITLE
getting-started: Say "storage" instead of "cache"

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -273,8 +273,7 @@ cli/build/install/ort/bin/ort scan --help
 The `mime-types` package has only one dependency in the `depenencies` scope, but a lot of dependencies in the
 `devDependencies` scope. Scanning all of the `devDependencies` would take a lot of time, so we will only run the
 scanner on the `dependencies` scope in this tutorial. If you also want to scan the `devDependencies` it is strongly
-advised to configure a cache for the scan results as documented in the [README](../README.md) to speed up repeated
-scans.
+advised to configure a [scan storage](../README.md#storage-backends) for the scan results to speed up repeated scans.
 
 As during the _analyzer_ step an `.ort.yml` configuration file was provided to exclude `devDependencies`,
 the `--skip-excluded` option can be used to avoid the download and scanning of that scope.


### PR DESCRIPTION
And link to the README.md instead of just mentioning it.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>