### PR TITLE
scanner: Fix storage stats when using FileBasedStorage

### DIFF
--- a/scanner/src/main/kotlin/storages/FileBasedStorage.kt
+++ b/scanner/src/main/kotlin/storages/FileBasedStorage.kt
@@ -73,7 +73,7 @@ class FileBasedStorage(
     }
 
     override fun readFromStorage(pkg: Package, scannerDetails: ScannerDetails): ScanResultContainer {
-        val scanResults = read(pkg.id).results.toMutableList()
+        val scanResults = readFromStorage(pkg.id).results.toMutableList()
 
         if (scanResults.isEmpty()) return ScanResultContainer(pkg.id, scanResults)
 


### PR DESCRIPTION
Use `readFromStorage(id)` in `readFromStorage(pkg, scannerDetails)`
instead of the `read(id)` function. Otherwise the storage stats are
incremented twice when calling
`ScanResultsStorage.read(pkg, scannerDetails)` with a
`FileBasedStorage`.