### PR TITLE
model: Reduce the severity for unmapped declared licenses

### DIFF
--- a/model/src/main/kotlin/Package.kt
+++ b/model/src/main/kotlin/Package.kt
@@ -153,7 +153,7 @@ data class Package(
     fun collectIssues() =
         declaredLicensesProcessed.unmapped.map { unmappedLicense ->
             OrtIssue(
-                severity = Severity.ERROR,
+                severity = Severity.WARNING,
                 source = id.toCoordinates(),
                 message = "The declared license '$unmappedLicense' could not be mapped to a valid license or " +
                         "parsed as an SPDX expression."

--- a/model/src/main/kotlin/Project.kt
+++ b/model/src/main/kotlin/Project.kt
@@ -132,7 +132,7 @@ data class Project(
 
         declaredLicensesProcessed.unmapped.forEach { unmappedLicense ->
             collectedIssues.getOrPut(id) { mutableSetOf() } += OrtIssue(
-                severity = Severity.ERROR,
+                severity = Severity.WARNING,
                 source = id.toCoordinates(),
                 message = "The declared license '$unmappedLicense' could not be mapped to a valid license or " +
                         "parsed as an SPDX expression."

--- a/model/src/test/kotlin/AnalyzerResultTest.kt
+++ b/model/src/test/kotlin/AnalyzerResultTest.kt
@@ -118,7 +118,7 @@ class AnalyzerResultTest : WordSpec() {
 
                 issues.getValue(project1.id).let { projectIssues ->
                     projectIssues should haveSize(1)
-                    projectIssues.first().severity shouldBe Severity.ERROR
+                    projectIssues.first().severity shouldBe Severity.WARNING
                     projectIssues.first().source shouldBe project1.id.toCoordinates()
                     projectIssues.first().message shouldBe "The declared license 'invalid project license' could not " +
                             "be mapped to a valid license or parsed as an SPDX expression."
@@ -126,7 +126,7 @@ class AnalyzerResultTest : WordSpec() {
 
                 issues.getValue(package1.id).let { packageIssues ->
                     packageIssues should haveSize(1)
-                    packageIssues.first().severity shouldBe Severity.ERROR
+                    packageIssues.first().severity shouldBe Severity.WARNING
                     packageIssues.first().source shouldBe package1.id.toCoordinates()
                     packageIssues.first().message shouldBe "The declared license 'invalid package license' could not " +
                             "be mapped to a valid license or parsed as an SPDX expression."


### PR DESCRIPTION
Reduce the severity for unmapped declared licenses from `ERROR` to
`WARNING`. The decision if an unmapped license is an error should be
made in the evaluator rules. Further improvements to simplify this will
be implemented in separate commits.