### PR TITLE
Tests: Consistently call safeDeleteRecursively() without `force` 

### DIFF
--- a/analyzer/src/funTest/kotlin/GitRepoTest.kt
+++ b/analyzer/src/funTest/kotlin/GitRepoTest.kt
@@ -57,7 +57,7 @@ class GitRepoTest : StringSpec() {
     }
 
     override fun afterSpec(spec: Spec) {
-        outputDir.safeDeleteRecursively(force = true)
+        outputDir.safeDeleteRecursively()
     }
 
     init {

--- a/analyzer/src/funTest/kotlin/integration/AbstractIntegrationSpec.kt
+++ b/analyzer/src/funTest/kotlin/integration/AbstractIntegrationSpec.kt
@@ -81,7 +81,7 @@ abstract class AbstractIntegrationSpec : StringSpec() {
     }
 
     override fun afterSpec(spec: Spec) {
-        outputDir.safeDeleteRecursively(force = true)
+        outputDir.safeDeleteRecursively()
     }
 
     init {

--- a/analyzer/src/funTest/kotlin/managers/BundlerTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/BundlerTest.kt
@@ -58,7 +58,7 @@ class BundlerTest : WordSpec() {
 
                     yamlMapper.writeValueAsString(actualResult) shouldBe expectedResult
                 } finally {
-                    File(definitionFile.parentFile, ".bundle").safeDeleteRecursively(force = true)
+                    File(definitionFile.parentFile, ".bundle").safeDeleteRecursively()
                 }
             }
 
@@ -92,7 +92,7 @@ class BundlerTest : WordSpec() {
 
                     yamlMapper.writeValueAsString(actualResult) shouldBe expectedResult
                 } finally {
-                    File(definitionFile.parentFile, ".bundle").safeDeleteRecursively(force = true)
+                    File(definitionFile.parentFile, ".bundle").safeDeleteRecursively)
                 }
             }
         }

--- a/analyzer/src/funTest/kotlin/managers/MavenTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/MavenTest.kt
@@ -114,7 +114,7 @@ class MavenTest : StringSpec() {
             // Delete the parent POM from the local repository to make sure it has to be resolved from Maven central.
             getUserHomeDirectory()
                 .resolve(".m2/repository/org/springframework/boot/spring-boot-starter-parent/1.5.3.RELEASE")
-                .safeDeleteRecursively(force = true)
+                .safeDeleteRecursively()
 
             val projectDir = File("src/funTest/assets/projects/synthetic/maven-parent").absoluteFile
             val pomFile = File(projectDir, "pom.xml")

--- a/analyzer/src/test/kotlin/managers/utils/NodeSupportTest.kt
+++ b/analyzer/src/test/kotlin/managers/utils/NodeSupportTest.kt
@@ -225,7 +225,7 @@ class NodeSupportTest : WordSpec() {
     }
 
     override fun afterTest(testCase: TestCase, result: TestResult) {
-        tempDir.safeDeleteRecursively(force = true)
+        tempDir.safeDeleteRecursively()
         definitionFiles.clear()
         super.afterTest(testCase, result)
     }

--- a/cli/src/funTest/kotlin/OrtMainTest.kt
+++ b/cli/src/funTest/kotlin/OrtMainTest.kt
@@ -53,7 +53,7 @@ class OrtMainTest : StringSpec() {
     }
 
     override fun afterTest(testCase: TestCase, result: TestResult) {
-        outputDir.safeDeleteRecursively(force = true)
+        outputDir.safeDeleteRecursively()
     }
 
     init {

--- a/downloader/src/funTest/kotlin/BabelTest.kt
+++ b/downloader/src/funTest/kotlin/BabelTest.kt
@@ -45,7 +45,7 @@ class BabelTest : StringSpec() {
     }
 
     override fun afterTest(testCase: TestCase, result: TestResult) {
-        outputDir.safeDeleteRecursively(force = true)
+        outputDir.safeDeleteRecursively()
     }
 
     init {

--- a/downloader/src/funTest/kotlin/BeanUtilsTest.kt
+++ b/downloader/src/funTest/kotlin/BeanUtilsTest.kt
@@ -43,7 +43,7 @@ class BeanUtilsTest : StringSpec() {
     }
 
     override fun afterTest(testCase: TestCase, result: TestResult) {
-        outputDir.safeDeleteRecursively(force = true)
+        outputDir.safeDeleteRecursively()
     }
 
     init {

--- a/downloader/src/funTest/kotlin/DirectoryTest.kt
+++ b/downloader/src/funTest/kotlin/DirectoryTest.kt
@@ -44,7 +44,7 @@ class DirectoryTest : StringSpec() {
     }
 
     override fun afterTest(testCase: TestCase, result: TestResult) {
-        outputDir.safeDeleteRecursively(force = true)
+        outputDir.safeDeleteRecursively()
     }
 
     init {

--- a/downloader/src/funTest/kotlin/DownloaderTest.kt
+++ b/downloader/src/funTest/kotlin/DownloaderTest.kt
@@ -46,7 +46,7 @@ class DownloaderTest : StringSpec() {
     }
 
     override fun afterTest(testCase: TestCase, result: TestResult) {
-        outputDir.safeDeleteRecursively(force = true)
+        outputDir.safeDeleteRecursively()
     }
 
     init {

--- a/downloader/src/funTest/kotlin/vcs/CvsDownloadTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/CvsDownloadTest.kt
@@ -51,7 +51,7 @@ class CvsDownloadTest : StringSpec() {
     }
 
     override fun afterTest(testCase: TestCase, result: TestResult) {
-        outputDir.safeDeleteRecursively(force = true)
+        outputDir.safeDeleteRecursively()
     }
 
     init {

--- a/downloader/src/funTest/kotlin/vcs/CvsWorkingTreeTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/CvsWorkingTreeTest.kt
@@ -46,7 +46,7 @@ class CvsWorkingTreeTest : StringSpec() {
     }
 
     override fun afterSpec(spec: Spec) {
-        zipContentDir.safeDeleteRecursively(force = true)
+        zipContentDir.safeDeleteRecursively()
     }
 
     init {

--- a/downloader/src/funTest/kotlin/vcs/GitDownloadTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/GitDownloadTest.kt
@@ -52,7 +52,7 @@ class GitDownloadTest : StringSpec() {
     }
 
     override fun afterTest(testCase: TestCase, result: TestResult) {
-        outputDir.safeDeleteRecursively(force = true)
+        outputDir.safeDeleteRecursively()
     }
 
     init {

--- a/downloader/src/funTest/kotlin/vcs/GitRepoDownloadTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/GitRepoDownloadTest.kt
@@ -48,7 +48,7 @@ class GitRepoDownloadTest : StringSpec() {
     }
 
     override fun afterTest(testCase: TestCase, result: TestResult) {
-        outputDir.safeDeleteRecursively(force = true)
+        outputDir.safeDeleteRecursively()
     }
 
     init {

--- a/downloader/src/funTest/kotlin/vcs/GitWorkingTreeTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/GitWorkingTreeTest.kt
@@ -48,7 +48,7 @@ class GitWorkingTreeTest : StringSpec() {
     }
 
     override fun afterSpec(spec: Spec) {
-        zipContentDir.safeDeleteRecursively(force = true)
+        zipContentDir.safeDeleteRecursively()
     }
 
     init {

--- a/downloader/src/funTest/kotlin/vcs/MercurialDownloadTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/MercurialDownloadTest.kt
@@ -52,7 +52,7 @@ class MercurialDownloadTest : StringSpec() {
     }
 
     override fun afterTest(testCase: TestCase, result: TestResult) {
-        outputDir.safeDeleteRecursively(force = true)
+        outputDir.safeDeleteRecursively()
     }
 
     init {

--- a/downloader/src/funTest/kotlin/vcs/MercurialWorkingTreeTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/MercurialWorkingTreeTest.kt
@@ -46,7 +46,7 @@ class MercurialWorkingTreeTest : StringSpec() {
     }
 
     override fun afterSpec(spec: Spec) {
-        zipContentDir.safeDeleteRecursively(force = true)
+        zipContentDir.safeDeleteRecursively()
     }
 
     init {

--- a/downloader/src/funTest/kotlin/vcs/SubversionDownloadTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/SubversionDownloadTest.kt
@@ -52,7 +52,7 @@ class SubversionDownloadTest : StringSpec() {
     }
 
     override fun afterTest(testCase: TestCase, result: TestResult) {
-        outputDir.safeDeleteRecursively(force = true)
+        outputDir.safeDeleteRecursively()
     }
 
     init {

--- a/downloader/src/funTest/kotlin/vcs/SubversionWorkingTreeTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/SubversionWorkingTreeTest.kt
@@ -48,7 +48,7 @@ class SubversionWorkingTreeTest : StringSpec() {
 
     override fun afterSpec(spec: Spec) {
         print("Deleting '$zipContentDir'... ")
-        zipContentDir.safeDeleteRecursively(force = true)
+        zipContentDir.safeDeleteRecursively()
         println("done.")
     }
 

--- a/scanner/src/funTest/kotlin/scanners/FileCounterScannerTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/FileCounterScannerTest.kt
@@ -54,7 +54,7 @@ class FileCounterScannerTest : StringSpec() {
 
             patchActualResult(result, patchDownloadTime = true, patchStartAndEndTime = true) shouldBe expectedResult
 
-            outputRootDir.safeDeleteRecursively(force = true)
+            outputRootDir.safeDeleteRecursively()
             ScanResultsStorage.storage.stats.reset()
         }
     }

--- a/utils/src/test/kotlin/ArchiveUtilsTest.kt
+++ b/utils/src/test/kotlin/ArchiveUtilsTest.kt
@@ -34,7 +34,7 @@ class ArchiveUtilsTest : StringSpec() {
     }
 
     override fun afterTest(testCase: TestCase, result: TestResult) {
-        outputDir.safeDeleteRecursively(force = true)
+        outputDir.safeDeleteRecursively()
     }
 
     init {

--- a/utils/src/test/kotlin/DirectoryStashTest.kt
+++ b/utils/src/test/kotlin/DirectoryStashTest.kt
@@ -49,7 +49,7 @@ class DirectoryStashTest : StringSpec() {
     }
 
     override fun afterTest(testCase: TestCase, result: TestResult) {
-        sandboxDir.safeDeleteRecursively(force = true)
+        sandboxDir.safeDeleteRecursively()
     }
 
     private fun sandboxDirShouldBeInOriginalState() {


### PR DESCRIPTION
This should not be needed as we have full control over the files being
created there.

Signed-off-by: Frank Viernau <frank.viernau@here.com>