### PR TITLE
Remove JCenter from repository declarations in CLI projects

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -44,8 +44,6 @@ tasks.named<CreateStartScripts>("startScripts") {
 }
 
 repositories {
-    jcenter()
-
     // Need to repeat the analyzer's custom repository definition here, see
     // https://github.com/gradle/gradle/issues/4106.
     exclusiveContent {

--- a/helper-cli/build.gradle.kts
+++ b/helper-cli/build.gradle.kts
@@ -41,8 +41,6 @@ tasks.named<CreateStartScripts>("startScripts") {
 }
 
 repositories {
-    jcenter()
-
     // Need to repeat the analyzer's custom repository definition here, see
     // https://github.com/gradle/gradle/issues/4106.
     exclusiveContent {


### PR DESCRIPTION
As of 655bb22 JCenter is declared for all projects.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>